### PR TITLE
Feat: Exclude pre-existing overloads in N-1 analysis unless worsened

### DIFF
--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -34,6 +34,7 @@ class ConfigRequest(BaseModel):
     n_prioritized_actions: int = 10
     lines_monitoring_path: str | None = None
     monitoring_factor: float = 0.95
+    pre_existing_overload_threshold: float = 0.02
 
 class AnalysisRequest(BaseModel):
     disconnected_element: str

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ function App() {
   const [nPrioritizedActions, setNPrioritizedActions] = useState<number>(10);
   const [linesMonitoringPath, setLinesMonitoringPath] = useState<string>('');
   const [monitoringFactor, setMonitoringFactor] = useState<number>(0.95);
+  const [preExistingOverloadThreshold, setPreExistingOverloadThreshold] = useState<number>(0.02);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<'recommender' | 'configurations'>('recommender');
   const [settingsBackup, setSettingsBackup] = useState<any>(null);
@@ -43,10 +44,11 @@ function App() {
       minLineDisconnections,
       nPrioritizedActions,
       linesMonitoringPath,
-      monitoringFactor
+      monitoringFactor,
+      preExistingOverloadThreshold
     });
     setIsSettingsOpen(true);
-  }, [minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, nPrioritizedActions, linesMonitoringPath, monitoringFactor]);
+  }, [minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold]);
 
   const handleCloseSettings = useCallback(() => {
     if (settingsBackup) {
@@ -57,6 +59,7 @@ function App() {
       setNPrioritizedActions(settingsBackup.nPrioritizedActions);
       setLinesMonitoringPath(settingsBackup.linesMonitoringPath);
       setMonitoringFactor(settingsBackup.monitoringFactor);
+      setPreExistingOverloadThreshold(settingsBackup.preExistingOverloadThreshold);
     }
     setIsSettingsOpen(false);
   }, [settingsBackup]);
@@ -73,6 +76,7 @@ function App() {
         n_prioritized_actions: nPrioritizedActions,
         lines_monitoring_path: linesMonitoringPath,
         monitoring_factor: monitoringFactor,
+        pre_existing_overload_threshold: preExistingOverloadThreshold,
       });
       setSettingsBackup({
         minLineReconnections,
@@ -81,7 +85,8 @@ function App() {
         minLineDisconnections,
         nPrioritizedActions,
         linesMonitoringPath,
-        monitoringFactor
+        monitoringFactor,
+        preExistingOverloadThreshold
       });
       setInfoMessage('Settings applied successfully.');
       setIsSettingsOpen(false);
@@ -89,7 +94,7 @@ function App() {
       const e = err as { response?: { data?: { detail?: string } }; message?: string };
       setError('Failed to apply settings: ' + (e.response?.data?.detail || e.message));
     }
-  }, [networkPath, actionPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, nPrioritizedActions, linesMonitoringPath, monitoringFactor]);
+  }, [networkPath, actionPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold]);
 
   const pickSettingsPath = async (type: 'file' | 'dir', setter: (path: string) => void) => {
     try {
@@ -174,6 +179,7 @@ function App() {
         n_prioritized_actions: nPrioritizedActions,
         lines_monitoring_path: linesMonitoringPath,
         monitoring_factor: monitoringFactor,
+        pre_existing_overload_threshold: preExistingOverloadThreshold,
       });
 
       const [branchesList, vlRes, nomVRes] = await Promise.all([
@@ -201,7 +207,7 @@ function App() {
     } finally {
       setConfigLoading(false);
     }
-  }, [networkPath, actionPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, nPrioritizedActions, monitoringFactor, linesMonitoringPath]);
+  }, [networkPath, actionPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, nPrioritizedActions, monitoringFactor, linesMonitoringPath, preExistingOverloadThreshold]);
 
   const fetchBaseDiagram = async (vlCount: number) => {
     try {
@@ -732,6 +738,13 @@ function App() {
                     <input type="text" value={linesMonitoringPath} onChange={e => setLinesMonitoringPath(e.target.value)} placeholder="Leave empty for IGNORE_LINES_MONITORING=True" style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
                     <button onClick={() => pickSettingsPath('file', setLinesMonitoringPath)} style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📁</button>
                   </div>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <label style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>Pre-existing Overload Threshold</label>
+                  <input type="number" step="0.01" min="0" max="1" value={preExistingOverloadThreshold} onChange={e => setPreExistingOverloadThreshold(parseFloat(e.target.value))} style={{ width: '80px', padding: '5px', border: '1px solid #ccc', borderRadius: '4px' }} />
+                </div>
+                <div style={{ fontSize: '0.75rem', color: '#666', marginTop: '-10px' }}>
+                  Pre-existing overloads excluded from N-1 & max_rho unless worsened by this fraction (default 2%)
                 </div>
               </div>
             )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,6 +8,7 @@ export interface ConfigRequest {
     n_prioritized_actions: number;
     lines_monitoring_path?: string;
     monitoring_factor: number;
+    pre_existing_overload_threshold?: number;
 }
 
 export interface AnalysisRequest {

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -862,6 +862,7 @@
             const [minLineDisconnections, setMinLineDisconnections] = useState(3.0);
             const [nPrioritizedActions, setNPrioritizedActions] = useState(10);
             const [monitoringFactor, setMonitoringFactor] = useState(0.95);
+            const [preExistingOverloadThreshold, setPreExistingOverloadThreshold] = useState(0.02);
             const [monitoredLinesCount, setMonitoredLinesCount] = useState(0);
             const [totalLinesCount, setTotalLinesCount] = useState(0);
             const [showMonitoringWarning, setShowMonitoringWarning] = useState(false);
@@ -879,7 +880,8 @@
                     minLineDisconnections,
                     nPrioritizedActions,
                     linesMonitoringPath,
-                    monitoringFactor
+                    monitoringFactor,
+                    preExistingOverloadThreshold
                 });
                 setIsSettingsOpen(true);
             };
