### PR TITLE
feat: Enhance SLD search and tab synchronization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1190,6 +1190,8 @@ function App() {
             vlOverlay={vlOverlay}
             onOverlayClose={handleOverlayClose}
             onOverlaySldTabChange={handleOverlaySldTabChange}
+            voltageLevels={voltageLevels}
+            onVlOpen={(vlName) => handleVlDoubleClick(activeTab === 'action' ? selectedActionId || '' : '', vlName)}
           />
         </div>
       </div>

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -36,6 +36,8 @@ const createDefaultProps = (overrides: Record<string, unknown> = {}) => ({
     vlOverlay: null,
     onOverlayClose: vi.fn(),
     onOverlaySldTabChange: vi.fn(),
+    voltageLevels: [] as string[],
+    onVlOpen: vi.fn(),
     ...overrides,
 });
 
@@ -198,6 +200,8 @@ describe('VisualizationPanel', () => {
                 vlOverlay,
                 actionViewMode: 'network', // Doesn't matter which mode, cleanup runs first always
                 activeTab: 'n',
+                n1Diagram: null,
+                actionDiagram: null,
             });
 
             const { container } = render(<VisualizationPanel {...props} />);

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -32,6 +32,8 @@ interface VisualizationPanelProps {
     vlOverlay: VlOverlay | null;
     onOverlayClose: () => void;
     onOverlaySldTabChange: (tab: SldTab) => void;
+    voltageLevels: string[];
+    onVlOpen: (vlName: string) => void;
 }
 
 // ===== SLD Overlay sub-component =====
@@ -42,11 +44,14 @@ interface SldOverlayProps {
     actionViewMode: 'network' | 'delta';
     onOverlayClose: () => void;
     onOverlaySldTabChange: (tab: SldTab) => void;
+    n1Diagram: DiagramData | null;
+    actionDiagram: DiagramData | null;
 }
 
 const SldOverlay: React.FC<SldOverlayProps> = ({
     vlOverlay, actionViewMode,
     onOverlayClose, onOverlaySldTabChange,
+    n1Diagram, actionDiagram,
 }) => {
     const overlayBodyRef = useRef<HTMLDivElement>(null);
     const [overlayPos, setOverlayPos] = useState({ x: 16, y: 16 });
@@ -448,7 +453,11 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                         </span>
                     </div>
                     <div style={{ display: 'flex', gap: '4px' }}>
-                        {(['n', 'n-1', 'action'] as SldTab[]).map(tabMode => (
+                        {(['n', 'n-1', 'action'] as SldTab[]).filter(tabMode => {
+                            if (tabMode === 'n-1') return !!n1Diagram;
+                            if (tabMode === 'action') return !!actionDiagram;
+                            return true; // always show N
+                        }).map(tabMode => (
                             <button
                                 key={tabMode}
                                 onMouseDown={e => e.stopPropagation()}
@@ -530,6 +539,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     vlOverlay,
     onOverlayClose,
     onOverlaySldTabChange,
+    voltageLevels,
+    onVlOpen,
 }) => {
     const showViewModeToggle = activeTab !== 'overflow' && (
         (activeTab === 'n' && !!nDiagram?.svg) ||
@@ -811,6 +822,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         actionViewMode={actionViewMode}
                         onOverlayClose={onOverlayClose}
                         onOverlaySldTabChange={onOverlaySldTabChange}
+                        n1Diagram={n1Diagram}
+                        actionDiagram={actionDiagram}
                     />
                 )}
 
@@ -887,6 +900,20 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                 <datalist id="inspectables">
                                     {inspectableItems.map(b => <option key={b} value={b} />)}
                                 </datalist>
+                                {inspectQuery && voltageLevels.includes(inspectQuery) && (
+                                    <button
+                                        onClick={() => onVlOpen(inspectQuery)}
+                                        style={{
+                                            background: '#d1fae5', color: '#065f46', border: 'none',
+                                            borderRadius: '4px', padding: '4px 8px', cursor: 'pointer',
+                                            fontSize: '12px', boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
+                                            fontWeight: 600
+                                        }}
+                                        title="Open Single Line Diagram"
+                                    >
+                                        📄 SLD
+                                    </button>
+                                )}
                                 {inspectQuery && (
                                     <button
                                         onClick={() => onInspectQueryChange('')}

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -2638,7 +2638,11 @@
                                             </span>
                                         </div>
                                         <div style={{ display: 'flex', gap: '4px' }}>
-                                            {['n', 'n-1', 'action'].map(tabMode => (
+                                            {['n', 'n-1', 'action'].filter(tabMode => {
+                                                if (tabMode === 'n-1') return !!n1Diagram;
+                                                if (tabMode === 'action') return !!actionDiagram;
+                                                return true; // always show N
+                                            }).map(tabMode => (
                                                 <button
                                                     key={tabMode}
                                                     onMouseDown={e => e.stopPropagation()} // Prevent dragging when clicking tabs
@@ -3556,6 +3560,20 @@
                                                     }}
                                                 />
                                                 <datalist id="inspectables">{inspectableItems.map(b => <option key={b} value={b} />)}</datalist>
+                                                {inspectQuery && voltageLevels.includes(inspectQuery) && (
+                                                    <button
+                                                        onClick={() => handleVlDoubleClick(activeTab === 'action' ? selectedActionId || '' : '', inspectQuery)}
+                                                        style={{
+                                                            background: '#d1fae5', color: '#065f46', border: 'none',
+                                                            borderRadius: '4px', padding: '4px 8px', cursor: 'pointer',
+                                                            fontSize: '12px', boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
+                                                            fontWeight: 600
+                                                        }}
+                                                        title="Open Single Line Diagram"
+                                                    >
+                                                        📄 SLD
+                                                    </button>
+                                                )}
                                                 {inspectQuery && (
                                                     <button onClick={() => setInspectQuery('')} style={{ background: '#e74c3c', color: 'white', border: 'none', borderRadius: '4px', padding: '4px 8px', cursor: 'pointer', fontSize: '12px', boxShadow: '0 2px 5px rgba(0,0,0,0.15)' }} title="Clear">
                                                         ✖


### PR DESCRIPTION
# Walkthrough: SLD Button in Visualization Panel

## Changes Made

1. **`App.tsx`**: Passed the `voltageLevels` state and an `onVlOpen` callback to the `VisualizationPanel` component. This callback triggers the existing `handleVlDoubleClick` function.
2. **`VisualizationPanel.tsx`**: Added the `voltageLevels` and `onVlOpen` props. In the "Inspect..." search bar section, added a condition to check if the current `inspectQuery` matches a known voltage level from the `voltageLevels` list. If it does, a "📄 SLD" button is rendered next to the "Clear" (✖) button. Clicking this button triggers `onVlOpen(inspectQuery)`.
3. **`standalone_interface.html`**: Replicated the `VisualizationPanel` changes directly within the standalone React component, using the existing `voltageLevels` state and `handleVlDoubleClick` function to render and wire up the "📄 SLD" button inside the search field datalist section.
4. **SLD Tab Synchronization**: Updated `SldOverlay` in both the main React app and `standalone_interface.html` to filter the available tabs (`N`, `N-1`, `ACTION`). These tabs now only appear if their corresponding network diagrams (`nDiagram`, `n1Diagram`, or `actionDiagram`) are currently active and loaded in the main visualization panel.
5. **`VisualizationPanel.test.tsx`**: Updated the mock properties (`voltageLevels: [] as string[]`, `onVlOpen: vi.fn()`, etc.) passed to the `VisualizationPanel` to resolve TypeScript compilation errors and match the new props.

## Validation Results

- The `npm run build` process was executed successfully, verifying that no TypeScript or syntax errors were introduced during the implementation.
- The "📄 SLD" button dynamically shows and hides in the search field based on whether the `inspectQuery` matches a voltage level.
- The SLD overlay tabs (`N`, `N-1`, `ACTION`) are now conditionally rendered. For example, if no N-1 analysis has been run, the `N-1` tab will not be visible in the SLD overlay header.
- These changes are consistent across both the main React application and the single-file `standalone_interface.html`.