### PR TITLE
Refactor voltage filter: grid-detected clustering and <25kV bucketing

### DIFF
--- a/expert_backend/services/network_service.py
+++ b/expert_backend/services/network_service.py
@@ -50,14 +50,50 @@ class NetworkService:
         return []
 
     def get_nominal_voltages(self):
-        """Return {vl_id: nominal_v_kv} mapping for all voltage levels."""
+        """Return {vl_id: nominal_v_kv} mapping for all voltage levels, snapped to detected grid values."""
         if not self.network:
             raise ValueError("Network not loaded")
 
         voltage_levels = self.network.get_voltage_levels()
-        if voltage_levels is not None and not voltage_levels.empty:
-            return {vl_id: float(row['nominal_v']) for vl_id, row in voltage_levels.iterrows()}
-        return {}
+        if voltage_levels is None or voltage_levels.empty:
+            return {}
+
+        # 1. Collect all unique nominal voltages
+        raw_voltages = sorted(voltage_levels['nominal_v'].unique())
+        if not raw_voltages:
+            return {}
+
+        # 2. Cluster voltages within 2% of each other
+        clusters = []
+        if raw_voltages:
+            current_cluster = [raw_voltages[0]]
+            for v in raw_voltages[1:]:
+                # If v is within 2% of the cluster average, add it
+                avg = sum(current_cluster) / len(current_cluster)
+                if abs(v - avg) / avg < 0.02:
+                    current_cluster.append(v)
+                else:
+                    clusters.append(current_cluster)
+                    current_cluster = [v]
+            clusters.append(current_cluster)
+
+        # 3. Create representative cleaned values for each cluster
+        # Map each raw voltage to its clean representative
+        raw_to_clean = {}
+        for cluster in clusters:
+            avg = sum(cluster) / len(cluster)
+            # Bucketing: anything < 25kV goes into the 25kV bucket
+            if avg < 25:
+                clean_v = 25.0
+            else:
+                # Clean representative: round to int
+                clean_v = round(avg, 0)
+            
+            for v in cluster:
+                raw_to_clean[v] = clean_v
+
+        # 4. Map each voltage level to its clean representative
+        return {vl_id: raw_to_clean[float(row['nominal_v'])] for vl_id, row in voltage_levels.iterrows()}
 
     def get_element_voltage_levels(self, element_id: str):
         """Resolve an equipment ID (line, transformer, or VL) to its voltage level IDs."""

--- a/expert_backend/tests/test_network_service.py
+++ b/expert_backend/tests/test_network_service.py
@@ -132,7 +132,7 @@ class TestGetNominalVoltages:
             "VL2": 225.0,
             "VL3": 90.0,
             "VL4": 63.0,
-            "VL5": 20.0,
+            "VL5": 25.0,
         }
 
     def test_empty_voltage_levels(self):

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -315,7 +315,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                 />
                                 <div className="voltage-slider-ticks">
                                     {uniqueVoltages.map(kv => (
-                                        <span key={kv} style={{ bottom: logScale(kv) + '%' }}>{kv}</span>
+                                        <span key={kv} style={{ bottom: logScale(kv) + '%' }}>
+                                            {kv === 25 ? '<25' : kv}
+                                        </span>
                                     ))}
                                 </div>
                             </div>


### PR DESCRIPTION
Walkthrough - Voltage Filter Bucketing
I have implemented a bucketing workaround for small voltages (< 25kV) to prevent the filter slider from becoming cluttered.

Changes
1. Low-Voltage Bucketing
Updated 
network_service.py
 to:

Group all identified nominal voltages below 25kV into a single bucket.
This allows the user to filter all low-voltage lines (e.g., 20kV, 15kV, 3.3kV) at once with a single slider step.
2. UI Labeling
Updated 
VisualizationPanel.tsx
 to:

Explicitly label the bottom bucket as "<25" in the slider ticks.
This provides clear feedback that the entire low-voltage range is being controlled together.
Verification
Automated Tests
I successfully ran a new test script 
run_bucket_test.py
 verifying that:

Cluster averages below 25kV (e.g., 20kV, 3.3kV) all map to the same 25.0 value.
The unique voltages list correctly consolidates these into a single entry.
Manual Verification
The "kV Filter" sidebar now shows a single step for all voltages below 25kV, labeled "<25". High-voltage levels (e.g., 400kV, 225kV) remain as individual, clean ticks. This drastically simplifies the interface while maintaining full functionality for filtering the grid's core infrastructure.