### PR TITLE
feat: improve PST asset detection in combined actions and main UI

### DIFF
--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -134,6 +134,7 @@ class RecommenderService:
                 "max_rho_line": action_data.get("max_rho_line", ""),
                 "is_rho_reduction": bool(action_data.get("is_rho_reduction", False)),
                 "non_convergence": non_convergence,
+                "affected_line": action_data.get("affected_line"),
             }
 
             # Extract topology from the underlying action object
@@ -1908,6 +1909,17 @@ class RecommenderService:
              baseline_rho = obs_start.rho[lines_overloaded_ids]
              is_rho_reduction = bool(np.all(rho_after + 0.01 < baseline_rho))
 
+             # Build action_topology for the combined result
+             topo1 = {field: getattr(act1_obj, field, {}) for field in ("lines_ex_bus", "lines_or_bus", "gens_bus", "loads_bus", "pst_tap", "substations", "switches")}
+             topo2 = {field: getattr(act2_obj, field, {}) for field in ("lines_ex_bus", "lines_or_bus", "gens_bus", "loads_bus", "pst_tap", "substations", "switches")}
+             
+             combined_topo = {}
+             for field in ("lines_ex_bus", "lines_or_bus", "gens_bus", "loads_bus", "pst_tap", "substations", "switches"):
+                 d1 = topo1.get(field) or {}
+                 d2 = topo2.get(field) or {}
+                 # Merge dictionaries (priority to act2 if same keys, which is fine for combined)
+                 combined_topo[field] = {**d1, **d2}
+
              result.update({
                  "max_rho": res_max_rho,
                  "max_rho_line": max_rho_line,
@@ -1915,6 +1927,7 @@ class RecommenderService:
                  "rho_after": res_rho_after,
                  "rho_before": res_rho_before,
                  "is_estimated": True,
+                 "action_topology": sanitize_for_json(combined_topo),
              })
 
         n.set_working_variant(original_variant)

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -1506,6 +1506,11 @@ class RecommenderService:
         if switches:
             content["switches"] = switches
 
+        # Include PST tap changes if present
+        pst_tap = topo.get("pst_tap") or {}
+        if pst_tap:
+            content["pst_tap"] = pst_tap
+
         entry["content"] = content if content else {}
         return entry
 
@@ -1783,9 +1788,24 @@ class RecommenderService:
 
         env = self._get_simulation_env()
         classifier = ActionClassifier()
-        
+
+        # Detect PST actions early to relax element identification checks if needed
+        action_desc1 = self._dict_action.get(action1_id, {})
+        action_desc2 = self._dict_action.get(action2_id, {})
+        action_type1 = classifier.identify_action_type(action_desc1, by_description=True)
+        action_type2 = classifier.identify_action_type(action_desc2, by_description=True)
+        act1_is_pst = (
+            action_type1 == "pst_tap"
+            or "pst_tap" in action1_id
+            or action1_id.startswith("pst_")
+        )
+        act2_is_pst = (
+            action_type2 == "pst_tap"
+            or "pst_tap" in action2_id
+            or action2_id.startswith("pst_")
+        )
+
         # Identify elements for both actions
-        # First check if they have action topology enriched
         act1_obj = all_actions[action1_id]["action"]
         act2_obj = all_actions[action2_id]["action"]
 
@@ -1796,14 +1816,11 @@ class RecommenderService:
             act2_obj, action2_id, self._dict_action, classifier, env
         )
 
-        if not line_idxs1 and not sub_idxs1 and not line_idxs2 and not sub_idxs2:
-             # Fallback: if they are in _dict_action, maybe identify_action_elements needs it
-             # but they were already identified above?
-             pass
-
-        if (not line_idxs1 and not sub_idxs1) or (not line_idxs2 and not sub_idxs2):
+        # Mandatory check: both actions must have at least one recognized element (line or sub)
+        # Exception for PST actions where identification might be looser
+        if (not line_idxs1 and not sub_idxs1 and not act1_is_pst) or \
+           (not line_idxs2 and not sub_idxs2 and not act2_is_pst):
              return {"error": f"Cannot identify elements for one or both actions (Act1: {len(line_idxs1)} lines, {len(sub_idxs1)} subs; Act2: {len(line_idxs2)} lines, {len(sub_idxs2)} subs)"}
-
 
         # Get obs_start (N-1 state)
         n = env.network_manager.network
@@ -1811,20 +1828,20 @@ class RecommenderService:
         n1_variant_id = self._get_n1_variant(disconnected_element)
         n.set_working_variant(n1_variant_id)
         obs_start = env.get_obs()
-        
+
         # Get pre-existing rho for reduction calculation
         n_variant_id = self._get_n_variant()
         n.set_working_variant(n_variant_id)
         obs_n = env.get_obs()
         pre_existing_rho = {i: obs_n.rho[i] for i in range(len(obs_n.rho))}
-        
+
         # Filter lines we care about
         lines_overloaded_ids = []
         monitoring_factor = getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95)
         for i in range(len(obs_start.rho)):
             if obs_start.rho[i] >= monitoring_factor:
                  lines_overloaded_ids.append(i)
-                 
+
         lines_we_care_about, branches_with_limits = self._get_monitoring_parameters(obs_start)
 
         result = compute_combined_pair_superposition(
@@ -1835,6 +1852,8 @@ class RecommenderService:
             act1_sub_idxs=sub_idxs1,
             act2_line_idxs=line_idxs2,
             act2_sub_idxs=sub_idxs2,
+            act1_is_pst=act1_is_pst,
+            act2_is_pst=act2_is_pst,
             obs_combined=all_actions.get(f"{action1_id}+{action2_id}", {}).get("observation")
         )
         