@@ -893,6 +895,7 @@
                     setNPrioritizedActions(settingsBackup.nPrioritizedActions);
                     setLinesMonitoringPath(settingsBackup.linesMonitoringPath);
                     setMonitoringFactor(settingsBackup.monitoringFactor);
+                    setPreExistingOverloadThreshold(settingsBackup.preExistingOverloadThreshold);
                 }
                 setIsSettingsOpen(false);
             };
@@ -908,7 +911,8 @@
                         min_line_disconnections: minLineDisconnections,
                         n_prioritized_actions: nPrioritizedActions,
                         lines_monitoring_path: linesMonitoringPath,
-                        monitoring_factor: monitoringFactor
+                        monitoring_factor: monitoringFactor,
+                        pre_existing_overload_threshold: preExistingOverloadThreshold
                     });
 
                     if (configRes.data && configRes.data.total_lines_count !== undefined) {
@@ -924,7 +928,8 @@
                         minLineDisconnections,
                         nPrioritizedActions,
                         linesMonitoringPath,
-                        monitoringFactor
+                        monitoringFactor,
+                        preExistingOverloadThreshold
                     });
                     setInfoMessage('Settings applied successfully. Reloading network state...');
                     setIsSettingsOpen(false);
@@ -1037,7 +1042,8 @@
                         min_line_disconnections: minLineDisconnections,
                         n_prioritized_actions: nPrioritizedActions,
                         lines_monitoring_path: linesMonitoringPath,
-                        monitoring_factor: monitoringFactor
+                        monitoring_factor: monitoringFactor,
+                        pre_existing_overload_threshold: preExistingOverloadThreshold
                     });
 
                     if (configRes.data && configRes.data.total_lines_count !== undefined) {
@@ -2138,6 +2144,13 @@
                                                     <input type="text" value={linesMonitoringPath} onChange={e => setLinesMonitoringPath(e.target.value)} placeholder="Leave empty for IGNORE_LINES_MONITORING=True" style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
                                                     <button onClick={() => pickPath('file', setLinesMonitoringPath)} style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}>📁</button>
                                                 </div>