--- a/expert_backend/tests/test_pst_integration.py
+++ b/expert_backend/tests/test_pst_integration.py
@@ -1,0 +1,92 @@
+
+import pytest
+import numpy as np
+from unittest.mock import MagicMock, patch
+from expert_backend.services.recommender_service import RecommenderService
+
+@pytest.fixture
+def recommender():
+    svc = RecommenderService()
+    svc._dict_action = {}
+    svc._last_result = {"prioritized_actions": {}}
+    return svc
+
+def test_enrich_actions_includes_affected_line(recommender):
+    """Verify that _enrich_actions propagates affected_line from prioritized_actions_dict."""
+    prioritized_actions_dict = {
+        "pst_action": {
+            "description_unitaire": "PST tap change",
+            "rho_before": np.array([0.8]),
+            "rho_after": np.array([0.7]),
+            "max_rho": 0.7,
+            "max_rho_line": "LINE1",
+            "is_rho_reduction": True,
+            "affected_line": "PST_BRANCH_1",
+            "action": MagicMock()
+        }
+    }
+    
+    with patch('expert_backend.services.recommender_service.sanitize_for_json', side_effect=lambda x: x):
+        enriched = recommender._enrich_actions(prioritized_actions_dict)
+        
+        assert "pst_action" in enriched
+        assert enriched["pst_action"]["affected_line"] == "PST_BRANCH_1"
+        assert enriched["pst_action"]["max_rho_line"] == "LINE1"
+
+def test_compute_superposition_merged_topology(recommender):
+    """Verify that compute_superposition merges action_topology from both actions."""
+    aid1, aid2 = "act1", "act2"
+    
+    # Mock actions with topology
+    act1_obj = MagicMock()
+    act1_obj.pst_tap = {"PST1": 2}
+    act1_obj.lines_ex_bus = {"LINE1": 1}
+    
+    act2_obj = MagicMock()
+    act2_obj.lines_ex_bus = {"LINE2": 1}
+    act2_obj.substations = {"SUB1": 1}
+    
+    recommender._last_result["prioritized_actions"] = {
+        aid1: {"action": act1_obj, "observation": MagicMock()},
+        aid2: {"action": act2_obj, "observation": MagicMock()}
+    }
+    
+    # Mock obs
+    recommender._last_result["prioritized_actions"][aid1]["observation"].rho = np.array([0.9])
+    recommender._last_result["prioritized_actions"][aid2]["observation"].rho = np.array([0.9])
+    
+    # Mock dependencies for compute_superposition
+    recommender._get_simulation_env = MagicMock()
+    recommender._get_n_variant = MagicMock(return_value="N")
+    recommender._get_n1_variant = MagicMock(return_value="N-1")
+    recommender._get_lines_we_care_about = MagicMock(return_value=None)
+    
+    env = recommender._get_simulation_env.return_value
+    env.name_line = ["LINE1", "LINE2"]
+    env.network_manager.network.get_working_variant_id.return_value = "ORIG"
+    
+    obs_start = MagicMock()
+    obs_start.rho = np.array([1.1])
+    env.get_obs.return_value = obs_start
+    
+    with patch('expert_backend.services.recommender_service._identify_action_elements', return_value=([0, 1], [])), \
+         patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
+        
+        mock_combine.return_value = {
+            "betas": [0.5, 0.5],
+            "p_or_combined": [100.0, 100.0]
+        }
+        
+        result = recommender.compute_superposition(aid1, aid2, "contingency")
+        
+        assert "action_topology" in result
+        topo = result["action_topology"]
+        
+        # Check merged fields
+        assert "PST1" in topo["pst_tap"]
+        assert "LINE1" in topo["lines_ex_bus"]
+        assert "LINE2" in topo["lines_ex_bus"]
+        assert "SUB1" in topo["substations"]
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/expert_backend/tests/test_superposition_service.py
+++ b/expert_backend/tests/test_superposition_service.py
@@ -104,3 +104,139 @@ def test_compute_superposition_triggers_simulation(recommender):
 
 if __name__ == "__main__":
     pytest.main([__file__])
+
+
+def _setup_superposition_mocks(recommender, aid1, aid2):
+    """Shared mock setup for compute_superposition tests."""
+    recommender._get_simulation_env = MagicMock()
+    recommender._get_n_variant = MagicMock(return_value="N")
+    recommender._get_n1_variant = MagicMock(return_value="N-1")
+
+    env = recommender._get_simulation_env.return_value
+    env.name_line = ["PST_LINE"]
+    env.network_manager.network.get_working_variant_id.return_value = "ORIG"
+
+    obs_start = MagicMock()
+    obs_start.rho = np.array([0.8])
+    env.get_obs.return_value = obs_start
+
+    recommender._last_result["prioritized_actions"][aid1]["observation"].rho = np.array([0.7])
+    recommender._last_result["prioritized_actions"][aid2]["observation"].rho = np.array([0.75])
+    return env
+
+
+def test_compute_superposition_pst_flag_detected_by_id(recommender):
+    """compute_superposition should detect PST actions by ID prefix and
+    pass act1_is_pst=True / act2_is_pst to compute_combined_pair_superposition."""
+    aid1 = "pst_transformer_A"
+    aid2 = "act2"
+    recommender._last_result["prioritized_actions"] = {
+        aid1: {"action": MagicMock(), "observation": MagicMock()},
+        aid2: {"action": MagicMock(), "observation": MagicMock()},
+    }
+    recommender._dict_action = {
+        # aid1 has no description — ID-based detection must fire
+        aid1: {},
+        aid2: {"description_unitaire": "Fermeture ligne X"},
+    }
+
+    _setup_superposition_mocks(recommender, aid1, aid2)
+
+    with patch('expert_backend.services.recommender_service._identify_action_elements',
+               return_value=([0], [])) as mock_identify, \
+         patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
+
+        mock_combine.return_value = {"betas": [0.6, 0.4], "p_or_combined": [50.0]}
+        del mock_identify  # used positionally; suppress unused-var warning
+
+        recommender.compute_superposition(aid1, aid2, "contingency")
+
+        # Verify the PST flag is passed correctly
+        call_kwargs = mock_combine.call_args.kwargs
+        assert call_kwargs.get("act1_is_pst") is True, (
+            f"Expected act1_is_pst=True for id '{aid1}', got {call_kwargs.get('act1_is_pst')}"
+        )
+        assert call_kwargs.get("act2_is_pst") is False, (
+            f"Expected act2_is_pst=False for id '{aid2}', got {call_kwargs.get('act2_is_pst')}"
+        )
+
+
+def test_compute_superposition_pst_flag_detected_by_classifier(recommender):
+    """compute_superposition should detect PST actions via ActionClassifier
+    (description contains 'tap') and pass act1_is_pst=True."""
+    aid1 = "action_for_trafo"
+    aid2 = "action_topo"
+    recommender._last_result["prioritized_actions"] = {
+        aid1: {"action": MagicMock(), "observation": MagicMock()},
+        aid2: {"action": MagicMock(), "observation": MagicMock()},
+    }
+    recommender._dict_action = {
+        # ActionClassifier.identify_action_type returns 'pst_tap' when description
+        # contains 'Variation de slot' or 'tap'
+        aid1: {"description_unitaire": "Variation de slot PST trafo"},
+        aid2: {"description_unitaire": "Ouverture ligne B"},
+    }
+
+    _setup_superposition_mocks(recommender, aid1, aid2)
+
+    with patch('expert_backend.services.recommender_service._identify_action_elements',
+               return_value=([0], [])), \
+         patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
+
+        mock_combine.return_value = {"betas": [0.5, 0.5], "p_or_combined": [60.0]}
+
+        recommender.compute_superposition(aid1, aid2, "contingency")
+
+        call_kwargs = mock_combine.call_args.kwargs
+        assert call_kwargs.get("act1_is_pst") is True, (
+            f"Expected act1_is_pst=True for description-based PST action, got {call_kwargs.get('act1_is_pst')}"
+        )
+        assert call_kwargs.get("act2_is_pst") is False, (
+            f"Expected act2_is_pst=False for id '{aid2}', got {call_kwargs.get('act2_is_pst')}"
+        )
+
+def test_identify_pst_elements_robustness(recommender):
+    from expert_op4grid_recommender.utils.superposition import _identify_action_elements
+    from expert_op4grid_recommender.action_evaluation.classifier import ActionClassifier
+    
+    env = MagicMock()
+    env.name_line = ["ARKA TD 661_inc2", "OTHER_LINE"]
+    env.name_sub = ["SUB1"]
+    
+    classifier = ActionClassifier()
+    
+    # Test case 1: Leading dot in ID and discovery suffix (_inc2)
+    # The regex should strip _inc2, and lstrip('.') should handle the dot.
+    aid = "pst_tap_.ARKA TD 661_inc2"
+    action = MagicMock()
+    # Classifier needs "tap" in description to recognize as PST
+    dict_action = {aid: {"description": "PST tap change"}}
+    
+    line_idxs, sub_idxs = _identify_action_elements(
+        action, aid, dict_action, classifier, env
+    )
+    
+    # "ARKA TD 661" (extracted) is a substring of "ARKA TD 661_inc2"
+    assert line_idxs == [0]
+    assert sub_idxs == []
+
+    # Test case 2: Nested content structure
+    aid2 = "some_pst"
+    action2 = MagicMock()
+    # Content structure used in RecommenderService._dict_action
+    dict_action2 = {aid2: {
+        "description": "Variation de slot",
+        "content": {"pst_tap": {"OTHER_LINE": 5}}
+    }}
+    
+    line_idxs2, sub_idxs2 = _identify_action_elements(
+        action2, aid2, dict_action2, classifier, env
+    )
+    assert line_idxs2 == [1]
+
+    # Test case 3: Leading dot with exact match (after stripping dot)
+    env.name_line = ["ARKA TD 661", "OTHER_LINE"]
+    line_idxs3, sub_idxs3 = _identify_action_elements(
+        action, aid, dict_action, classifier, env
+    )
+    assert line_idxs3 == [0]

--- a/frontend/src/components/CombinedActionsModal.tsx
+++ b/frontend/src/components/CombinedActionsModal.tsx
@@ -57,7 +57,9 @@ const CombinedActionsModal: React.FC<Props> = ({
             .map(([id, detail]) => ({
                 id,
                 description: detail.description_unitaire,
-                max_rho: detail.max_rho
+                max_rho: detail.max_rho,
+                is_pst: id.toLowerCase().includes('pst_') ||
+                    Object.keys(detail.action_topology?.pst_tap ?? {}).length > 0
             })).sort((a, b) => (a.max_rho ?? 999) - (b.max_rho ?? 999));
     }, [analysisResult]);
 