+                                            </div>
+                                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                                <label style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>Pre-existing Overload Threshold</label>
+                                                <input type="number" step="0.01" min="0" max="1" value={preExistingOverloadThreshold} onChange={e => setPreExistingOverloadThreshold(parseFloat(e.target.value))} style={{ width: '80px', padding: '5px', border: '1px solid #ccc', borderRadius: '4px' }} />
+                                            </div>
+                                            <div style={{ fontSize: '0.75rem', color: '#666', marginTop: '-10px' }}>
+                                                Pre-existing overloads excluded from N-1 & max_rho unless worsened by this fraction (default 2%)
                                             </div>
                                         </div>
                                     )}


### PR DESCRIPTION
Based on the implementation plan, this PR introduces a filtering mechanism for N-1 overloads. Lines that are already overloaded in the base N-state are excluded from the N-1 overloaded lines list, unless their maximum current has increased by a specified threshold (default 2%). Configured for both React and Standalone UIs.

---

# Implementation Plan

**Pre-Existing Overloads: Exclude from N-1 Display, Analysis & max_rho**

Pre-existing overloads (lines already overloaded in N state) should be excluded from N-1 overloads display, contingency analysis, and action `max_rho` — unless worsened by a configurable threshold (default 2% of initial current).

## Proposed Changes

### Expert_op4grid_recommender — Config

#### [MODIFY] config.py
Add `PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02` alongside other config parameters.

---

### Expert_op4grid_recommender — Analysis Engine

#### [MODIFY] main.py

**Overload filtering** (lines 375-389): Already done ✅ — Pre-existing overloads filtered from `lines_overloaded_ids`.

**Store pre-existing rho** (~line 384): Also store a dict `{line_idx: rho_N}` for pre-existing overloads, needed for the worsening check.

**Reassessment max_rho** (lines 579-593): When computing `max_rho` for each action, exclude lines where `obs.rho[i] >= 1` (pre-existing) unless the action's rho exceeds `obs.rho[i] * (1 + threshold)`.

**Return value** (line 614-618): Include `pre_existing_overloads` info in the result dict (list of `{name, rho_N}`).

---

### ExpertAssist Backend

#### [MODIFY] main.py
Add `pre_existing_overload_threshold: float = 0.02` to `ConfigRequest`.

#### [MODIFY] recommender_service.py

1. **`update_config`**: Set `config.PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD` from settings.
2. **`_get_overloaded_lines`**: Add optional params `n_state_currents` and `worsening_threshold` to filter pre-existing overloads.
3. **`get_network_diagram`**: Also store N-state element currents in `self._n_state_currents` for comparison.
4. **`get_n1_diagram`**: Call `_get_overloaded_lines` with N-state currents to exclude pre-existing overloads unless worsened.

---

### ExpertAssist Frontend

#### [MODIFY] App.tsx
Add `preExistingOverloadThreshold` state, backup/restore in settings, pass to config updates.

#### [MODIFY] standalone_interface.html
Mirror the same threshold setting in the standalone interface.

## Verification Plan

### Manual Verification
1. Start ExpertAssist backend, load `bare_env_small_grid_test`, select contingency `P.SAOL31RONCI`
2. With no `lignes_a_monitorer` specified:
   - **N Overloads** should show `BUGEYY712`, `BUGEYY714`, `N.SE5Y711`, `N.SE5Y712`
   - **N-1 Overloads** should ONLY show `BEON L31CPVAN` (pre-existing excluded)
   - **Run Analysis** should produce action cards with `max_rho` NOT referencing `N.SE5Y711`
3. Adjust the threshold in settings to `0` (0%) → pre-existing overloads should re-appear in N-1 if their current changed at all