@@ -409,7 +411,12 @@ const CombinedActionsModal: React.FC<Props> = ({
                                                             onClick={(e) => e.stopPropagation()}
                                                         />
                                                     </td>
-                                                    <td style={{ padding: '8px', fontWeight: 600 }}>{a.id}</td>
+                                                    <td style={{ padding: '8px', fontWeight: 600 }}>
+                                                        {a.id}
+                                                        {a.is_pst && (
+                                                            <span title="Phase Shifting Transformer action" style={{ marginLeft: '6px', fontSize: '10px', background: '#e3f2fd', color: '#1565c0', padding: '1px 5px', borderRadius: '4px', fontWeight: 700, letterSpacing: '0.5px', verticalAlign: 'middle' }}>PST</span>
+                                                        )}
+                                                    </td>
                                                     <td style={{ padding: '8px', color: '#555' }}>{a.description}</td>
                                                     <td style={{ padding: '8px', textAlign: 'right' }}>{a.max_rho ? `${(a.max_rho * 100).toFixed(1)}%` : '-'}</td>
                                                 </tr>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -44,6 +44,7 @@ export interface ActionDetail {
     n_components?: number;
     disconnected_mw?: number;
     non_convergence?: string | null;
+    affected_line?: string;
     action_topology?: ActionTopology;
 }
 

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -168,9 +168,19 @@ export const getActionTargetLines = (
 ): string[] => {
     const targets = new Set<string>();
 
-    // 1. From topology
+    // 1. From affected_line (explicit from backend)
+    if (actionDetail?.affected_line) {
+        targets.add(actionDetail.affected_line);
+    }
+
+    // 2. From topology
     const topo = actionDetail?.action_topology;
     if (topo) {
+        // Handle PST tap (if present)
+        if (topo.pst_tap) {
+            Object.keys(topo.pst_tap).forEach(k => targets.add(k));
+        }
+
         const lineKeys = new Set([
             ...Object.keys(topo.lines_ex_bus || {}),
             ...Object.keys(topo.lines_or_bus || {}),
@@ -193,7 +203,7 @@ export const getActionTargetLines = (
         }
     }
 
-    // 2. From action ID (handles combined IDs)
+    // 3. From action ID (handles combined IDs)
     if (actionId) {
         actionId.split('+').forEach(part => {
             if (edgesByEquipmentId.has(part)) {
@@ -201,17 +211,30 @@ export const getActionTargetLines = (
                 return;
             }
             const subParts = part.split('_');
-            for (let i = 1; i < subParts.length; i++) {
-                const candidate = subParts.slice(i).join('_');
-                if (edgesByEquipmentId.has(candidate)) {
-                    targets.add(candidate);
-                    return;
+            if (subParts.length < 2) return;
+
+            let candidate = subParts[subParts.length - 1];
+
+            // Handle PST tap variety suffix (e.g. pst_tap_ID_inc2)
+            if (part.startsWith('pst_tap_') && subParts.length >= 4) {
+                const lastPart = subParts[subParts.length - 1];
+                if (lastPart.startsWith('inc') || lastPart.startsWith('dec')) {
+                    candidate = subParts[subParts.length - 2];
                 }
             }
-            // Fallback: last segment
-            const last = subParts[subParts.length - 1];
-            if (edgesByEquipmentId.has(last)) {
-                targets.add(last);
+
+            if (edgesByEquipmentId.has(candidate)) {
+                targets.add(candidate);
+                return;
+            }
+
+            // Legacy fallback
+            for (let i = 1; i < subParts.length; i++) {
+                const c = subParts.slice(i).join('_');
+                if (edgesByEquipmentId.has(c)) {
+                    targets.add(c);
+                    return;
+                }
             }
         });
     }

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1261,6 +1261,7 @@
                         min_close_coupling: minCloseCoupling,
                         min_open_coupling: minOpenCoupling,
                         min_line_disconnections: minLineDisconnections,
+                        min_pst: minPst,
                         n_prioritized_actions: nPrioritizedActions,
                         lines_monitoring_path: linesMonitoringPath,
                         monitoring_factor: monitoringFactor,
@@ -3081,7 +3082,11 @@
                         const isReco = t.includes('reco') || t.includes('close_line') || t.includes('close_load') || actionDesc.includes('fermeture');
                         const isOpenCoupling = t.includes('open_coupling');
                         const isCloseCoupling = t.includes('close_coupling');
-                        const isPstAction = (actionId.includes('pst') || actionDesc.includes('pst') || t.includes('pst')) && !isDisco && !isReco && !isOpenCoupling && !isCloseCoupling;
+                        const isPstAction = (actionId.includes('pst') ||
+                            actionDesc.includes('pst') ||
+                            t.includes('pst') ||
+                            Object.keys(a.action_topology?.pst_tap ?? {}).length > 0) &&
+                            !isDisco && !isReco && !isOpenCoupling && !isCloseCoupling;
 
                         if (isDisco) return typeFilters.disco;
                         if (isReco) return typeFilters.reco;
@@ -3111,7 +3116,11 @@
                         const isReco = t.includes('reco') || t.includes('close_line') || t.includes('close_load') || actionDesc.includes('fermeture');
                         const isOpenCoupling = t.includes('open_coupling');
                         const isCloseCoupling = t.includes('close_coupling');
-                        const isPstAction = (aid.includes('pst') || actionDesc.includes('pst') || t.includes('pst')) && !isDisco && !isReco && !isOpenCoupling && !isCloseCoupling;
+                        const isPstAction = (aid.includes('pst') ||
+                            actionDesc.includes('pst') ||
+                            t.includes('pst') ||
+                            Object.keys(actionDetail?.action_topology?.pst_tap ?? {}).length > 0) &&
+                            !isDisco && !isReco && !isOpenCoupling && !isCloseCoupling;
 
                         let shouldShow = false;
                         if (isDisco) shouldShow = typeFilters.disco;
@@ -3126,7 +3135,12 @@
                         // Filter out combined actions that are only estimations
                         if (actionId.includes('+') && (actionDetail?.is_estimated || !actionDetail?.rho_after || actionDetail?.rho_after.length === 0)) continue;
 
-                        list.push({ actionId, score, type });
+                        list.push({
+                            actionId,
+                            score,
+                            type,
+                            isPst: isPstAction
+                        });
                     }
                 }
                 return list.sort((a, b) => {
@@ -4683,6 +4697,9 @@
                                                                                             }}>
                                                                                             <td style={{ padding: '4px 6px', fontWeight: 600, display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '4px' }}>
                                                                                                 {item.actionId}
+                                                                                                {item.isPst && (
+                                                                                                    <span title="Phase Shifting Transformer action" style={{ background: '#e3f2fd', color: '#1565c0', padding: '1px 4px', borderRadius: '3px', fontSize: '9px', fontWeight: 700 }}>PST</span>
+                                                                                                )}
                                                                                                 {isComputed && (
                                                                                                     result?.actions?.[item.actionId]?.non_convergence ? (
                                                                                                         <span style={{ background: '#dc3545', color: '#fff', padding: '2px 4px', borderRadius: '4px', fontSize: '9px', fontWeight: 'bold' }} title={result.actions[item.actionId].non_convergence}>divergent</span>
@@ -4746,8 +4763,11 @@
                                                             onMouseEnter={(e) => { if (!simulatingActionId) e.currentTarget.style.backgroundColor = '#f0f0f0'; }}
                                                             onMouseLeave={(e) => { if (simulatingActionId !== a.id) e.currentTarget.style.backgroundColor = 'transparent'; }}
                                                         >
-                                                            <div style={{ fontWeight: 600, fontSize: '12px', color: '#333' }}>
+                                                            <div style={{ fontWeight: 600, fontSize: '12px', color: '#333', display: 'flex', alignItems: 'center', gap: '6px' }}>
                                                                 {simulatingActionId === a.id ? '⏳ Simulating...' : a.id}
+                                                                {(a.id.toLowerCase().includes('pst') || (a.description || '').toLowerCase().includes('pst') || (a.type || '').toLowerCase().includes('pst') || Object.keys(a.action_topology?.pst_tap ?? {}).length > 0) && (
+                                                                    <span title="Phase Shifting Transformer action" style={{ fontSize: '9px', background: '#e3f2fd', color: '#1565c0', padding: '1px 4px', borderRadius: '3px', fontWeight: 700 }}>PST</span>
+                                                                )}
                                                             </div>
                                                             {a.description && (
                                                                 <div style={{ fontSize: '11px', color: '#777', marginTop: '2px' }}>
@@ -5282,94 +5302,105 @@
                                                         ...simulatedOnly.map(([id, data]) => [id, data]),
                                                     ];
                                                     return allPairs
-                                                    .sort((a, b) => ((a[1].estimated_max_rho ?? a[1].max_rho) ?? 999) - ((b[1].estimated_max_rho ?? b[1].max_rho) ?? 999))
-                                                    .map(([id, data]) => {
-                                                        const parts = id.split('+').map(p => p.trim());
-                                                        const simData = data._simData || result?.actions?.[id] || result?.actions?.[canonicalizeId(id)];
-                                                        const isSimulated = simData && !simData.is_estimated && simData.rho_after && simData.rho_after.length > 0;
-                                                        const estMaxRho = data.estimated_max_rho ?? data.max_rho;
-                                                        const estMaxRhoLine = data.estimated_max_rho_line ?? data.max_rho_line;
+                                                        .sort((a, b) => ((a[1].estimated_max_rho ?? a[1].max_rho) ?? 999) - ((b[1].estimated_max_rho ?? b[1].max_rho) ?? 999))
+                                                        .map(([id, data]) => {
+                                                            const parts = id.split('+').map(p => p.trim());
+                                                            const simData = data._simData || result?.actions?.[id] || result?.actions?.[canonicalizeId(id)];
+                                                            const isSimulated = simData && !simData.is_estimated && simData.rho_after && simData.rho_after.length > 0;
+                                                            const estMaxRho = data.estimated_max_rho ?? data.max_rho;
+                                                            const estMaxRhoLine = data.estimated_max_rho_line ?? data.max_rho_line;
 
-                                                        return (
-                                                            <tr key={id}>
-                                                                <td style={{ fontWeight: 'bold', fontSize: '12px' }}>{parts[0]}</td>
-                                                                <td style={{ fontWeight: 'bold', fontSize: '12px' }}>{parts[1]}</td>
-                                                                <td style={{ fontSize: '11px', fontFamily: 'monospace', color: '#666' }}>
-                                                                    {data.betas ? (Array.isArray(data.betas) ? data.betas : Object.values(data.betas)).map(b => b.toFixed(2)).join(', ') : '-'}
-                                                                </td>
-                                                                <td>
-                                                                    <span className="metric-badge metric-rho" style={{
-                                                                        background: estMaxRho > monitoringFactor ? '#ffebee' : estMaxRho > (monitoringFactor - 0.05) ? '#fff3cd' : '#e8f5e9',
-                                                                        color: estMaxRho > monitoringFactor ? '#c62828' : estMaxRho > (monitoringFactor - 0.05) ? '#856404' : '#2e7d32',
-                                                                        fontWeight: 'bold',
-                                                                        opacity: 0.9,
-                                                                        border: estMaxRho > monitoringFactor ? '1px solid #c62828' : estMaxRho > (monitoringFactor - 0.05) ? '1px solid #856404' : '1px dashed #2e7d32'
-                                                                    }}>
-                                                                        {estMaxRho != null && !isNaN(estMaxRho) ? `${(estMaxRho * 100).toFixed(1)}%` : '—'}
-                                                                        {data.is_islanded && (
-                                                                            <span style={{ marginLeft: '4px' }} title="Estimation suspect due to islanding or linear superposition breakdown">⚠️</span>
+                                                            return (
+                                                                <tr key={id}>
+                                                                    <td style={{ fontWeight: 'bold', fontSize: '12px' }}>
+                                                                        {parts[0]}
+                                                                        {(parts[0].toLowerCase().includes('pst') || Object.keys(result?.actions?.[parts[0]]?.action_topology?.pst_tap ?? {}).length > 0) && (
+                                                                            <span title="Phase Shifting Transformer action" style={{ marginLeft: '6px', fontSize: '9px', background: '#e3f2fd', color: '#1565c0', padding: '1px 4px', borderRadius: '3px', fontWeight: 700, verticalAlign: 'middle' }}>PST</span>
                                                                         )}
-                                                                    </span>
-                                                                </td>
-                                                                <td style={{ fontSize: '11px', color: '#666', fontStyle: 'italic' }}>{estMaxRhoLine || 'N/A'}</td>
-
-                                                                <td style={{ textAlign: 'center' }}>
-                                                                    {isSimulated ? (
+                                                                    </td>
+                                                                    <td style={{ fontWeight: 'bold', fontSize: '12px' }}>
+                                                                        {parts[1]}
+                                                                        {(parts[1].toLowerCase().includes('pst') || Object.keys(result?.actions?.[parts[1]]?.action_topology?.pst_tap ?? {}).length > 0) && (
+                                                                            <span title="Phase Shifting Transformer action" style={{ marginLeft: '6px', fontSize: '9px', background: '#e3f2fd', color: '#1565c0', padding: '1px 4px', borderRadius: '3px', fontWeight: 700, verticalAlign: 'middle' }}>PST</span>
+                                                                        )}
+                                                                    </td>
+                                                                    <td style={{ fontSize: '11px', fontFamily: 'monospace', color: '#666' }}>
+                                                                        {data.betas ? (Array.isArray(data.betas) ? data.betas : Object.values(data.betas)).map(b => b.toFixed(2)).join(', ') : '-'}
+                                                                    </td>
+                                                                    <td>
                                                                         <span className="metric-badge metric-rho" style={{
+                                                                            background: estMaxRho > monitoringFactor ? '#ffebee' : estMaxRho > (monitoringFactor - 0.05) ? '#fff3cd' : '#e8f5e9',
+                                                                            color: estMaxRho > monitoringFactor ? '#c62828' : estMaxRho > (monitoringFactor - 0.05) ? '#856404' : '#2e7d32',
                                                                             fontWeight: 'bold',
-                                                                            fontSize: '13px',
-                                                                            background: simData.max_rho > monitoringFactor ? '#ffebee' : simData.max_rho > (monitoringFactor - 0.05) ? '#fff3cd' : '#e8f5e9',
-                                                                            color: simData.max_rho > monitoringFactor ? '#c62828' : simData.max_rho > (monitoringFactor - 0.05) ? '#856404' : '#2e7d32'
+                                                                            opacity: 0.9,
+                                                                            border: estMaxRho > monitoringFactor ? '1px solid #c62828' : estMaxRho > (monitoringFactor - 0.05) ? '1px solid #856404' : '1px dashed #2e7d32'
                                                                         }}>
-                                                                            {(simData.max_rho * 100).toFixed(1)}%
-                                                                            {simData.is_islanded && (
-                                                                                <span style={{ fontSize: '10px', marginLeft: '4px', border: '1px solid #721c24', padding: '1px 3px', borderRadius: '3px', color: '#721c24', background: '#f8d7da' }} title={`Islanding: ${simData.disconnected_mw?.toFixed(1)} MW disconnected`}>🏝️</span>
+                                                                            {estMaxRho != null && !isNaN(estMaxRho) ? `${(estMaxRho * 100).toFixed(1)}%` : '—'}
+                                                                            {data.is_islanded && (
+                                                                                <span style={{ marginLeft: '4px' }} title="Estimation suspect due to islanding or linear superposition breakdown">⚠️</span>
                                                                             )}
                                                                         </span>
-                                                                    ) : (
-                                                                        <span style={{ color: '#aaa', fontSize: '11px' }}>Not simulated</span>
-                                                                    )}
-                                                                </td>
-                                                                <td style={{ fontSize: '11px', color: '#333', fontWeight: isSimulated ? 'bold' : 'normal' }}>
-                                                                    {isSimulated ? simData.max_rho_line : '-'}
-                                                                </td>
+                                                                    </td>
+                                                                    <td style={{ fontSize: '11px', color: '#666', fontStyle: 'italic' }}>{estMaxRhoLine || 'N/A'}</td>
 
-                                                                <td>
-                                                                    <button
-                                                                        onClick={(e) => {
-                                                                            e.stopPropagation();
-                                                                            handleAddManualAction(id);
-                                                                        }}
-                                                                        disabled={!!simulatingActionId}
-                                                                        style={{
-                                                                            padding: '6px 14px',
-                                                                            background: isSimulated ? '#007bff' : '#28a745',
-                                                                            color: 'white',
-                                                                            border: 'none',
-                                                                            borderRadius: '4px',
-                                                                            cursor: simulatingActionId ? 'not-allowed' : 'pointer',
-                                                                            fontSize: '11px',
-                                                                            fontWeight: 'bold',
-                                                                            boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
-                                                                            opacity: simulatingActionId ? 0.6 : 1,
-                                                                            minWidth: '100px'
-                                                                        }}
-                                                                    >
-                                                                        {simulatingActionId === canonicalizeId(id) ? '⌛' : (isSimulated ? 'Re-Simulate' : 'Simulate')}
-                                                                    </button>
-                                                                </td>
-                                                            </tr>
-                                                        );
-                                                    });}
+                                                                    <td style={{ textAlign: 'center' }}>
+                                                                        {isSimulated ? (
+                                                                            <span className="metric-badge metric-rho" style={{
+                                                                                fontWeight: 'bold',
+                                                                                fontSize: '13px',
+                                                                                background: simData.max_rho > monitoringFactor ? '#ffebee' : simData.max_rho > (monitoringFactor - 0.05) ? '#fff3cd' : '#e8f5e9',
+                                                                                color: simData.max_rho > monitoringFactor ? '#c62828' : simData.max_rho > (monitoringFactor - 0.05) ? '#856404' : '#2e7d32'
+                                                                            }}>
+                                                                                {(simData.max_rho * 100).toFixed(1)}%
+                                                                                {simData.is_islanded && (
+                                                                                    <span style={{ fontSize: '10px', marginLeft: '4px', border: '1px solid #721c24', padding: '1px 3px', borderRadius: '3px', color: '#721c24', background: '#f8d7da' }} title={`Islanding: ${simData.disconnected_mw?.toFixed(1)} MW disconnected`}>🏝️</span>
+                                                                                )}
+                                                                            </span>
+                                                                        ) : (
+                                                                            <span style={{ color: '#aaa', fontSize: '11px' }}>Not simulated</span>
+                                                                        )}
+                                                                    </td>
+                                                                    <td style={{ fontSize: '11px', color: '#333', fontWeight: isSimulated ? 'bold' : 'normal' }}>
+                                                                        {isSimulated ? simData.max_rho_line : '-'}
+                                                                    </td>
+
+                                                                    <td>
+                                                                        <button
+                                                                            onClick={(e) => {
+                                                                                e.stopPropagation();
+                                                                                handleAddManualAction(id);
+                                                                            }}
+                                                                            disabled={!!simulatingActionId}
+                                                                            style={{
+                                                                                padding: '6px 14px',
+                                                                                background: isSimulated ? '#007bff' : '#28a745',
+                                                                                color: 'white',
+                                                                                border: 'none',
+                                                                                borderRadius: '4px',
+                                                                                cursor: simulatingActionId ? 'not-allowed' : 'pointer',
+                                                                                fontSize: '11px',
+                                                                                fontWeight: 'bold',
+                                                                                boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                                                                                opacity: simulatingActionId ? 0.6 : 1,
+                                                                                minWidth: '100px'
+                                                                            }}
+                                                                        >
+                                                                            {simulatingActionId === canonicalizeId(id) ? '⌛' : (isSimulated ? 'Re-Simulate' : 'Simulate')}
+                                                                        </button>
+                                                                    </td>
+                                                                </tr>
+                                                            );
+                                                        });
+                                                }
                                                 )()}
                                                 {Object.keys(result?.combined_actions || {}).length === 0 &&
-                                                 Object.entries(result?.actions || {}).filter(([id]) => id.includes('+')).length === 0 && (
-                                                    <tr>
-                                                        <td colSpan="6" style={{ textAlign: 'center', color: '#888', fontStyle: 'italic', padding: '40px 20px' }}>
-                                                            No computed combinations found.<br />Go to <strong>Explore Pairs</strong> to create new ones.
-                                                        </td>
-                                                    </tr>
-                                                )}
+                                                    Object.entries(result?.actions || {}).filter(([id]) => id.includes('+')).length === 0 && (
+                                                        <tr>
+                                                            <td colSpan="6" style={{ textAlign: 'center', color: '#888', fontStyle: 'italic', padding: '40px 20px' }}>
+                                                                No computed combinations found.<br />Go to <strong>Explore Pairs</strong> to create new ones.
+                                                            </td>
+                                                        </tr>
+                                                    )}
                                             </tbody>
                                         </table>
                                     </div>
@@ -5447,7 +5478,15 @@
                                                                                 <td style={{ width: '10px', paddingRight: 0 }}>
                                                                                     <input type="checkbox" checked={isSelected} readOnly style={{ cursor: 'pointer' }} />
                                                                                 </td>
-                                                                                <td style={{ fontWeight: 'bold', fontSize: '12px' }}>{actionId}</td>
+                                                                                <td style={{ fontWeight: 'bold', fontSize: '12px' }}>
+                                                                                    {actionId}
+                                                                                    {isSelected && (
+                                                                                        <span title="Phase Shifting Transformer action" style={{ marginLeft: '6px', fontSize: '9px', background: '#e3f2fd', color: '#1565c0', padding: '1px 4px', borderRadius: '3px', fontWeight: 700, verticalAlign: 'middle' }}>PST</span>
+                                                                                    )}
+                                                                                    {scoredActionsList.find(item => item.actionId === actionId)?.isPst && (
+                                                                                        <span title="Phase Shifting Transformer action" style={{ marginLeft: '6px', fontSize: '9px', background: '#e3f2fd', color: '#1565c0', padding: '1px 4px', borderRadius: '3px', fontWeight: 700, verticalAlign: 'middle' }}>PST</span>
+                                                                                    )}
+                                                                                </td>
                                                                                 <td style={{ width: '60px' }}>
                                                                                     <span className="metric-badge metric-score" style={{ scale: '0.9' }}>
                                                                                         {score.toFixed(2)}

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -896,12 +896,17 @@
 
         // Determine which lines an action acts upon (for line disconnection/reconnection actions).
         // Returns an array of line names.
-        const getActionTargetLines = (actionDetail, actionId, edgesByEquipmentId) => {
+        const getActionTargetLines = (actionDetail, actionId, edgesByEquipmentId, params) => {
             const targets = new Set();
 
-            // 1. From topology
+            // 1. From params (Direct asset tagging)
+            if (params && params.affected_line && typeof params.affected_line === 'string') {
+                targets.add(params.affected_line);
+            }
+
+            // 2. From topology
             const topo = actionDetail?.action_topology;
-            if (topo) {
+            if (topo && typeof topo === 'object') {
                 const lineKeys = new Set([
                     ...Object.keys(topo.lines_ex_bus || {}),
                     ...Object.keys(topo.lines_or_bus || {}),
@@ -911,6 +916,11 @@
 
                 if (lineKeys.size > 0 && genKeys.length === 0 && loadKeys.length === 0) {
                     lineKeys.forEach(l => targets.add(l));
+                } else if (topo.pst_tap) {
+                    // PST tap actions also target specific lines
+                    Object.keys(topo.pst_tap).forEach(pstId => {
+                        if (pstId) targets.add(String(pstId));
+                    });
                 } else {
                     const allValues = [
                         ...Object.values(topo.lines_ex_bus || {}),
@@ -924,11 +934,22 @@
                 }
             }
 
-            // 2. From action ID (handles combined IDs)
+            // 3. From action ID (handles combined IDs)
             if (actionId) {
                 actionId.split('+').forEach(part => {
                     const subParts = part.split('_');
-                    const candidate = subParts[subParts.length - 1];
+                    if (subParts.length < 2) return;
+
+                    let candidate = subParts[subParts.length - 1];
+
+                    // Handle PST tap variety suffix (e.g. pst_tap_ID_inc2 or pst_tap_ID_dec1)
+                    if (part.startsWith('pst_tap_') && subParts.length >= 4) {
+                        const lastPart = subParts[subParts.length - 1];
+                        if (lastPart.startsWith('inc') || lastPart.startsWith('dec')) {
+                            candidate = subParts[subParts.length - 2];
+                        }
+                    }
+
                     if (edgesByEquipmentId && edgesByEquipmentId.has(candidate)) {
                         targets.add(candidate);
                     }
@@ -4124,7 +4145,10 @@
                     });
                 } catch (err) {
                     console.error('[renderActionList] crash:', err);
-                    return <div className="error-box">Render Error in list</div>;
+                    return <div className="error-box" style={{ padding: '20px', color: '#721c24', background: '#f8d7da', border: '1px solid #f5c6cb', borderRadius: '4px', margin: '10px 0' }}>
+                        <strong>Render Error in list:</strong> {err.message}
+                        <div style={{ fontSize: '10px', marginTop: '5px', opacity: 0.7 }}>Check console for stack trace.</div>
+                    </div>;
                 }
             };
 


### PR DESCRIPTION
# PST Actions in Combined Action Modal — Walkthrough

The `superposition.py` module already had full PST support (`act1_is_pst` / `act2_is_pst` flags). ExpertAssist now correctly wires these through the backend and surfaces PST actions visually in the frontend.

## Changes Made

### Backend — [recommender_service.py](file:///home/marotant/dev/AntiGravity/ExpertAssist/expert_backend/services/recommender_service.py)

**1. PST flag detection in `compute_superposition`** ([L1812–L1827](file:///home/marotant/dev/AntiGravity/ExpertAssist/expert_backend/services/recommender_service.py#L1812-L1827))

After identifying action elements, we now detect whether each action is a PST type and pass the flags to `compute_combined_pair_superposition`. This prevents incorrect no-op detection for PST lines (which change tap, not status).

Detection uses two complementary methods — matching the `ActionClassifier` returning `"pst_tap"`, or id-based patterns (`pst_*` / `pst_tap_*`) — consistent with how `superposition.py` itself detects PST in `compute_all_pairs_superposition`.

```python
# Detect PST actions — needed so superposition skips status-based no-op detection
action_type1 = classifier.identify_action_type(action_desc1, by_description=True)
act1_is_pst = (
    action_type1 == "pst_tap"  # classifier returns 'pst_tap' for PST actions
    or "pst_tap" in action1_id
    or action1_id.startswith("pst_")
)
# ... (same for act2)
result = compute_combined_pair_superposition(
    ...
    act1_is_pst=act1_is_pst,
    act2_is_pst=act2_is_pst,
    ...
)
```

**2. PST tap in `_build_action_entry_from_topology`** ([L1506–L1510](file:///home/marotant/dev/AntiGravity/ExpertAssist/expert_backend/services/recommender_service.py#L1506-L1510))

When PST actions are restored from a saved session, the `pst_tap` field from `action_topology` is now included in the reconstructed action content so re-simulation works correctly.

```python
pst_tap = topo.get("pst_tap") or {}
if pst_tap:
    content["pst_tap"] = pst_tap
```

### Frontend — [CombinedActionsModal.tsx](file:///home/marotant/dev/AntiGravity/ExpertAssist/frontend/src/components/CombinedActionsModal.tsx)

**PST badge in Explore Pairs action list** ([L57–L65, L411–L417](file:///home/marotant/dev/AntiGravity/ExpertAssist/frontend/src/components/CombinedActionsModal.tsx#L57-L65))

The `availableActions` memo now includes an `is_pst` flag, detected by ID prefix or non-empty `pst_tap` topology. PST actions get a blue `PST` badge in the explore tab table.

```tsx
is_pst: id.toLowerCase().includes('pst_') ||
        Object.keys(detail.action_topology?.pst_tap ?? {}).length > 0
```

### Tests — [test_superposition_service.py](file:///home/marotant/dev/AntiGravity/ExpertAssist/expert_backend/tests/test_superposition_service.py)

Two new tests added:
- `test_compute_superposition_pst_flag_detected_by_id` — verifies ID-prefix detection (`pst_*`)
- `test_compute_superposition_pst_flag_detected_by_classifier` — verifies classifier description-based detection (`"Variation de slot"`)

Both assert that `act1_is_pst=True` and `act2_is_pst=False` are passed through to `compute_combined_pair_superposition`.

### Bug Fix — Debugging PST Combination Issues

We resolved the "Cannot identify elements" error that occurred when manually estimating PST combinations or automatically generating them.

#### 1. Robust Element Identification in `superposition.py`
The `_identify_action_elements` function was updated to handle PST line names more robustly:
- **Leading Dots**: Strips leading dots (e.g., `.ARKA TD 661` → `ARKA TD 661`).
- **Discovery Suffixes**: Uses regex to strip suffixes like `_inc1`, `_dec2` added during action discovery.
- **Fuzzy Matching**: Falls back to substring matching if exact match fails, ensuring the PST line index is found even with slight naming variations.

#### 2. Relaxed Backend Checks in `recommender_service.py`
The manual estimation endpoint now moves PST detection *before* the element check and allows actions recognized as PSTs to bypass strict identification if necessary (though the `superposition.py` fix usually ensures identification succeeds).

#### 3. New Verification Tests
Added `test_identify_pst_elements_robustness` to `test_superposition_service.py`:
- Verifies leading dot + `_inc2` suffix handling.
- Verifies nested `content.pst_tap` structure mapping.
- Verifies exact match after stripping dot.

## Verification Results

| Suite | Result |
|-------|--------|
| `test_superposition_service.py` | ✅ 5/5 passed |
| All backend tests (160 tests) | ✅ 160 passed, 0 failed |
| All frontend tests (229 tests) | ✅ 229 passed, 0 failed |

## PST Asset Detection and Highlight

We enabled the detection and highlighting of specific PST branches in the UI.

### Backend — [discovery.py](file:///home/marotant/dev/Expert_op4grid_recommender/expert_op4grid_recommender/action_evaluation/discovery.py)

In `find_relevant_pst_actions`, we now include the PST branch name as `affected_line` in the action details. This allows the UI to know which specific branch is being acted upon by a "PST tap" action.

```python
details_map[action_id] = {
    "pst_id": pst_id,
    # ...
    "affected_line": pst_id
}
```

### Frontend — [standalone_interface.html](file:///home/marotant/dev/AntiGravity/ExpertAssist/standalone_interface.html)

The `getActionTargetLines` helper was updated to extract the PST branch name from either the action topology or the new `affected_line` parameter. In `renderActionList`, we now pass the action parameters to `getActionTargetLines` so that PST branch "chips" (badges) are rendered correctly. These badges are clickable and will zoom the network view to the affected PST branch.

```javascript
const lineNames = edgeMeta
    ? getActionTargetLines(details, id, edgeMeta, typeData.params?.[id])
    : // ...
```

### Combined Action PST Detection Fix

We resolved an issue where PST branches were not detected for combined actions (superposition results).

#### Backend — [recommender_service.py](file:///home/marotant/dev/AntiGravity/ExpertAssist/expert_backend/services/recommender_service.py)

In `compute_superposition`, we now build a merged `action_topology` from both underlying actions. This ensures that `pst_tap` information is preserved in the combined action result.

#### Main Frontend — [svgUtils.ts](file:///home/marotant/dev/AntiGravity/ExpertAssist/frontend/src/utils/svgUtils.ts)

The `getActionTargetLines` function in the main frontend was updated with the same logic as the standalone interface:
- **Priority 1**: Use `actionDetail.affected_line` if provided by the backend.
- **Priority 2**: Check `pst_tap` in `action_topology`.
- **Priority 3**: Improved ID parsing to handle `_inc`/`_dec` suffixes.

### Verification Results

| Suite | Result |
|-------|--------|
| `test_pst_actions.py` | ✅ 10/10 passed |
| `test_pst_integration.py` | ✅ 2/2 passed (verified `affected_line` and merged topology) |
| Backend Tests Integration | ✅ Successful run |
| Manual Verification | ✅ PST branch now appears in both standalone and main UI |