### PR TITLE
Add PST tap position re-simulation support

### DIFF
--- a/docs/curtailment-loadshedding-pst-actions.md
+++ b/docs/curtailment-loadshedding-pst-actions.md
@@ -1,6 +1,6 @@
-# Renewable Curtailment & Load Shedding — Implementation Status
+# Renewable Curtailment, Load Shedding & PST Actions — Implementation Status
 
-This document describes the implementation of renewable curtailment and load shedding actions in Co-Study4Grid, including the recent migration to the **power reduction format** (`set_load_p`/`set_gen_p`) introduced in [Expert_op4grid_recommender PR #74](https://github.com/marota/Expert_op4grid_recommender/pull/74).
+This document describes the implementation of renewable curtailment, load shedding, and **Phase Shifting Transformer (PST)** actions in Co-Study4Grid. It covers the power reduction format (`set_load_p`/`set_gen_p`) introduced in [Expert_op4grid_recommender PR #74](https://github.com/marota/Expert_op4grid_recommender/pull/74), as well as PST tap actions and their integration with the superposition estimation engine.
 
 ## 1. Action Format Evolution
 
@@ -232,3 +232,206 @@ When `target_mw` is provided for an action already in `_dict_action`:
 - **Re-simulate button**: Triggers `simulateManualAction` with the new `target_mw` value
 - Default value: the total shedded/curtailed MW from the current simulation result
 - The action card updates in-place with the new simulation results
+
+## 7. PST (Phase Shifting Transformer) Actions
+
+PST actions change the tap position of a phase-shifting transformer to redirect power flows and relieve overloads. Unlike topology actions (switching, coupling) or power reduction actions (curtailment, load shedding), PST actions modify a continuous parameter.
+
+### Action Format
+
+```python
+# PST tap change
+{"pst_tap": {".ARKA TD 661": 32}}
+# Topology: pst_tap = {".ARKA TD 661": 32}
+```
+
+The tap value is an integer within the transformer's valid range (e.g., `[0..32]`).
+
+### Action Classification
+
+`ActionClassifier.identify_action_type()` returns `"pst"` or `"pst_tap"` for PST actions. The action ID convention is `pst_tap_<transformer_name>_inc<N>` (e.g., `pst_tap_.ARKA TD 661_inc2`).
+
+### Configurable Tap Position
+
+Users can manually adjust the target tap value when simulating PST actions, similar to configurable MW for load shedding/curtailment.
+
+#### API
+
+`POST /api/simulate-manual-action` accepts an optional `target_tap` field:
+
+```json
+{
+    "action_id": "pst_tap_.ARKA TD 661_inc2",
+    "disconnected_element": "LINE_X",
+    "target_tap": 30
+}
+```
+
+#### Backend (`recommender_service.py`)
+
+When `target_tap` is provided:
+1. The `content.pst_tap` dictionary is updated with the new tap value
+2. The action entry in `_dict_action` is merged (preserving library keys)
+3. Simulation runs with the updated tap position
+
+#### Frontend
+
+- **Action card**: Shows editable tap input with valid range `[0..max_tap]`
+- **Re-simulate button**: Triggers re-simulation with updated `target_tap`
+- **PST details**: Purple background (`#f3e8ff`), shows transformer name and tap value
+- **Combined actions**: After re-simulation, refreshes all combined pair estimations involving this PST action
+
+### PST Details Metadata
+
+```python
+# Backend returns:
+{
+    "pst_details": [
+        {"pst_name": ".ARKA TD 661", "tap_position": 32}
+    ]
+}
+```
+
+### Dynamic PST Action Creation
+
+When a user manually simulates `pst_tap_<name>_inc<N>`, the backend:
+1. Extracts the transformer name from the action ID
+2. Looks up the current tap position from the N-1 observation
+3. Computes `new_tap = current_tap + N` (clamped to valid range)
+4. Creates topology: `{"pst_tap": {"<name>": new_tap}}`
+
+## 8. PST Actions in Superposition Estimation
+
+PST tap changes require special handling in the superposition theorem because they don't disconnect/reconnect elements. The standard no-op detection (comparing line status arrays) fails for PSTs.
+
+### The `is_pst` Flag
+
+When computing superposition for a pair that includes a PST action, the backend passes `act1_is_pst=True` or `act2_is_pst=True` to `compute_combined_pair_superposition()`. This tells the library to use **flow-based no-op detection** (comparing `p_or` deltas) instead of line-status comparison.
+
+```python
+# In compute_superposition():
+act1_is_pst = _is_pst_action(action1_id)
+act2_is_pst = _is_pst_action(action2_id)
+
+result = compute_combined_pair_superposition(
+    ...,
+    act1_is_pst=act1_is_pst,
+    act2_is_pst=act2_is_pst,
+)
+```
+
+Detection heuristic (`_is_pst_action`):
+- `ActionClassifier.identify_action_type()` returns `"pst"` or `"pst_tap"`
+- OR the action ID contains `"pst_tap"` or `"pst_"`
+
+### PST Element Identification Fallback
+
+`_identify_action_elements()` may return empty line indices for PST actions (since they don't disconnect lines). The fallback extracts the transformer index from the `pst_tap` content in `_dict_action`:
+
+```python
+if len(line_idxs) == 0 and _is_pst_action(aid):
+    pst_content = _dict_action.get(aid, {}).get("content", {}).get("pst_tap", {})
+    for pst_name in pst_content:
+        idx = name_line.index(pst_name)  # find index in env.name_line
+        line_idxs = [idx]
+```
+
+### Re-simulation and Combined Pair Refresh
+
+When a PST tap is re-simulated at a different position:
+1. The PST action's observation is updated in `_last_result["prioritized_actions"]`
+2. All combined pairs containing this PST action are re-estimated via `refreshCombinedEstimations()`
+3. The superposition formula uses the updated observation for the new betas computation
+
+## 9. Monitoring Consistency (Estimation vs Simulation)
+
+The superposition estimation (`compute_superposition`) and the full simulation (`simulate_manual_action`) must use the **same set of monitored lines** for `max_rho` computation. Inconsistency leads to the estimation and simulation reporting different worst-case lines.
+
+### Monitored Lines Definition
+
+Both paths use a `care_mask` built identically:
+
+1. **lines_we_care_about** — from analysis context or all lines (configurable)
+2. **AND branches_with_limits** — lines with permanent thermal limits in pypowsybl (type=CURRENT, acceptable_duration=-1)
+3. **EXCLUDE** pre-existing N-state overloads unless the action **worsens** them beyond a threshold (default 2%)
+4. **FORCE-INCLUDE** `lines_overloaded_ids` — the N-1 overloaded lines under active monitoring
+
+```
+care_mask = (lines_we_care_about & branches_with_limits)
+          & ~(pre_existing & not_worsened)
+          | lines_overloaded_ids
+```
+
+### lines_overloaded_ids Priority
+
+Both `compute_superposition` and `simulate_manual_action` use the same priority for determining `lines_overloaded_ids`:
+
+1. **Analysis context** (`_analysis_context["lines_overloaded"]`) — set during step1 analysis, contains line names already filtered by monitoring parameters
+2. **Recomputation fallback** — lines with `rho >= monitoring_factor` in N-1 state, filtered by `lines_we_care_about` AND `branches_with_limits`
+
+### branches_with_limits Resolution
+
+The `_get_monitoring_parameters()` method queries pypowsybl for permanent thermal limits:
+
+```python
+limits = network.get_operational_limits()
+perm_limits = limits[(limits['type'] == 'CURRENT') & (limits['acceptable_duration'] == -1)]
+branches_with_limits = set(perm_limits['element_id'].unique())
+```
+
+If this query fails (e.g., `'type'` column not found), the fallback includes ALL lines. This warning appears as:
+```
+Warning: Failed to identify branches with limits: 'type'
+```
+
+### Superposition Estimation Accuracy
+
+The superposition formula `rho_combined = |(1-β₁-β₂)·ρ_N1 + β₁·ρ_act1 + β₂·ρ_act2|` is a **linear approximation** of the nonlinear power flow. Typical accuracy is within ~1-2% of the full simulation, but:
+
+- Lines with loading driven by **nonlinear redistribution** (not direct action effect) may be under/overestimated
+- When two lines have very close loading (e.g., 93.1% vs 93.6%), the ~1% estimation error can **flip the ranking** of which line appears as the worst
+- The estimated `max_rho_line` may differ from the simulated one, even though both are within the accuracy band
+- This is an inherent limitation of the linear superposition approach, not a code bug
+
+**Example from real data:**
+
+| Line | Estimated rho | Simulated rho | Error |
+|------|--------------|---------------|-------|
+| CANTEY761 | 93.6% | 92.8% | +0.8% (overestimate) |
+| .BIESL61PRAGN | 93.1% | 94.4% | -1.3% (underestimate) |
+
+Estimation picks CANTEY761 as worst; simulation picks .BIESL61PRAGN. Both are correct within the linear approximation error band.
+
+## 10. Testing
+
+### Backend (`expert_backend/tests/`)
+
+#### Load Shedding & Curtailment Tests
+- `test_power_reduction_format.py` — 23 tests for new format scenarios
+- `test_renewable_curtailment.py` — curtailment detail computation
+- `test_manual_action_enrichment.py` — enrichment with new topology format
+- `test_dynamic_actions.py` — on-the-fly action creation
+- `test_mw_start.py` — MW start computation for all action types
+- `test_configurable_mw.py` — 8 tests for configurable MW reduction
+
+#### PST & Superposition Tests
+- `test_superposition_service.py` — PST flag passing, element identification fallback, dict_action merge preservation
+- `test_superposition_accuracy.py` — estimation vs simulation discrepancy detection
+- `test_superposition_filtering_regression.py` — heavily loaded lines not filtered from max_rho
+- `test_superposition_monitoring_consistency.py` — 11 tests for monitoring alignment:
+  - Lines without thermal limits excluded from max_rho (CIVAUY712 regression)
+  - Fallback lines_overloaded_ids filtered by lines_we_care_about AND branches_with_limits
+  - N-1 overloaded lines force-included despite pre-existing N-state overloads
+  - Analysis context lines_overloaded takes priority over recomputation
+  - Pre-existing N-state overloads excluded unless combined action worsens them
+  - Pre-existing overloads included when worsened beyond threshold
+  - All monitored lines eligible without N-state overloads
+  - Global max scan across all monitored lines (no caching)
+  - PST + switching pair monitors same lines as switching + switching
+  - is_rho_reduction computed on overloaded lines
+  - max_rho scaled by monitoring_factor
+
+### Frontend (`frontend/src/`)
+- `ActionFeed.test.tsx` — rendering of load shedding/curtailment/PST details
+- `CombinedActionsModal.test.tsx` — combined action pair computation modal
+- `svgUtils.test.ts` — target detection with all topology formats

--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -184,6 +184,7 @@ class ManualActionRequest(BaseModel):
     action_content: dict | None = None  # Optional switches dict for actions not in the dictionary
     lines_overloaded: list[str] | None = None  # Optional overloaded line names from saved session
     target_mw: float | None = None  # Optional MW reduction amount for load shedding / curtailment
+    target_tap: int | None = None  # Optional tap position for PST actions (clamped to [low_tap, high_tap])
 
 class SaveSessionRequest(BaseModel):
     session_name: str
@@ -664,6 +665,7 @@ def simulate_manual_action(request: ManualActionRequest):
             action_content=request.action_content,
             lines_overloaded=request.lines_overloaded,
             target_mw=request.target_mw,
+            target_tap=request.target_tap,
         )
         return result
     except Exception as e:

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -489,6 +489,7 @@ class RecommenderService:
         """Compute MW at start for each action in action_scores.
 
         Adds a 'mw_start' dict ({action_id: float|null}) to each action type entry.
+        For PST types, also adds 'tap_start' dict ({action_id: {tap, low_tap, high_tap}|null}).
 
         Rules per action type:
         - line_disconnection: abs(p_or) of the disconnected line in N-1 state
@@ -523,8 +524,10 @@ class RecommenderService:
             is_reco = 'reco' in t or 'line_reconnection' in t
             is_close = 'close_coupling' in t
             is_na_type = is_reco or is_close
+            is_pst = 'pst' in t
 
             mw_start = {}
+            tap_start = {} if is_pst else None
             for action_id in scores:
                 if is_na_type:
                     mw_start[action_id] = None
@@ -534,9 +537,52 @@ class RecommenderService:
                                                     line_name_to_idx, load_name_to_idx, gen_name_to_idx)
                 mw_start[action_id] = mw_val
 
+                # For PST types, also compute tap start info
+                if is_pst:
+                    tap_start[action_id] = self._get_pst_tap_start(action_id)
+
             type_data["mw_start"] = sanitize_for_json(mw_start)
+            if tap_start is not None:
+                type_data["tap_start"] = sanitize_for_json(tap_start)
 
         return action_scores
+
+    def _get_pst_tap_start(self, action_id):
+        """Return {tap, low_tap, high_tap} for a PST action, or None."""
+        action_entry = self._dict_action.get(action_id) if self._dict_action else None
+        if action_entry is None:
+            return None
+
+        content = action_entry.get("content", {})
+        if not content:
+            return None
+
+        pst_tap = content.get("pst_tap", {})
+        if not pst_tap:
+            pst_tap = content.get("redispatch", {}).get("pst_tap", {})
+        if not pst_tap:
+            return None
+
+        # Get the first PST entry (most actions target a single PST)
+        pst_name = next(iter(pst_tap))
+        target_tap = int(pst_tap[pst_name])
+
+        # Query network for tap bounds
+        try:
+            env = self._get_simulation_env()
+            nm = env.network_manager
+            pst_info = nm.get_pst_tap_info(pst_name)
+            if pst_info:
+                return {
+                    "pst_name": pst_name,
+                    "tap": target_tap,
+                    "low_tap": pst_info.get("low_tap"),
+                    "high_tap": pst_info.get("high_tap"),
+                }
+        except Exception:
+            pass
+
+        return {"pst_name": pst_name, "tap": target_tap, "low_tap": None, "high_tap": None}
 
     def _get_action_mw_start(self, action_id, action_type, obs_n1, line_idx_map, load_idx_map, gen_idx_map):
         """Return MW at start for a single action, or None if not computable."""

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -548,7 +548,12 @@ class RecommenderService:
         return action_scores
 
     def _get_pst_tap_start(self, action_id):
-        """Return {pst_name, tap, low_tap, high_tap} for a PST action from the base N-state network, or None."""
+        """Return {pst_name, tap, low_tap, high_tap} for a PST action from the base N-state network, or None.
+
+        Reads tap position directly from the pypowsybl base network's initial variant
+        to guarantee the original N-state value, regardless of any simulation that may
+        have modified the working variant.
+        """
         action_entry = self._dict_action.get(action_id) if self._dict_action else None
         if action_entry is None:
             return None
@@ -566,7 +571,31 @@ class RecommenderService:
         # Get the first PST entry (most actions target a single PST)
         pst_name = next(iter(pst_tap))
 
-        # Query network for current tap position (N-state) and bounds
+        # Read tap position from the base pypowsybl network's initial variant (N-state)
+        try:
+            network = self._get_base_network()
+            original_variant = network.get_working_variant_id()
+            try:
+                # Switch to the N-state variant (or initial variant) to read unmodified taps
+                n_variant = self._get_n_variant()
+                network.set_working_variant(n_variant)
+
+                import pandas as pd
+                ptc = network.get_phase_tap_changers()
+                if ptc is not None and not ptc.empty and pst_name in ptc.index:
+                    row = ptc.loc[pst_name]
+                    return {
+                        "pst_name": pst_name,
+                        "tap": int(row.get("tap_position", 0)) if pd.notna(row.get("tap_position")) else 0,
+                        "low_tap": int(row.get("low_tap_position", 0)) if pd.notna(row.get("low_tap_position")) else None,
+                        "high_tap": int(row.get("high_tap_position", 0)) if pd.notna(row.get("high_tap_position")) else None,
+                    }
+            finally:
+                network.set_working_variant(original_variant)
+        except Exception as e:
+            print(f"[_get_pst_tap_start] Error reading N-state tap for {pst_name}: {e}")
+
+        # Fallback: try via simulation environment (may not be N-state)
         try:
             env = self._get_simulation_env()
             nm = env.network_manager

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2960,14 +2960,16 @@ class RecommenderService:
         name_line = list(env.name_line)
         for _aid, _lidxs in [(action1_id, line_idxs1), (action2_id, line_idxs2)]:
             obs_act = all_actions[_aid]["observation"]
-            for _li in _lidxs:
-                _ln = name_line[_li] if _li < len(name_line) else f"idx_{_li}"
-                print(f"[compute_superposition] rho at {_ln}(idx={_li}): obs_start={obs_start.rho[_li]:.6f}, obs_act({_aid})={obs_act.rho[_li]:.6f}, delta={obs_act.rho[_li] - obs_start.rho[_li]:.6f}")
-            # Also check p_or (active power) if available
-            if hasattr(obs_start, 'p_or') and hasattr(obs_act, 'p_or'):
+            try:
                 for _li in _lidxs:
                     _ln = name_line[_li] if _li < len(name_line) else f"idx_{_li}"
-                    print(f"[compute_superposition] p_or at {_ln}(idx={_li}): obs_start={obs_start.p_or[_li]:.2f}, obs_act({_aid})={obs_act.p_or[_li]:.2f}, delta={obs_act.p_or[_li] - obs_start.p_or[_li]:.2f}")
+                    print(f"[compute_superposition] rho at {_ln}(idx={_li}): obs_start={float(obs_start.rho[_li]):.6f}, obs_act({_aid})={float(obs_act.rho[_li]):.6f}, delta={float(obs_act.rho[_li] - obs_start.rho[_li]):.6f}")
+                if hasattr(obs_start, 'p_or') and hasattr(obs_act, 'p_or'):
+                    for _li in _lidxs:
+                        _ln = name_line[_li] if _li < len(name_line) else f"idx_{_li}"
+                        print(f"[compute_superposition] p_or at {_ln}(idx={_li}): obs_start={float(obs_start.p_or[_li]):.2f}, obs_act({_aid})={float(obs_act.p_or[_li]):.2f}, delta={float(obs_act.p_or[_li] - obs_start.p_or[_li]):.2f}")
+            except (TypeError, ValueError, IndexError):
+                print(f"[compute_superposition] Could not log rho/p_or for {_aid} (mock or missing data)")
         
         # Filter lines we care about
         monitoring_factor = getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95)
@@ -2985,9 +2987,18 @@ class RecommenderService:
                  
         lines_we_care_about, branches_with_limits = self._get_monitoring_parameters(obs_start)
 
+        # Detect PST actions — same logic the library uses in compute_all_pairs_superposition
+        def _is_pst_action(aid):
+            desc = self._dict_action.get(aid, {}) if self._dict_action else {}
+            action_type = classifier.identify_action_type(desc, by_description=True)
+            return action_type == "pst" or action_type == "pst_tap" or "pst_tap" in aid or "pst_" in aid
+
+        act1_is_pst = _is_pst_action(action1_id)
+        act2_is_pst = _is_pst_action(action2_id)
+
         print(f"[compute_superposition] Calling compute_combined_pair_superposition with:")
-        print(f"  act1_line_idxs={line_idxs1}, act1_sub_idxs={sub_idxs1}")
-        print(f"  act2_line_idxs={line_idxs2}, act2_sub_idxs={sub_idxs2}")
+        print(f"  act1_line_idxs={line_idxs1}, act1_sub_idxs={sub_idxs1}, act1_is_pst={act1_is_pst}")
+        print(f"  act2_line_idxs={line_idxs2}, act2_sub_idxs={sub_idxs2}, act2_is_pst={act2_is_pst}")
         print(f"  obs_combined present: {all_actions.get(f'{action1_id}+{action2_id}', {}).get('observation') is not None}")
         result = compute_combined_pair_superposition(
             obs_start=obs_start,
@@ -2997,7 +3008,9 @@ class RecommenderService:
             act1_sub_idxs=sub_idxs1,
             act2_line_idxs=line_idxs2,
             act2_sub_idxs=sub_idxs2,
-            obs_combined=all_actions.get(f"{action1_id}+{action2_id}", {}).get("observation")
+            obs_combined=all_actions.get(f"{action1_id}+{action2_id}", {}).get("observation"),
+            act1_is_pst=act1_is_pst,
+            act2_is_pst=act2_is_pst,
         )
         print(f"[compute_superposition] Library result: {'error: ' + str(result.get('error')) if 'error' in result else 'betas=' + str(result.get('betas'))}")
 

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2701,6 +2701,19 @@ class RecommenderService:
                 if len(monitored_rho) > 0:
                     max_rho = float(np.max(monitored_rho)) * mf
                     max_rho_line = monitored_names[np.argmax(monitored_rho)]
+                    # Diagnostic: top 5 simulated lines
+                    top_indices = np.argsort(monitored_rho)[::-1][:5]
+                    print(f"[simulate_manual_action] TOP 5 simulated rho (among {len(monitored_rho)} monitored):")
+                    for rank, ti in enumerate(top_indices):
+                        print(f"  #{rank+1}: {monitored_names[ti]} = {float(monitored_rho[ti]):.6f} "
+                              f"(scaled: {float(monitored_rho[ti]) * mf:.4f})")
+                    # Diagnostic: check .BIESL61PRAGN specifically
+                    biesl_mask = (action_names == '.BIESL61PRAGN')
+                    if np.any(biesl_mask):
+                        biesl_in_care = bool(care_mask[np.where(biesl_mask)[0][0]])
+                        biesl_rho = float(action_rho[np.where(biesl_mask)[0][0]])
+                        print(f"[simulate_manual_action] .BIESL61PRAGN: in_care_mask={biesl_in_care}, "
+                              f"rho={biesl_rho:.6f} (scaled: {biesl_rho * mf:.4f})")
                 else:
                     max_rho = 0.0
                     max_rho_line = "N/A"
@@ -3078,13 +3091,39 @@ class RecommenderService:
              max_rho_line = "N/A"
              if np.any(care_mask):
                  masked_rho = rho_combined[care_mask]
+                 masked_names = np.array(name_line_list)[care_mask]
                  max_idx = np.argmax(masked_rho)
                  max_rho = float(masked_rho[max_idx])
-                 max_rho_line = name_line_list[np.where(care_mask)[0][max_idx]]
+                 max_rho_line = masked_names[max_idx]
 
+             # Diagnostic: top 5 monitored lines by estimated rho
              print(f"[compute_superposition] monitored lines: {int(np.sum(care_mask))}/{num_lines}, "
-                   f"lines_overloaded force-included: {len(lines_overloaded_ids)}, "
-                   f"max_rho_line={max_rho_line}, max_rho_raw={max_rho:.6f}")
+                   f"lines_overloaded force-included: {len(lines_overloaded_ids)}")
+             if np.any(care_mask):
+                 top_indices = np.argsort(masked_rho)[::-1][:5]
+                 print(f"[compute_superposition] TOP 5 estimated rho (among {len(masked_rho)} monitored):")
+                 for rank, ti in enumerate(top_indices):
+                     print(f"  #{rank+1}: {masked_names[ti]} = {float(masked_rho[ti]):.6f} "
+                           f"(scaled: {float(masked_rho[ti]) * mf:.4f})")
+
+             # Diagnostic: check .BIESL61PRAGN specifically
+             biesl_idx = name_to_idx_map.get('.BIESL61PRAGN')
+             if biesl_idx is not None:
+                 in_care = bool(care_mask[biesl_idx])
+                 in_limits = '.BIESL61PRAGN' in branches_with_limits
+                 in_lwca = lines_we_care_about is None or '.BIESL61PRAGN' in (lines_we_care_about or [])
+                 est_rho = float(rho_combined[biesl_idx])
+                 n1_rho = float(obs_start.rho[biesl_idx])
+                 n_rho = float(obs_n.rho[biesl_idx])
+                 print(f"[compute_superposition] .BIESL61PRAGN check: "
+                       f"in_care_mask={in_care}, in_limits={in_limits}, in_lwca={in_lwca}, "
+                       f"rho_est={est_rho:.6f} (scaled:{est_rho*mf:.4f}), "
+                       f"rho_N1={n1_rho:.6f}, rho_N={n_rho:.6f}")
+             else:
+                 print(f"[compute_superposition] .BIESL61PRAGN NOT FOUND in name_line_list")
+
+             print(f"[compute_superposition] RESULT: max_rho_line={max_rho_line}, "
+                   f"max_rho_raw={max_rho:.6f}, max_rho_scaled={max_rho * mf:.4f}")
 
              # Scale by monitoring_factor for operational loading display
              res_max_rho = max_rho * monitoring_factor

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2973,20 +2973,11 @@ class RecommenderService:
         
         # Filter lines we care about
         monitoring_factor = getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95)
+        worsening_threshold = getattr(config, 'PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD', 0.02)
 
-        # Determine lines_overloaded_ids: prefer analysis context (consistent with simulate_manual_action)
         name_line_list = list(env.name_line)
         name_to_idx_map = {l: i for i, l in enumerate(name_line_list)}
-        ctx_overloaded = (self._analysis_context or {}).get("lines_overloaded")
-        if ctx_overloaded:
-            lines_overloaded_ids = [name_to_idx_map[l] for l in ctx_overloaded if l in name_to_idx_map]
-            print(f"[compute_superposition] Using analysis context lines_overloaded: {len(lines_overloaded_ids)} lines")
-        else:
-            lines_overloaded_ids = []
-            for i in range(len(obs_start.rho)):
-                if obs_start.rho[i] >= monitoring_factor:
-                     lines_overloaded_ids.append(i)
-            print(f"[compute_superposition] Computed lines_overloaded from N-1 state: {len(lines_overloaded_ids)} lines")
+        num_lines = len(name_line_list)
 
         # Get pre-existing rho for reduction calculation
         n_variant_id = self._get_n_variant()
@@ -2996,6 +2987,31 @@ class RecommenderService:
         pre_existing_rho = {i: obs_n.rho[i] for i in range(len(obs_n.rho)) if obs_n.rho[i] >= monitoring_factor}
 
         lines_we_care_about, branches_with_limits = self._get_monitoring_parameters(obs_start)
+
+        # Determine lines_overloaded_ids: prefer analysis context (consistent with simulate_manual_action)
+        ctx_overloaded = (self._analysis_context or {}).get("lines_overloaded")
+        if ctx_overloaded:
+            lines_overloaded_ids = [name_to_idx_map[l] for l in ctx_overloaded if l in name_to_idx_map]
+            print(f"[compute_superposition] Using analysis context lines_overloaded: {len(lines_overloaded_ids)} lines")
+        else:
+            # Recompute: filter by lines_we_care_about AND branches_with_limits (matching simulate_manual_action)
+            mf = float(monitoring_factor)
+            wt = float(worsening_threshold)
+            lwca_set = set(lines_we_care_about) if lines_we_care_about else set(name_line_list)
+            bwl_set = set(branches_with_limits)
+            lines_overloaded_ids = []
+            for i in range(len(obs_start.rho)):
+                ln = name_line_list[i]
+                if (obs_start.rho[i] >= mf
+                    and ln in lwca_set
+                    and ln in bwl_set):
+                    # Exclude pre-existing N-state overloads unless worsened
+                    if i in pre_existing_rho:
+                        if obs_start.rho[i] <= pre_existing_rho[i] * (1 + wt):
+                            continue
+                    lines_overloaded_ids.append(i)
+            print(f"[compute_superposition] Computed lines_overloaded from N-1 state: {len(lines_overloaded_ids)} lines "
+                  f"(filtered by {len(lwca_set)} care + {len(bwl_set)} with-limits)")
 
         # Detect PST actions — same logic the library uses in compute_all_pairs_superposition
         def _is_pst_action(aid):
@@ -3025,26 +3041,20 @@ class RecommenderService:
         print(f"[compute_superposition] Library result: {'error: ' + str(result.get('error')) if 'error' in result else 'betas=' + str(result.get('betas'))}")
 
         if "error" not in result:
-             # Logic to compute max_rho and other details, similar to compute_all_pairs_superposition
-             name_line = list(env.name_line)
-             num_lines = len(name_line)
-             worsening_threshold = getattr(config, 'PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD', 0.02)
-
-             pre_existing_baseline = np.zeros(num_lines)
-             is_pre_existing = np.zeros(num_lines, dtype=bool)
-             for idx, rho_val in pre_existing_rho.items():
-                 pre_existing_baseline[idx] = rho_val
-                 is_pre_existing[idx] = True
+             # Build care_mask matching simulate_manual_action:
+             # 1) lines_we_care_about AND branches_with_limits
+             # 2) exclude pre-existing N-state overloads unless worsened
+             # 3) force-include lines_overloaded_ids (N-1 overloaded lines)
+             mf = float(monitoring_factor)
+             wt = float(worsening_threshold)
 
              if lines_we_care_about is not None and len(lines_we_care_about) > 0:
-                 care_mask = np.isin(name_line, list(lines_we_care_about))
+                 care_mask = np.isin(name_line_list, list(lines_we_care_about))
              else:
                  care_mask = np.ones(num_lines, dtype=bool)
 
-             # Filter out branches without explicit thermal limits in pypowsybl (consistency with simulation)
-             for i, l in enumerate(name_line):
-                 if care_mask[i] and l not in branches_with_limits:
-                     care_mask[i] = False
+             limits_mask = np.isin(name_line_list, list(branches_with_limits))
+             care_mask &= limits_mask
 
              rho_combined = np.abs(
                  (1.0 - sum(result["betas"])) * obs_start.rho +
@@ -3052,24 +3062,27 @@ class RecommenderService:
                  result["betas"][1] * all_actions[action2_id]["observation"].rho
              )
 
-             # Max rho among monitored lines
-             worsened_mask = rho_combined > pre_existing_baseline * (1 + worsening_threshold)
-             eligible_mask = care_mask & (~is_pre_existing | worsened_mask)
+             # Exclude pre-existing N-state overloads unless the combined action worsens them
+             base_rho_n = np.array(obs_n.rho[:num_lines]) if len(obs_n.rho) >= num_lines else np.array(obs_n.rho)
+             pre_existing = (base_rho_n >= mf)
+             not_worsened = (rho_combined[:num_lines] <= base_rho_n * (1 + wt))
+             care_mask &= ~(pre_existing & not_worsened)
 
              # Always include lines_overloaded_ids (active monitoring) — consistent with simulate_manual_action
              for idx in lines_overloaded_ids:
-                 if idx < len(eligible_mask):
-                     eligible_mask[idx] = True
+                 if idx < len(care_mask):
+                     care_mask[idx] = True
 
+             # Find max rho among monitored lines
              max_rho = 0.0
              max_rho_line = "N/A"
-             if np.any(eligible_mask):
-                 masked_rho = rho_combined[eligible_mask]
+             if np.any(care_mask):
+                 masked_rho = rho_combined[care_mask]
                  max_idx = np.argmax(masked_rho)
                  max_rho = float(masked_rho[max_idx])
-                 max_rho_line = name_line[np.where(eligible_mask)[0][max_idx]]
+                 max_rho_line = name_line_list[np.where(care_mask)[0][max_idx]]
 
-             print(f"[compute_superposition] eligible lines: {int(np.sum(eligible_mask))}/{num_lines}, "
+             print(f"[compute_superposition] monitored lines: {int(np.sum(care_mask))}/{num_lines}, "
                    f"lines_overloaded force-included: {len(lines_overloaded_ids)}, "
                    f"max_rho_line={max_rho_line}, max_rho_raw={max_rho:.6f}")
 

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2805,10 +2805,21 @@ class RecommenderService:
                 self._last_result["prioritized_actions"] = {}
             self._last_result["prioritized_actions"][action_id] = action_data
 
-        # CRITICAL: Also update the global action registry used by the SLD generator
+        # Update the global action registry: merge into the existing entry
+        # rather than replacing it, so the library's _identify_action_elements
+        # can still find the original structure it expects.
         if self._dict_action is None:
             self._dict_action = {}
-        self._dict_action[action_id] = action_data
+        if action_id in self._dict_action:
+            existing = self._dict_action[action_id]
+            existing["observation"] = action_data.get("observation")
+            existing["action"] = action_data.get("action")
+            existing["action_topology"] = action_data.get("action_topology")
+            # Update content with the latest (tap/MW may have changed)
+            if action_data.get("content"):
+                existing["content"] = action_data["content"]
+        else:
+            self._dict_action[action_id] = action_data
 
         # Sanitize for JSON serialization (remove raw objects and fix float values)
         serializable_data = {
@@ -2946,16 +2957,6 @@ class RecommenderService:
             act2_sub_idxs=sub_idxs2,
             obs_combined=all_actions.get(f"{action1_id}+{action2_id}", {}).get("observation")
         )
-
-        # Fallback for PST actions: the library detects "No-op" because PST tap
-        # changes don't produce topology changes. Use additive superposition
-        # (betas=[1,1]) with the stored observations instead.
-        if "error" in result and "No-op" in str(result.get("error", "")):
-            has_pst = (action1_id.startswith("pst_tap_") or action1_id.startswith("pst_") or
-                       action2_id.startswith("pst_tap_") or action2_id.startswith("pst_"))
-            if has_pst:
-                print(f"[compute_superposition] Library returned No-op for PST pair, using additive superposition fallback")
-                result = {"betas": [1.0, 1.0]}
 
         if "error" not in result:
              # Logic to compute max_rho and other details, similar to compute_all_pairs_superposition

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -201,6 +201,11 @@ class RecommenderService:
             if curtailment:
                 enriched_actions[action_id]["curtailment_details"] = curtailment
 
+            # Detect PST actions and compute tap details with bounds
+            pst_details = self._compute_pst_details(action_data)
+            if pst_details:
+                enriched_actions[action_id]["pst_details"] = pst_details
+
         return enriched_actions
 
     def _compute_load_shedding_details(self, action_data, obs_n1=None):
@@ -382,6 +387,74 @@ class RecommenderService:
                 "gen_name": gen_name,
                 "voltage_level_id": vl_id,
                 "curtailed_mw": round(curtailed_mw, 1),
+            })
+
+        return details if details else None
+
+    def _compute_pst_details(self, action_data):
+        """Compute per-PST tap change details.
+
+        Returns a list of {pst_name, tap_position, low_tap, high_tap} or None.
+        Reads tap bounds from the network via get_pst_tap_info.
+        """
+        action_obj = action_data.get("action")
+        content = action_data.get("content")
+        if action_obj is None and content is None:
+            return None
+
+        # Collect affected PST names and their target tap positions
+        pst_entries = {}
+
+        # From action object attributes
+        pst_tap_attr = getattr(action_obj, "pst_tap", None)
+        if pst_tap_attr is None and isinstance(action_obj, dict):
+            pst_tap_attr = action_obj.get("pst_tap")
+        if pst_tap_attr and isinstance(pst_tap_attr, dict):
+            for name, tap in pst_tap_attr.items():
+                pst_entries[name] = int(tap)
+
+        # From content dict (pst_tap key)
+        if not pst_entries and isinstance(content, dict):
+            pst_tap_content = content.get("pst_tap", {})
+            if pst_tap_content and isinstance(pst_tap_content, dict):
+                for name, tap in pst_tap_content.items():
+                    pst_entries[name] = int(tap)
+
+        # From action_topology
+        action_topo = action_data.get("action_topology", {})
+        if not pst_entries and action_topo:
+            pst_tap_topo = action_topo.get("pst_tap", {})
+            if pst_tap_topo and isinstance(pst_tap_topo, dict):
+                for name, tap in pst_tap_topo.items():
+                    pst_entries[name] = int(tap)
+
+        if not pst_entries:
+            return None
+
+        details = []
+        try:
+            env = self._get_simulation_env()
+            nm = env.network_manager
+        except Exception:
+            nm = None
+
+        for pst_name, tap_position in pst_entries.items():
+            low_tap = None
+            high_tap = None
+            if nm is not None:
+                try:
+                    pst_info = nm.get_pst_tap_info(pst_name)
+                    if pst_info:
+                        low_tap = pst_info.get('low_tap')
+                        high_tap = pst_info.get('high_tap')
+                except Exception:
+                    pass
+
+            details.append({
+                "pst_name": pst_name,
+                "tap_position": tap_position,
+                "low_tap": low_tap,
+                "high_tap": high_tap,
             })
 
         return details if details else None
@@ -2093,7 +2166,7 @@ class RecommenderService:
         entry["content"] = content if content else {}
         return entry
 
-    def simulate_manual_action(self, raw_action_id: str, disconnected_element: str, action_content=None, lines_overloaded=None, target_mw=None):
+    def simulate_manual_action(self, raw_action_id: str, disconnected_element: str, action_content=None, lines_overloaded=None, target_mw=None, target_tap=None):
         """Simulate a single or combined action and return its impact.
 
         raw_action_id can be a single ID or multiple IDs combined with '+' (e.g. 'act1+act2').
@@ -2105,6 +2178,9 @@ class RecommenderService:
         target_mw: optional MW reduction amount for load shedding / curtailment actions.
                    When provided, the action reduces power by this amount instead of fully
                    shedding/curtailing. The resulting setpoint is (current_mw - target_mw).
+        target_tap: optional integer tap position for PST actions.
+                    When provided, updates the pst_tap content to the given tap value
+                    (clamped to [low_tap, high_tap] from the network).
         """
         if not self._dict_action:
             raise ValueError("No action dictionary loaded. Load a config first.")
@@ -2378,6 +2454,23 @@ class RecommenderService:
                             content["set_gen_p"][gen_name] = sp
                             print(f"[simulate_manual_action] Updated set_gen_p[{gen_name}] = {sp} MW")
 
+        # If target_tap is provided for a PST action, update the pst_tap content
+        if target_tap is not None:
+            for aid in action_ids:
+                if aid in self._dict_action:
+                    content = self._dict_action[aid].get("content", {})
+                    if "pst_tap" in content:
+                        for pst_id in content["pst_tap"]:
+                            # Clamp to valid range from network
+                            pst_info = nm.get_pst_tap_info(pst_id)
+                            if pst_info:
+                                clamped = max(pst_info['low_tap'], min(pst_info['high_tap'], int(target_tap)))
+                                content["pst_tap"][pst_id] = clamped
+                                print(f"[simulate_manual_action] Updated pst_tap[{pst_id}] = {clamped}")
+                            else:
+                                content["pst_tap"][pst_id] = int(target_tap)
+                                print(f"[simulate_manual_action] Updated pst_tap[{pst_id}] = {target_tap} (no bounds info)")
+
         # Build the action object
         try:
             action = None
@@ -2588,6 +2681,7 @@ class RecommenderService:
         # Capture curtailment/load-shedding details for heuristic actions
         action_data["curtailment_details"] = self._compute_curtailment_details(action_data, obs_n1=obs_n1)
         action_data["load_shedding_details"] = self._compute_load_shedding_details(action_data, obs_n1=obs_n1)
+        action_data["pst_details"] = self._compute_pst_details(action_data)
 
         if not info_action["exception"] and obs_simu_action is not None:
             if self._last_result is None:
@@ -2620,6 +2714,7 @@ class RecommenderService:
             "action_topology": action_data.get("action_topology"),
             "curtailment_details": action_data.get("curtailment_details"),
             "load_shedding_details": action_data.get("load_shedding_details"),
+            "pst_details": action_data.get("pst_details"),
             "content": action_data.get("content"),
         }
 

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2946,7 +2946,17 @@ class RecommenderService:
             act2_sub_idxs=sub_idxs2,
             obs_combined=all_actions.get(f"{action1_id}+{action2_id}", {}).get("observation")
         )
-        
+
+        # Fallback for PST actions: the library detects "No-op" because PST tap
+        # changes don't produce topology changes. Use additive superposition
+        # (betas=[1,1]) with the stored observations instead.
+        if "error" in result and "No-op" in str(result.get("error", "")):
+            has_pst = (action1_id.startswith("pst_tap_") or action1_id.startswith("pst_") or
+                       action2_id.startswith("pst_tap_") or action2_id.startswith("pst_"))
+            if has_pst:
+                print(f"[compute_superposition] Library returned No-op for PST pair, using additive superposition fallback")
+                result = {"betas": [1.0, 1.0]}
+
         if "error" not in result:
              # Logic to compute max_rho and other details, similar to compute_all_pairs_superposition
              name_line = list(env.name_line)

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -74,6 +74,8 @@ class RecommenderService:
         self._cached_obs_n1_id = None
         # Pre-built SimulationEnvironment reused across contingency analyses
         self._cached_env_context = None
+        # N-state PST tap positions captured at network load time
+        self._initial_pst_taps = None  # dict: pst_name -> {tap, low_tap, high_tap}
 
     def reset(self):
         """Clear all cached analysis state. Called when loading a new study."""
@@ -92,6 +94,7 @@ class RecommenderService:
         self._cached_obs_n1 = None
         self._cached_obs_n1_id = None
         self._cached_env_context = None
+        self._initial_pst_taps = None
 
     def restore_analysis_context(self, lines_we_care_about, disconnected_element=None, lines_overloaded=None, computed_pairs=None):
         """Restore analysis context from a saved session.
@@ -548,11 +551,12 @@ class RecommenderService:
         return action_scores
 
     def _get_pst_tap_start(self, action_id):
-        """Return {pst_name, tap, low_tap, high_tap} for a PST action from the base N-state network, or None.
+        """Return {pst_name, tap, low_tap, high_tap} for a PST action's N-state tap, or None.
 
-        Reads tap position directly from the pypowsybl base network's initial variant
-        to guarantee the original N-state value, regardless of any simulation that may
-        have modified the working variant.
+        Priority for the N-state (start) tap value:
+        1. Action's 'parameters' -> 'previous tap' (stored in the action JSON file)
+        2. Stable cache captured at network load time (_initial_pst_taps)
+        3. Simulation environment fallback (get_pst_tap_info)
         """
         action_entry = self._dict_action.get(action_id) if self._dict_action else None
         if action_entry is None:
@@ -571,31 +575,43 @@ class RecommenderService:
         # Get the first PST entry (most actions target a single PST)
         pst_name = next(iter(pst_tap))
 
-        # Read tap position from the base pypowsybl network's initial variant (N-state)
-        try:
-            network = self._get_base_network()
-            original_variant = network.get_working_variant_id()
-            try:
-                # Switch to the N-state variant (or initial variant) to read unmodified taps
-                n_variant = self._get_n_variant()
-                network.set_working_variant(n_variant)
+        # Priority 1: read "previous tap" from action parameters (original N-state tap)
+        params = action_entry.get("parameters", {})
+        if params:
+            prev_tap = params.get("previous tap")
+            if prev_tap is not None:
+                # Get bounds from cache or simulation env
+                low_tap, high_tap = None, None
+                if self._initial_pst_taps and pst_name in self._initial_pst_taps:
+                    low_tap = self._initial_pst_taps[pst_name].get("low_tap")
+                    high_tap = self._initial_pst_taps[pst_name].get("high_tap")
+                elif hasattr(self, '_simulation_env') and self._simulation_env:
+                    try:
+                        nm = self._simulation_env.network_manager
+                        pst_info = nm.get_pst_tap_info(pst_name)
+                        if pst_info:
+                            low_tap = pst_info.get("low_tap")
+                            high_tap = pst_info.get("high_tap")
+                    except Exception:
+                        pass
+                return {
+                    "pst_name": pst_name,
+                    "tap": int(prev_tap),
+                    "low_tap": low_tap,
+                    "high_tap": high_tap,
+                }
 
-                import pandas as pd
-                ptc = network.get_phase_tap_changers()
-                if ptc is not None and not ptc.empty and pst_name in ptc.index:
-                    row = ptc.loc[pst_name]
-                    return {
-                        "pst_name": pst_name,
-                        "tap": int(row.get("tap_position", 0)) if pd.notna(row.get("tap_position")) else 0,
-                        "low_tap": int(row.get("low_tap_position", 0)) if pd.notna(row.get("low_tap_position")) else None,
-                        "high_tap": int(row.get("high_tap_position", 0)) if pd.notna(row.get("high_tap_position")) else None,
-                    }
-            finally:
-                network.set_working_variant(original_variant)
-        except Exception as e:
-            print(f"[_get_pst_tap_start] Error reading N-state tap for {pst_name}: {e}")
+        # Priority 2: stable cache captured at network load time
+        if self._initial_pst_taps and pst_name in self._initial_pst_taps:
+            info = self._initial_pst_taps[pst_name]
+            return {
+                "pst_name": pst_name,
+                "tap": info["tap"],
+                "low_tap": info["low_tap"],
+                "high_tap": info["high_tap"],
+            }
 
-        # Fallback: try via simulation environment (may not be N-state)
+        # Priority 3: simulation environment fallback
         try:
             env = self._get_simulation_env()
             nm = env.network_manager
@@ -1272,7 +1288,32 @@ class RecommenderService:
         # Convenience method not in pypowsybl API: return line IDs as a list
         n.get_line_ids = lambda: n.get_lines().index.tolist()
         self._base_network = n
+
+        # Capture N-state PST tap positions immediately after loading (before any simulation)
+        self._capture_initial_pst_taps(n)
+
         return self._base_network
+
+    def _capture_initial_pst_taps(self, network):
+        """Snapshot all PST tap positions from the freshly-loaded network.
+
+        Called once at network load time so the values are guaranteed to be
+        the original N-state taps, unaffected by any subsequent simulation.
+        """
+        import pandas as pd
+        self._initial_pst_taps = {}
+        try:
+            ptc = network.get_phase_tap_changers()
+            if ptc is not None and not ptc.empty:
+                for pst_name, row in ptc.iterrows():
+                    self._initial_pst_taps[pst_name] = {
+                        "tap": int(row["tap_position"]) if pd.notna(row.get("tap_position")) else 0,
+                        "low_tap": int(row["low_tap_position"]) if pd.notna(row.get("low_tap_position")) else None,
+                        "high_tap": int(row["high_tap_position"]) if pd.notna(row.get("high_tap_position")) else None,
+                    }
+                print(f"[_capture_initial_pst_taps] Captured {len(self._initial_pst_taps)} PST tap positions")
+        except Exception as e:
+            print(f"[_capture_initial_pst_taps] Warning: could not read phase tap changers: {e}")
 
     def _get_n_variant(self):
         """Return the variant ID for the N state, creating and simulating it if necessary."""

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2878,10 +2878,36 @@ class RecommenderService:
             act2_obj, action2_id, self._dict_action, classifier, env
         )
 
-        if not line_idxs1 and not sub_idxs1 and not line_idxs2 and not sub_idxs2:
-             # Fallback: if they are in _dict_action, maybe identify_action_elements needs it
-             # but they were already identified above?
-             pass
+        # Fallback for PST actions: _identify_action_elements may return empty
+        # because PST tap changes are not topology changes (no line/bus switches).
+        # Identify the PST transformer line index from the action content instead.
+        def _pst_fallback_line_idxs(action_id):
+            entry = self._dict_action.get(action_id) or all_actions.get(action_id, {})
+            content = entry.get("content", {})
+            pst_tap = content.get("pst_tap", {})
+            if not pst_tap:
+                topo = entry.get("action_topology", {})
+                pst_tap = topo.get("pst_tap", {})
+            if not pst_tap:
+                return []
+            name_line = list(env.name_line)
+            idxs = []
+            for pst_name in pst_tap:
+                if pst_name in name_line:
+                    idxs.append(name_line.index(pst_name))
+            return idxs
+
+        if not line_idxs1 and not sub_idxs1:
+            fallback1 = _pst_fallback_line_idxs(action1_id)
+            if fallback1:
+                line_idxs1 = fallback1
+                print(f"[compute_superposition] PST fallback for action1 '{action1_id}': line_idxs={line_idxs1}")
+
+        if not line_idxs2 and not sub_idxs2:
+            fallback2 = _pst_fallback_line_idxs(action2_id)
+            if fallback2:
+                line_idxs2 = fallback2
+                print(f"[compute_superposition] PST fallback for action2 '{action2_id}': line_idxs={line_idxs2}")
 
         if (not line_idxs1 and not sub_idxs1) or (not line_idxs2 and not sub_idxs2):
              return {"error": f"Cannot identify elements for one or both actions (Act1: {len(line_idxs1)} lines, {len(sub_idxs1)} subs; Act2: {len(line_idxs2)} lines, {len(sub_idxs2)} subs)"}

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -548,7 +548,7 @@ class RecommenderService:
         return action_scores
 
     def _get_pst_tap_start(self, action_id):
-        """Return {tap, low_tap, high_tap} for a PST action, or None."""
+        """Return {pst_name, tap, low_tap, high_tap} for a PST action from the base N-state network, or None."""
         action_entry = self._dict_action.get(action_id) if self._dict_action else None
         if action_entry is None:
             return None
@@ -565,9 +565,8 @@ class RecommenderService:
 
         # Get the first PST entry (most actions target a single PST)
         pst_name = next(iter(pst_tap))
-        target_tap = int(pst_tap[pst_name])
 
-        # Query network for tap bounds
+        # Query network for current tap position (N-state) and bounds
         try:
             env = self._get_simulation_env()
             nm = env.network_manager
@@ -575,14 +574,14 @@ class RecommenderService:
             if pst_info:
                 return {
                     "pst_name": pst_name,
-                    "tap": target_tap,
+                    "tap": pst_info.get("tap"),
                     "low_tap": pst_info.get("low_tap"),
                     "high_tap": pst_info.get("high_tap"),
                 }
         except Exception:
             pass
 
-        return {"pst_name": pst_name, "tap": target_tap, "low_tap": None, "high_tap": None}
+        return None
 
     def _get_action_mw_start(self, action_id, action_type, obs_n1, line_idx_map, load_idx_map, gen_idx_map):
         """Return MW at start for a single action, or None if not computable."""

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2812,13 +2812,19 @@ class RecommenderService:
             self._dict_action = {}
         if action_id in self._dict_action:
             existing = self._dict_action[action_id]
+            print(f"[simulate_manual_action] Merging into existing _dict_action['{action_id}']")
+            print(f"  existing keys: {list(existing.keys())}")
+            print(f"  action_data keys: {list(action_data.keys())}")
             existing["observation"] = action_data.get("observation")
             existing["action"] = action_data.get("action")
             existing["action_topology"] = action_data.get("action_topology")
             # Update content with the latest (tap/MW may have changed)
             if action_data.get("content"):
                 existing["content"] = action_data["content"]
+            print(f"  merged keys: {list(existing.keys())}")
         else:
+            print(f"[simulate_manual_action] NEW _dict_action['{action_id}'] (no existing entry)")
+            print(f"  action_data keys: {list(action_data.keys())}")
             self._dict_action[action_id] = action_data
 
         # Sanitize for JSON serialization (remove raw objects and fix float values)
@@ -2876,11 +2882,28 @@ class RecommenderService:
 
         env = self._get_simulation_env()
         classifier = ActionClassifier()
-        
+
         # Identify elements for both actions
         # First check if they have action topology enriched
         act1_obj = all_actions[action1_id]["action"]
         act2_obj = all_actions[action2_id]["action"]
+
+        # --- DEBUG: log _dict_action entry keys for the actions ---
+        for _aid in (action1_id, action2_id):
+            _de = self._dict_action.get(_aid) if self._dict_action else None
+            if _de:
+                print(f"[compute_superposition] _dict_action['{_aid}'] keys: {list(_de.keys())}")
+                if "content" in _de:
+                    print(f"[compute_superposition]   content keys: {list(_de['content'].keys()) if isinstance(_de['content'], dict) else type(_de['content'])}")
+                    if isinstance(_de.get("content"), dict) and "pst_tap" in _de["content"]:
+                        print(f"[compute_superposition]   pst_tap: {_de['content']['pst_tap']}")
+            else:
+                print(f"[compute_superposition] _dict_action['{_aid}'] = NOT FOUND")
+            _ae = all_actions.get(_aid)
+            if _ae:
+                print(f"[compute_superposition] all_actions['{_aid}'] keys: {list(_ae.keys())}")
+            else:
+                print(f"[compute_superposition] all_actions['{_aid}'] = NOT FOUND")
 
         line_idxs1, sub_idxs1 = _identify_action_elements(
             act1_obj, action1_id, self._dict_action, classifier, env
@@ -2888,6 +2911,8 @@ class RecommenderService:
         line_idxs2, sub_idxs2 = _identify_action_elements(
             act2_obj, action2_id, self._dict_action, classifier, env
         )
+        print(f"[compute_superposition] _identify_action_elements: act1 line_idxs={line_idxs1}, sub_idxs={sub_idxs1}")
+        print(f"[compute_superposition] _identify_action_elements: act2 line_idxs={line_idxs2}, sub_idxs={sub_idxs2}")
 
         # Fallback for PST actions: _identify_action_elements may return empty
         # because PST tap changes are not topology changes (no line/bus switches).
@@ -2930,6 +2955,19 @@ class RecommenderService:
         n1_variant_id = self._get_n1_variant(disconnected_element)
         n.set_working_variant(n1_variant_id)
         obs_start = env.get_obs()
+
+        # --- DEBUG: log rho at identified line indexes for obs_start vs obs_act ---
+        name_line = list(env.name_line)
+        for _aid, _lidxs in [(action1_id, line_idxs1), (action2_id, line_idxs2)]:
+            obs_act = all_actions[_aid]["observation"]
+            for _li in _lidxs:
+                _ln = name_line[_li] if _li < len(name_line) else f"idx_{_li}"
+                print(f"[compute_superposition] rho at {_ln}(idx={_li}): obs_start={obs_start.rho[_li]:.6f}, obs_act({_aid})={obs_act.rho[_li]:.6f}, delta={obs_act.rho[_li] - obs_start.rho[_li]:.6f}")
+            # Also check p_or (active power) if available
+            if hasattr(obs_start, 'p_or') and hasattr(obs_act, 'p_or'):
+                for _li in _lidxs:
+                    _ln = name_line[_li] if _li < len(name_line) else f"idx_{_li}"
+                    print(f"[compute_superposition] p_or at {_ln}(idx={_li}): obs_start={obs_start.p_or[_li]:.2f}, obs_act({_aid})={obs_act.p_or[_li]:.2f}, delta={obs_act.p_or[_li] - obs_start.p_or[_li]:.2f}")
         
         # Filter lines we care about
         monitoring_factor = getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95)
@@ -2947,6 +2985,10 @@ class RecommenderService:
                  
         lines_we_care_about, branches_with_limits = self._get_monitoring_parameters(obs_start)
 
+        print(f"[compute_superposition] Calling compute_combined_pair_superposition with:")
+        print(f"  act1_line_idxs={line_idxs1}, act1_sub_idxs={sub_idxs1}")
+        print(f"  act2_line_idxs={line_idxs2}, act2_sub_idxs={sub_idxs2}")
+        print(f"  obs_combined present: {all_actions.get(f'{action1_id}+{action2_id}', {}).get('observation') is not None}")
         result = compute_combined_pair_superposition(
             obs_start=obs_start,
             obs_act1=all_actions[action1_id]["observation"],
@@ -2957,6 +2999,7 @@ class RecommenderService:
             act2_sub_idxs=sub_idxs2,
             obs_combined=all_actions.get(f"{action1_id}+{action2_id}", {}).get("observation")
         )
+        print(f"[compute_superposition] Library result: {'error: ' + str(result.get('error')) if 'error' in result else 'betas=' + str(result.get('betas'))}")
 
         if "error" not in result:
              # Logic to compute max_rho and other details, similar to compute_all_pairs_superposition

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -2973,18 +2973,28 @@ class RecommenderService:
         
         # Filter lines we care about
         monitoring_factor = getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95)
-        lines_overloaded_ids = []
-        for i in range(len(obs_start.rho)):
-            if obs_start.rho[i] >= monitoring_factor:
-                 lines_overloaded_ids.append(i)
-                 
+
+        # Determine lines_overloaded_ids: prefer analysis context (consistent with simulate_manual_action)
+        name_line_list = list(env.name_line)
+        name_to_idx_map = {l: i for i, l in enumerate(name_line_list)}
+        ctx_overloaded = (self._analysis_context or {}).get("lines_overloaded")
+        if ctx_overloaded:
+            lines_overloaded_ids = [name_to_idx_map[l] for l in ctx_overloaded if l in name_to_idx_map]
+            print(f"[compute_superposition] Using analysis context lines_overloaded: {len(lines_overloaded_ids)} lines")
+        else:
+            lines_overloaded_ids = []
+            for i in range(len(obs_start.rho)):
+                if obs_start.rho[i] >= monitoring_factor:
+                     lines_overloaded_ids.append(i)
+            print(f"[compute_superposition] Computed lines_overloaded from N-1 state: {len(lines_overloaded_ids)} lines")
+
         # Get pre-existing rho for reduction calculation
         n_variant_id = self._get_n_variant()
         n.set_working_variant(n_variant_id)
         obs_n = env.get_obs()
         # Only consider a line as "pre-existing" if it is actually an overload in the N state
         pre_existing_rho = {i: obs_n.rho[i] for i in range(len(obs_n.rho)) if obs_n.rho[i] >= monitoring_factor}
-                 
+
         lines_we_care_about, branches_with_limits = self._get_monitoring_parameters(obs_start)
 
         # Detect PST actions — same logic the library uses in compute_all_pairs_superposition
@@ -3046,6 +3056,11 @@ class RecommenderService:
              worsened_mask = rho_combined > pre_existing_baseline * (1 + worsening_threshold)
              eligible_mask = care_mask & (~is_pre_existing | worsened_mask)
 
+             # Always include lines_overloaded_ids (active monitoring) — consistent with simulate_manual_action
+             for idx in lines_overloaded_ids:
+                 if idx < len(eligible_mask):
+                     eligible_mask[idx] = True
+
              max_rho = 0.0
              max_rho_line = "N/A"
              if np.any(eligible_mask):
@@ -3053,6 +3068,10 @@ class RecommenderService:
                  max_idx = np.argmax(masked_rho)
                  max_rho = float(masked_rho[max_idx])
                  max_rho_line = name_line[np.where(eligible_mask)[0][max_idx]]
+
+             print(f"[compute_superposition] eligible lines: {int(np.sum(eligible_mask))}/{num_lines}, "
+                   f"lines_overloaded force-included: {len(lines_overloaded_ids)}, "
+                   f"max_rho_line={max_rho_line}, max_rho_raw={max_rho:.6f}")
 
              # Scale by monitoring_factor for operational loading display
              res_max_rho = max_rho * monitoring_factor

--- a/expert_backend/tests/CLAUDE.md
+++ b/expert_backend/tests/CLAUDE.md
@@ -87,6 +87,7 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 | `test_superposition_accuracy.py` | Superposition vs simulation discrepancy detection |
 | `test_superposition_filtering_regression.py` | Max rho filtering for heavily loaded lines |
 | `test_superposition_service.py` | On-demand superposition computation |
+| `test_superposition_monitoring_consistency.py` | Monitoring alignment between estimation and simulation (11 tests) |
 
 #### Performance & Regression
 | File | Description |

--- a/expert_backend/tests/test_superposition_monitoring_consistency.py
+++ b/expert_backend/tests/test_superposition_monitoring_consistency.py
@@ -1,0 +1,514 @@
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Co-Study4Grid, a Power Grid Study tool.
+
+"""Tests for superposition estimation monitoring consistency.
+
+These tests verify that compute_superposition and simulate_manual_action
+use the same set of monitored lines for max_rho computation:
+
+1. Lines without permanent thermal limits (branches_with_limits) must be
+   excluded from both estimation and simulation max_rho.
+2. N-1 overloaded lines (lines_overloaded_ids) must be force-included
+   in both paths, even if they are pre-existing N-state overloads.
+3. The fallback lines_overloaded_ids computation must filter by
+   lines_we_care_about AND branches_with_limits.
+4. PST actions must pass the is_pst flag so betas are computed correctly.
+5. Analysis context lines_overloaded takes priority over recomputation.
+"""
+
+import pytest
+import numpy as np
+from unittest.mock import MagicMock, patch
+from expert_backend.services.recommender_service import RecommenderService
+from expert_op4grid_recommender import config
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_obs(rho_vals, p_or_vals=None, name_line=None):
+    """Create a mock observation with proper numpy arrays."""
+    obs = MagicMock()
+    obs.rho = np.array(rho_vals, dtype=float)
+    if p_or_vals is not None:
+        obs.p_or = np.array(p_or_vals, dtype=float)
+    else:
+        obs.p_or = np.zeros(len(rho_vals))
+    if name_line is not None:
+        obs.name_line = name_line
+    return obs
+
+
+def _setup_env(recommender, name_line, obs_n1_rho, obs_n_rho,
+               actions_dict, dict_action=None,
+               lines_we_care_about=None, branches_with_limits=None,
+               analysis_context=None):
+    """Common setup for monitoring consistency tests.
+
+    Returns the mock env so callers can add further configuration.
+    """
+    n_lines = len(name_line)
+
+    recommender._last_result = {"prioritized_actions": actions_dict}
+    recommender._dict_action = dict_action or {}
+    recommender._analysis_context = analysis_context
+
+    env = MagicMock()
+    env.name_line = name_line
+    recommender._get_simulation_env = MagicMock(return_value=env)
+    recommender._get_n_variant = MagicMock(return_value="N")
+    recommender._get_n1_variant = MagicMock(return_value="N-1")
+    env.network_manager.network.get_working_variant_id.return_value = "ORIG"
+
+    obs_n1 = _make_obs(obs_n1_rho, name_line=name_line)
+    obs_n = _make_obs(obs_n_rho, name_line=name_line)
+    # compute_superposition calls get_obs for N-1 then N
+    env.get_obs.side_effect = [obs_n1, obs_n]
+
+    lwca = set(lines_we_care_about) if lines_we_care_about is not None else set(name_line)
+    bwl = set(branches_with_limits) if branches_with_limits is not None else set(name_line)
+    recommender._get_monitoring_parameters = MagicMock(return_value=(lwca, bwl))
+
+    config.MONITORING_FACTOR_THERMAL_LIMITS = 0.95
+    config.PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02
+
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Tests: Lines without thermal limits must be excluded
+# ---------------------------------------------------------------------------
+
+class TestBranchesWithLimitsFiltering:
+    """Lines NOT in branches_with_limits must never appear as max_rho_line."""
+
+    def test_line_without_limits_excluded_from_max_rho(self):
+        """A line with high rho but no thermal limit must not be the max_rho_line.
+
+        Regression: CIVAUY712 had no permanent thermal limit, was force-included
+        via unfiltered lines_overloaded_ids, and showed 441% estimated loading.
+        """
+        svc = RecommenderService()
+        name_line = ["CANTEY761", "CIVAUY712", "BIESL61PRAGN"]
+
+        # CANTEY761 is overloaded in N-1, CIVAUY712 also high but no limit
+        obs_n1_rho = [1.10, 0.98, 0.86]
+        obs_n_rho = [0.50, 0.40, 0.74]
+
+        obs_act1 = _make_obs([0.90, 0.95, 0.85], name_line=name_line)
+        obs_act2 = _make_obs([0.88, 0.90, 0.80], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        # CIVAUY712 has NO permanent thermal limit
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   branches_with_limits=["CANTEY761", "BIESL61PRAGN"])
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            # betas that would give high rho for CIVAUY712 if it were monitored
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        assert result["max_rho_line"] != "CIVAUY712", \
+            "Line without thermal limit must not be the max_rho_line"
+        assert result["max_rho_line"] in ("CANTEY761", "BIESL61PRAGN")
+
+    def test_lines_overloaded_fallback_filters_by_limits(self):
+        """When no analysis context, lines_overloaded_ids must only include
+        lines that are in both lines_we_care_about AND branches_with_limits."""
+        svc = RecommenderService()
+        name_line = ["LINE_A", "LINE_B", "LINE_C"]
+
+        # LINE_B has rho >= 0.95 in N-1 but is NOT in branches_with_limits
+        obs_n1_rho = [0.50, 0.98, 0.96]
+        obs_n_rho = [0.30, 0.30, 0.30]
+
+        obs_act1 = _make_obs([0.45, 0.90, 0.90], name_line=name_line)
+        obs_act2 = _make_obs([0.45, 0.85, 0.85], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   branches_with_limits=["LINE_A", "LINE_C"],
+                   analysis_context=None)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # LINE_B should NOT be the max (no thermal limit)
+        assert result["max_rho_line"] != "LINE_B"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Force-inclusion of N-1 overloaded lines
+# ---------------------------------------------------------------------------
+
+class TestOverloadedLinesForceInclusion:
+    """N-1 overloaded lines must be force-included in the care_mask,
+    even when they are pre-existing N-state overloads."""
+
+    def test_n1_overloaded_line_included_despite_preexisting(self):
+        """A line overloaded in both N and N-1 must still be included
+        if it's in lines_overloaded_ids (from analysis context)."""
+        svc = RecommenderService()
+        name_line = ["OVERLOADED", "NORMAL"]
+
+        obs_n1_rho = [1.10, 0.50]
+        # OVERLOADED is also a pre-existing N-state overload
+        obs_n_rho = [0.96, 0.40]
+
+        obs_act1 = _make_obs([0.90, 0.45], name_line=name_line)
+        obs_act2 = _make_obs([0.85, 0.40], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        # Analysis context provides the overloaded line
+        ctx = {"lines_overloaded": ["OVERLOADED"]}
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=ctx)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # OVERLOADED should be the max because it's force-included and has higher rho
+        assert result["max_rho_line"] == "OVERLOADED"
+
+    def test_analysis_context_takes_priority_over_recomputation(self):
+        """When analysis context has lines_overloaded, use those instead of
+        recomputing from obs_start.rho >= monitoring_factor."""
+        svc = RecommenderService()
+        name_line = ["SELECTED", "NOT_SELECTED"]
+
+        # Both lines are overloaded in N-1
+        obs_n1_rho = [1.05, 1.08]
+        obs_n_rho = [0.30, 0.30]
+
+        obs_act1 = _make_obs([0.80, 0.85], name_line=name_line)
+        obs_act2 = _make_obs([0.75, 0.80], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        # Analysis context only includes SELECTED
+        ctx = {"lines_overloaded": ["SELECTED"]}
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=ctx)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # Both lines are monitored (both in lines_we_care_about), but
+        # the analysis context only force-includes SELECTED
+        assert "max_rho" in result
+        assert result["is_estimated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: Pre-existing overload handling uses rho_combined
+# ---------------------------------------------------------------------------
+
+class TestPreExistingOverloadHandling:
+    """Pre-existing N-state overloads should be excluded unless the combined
+    action worsens them. The worsening check must use rho_combined."""
+
+    def test_preexisting_excluded_when_not_worsened(self):
+        """A pre-existing N-state overload that improves should be excluded
+        from max_rho (unless force-included as lines_overloaded)."""
+        svc = RecommenderService()
+        name_line = ["PRE_EXISTING", "OTHER"]
+
+        obs_n1_rho = [0.80, 0.70]
+        # PRE_EXISTING is overloaded in N (>= 0.95)
+        obs_n_rho = [0.97, 0.40]
+
+        obs_act1 = _make_obs([0.70, 0.65], name_line=name_line)
+        obs_act2 = _make_obs([0.65, 0.60], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        # No analysis context — so force-inclusion won't add PRE_EXISTING
+        # (it's not in N-1 overloaded because rho_N1=0.80 < 0.95)
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=None)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # PRE_EXISTING (N-state overload at 97%, combined action improves it)
+        # should be excluded, so OTHER should be max
+        assert result["max_rho_line"] == "OTHER"
+
+    def test_preexisting_included_when_worsened(self):
+        """A pre-existing N-state overload that gets worse should be included."""
+        svc = RecommenderService()
+        name_line = ["PRE_EXISTING", "OTHER"]
+
+        obs_n1_rho = [0.80, 0.50]
+        obs_n_rho = [0.96, 0.40]
+
+        # Action observations that will make PRE_EXISTING worse
+        # Combined formula: |(1-1.0)*rho_n1 + 0.5*obs1 + 0.5*obs2|
+        # = |0 + 0.5*1.1 + 0.5*1.2| = |1.15|
+        # This is >> 0.96 * 1.02 = 0.9792, so worsened=True
+        obs_act1 = _make_obs([1.10, 0.45], name_line=name_line)
+        obs_act2 = _make_obs([1.20, 0.40], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=None)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # PRE_EXISTING should be included because it's worsened
+        assert result["max_rho_line"] == "PRE_EXISTING"
+
+
+# ---------------------------------------------------------------------------
+# Tests: No N-state overloads (user's actual scenario)
+# ---------------------------------------------------------------------------
+
+class TestNoNStateOverloads:
+    """When there are no N-state overloads, all lines in care_mask are eligible.
+    The estimation should see the correct set of monitored lines."""
+
+    def test_all_monitored_lines_eligible_without_n_overloads(self):
+        """Without N-state overloads, eligible lines = care_mask lines."""
+        svc = RecommenderService()
+        name_line = ["CANTEY761", "BIESL61PRAGN", "TRI_PY761"]
+
+        obs_n1_rho = [1.16, 0.86, 0.50]
+        obs_n_rho = [0.50, 0.74, 0.30]  # no N-state overloads
+
+        obs_act1 = _make_obs([1.06, 1.00, 0.95], name_line=name_line)
+        obs_act2 = _make_obs([0.98, 0.85, 0.90], name_line=name_line)
+        actions = {
+            "pst_tap_PST1_inc2": {"action": MagicMock(), "observation": obs_act1},
+            "reco_SWITCH1": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        ctx = {"lines_overloaded": ["CANTEY761"]}
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   dict_action={
+                       "pst_tap_PST1_inc2": {"content": {"pst_tap": {"PST1": 32}},
+                                             "description_unitaire": "Variation de slot"},
+                       "reco_SWITCH1": {"content": {"set_bus": {}},
+                                       "description_unitaire": "Reconnect"},
+                   },
+                   analysis_context=ctx)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.90, 0.93]}
+            result = svc.compute_superposition("pst_tap_PST1_inc2", "reco_SWITCH1", "CONTINGENCY")
+
+        # All 3 lines should be eligible (no N-state overloads to exclude)
+        assert result["max_rho_line"] in name_line
+        assert result["is_estimated"] is True
+        assert result["max_rho"] > 0
+
+    def test_estimation_considers_all_monitored_lines_globally(self):
+        """The estimation must consider ALL monitored lines and pick the
+        global max — not just the overloaded lines.
+
+        This verifies the estimation does a fresh global scan, not a
+        cached result from a previous call.
+        """
+        svc = RecommenderService()
+        name_line = ["LINE_A", "LINE_B", "LINE_C"]
+
+        obs_n1_rho = [1.05, 0.80, 0.70]
+        obs_n_rho = [0.40, 0.30, 0.20]
+
+        # After actions: LINE_B has the highest combined rho
+        obs_act1 = _make_obs([0.60, 0.95, 0.50], name_line=name_line)
+        obs_act2 = _make_obs([0.55, 0.90, 0.45], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        ctx = {"lines_overloaded": ["LINE_A"]}
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=ctx)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            # betas=[1.0, 1.0] → rho_combined = |-rho_n1 + obs1 + obs2|
+            # LINE_A: |-1.05 + 0.60 + 0.55| = 0.10
+            # LINE_B: |-0.80 + 0.95 + 0.90| = 1.05
+            # LINE_C: |-0.70 + 0.50 + 0.45| = 0.25
+            mock_sp.return_value = {"betas": [1.0, 1.0]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # LINE_B should be the max even though it's not in lines_overloaded
+        assert result["max_rho_line"] == "LINE_B"
+
+
+# ---------------------------------------------------------------------------
+# Tests: PST-specific superposition behavior
+# ---------------------------------------------------------------------------
+
+class TestPSTSuperpositionMonitoring:
+    """PST tap actions in combined pairs must be handled correctly:
+    - is_pst flag must be passed to the library
+    - Lines without limits must not leak into monitoring
+    - Re-simulation with different tap updates the observation
+    """
+
+    def test_pst_combined_with_switching_monitors_same_lines(self):
+        """A PST + switching action pair should monitor the same lines
+        as two switching actions paired together."""
+        svc = RecommenderService()
+        name_line = ["CANTEY761", "BIESL61PRAGN", "NO_LIMIT_LINE"]
+
+        obs_n1_rho = [1.10, 0.86, 0.90]
+        obs_n_rho = [0.50, 0.74, 0.40]
+
+        obs_pst = _make_obs([1.06, 1.00, 0.88], name_line=name_line)
+        obs_switch = _make_obs([0.98, 0.85, 0.82], name_line=name_line)
+        actions = {
+            "pst_tap_PST1": {"action": MagicMock(), "observation": obs_pst},
+            "reco_SWITCH": {"action": MagicMock(), "observation": obs_switch},
+        }
+
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   dict_action={
+                       "pst_tap_PST1": {"content": {"pst_tap": {"PST1": 32}},
+                                        "description_unitaire": "Variation de slot"},
+                       "reco_SWITCH": {"content": {"set_bus": {}},
+                                      "description_unitaire": "Reconnect"},
+                   },
+                   # NO_LIMIT_LINE not in branches_with_limits
+                   branches_with_limits=["CANTEY761", "BIESL61PRAGN"],
+                   analysis_context={"lines_overloaded": ["CANTEY761"]})
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.90, 0.93]}
+            result = svc.compute_superposition("pst_tap_PST1", "reco_SWITCH", "CONTINGENCY")
+
+        # NO_LIMIT_LINE must not appear as max
+        assert result["max_rho_line"] != "NO_LIMIT_LINE"
+        assert result["max_rho_line"] in ("CANTEY761", "BIESL61PRAGN")
+
+    def test_is_rho_reduction_computed_on_overloaded_lines(self):
+        """is_rho_reduction should be True when all overloaded lines see
+        a decrease in combined rho vs N-1 baseline."""
+        svc = RecommenderService()
+        name_line = ["OVERLOADED"]
+
+        obs_n1_rho = [1.10]
+        obs_n_rho = [0.50]
+
+        # Both actions reduce OVERLOADED
+        obs_act1 = _make_obs([0.80], name_line=name_line)
+        obs_act2 = _make_obs([0.75], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        ctx = {"lines_overloaded": ["OVERLOADED"]}
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=ctx)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            # rho_combined = |(1 - 0.5 - 0.5)*1.1 + 0.5*0.8 + 0.5*0.75|
+            # = |0 + 0.4 + 0.375| = 0.775 < 1.10 → reduction
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        assert result["is_rho_reduction"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: Monitoring factor scaling
+# ---------------------------------------------------------------------------
+
+class TestMonitoringFactorScaling:
+    """max_rho must be scaled by monitoring_factor for display."""
+
+    def test_max_rho_scaled_by_monitoring_factor(self):
+        """Result max_rho = raw_max_rho * monitoring_factor."""
+        svc = RecommenderService()
+        name_line = ["LINE1"]
+        obs_n1_rho = [1.10]
+        obs_n_rho = [0.30]
+
+        obs_act1 = _make_obs([0.90], name_line=name_line)
+        obs_act2 = _make_obs([0.85], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        ctx = {"lines_overloaded": ["LINE1"]}
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=ctx)
+
+        with patch('expert_backend.services.recommender_service._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # rho_combined = |(1-1.0)*1.1 + 0.5*0.9 + 0.5*0.85| = 0.875
+        # max_rho = 0.875 * 0.95 = 0.83125
+        expected_raw = abs((1.0 - 1.0) * 1.1 + 0.5 * 0.9 + 0.5 * 0.85)
+        expected_scaled = expected_raw * 0.95
+        assert abs(result["max_rho"] - expected_scaled) < 0.001
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/expert_backend/tests/test_superposition_service.py
+++ b/expert_backend/tests/test_superposition_service.py
@@ -3,12 +3,14 @@
 # If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
 # you can obtain one at http://mozilla.org/MPL/2.0/.
 # SPDX-License-Identifier: MPL-2.0
-# This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
+# This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import pytest
 import numpy as np
 from unittest.mock import MagicMock, patch
 from expert_backend.services.recommender_service import RecommenderService
+from expert_op4grid_recommender import config
+
 
 @pytest.fixture
 def recommender():
@@ -17,96 +19,263 @@ def recommender():
     svc._last_result = {"prioritized_actions": {}}
     return svc
 
-def test_compute_superposition_on_demand(recommender):
-    # Setup two actions in the result
-    aid1, aid2 = "act1", "act2"
-    recommender._last_result["prioritized_actions"] = {
-        aid1: {"action": MagicMock(), "observation": MagicMock()},
-        aid2: {"action": MagicMock(), "observation": MagicMock()}
-    }
-    
-    # Mock dependencies
+
+def _make_obs(rho_vals, p_or_vals=None):
+    """Create a mock observation with proper numpy arrays."""
+    obs = MagicMock()
+    obs.rho = np.array(rho_vals)
+    if p_or_vals is not None:
+        obs.p_or = np.array(p_or_vals)
+    else:
+        del obs.p_or  # Remove the auto-created MagicMock attribute
+    return obs
+
+
+def _setup_superposition_env(recommender, actions_dict, dict_action, name_line=None):
+    """Common setup for superposition tests: mock env, variants, observations."""
+    if name_line is None:
+        name_line = ["LINE1"]
+
+    recommender._last_result["prioritized_actions"] = actions_dict
+    recommender._dict_action = dict_action
     recommender._get_simulation_env = MagicMock()
-    recommender._get_n_variant = MagicMock()
-    recommender._get_n1_variant = MagicMock()
-    recommender._get_lines_we_care_about = MagicMock(return_value=None)
-    
+    recommender._get_n_variant = MagicMock(return_value="N")
+    recommender._get_n1_variant = MagicMock(return_value="N-1")
+
     env = recommender._get_simulation_env.return_value
-    env.name_line = ["LINE1"]
-    
-    # Mock observations
-    obs_start = MagicMock()
-    obs_start.rho = np.array([1.1])
-    env.get_obs.return_value = obs_start # Simplified mock for this test
-    
-    # Mock library functions
+    env.name_line = name_line
+
+    n_lines = len(name_line)
+    obs_n1 = _make_obs([1.1] * n_lines, [100.0] * n_lines)
+    obs_n = _make_obs([0.8] * n_lines, [80.0] * n_lines)
+    env.get_obs.side_effect = [obs_n1, obs_n]
+    env.network_manager.network.get_working_variant_id.return_value = "ORIG"
+
+    # Ensure config attributes used in compute_superposition are real numbers
+    config.MONITORING_FACTOR_THERMAL_LIMITS = 0.95
+    config.PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02
+
+    return env
+
+
+def test_compute_superposition_on_demand(recommender):
+    """Verify on-demand superposition returns betas and max_rho."""
+    aid1, aid2 = "act1", "act2"
+    obs1 = _make_obs([0.9], [90.0])
+    obs2 = _make_obs([0.9], [85.0])
+    actions = {
+        aid1: {"action": MagicMock(), "observation": obs1},
+        aid2: {"action": MagicMock(), "observation": obs2},
+    }
+    _setup_superposition_env(recommender, actions, {})
+
     with patch('expert_backend.services.recommender_service._identify_action_elements', return_value=([0], [])), \
          patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
-        
+
         mock_combine.return_value = {
             "betas": [0.5, 0.5],
             "p_or_combined": [100.0]
         }
-        
-        # We need to ensure results from compute_superposition can calculate max_rho
-        # It uses obs_start.rho, obs_act1.rho, obs_act2.rho
-        recommender._last_result["prioritized_actions"][aid1]["observation"].rho = np.array([0.9])
-        recommender._last_result["prioritized_actions"][aid2]["observation"].rho = np.array([0.9])
-        
-        # Mock n_variant/n1_variant to avoid real network access
-        recommender._get_n_variant = MagicMock(return_value="N")
-        recommender._get_n1_variant = MagicMock(return_value="N-1")
-        env.network_manager.network.get_working_variant_id.return_value = "ORIG"
-        
+
         result = recommender.compute_superposition(aid1, aid2, "contingency")
-        
+
         assert "betas" in result
         assert result["max_rho"] is not None
         assert result["is_estimated"] is True
 
+
 def test_compute_superposition_triggers_simulation(recommender):
-    # aid1 in result, aid2 NOT in result
+    """When one action is missing from results, simulate_manual_action is called."""
     aid1, aid2 = "act1", "act2"
-    recommender._last_result["prioritized_actions"] = {
-        aid1: {"action": MagicMock(), "observation": MagicMock()}
+    obs1 = _make_obs([0.9], [90.0])
+    actions = {
+        aid1: {"action": MagicMock(), "observation": obs1},
     }
-    recommender._dict_action = {
-        aid2: {"content": "content2", "description_unitaire": "Desc 2"}
-    }
-    
-    # Mock simulate_manual_action
+    da = {aid2: {"content": "content2", "description_unitaire": "Desc 2"}}
+
     def mock_simulate(aid, cont):
         recommender._last_result["prioritized_actions"][aid] = {
             "action": MagicMock(),
-            "observation": MagicMock()
+            "observation": _make_obs([0.9], [85.0]),
         }
-        recommender._last_result["prioritized_actions"][aid]["observation"].rho = np.array([0.9])
-    
+
     recommender.simulate_manual_action = MagicMock(side_effect=mock_simulate)
-    
-    # Mock other dependencies to avoid crash
-    recommender._get_simulation_env = MagicMock()
-    recommender._get_n_variant = MagicMock()
-    recommender._get_n1_variant = MagicMock()
-    recommender._get_lines_we_care_about = MagicMock(return_value=None)
-    
-    env = recommender._get_simulation_env.return_value
-    env.name_line = ["LINE1"]
-    obs_start = MagicMock()
-    obs_start.rho = np.array([1.1])
-    env.get_obs.return_value = obs_start
+    _setup_superposition_env(recommender, actions, da)
 
     with patch('expert_backend.services.recommender_service._identify_action_elements', return_value=([0], [])), \
          patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
-        
+
         mock_combine.return_value = {"betas": [0.5, 0.5]}
-        recommender._last_result["prioritized_actions"][aid1]["observation"].rho = np.array([0.9])
-        
         result = recommender.compute_superposition(aid1, aid2, "contingency")
-        
-        # Verify simulate_manual_action was called for aid2
+
         recommender.simulate_manual_action.assert_called_with(aid2, "contingency")
         assert "betas" in result
+
+
+def test_compute_superposition_passes_pst_flag_for_pst_action(recommender):
+    """When one action is a PST tap action, act1_is_pst must be True so the
+    library uses flow-based no-op detection instead of line-status comparison."""
+    pst_id = "pst_tap_.ARKA_TD_661_inc2"
+    other_id = "reco_LINE_A"
+
+    obs_pst = _make_obs([0.9], [95.0])
+    obs_other = _make_obs([0.85], [90.0])
+    actions = {
+        pst_id: {"action": MagicMock(), "observation": obs_pst},
+        other_id: {"action": MagicMock(), "observation": obs_other},
+    }
+    da = {
+        pst_id: {"content": {"pst_tap": {".ARKA TD 661": 32}}, "description_unitaire": "Variation de slot"},
+        other_id: {"content": {"set_bus": {"lines_or_bus": {"LINE_A": 2}}}, "description_unitaire": "Reconnect LINE_A"},
+    }
+    _setup_superposition_env(recommender, actions, da)
+
+    with patch('expert_backend.services.recommender_service._identify_action_elements', return_value=([0], [])), \
+         patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
+
+        mock_combine.return_value = {"betas": [0.6, 0.4]}
+        recommender.compute_superposition(pst_id, other_id, "contingency")
+
+        call_kwargs = mock_combine.call_args
+        assert call_kwargs.kwargs.get("act1_is_pst") is True, "act1_is_pst should be True for PST action"
+        assert call_kwargs.kwargs.get("act2_is_pst") is False, "act2_is_pst should be False for non-PST action"
+
+
+def test_compute_superposition_pst_flag_true_when_pst_is_second(recommender):
+    """When PST action is the second argument, act2_is_pst should be True."""
+    other_id = "reco_LINE_A"
+    pst_id = "pst_tap_.ARKA_TD_661_inc2"
+
+    obs_other = _make_obs([0.85], [90.0])
+    obs_pst = _make_obs([0.9], [95.0])
+    actions = {
+        other_id: {"action": MagicMock(), "observation": obs_other},
+        pst_id: {"action": MagicMock(), "observation": obs_pst},
+    }
+    da = {
+        other_id: {"content": {"set_bus": {"lines_or_bus": {"LINE_A": 2}}}, "description_unitaire": "Reconnect"},
+        pst_id: {"content": {"pst_tap": {".ARKA TD 661": 32}}, "description_unitaire": "Variation de slot"},
+    }
+    _setup_superposition_env(recommender, actions, da)
+
+    with patch('expert_backend.services.recommender_service._identify_action_elements', return_value=([0], [])), \
+         patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
+
+        mock_combine.return_value = {"betas": [0.5, 0.5]}
+        recommender.compute_superposition(other_id, pst_id, "contingency")
+
+        call_kwargs = mock_combine.call_args
+        assert call_kwargs.kwargs.get("act1_is_pst") is False, "act1_is_pst should be False for non-PST action"
+        assert call_kwargs.kwargs.get("act2_is_pst") is True, "act2_is_pst should be True for PST action"
+
+
+def test_compute_superposition_pst_flag_false_for_non_pst(recommender):
+    """Non-PST actions should have act_is_pst=False."""
+    aid1, aid2 = "reco_LINE_A", "reco_LINE_B"
+
+    obs1 = _make_obs([0.9], [90.0])
+    obs2 = _make_obs([0.85], [85.0])
+    actions = {
+        aid1: {"action": MagicMock(), "observation": obs1},
+        aid2: {"action": MagicMock(), "observation": obs2},
+    }
+    da = {
+        aid1: {"content": {"set_bus": {"lines_or_bus": {"LINE_A": 2}}}, "description_unitaire": "Reconnect"},
+        aid2: {"content": {"set_bus": {"lines_or_bus": {"LINE_B": 2}}}, "description_unitaire": "Reconnect"},
+    }
+    _setup_superposition_env(recommender, actions, da)
+
+    with patch('expert_backend.services.recommender_service._identify_action_elements', return_value=([0], [])), \
+         patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
+
+        mock_combine.return_value = {"betas": [0.5, 0.5]}
+        recommender.compute_superposition(aid1, aid2, "contingency")
+
+        call_kwargs = mock_combine.call_args
+        assert call_kwargs.kwargs.get("act1_is_pst") is False
+        assert call_kwargs.kwargs.get("act2_is_pst") is False
+
+
+def test_pst_fallback_line_idxs_used_when_identify_returns_empty(recommender):
+    """When _identify_action_elements returns empty for a PST action, the
+    fallback should find the line index from the pst_tap content."""
+    pst_id = "pst_tap_.ARKA_TD_661_inc2"
+    other_id = "reco_LINE_B"
+
+    obs_pst = _make_obs([0.9], [95.0])
+    obs_other = _make_obs([0.85], [90.0])
+    actions = {
+        pst_id: {"action": MagicMock(), "observation": obs_pst},
+        other_id: {"action": MagicMock(), "observation": obs_other},
+    }
+    da = {
+        pst_id: {"content": {"pst_tap": {".ARKA TD 661": 32}}, "description_unitaire": "Variation de slot"},
+        other_id: {"content": {"set_bus": {"lines_or_bus": {"LINE_B": 2}}}, "description_unitaire": "Reconnect"},
+    }
+    _setup_superposition_env(recommender, actions, da, name_line=[".ARKA TD 661", "LINE_B"])
+
+    # _identify_action_elements returns empty for PST, non-empty for other
+    def side_effect(act_obj, aid, dict_action, classifier, env):
+        if aid == pst_id:
+            return ([], [])  # PST actions often return empty
+        return ([1], [])  # LINE_B at index 1
+
+    with patch('expert_backend.services.recommender_service._identify_action_elements', side_effect=side_effect), \
+         patch('expert_backend.services.recommender_service.compute_combined_pair_superposition') as mock_combine:
+
+        mock_combine.return_value = {"betas": [0.6, 0.4]}
+        recommender.compute_superposition(pst_id, other_id, "contingency")
+
+        call_kwargs = mock_combine.call_args
+        # Fallback should have found index 0 (.ARKA TD 661) for the PST action
+        assert call_kwargs.kwargs.get("act1_line_idxs") == [0]
+        assert call_kwargs.kwargs.get("act1_is_pst") is True
+
+
+def test_dict_action_merge_preserves_original_keys(recommender):
+    """After re-simulation, _dict_action entry must retain original keys
+    from the library while updating observation/action/content."""
+
+    original_entry = {
+        "content": {"pst_tap": {".ARKA TD 661": 29}},
+        "description": "PST action",
+        "description_unitaire": "Variation de slot .ARKA TD 661 to 29",
+        "observation": MagicMock(),
+        "action": MagicMock(),
+        "action_topology": {"pst_tap": {".ARKA TD 661": 29}},
+        # Library-specific keys that must survive re-simulation
+        "library_extra_field": "some_value",
+        "action_type_info": {"type": "pst_tap"},
+    }
+
+    svc = RecommenderService()
+    svc._dict_action = {"pst_action_1": dict(original_entry)}
+
+    # Simulate the merge that happens after re-simulation
+    new_data = {
+        "content": {"pst_tap": {".ARKA TD 661": 32}},
+        "observation": MagicMock(),
+        "action": MagicMock(),
+        "action_topology": {"pst_tap": {".ARKA TD 661": 32}},
+    }
+
+    existing = svc._dict_action["pst_action_1"]
+    existing["observation"] = new_data["observation"]
+    existing["action"] = new_data["action"]
+    existing["action_topology"] = new_data["action_topology"]
+    if new_data.get("content"):
+        existing["content"] = new_data["content"]
+
+    result = svc._dict_action["pst_action_1"]
+
+    # Original library keys must still be present
+    assert result["library_extra_field"] == "some_value"
+    assert result["action_type_info"] == {"type": "pst_tap"}
+    # Updated keys should reflect the new values
+    assert result["content"]["pst_tap"][".ARKA TD 661"] == 32
+    assert result["observation"] is new_data["observation"]
+    assert result["action"] is new_data["action"]
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -170,6 +170,22 @@ function App() {
     [actionsHook, setResult, wrappedActionSelect]
   );
 
+  const handleUpdateCombinedEstimation = useCallback(
+    (pairId: string, estimation: { estimated_max_rho: number; estimated_max_rho_line: string }) => {
+      setResult(prev => {
+        if (!prev?.combined_actions?.[pairId]) return prev;
+        return {
+          ...prev,
+          combined_actions: {
+            ...prev.combined_actions,
+            [pairId]: { ...prev.combined_actions[pairId], ...estimation },
+          },
+        };
+      });
+    },
+    [setResult]
+  );
+
   const wrappedRunAnalysis = useCallback(
     () => analysis.handleRunAnalysis(selectedBranch, clearContingencyState, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab),
     [analysis, selectedBranch, clearContingencyState, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab]
@@ -658,6 +674,7 @@ function App() {
               actionDictFileName={actionDictFileName}
               actionDictStats={actionDictStats}
               onOpenSettings={handleOpenSettings}
+              onUpdateCombinedEstimation={handleUpdateCombinedEstimation}
             />
           </div>
         </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -172,7 +172,11 @@ function App() {
 
   const handleUpdateCombinedEstimation = useCallback(
     (pairId: string, estimation: { estimated_max_rho: number; estimated_max_rho_line: string }) => {
+      console.log('[handleUpdateCombinedEstimation] called with pairId:', pairId, 'estimation:', estimation);
       setResult(prev => {
+        console.log('[handleUpdateCombinedEstimation] prev combined_actions keys:',
+          prev?.combined_actions ? Object.keys(prev.combined_actions) : 'null',
+          'pairId exists:', !!prev?.combined_actions?.[pairId]);
         if (!prev?.combined_actions?.[pairId]) return prev;
         return {
           ...prev,

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -149,7 +149,7 @@ describe('api client', () => {
             const result = await api.simulateManualAction('act_1', 'LINE_B');
             expect(mockedAxios.post).toHaveBeenCalledWith(
                 'http://127.0.0.1:8000/api/simulate-manual-action',
-                { action_id: 'act_1', disconnected_element: 'LINE_B', action_content: null, lines_overloaded: null, target_mw: null },
+                { action_id: 'act_1', disconnected_element: 'LINE_B', action_content: null, lines_overloaded: null, target_mw: null, target_tap: null },
             );
             expect(result).toEqual(responseData);
         });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -90,7 +90,7 @@ export const api = {
         );
         return response.data.actions;
     },
-    simulateManualAction: async (actionId: string, disconnectedElement: string, actionContent?: Record<string, unknown> | null, linesOverloaded?: string[] | null, targetMw?: number | null): Promise<{
+    simulateManualAction: async (actionId: string, disconnectedElement: string, actionContent?: Record<string, unknown> | null, linesOverloaded?: string[] | null, targetMw?: number | null, targetTap?: number | null): Promise<{
         action_id: string;
         description_unitaire: string;
         rho_before: number[] | null;
@@ -106,11 +106,12 @@ export const api = {
         action_topology?: import('./types').ActionTopology;
         load_shedding_details?: import('./types').LoadSheddingDetail[];
         curtailment_details?: import('./types').CurtailmentDetail[];
+        pst_details?: import('./types').PstDetail[];
     }> => {
 
         const response = await axios.post(
             `${API_BASE_URL}/api/simulate-manual-action`,
-            { action_id: actionId, disconnected_element: disconnectedElement, action_content: actionContent ?? null, lines_overloaded: linesOverloaded ?? null, target_mw: targetMw ?? null }
+            { action_id: actionId, disconnected_element: disconnectedElement, action_content: actionContent ?? null, lines_overloaded: linesOverloaded ?? null, target_mw: targetMw ?? null, target_tap: targetTap ?? null }
         );
         return response.data;
     },

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -441,6 +441,7 @@ describe('ActionFeed', () => {
             null,
             ['LINE_1'],
             undefined,
+            undefined,
         );
     });
 
@@ -1228,6 +1229,386 @@ describe('ActionFeed', () => {
                 ['LINE_1'],
                 25,
             );
+        });
+    });
+
+    // =========================================================================
+    // PST Tap Start / Target Tap — score table tests
+    // =========================================================================
+    describe('PST score table - Tap Start and Target Tap', () => {
+        const pstActionId = 'pst_tap_ARKA_TD_661_inc2';
+        const pstActionId2 = 'pst_tap_PRAGNY661_inc2';
+
+        /** Helper: build actionScores for a PST type with params + tap_start */
+        function makePstScores(overrides?: {
+            params?: Record<string, Record<string, unknown>>;
+            tap_start?: Record<string, { pst_name: string; tap: number; low_tap: number | null; high_tap: number | null } | null>;
+            scores?: Record<string, number>;
+        }) {
+            return {
+                pst_tap_change: {
+                    scores: overrides?.scores ?? { [pstActionId]: -9.23, [pstActionId2]: -0.07 },
+                    params: overrides?.params ?? {
+                        [pstActionId]: { 'pst_tap': 'ARKA TD 661', 'selected_pst_tap': 29, 'previous tap': 27 },
+                        [pstActionId2]: { 'pst_tap': 'PRAGNY661', 'selected_pst_tap': 10, 'previous tap': 8 },
+                    },
+                    tap_start: overrides?.tap_start ?? {
+                        [pstActionId]: { pst_name: 'ARKA TD 661', tap: 29, low_tap: 8, high_tap: 31 },
+                        [pstActionId2]: { pst_name: 'PRAGNY661', tap: 10, low_tap: 0, high_tap: 16 },
+                    },
+                },
+            };
+        }
+
+        /** Helper: build a computed PST ActionDetail */
+        function makePstAction(tapPosition: number, pstName = 'ARKA TD 661'): ActionDetail {
+            return {
+                description_unitaire: `Variation PST ${pstName}`,
+                rho_before: [1.1],
+                rho_after: [0.95],
+                max_rho: 0.95,
+                max_rho_line: 'LINE_A',
+                is_rho_reduction: true,
+                action_topology: { ...emptyTopo, pst_tap: { [pstName]: tapPosition } },
+                pst_details: [{ pst_name: pstName, tap_position: tapPosition, low_tap: 8, high_tap: 31 }],
+            } as ActionDetail;
+        }
+
+        it('renders "Tap Start" and "Target Tap" headers for PST type in score table', async () => {
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+
+            expect(await screen.findByText('Tap Start')).toBeInTheDocument();
+            expect(screen.getByText('Target Tap')).toBeInTheDocument();
+        });
+
+        it('shows "previous tap" from params as Tap Start, NOT the action target tap', async () => {
+            // The key test: params has "previous tap": 27, but tap_start has tap: 29 (action target).
+            // Tap Start must display 27 (the N-state value from params), NOT 29.
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            // Find the table rows for PST actions
+            const rows = screen.getAllByRole('row');
+            // Find the row containing our PST action
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+
+            // Tap Start cell should show 27 (from params "previous tap"), not 29 (from tap_start.tap)
+            expect(actionRow!.textContent).toContain('27');
+            // It should NOT show 29 as the Tap Start display value
+            // (29 may appear in Target Tap input, but the start text should be 27)
+        });
+
+        it('shows "previous tap" from params for second PST action too', async () => {
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow2 = rows.find(r => r.textContent?.includes(pstActionId2));
+            expect(actionRow2).toBeDefined();
+            // Should show 8 (previous tap), not 10 (selected_pst_tap / tap_start)
+            expect(actionRow2!.textContent).toContain('8');
+        });
+
+        it('does NOT show N/A when params has "previous tap" even if action is not yet simulated', async () => {
+            // Actions not yet computed (not in actions dict) should still show Tap Start
+            // from params "previous tap" — should never be N/A when params exist
+            const props = {
+                ...defaultProps,
+                actions: {}, // No computed actions
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+            // Must show 27, NOT N/A
+            expect(actionRow!.textContent).toContain('27');
+            expect(actionRow!.textContent).not.toContain('N/A');
+        });
+
+        it('does NOT show N/A for second PST action when params exist but action is not simulated', async () => {
+            const props = {
+                ...defaultProps,
+                actions: {},
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow2 = rows.find(r => r.textContent?.includes(pstActionId2));
+            expect(actionRow2).toBeDefined();
+            expect(actionRow2!.textContent).toContain('8');
+            expect(actionRow2!.textContent).not.toContain('N/A');
+        });
+
+        it('Tap Start remains stable at "previous tap" after simulation with different target', async () => {
+            // After simulation, pst_details has tap_position: 29, but Tap Start must stay 27
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(29), // simulated with target tap 29
+                },
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+
+            // The Tap Start cell should contain "27", not "29"
+            // Get all td cells in the row
+            const cells = actionRow!.querySelectorAll('td');
+            // Second cell is Tap Start (first is Action name)
+            const tapStartCell = cells[1];
+            expect(tapStartCell).toBeDefined();
+            // The textContent of the Tap Start cell should start with 27
+            expect(tapStartCell.textContent).toMatch(/^27/);
+        });
+
+        it('Tap Start stays at "previous tap" even after re-simulation with a new tap', async () => {
+            // User re-simulated with tap 31. pst_details.tap_position is now 31.
+            // But Tap Start must still show 27 from params.
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(31), // re-simulated with target tap 31
+                },
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            const cells = actionRow!.querySelectorAll('td');
+            const tapStartCell = cells[1];
+            expect(tapStartCell.textContent).toMatch(/^27/);
+        });
+
+        it('Target Tap input defaults to "previous tap" value when no user edit', async () => {
+            // Default target tap should be the start tap (previous tap) for user convenience
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            // Should default to 27 (the previous tap / start tap)
+            expect(targetInput.value).toBe('27');
+        });
+
+        it('shows tap range [low..high] next to Tap Start', async () => {
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+            // Should show range from tap_start bounds
+            expect(actionRow!.textContent).toContain('[8..31]');
+        });
+
+        it('falls back to tap_start when params has no "previous tap"', async () => {
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores({
+                    params: {
+                        [pstActionId]: { 'pst_tap': 'ARKA TD 661', 'selected_pst_tap': 29 },
+                        // No 'previous tap' key
+                    },
+                    scores: { [pstActionId]: -9.23 },
+                }),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+            // Falls back to tap_start which has tap: 29
+            expect(actionRow!.textContent).toContain('29');
+            expect(actionRow!.textContent).not.toContain('N/A');
+        });
+
+        it('falls back to computedPst when neither params nor tap_start available', async () => {
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(29),
+                },
+                actionScores: makePstScores({
+                    params: {}, // No params
+                    tap_start: {}, // No tap_start
+                    scores: { [pstActionId]: -9.23 },
+                }),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+            // Falls back to pst_details[0].tap_position which is 29
+            expect(actionRow!.textContent).toContain('29');
+        });
+
+        it('shows N/A only when no params, no tap_start, and no pst_details', async () => {
+            const props = {
+                ...defaultProps,
+                actions: {}, // Not computed
+                actionScores: makePstScores({
+                    params: {},
+                    tap_start: {},
+                    scores: { [pstActionId]: -9.23 },
+                }),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+            expect(actionRow!.textContent).toContain('N/A');
+        });
+
+        it('syncs Target Tap input change to cardEditTap state', async () => {
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            fireEvent.change(targetInput, { target: { value: '30' } });
+            expect(targetInput.value).toBe('30');
+        });
+
+        it('reads "previous_tap" (underscore variant) from params as Tap Start', async () => {
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores({
+                    params: {
+                        [pstActionId]: { 'pst_tap': 'ARKA TD 661', 'selected_pst_tap': 29, 'previous_tap': 27 },
+                    },
+                    scores: { [pstActionId]: -9.23 },
+                }),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+            const cells = actionRow!.querySelectorAll('td');
+            const tapStartCell = cells[1];
+            expect(tapStartCell.textContent).toMatch(/^27/);
+        });
+
+        it('reads "previousTap" (camelCase variant) from params as Tap Start', async () => {
+            const props = {
+                ...defaultProps,
+                actionScores: makePstScores({
+                    params: {
+                        [pstActionId]: { 'pst_tap': 'ARKA TD 661', 'selected_pst_tap': 29, 'previousTap': 27 },
+                    },
+                    scores: { [pstActionId]: -9.23 },
+                }),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            expect(actionRow).toBeDefined();
+            const cells = actionRow!.querySelectorAll('td');
+            const tapStartCell = cells[1];
+            expect(tapStartCell.textContent).toMatch(/^27/);
+        });
+
+        it('re-simulate button in score table calls simulateManualAction with target_tap', async () => {
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+                action_id: pstActionId,
+                description_unitaire: 'Variation PST ARKA TD 661',
+                rho_before: [1.1],
+                rho_after: [0.9],
+                max_rho: 0.9,
+                max_rho_line: 'LINE_A',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                pst_details: [{ pst_name: 'ARKA TD 661', tap_position: 30, low_tap: 8, high_tap: 31 }],
+            });
+
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(29),
+                },
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            // Change target tap to 30
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            fireEvent.change(targetInput, { target: { value: '30' } });
+
+            // Click the row to trigger re-simulation
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            fireEvent.click(actionRow!);
+
+            await waitFor(() => {
+                expect(api.simulateManualAction).toHaveBeenCalledWith(
+                    pstActionId,
+                    'LINE_1',
+                    expect.anything(),
+                    ['LINE_1'],
+                    null,
+                    30,
+                );
+            });
         });
     });
 });

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -1410,10 +1410,11 @@ describe('ActionFeed', () => {
             expect(tapStartCell.textContent).toMatch(/^27/);
         });
 
-        it('Target Tap input defaults to "previous tap" value when no user edit', async () => {
-            // Default target tap should be the start tap (previous tap) for user convenience
+        it('Target Tap input defaults to "previous tap" (start tap) when action not yet simulated', async () => {
+            // When no action is computed, Target Tap defaults to start tap (previous tap)
             const props = {
                 ...defaultProps,
+                actions: {}, // NOT computed
                 actionScores: makePstScores(),
             };
             render(<ActionFeed {...props} />);
@@ -1421,7 +1422,7 @@ describe('ActionFeed', () => {
             await screen.findByText('Tap Start');
 
             const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
-            // Should default to 27 (the previous tap / start tap)
+            // Should default to 27 (the previous tap / start tap) since not yet simulated
             expect(targetInput.value).toBe('27');
         });
 
@@ -1563,6 +1564,100 @@ describe('ActionFeed', () => {
             const cells = actionRow!.querySelectorAll('td');
             const tapStartCell = cells[1];
             expect(tapStartCell.textContent).toMatch(/^27/);
+        });
+
+        it('Target Tap defaults to simulated tap (not start tap) when action is computed', async () => {
+            // Action was simulated with tap 29. Target Tap should show 29, not 27 (start tap).
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(29), // simulated with target tap 29
+                },
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            // Must be 29 (simulated tap), NOT 27 (start/previous tap)
+            expect(targetInput.value).toBe('29');
+        });
+
+        it('Target Tap defaults to start tap when action is NOT yet simulated', async () => {
+            // Action not yet computed — Target Tap should show 27 (the start tap)
+            const props = {
+                ...defaultProps,
+                actions: {}, // not computed
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            expect(targetInput.value).toBe('27');
+        });
+
+        it('Target Tap updates to re-simulated tap value (31) when action re-simulated', async () => {
+            // After re-simulation with tap 31, pst_details has tap_position 31
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(31), // re-simulated with tap 31
+                },
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            // Must show 31 (latest simulated tap), NOT 27 (start) or 29 (first sim)
+            expect(targetInput.value).toBe('31');
+        });
+
+        it('Tap Start stays at 27 while Target Tap shows 29 for a computed action', async () => {
+            // Verifies both columns are independently correct
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(29),
+                },
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            // Tap Start cell should show 27
+            const rows = screen.getAllByRole('row');
+            const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
+            const cells = actionRow!.querySelectorAll('td');
+            const tapStartCell = cells[1];
+            expect(tapStartCell.textContent).toMatch(/^27/);
+
+            // Target Tap input should show 29
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            expect(targetInput.value).toBe('29');
+        });
+
+        it('user editing Target Tap in score table overrides simulated tap', async () => {
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: makePstAction(29),
+                },
+                actionScores: makePstScores(),
+            };
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            await screen.findByText('Tap Start');
+
+            const targetInput = screen.getByTestId(`target-tap-${pstActionId}`) as HTMLInputElement;
+            expect(targetInput.value).toBe('29'); // starts at simulated
+            fireEvent.change(targetInput, { target: { value: '25' } });
+            expect(targetInput.value).toBe('25'); // user override
         });
 
         it('re-simulate button in score table calls simulateManualAction with target_tap', async () => {

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
@@ -1702,6 +1702,335 @@ describe('ActionFeed', () => {
                     ['LINE_1'],
                     null,
                     30,
+                );
+            });
+        });
+    });
+
+    // =========================================================================
+    // Combined estimation refresh on re-simulation
+    // =========================================================================
+    describe('Combined estimation refresh on re-simulation', () => {
+        beforeEach(() => {
+            vi.mocked(api.simulateManualAction).mockReset();
+            vi.mocked(api.computeSuperposition).mockReset();
+        });
+
+        const actionId = 'load_shedding_LOAD_X';
+        const otherActionId = 'line_reco_1';
+        const pairId = `${actionId}+${otherActionId}`;
+
+        const baseCombined: CombinedAction = {
+            action1_id: actionId,
+            action2_id: otherActionId,
+            betas: [0.5],
+            p_or_combined: [100],
+            max_rho: 0.85,
+            max_rho_line: 'LINE_1',
+            is_rho_reduction: true,
+            description: 'Combined action',
+            rho_after: [0.85],
+            rho_before: [1.05],
+            estimated_max_rho: 0.85,
+            estimated_max_rho_line: 'LINE_1',
+        };
+
+        it('calls computeSuperposition for related combined pairs after MW re-simulation', async () => {
+            const mockSimResult = {
+                action_id: actionId,
+                description_unitaire: 'Load shedding on LOAD_X',
+                rho_before: [0.95],
+                rho_after: [0.60],
+                max_rho: 0.60,
+                max_rho_line: 'LINE_1',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 25.0 }],
+            };
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSimResult);
+
+            const mockSuperposition: CombinedAction = {
+                ...baseCombined,
+                estimated_max_rho: 0.75,
+                estimated_max_rho_line: 'LINE_2',
+            };
+            (api.computeSuperposition as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSuperposition);
+
+            const onUpdateCombinedEstimation = vi.fn();
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [actionId]: {
+                        description_unitaire: 'Load shedding on LOAD_X',
+                        rho_before: [0.95],
+                        rho_after: [0.70],
+                        max_rho: 0.70,
+                        max_rho_line: 'LINE_1',
+                        is_rho_reduction: true,
+                        non_convergence: null,
+                        load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 42.5 }],
+                        action_topology: { ...emptyTopo, loads_p: { LOAD_X: 0.0 } },
+                    } as ActionDetail,
+                },
+                combinedActions: { [pairId]: baseCombined },
+                onUpdateCombinedEstimation,
+            };
+            render(<ActionFeed {...props} />);
+
+            // Change MW and re-simulate
+            const mwInput = screen.getByTestId(`edit-mw-${actionId}`);
+            fireEvent.change(mwInput, { target: { value: '25' } });
+            fireEvent.click(screen.getByTestId(`resimulate-${actionId}`));
+
+            await waitFor(() => {
+                expect(api.computeSuperposition).toHaveBeenCalledWith(
+                    actionId, otherActionId, 'LINE_1'
+                );
+            });
+
+            await waitFor(() => {
+                expect(onUpdateCombinedEstimation).toHaveBeenCalledWith(
+                    pairId,
+                    { estimated_max_rho: 0.75, estimated_max_rho_line: 'LINE_2' }
+                );
+            });
+        });
+
+        it('calls computeSuperposition for related combined pairs after PST tap re-simulation', async () => {
+            const pstActionId = 'pst_tap_ARKA_TD_661_inc2';
+            const pstPairId = `${pstActionId}+${otherActionId}`;
+
+            const mockSimResult = {
+                action_id: pstActionId,
+                description_unitaire: 'Variation PST ARKA TD 661',
+                rho_before: [1.1],
+                rho_after: [0.90],
+                max_rho: 0.90,
+                max_rho_line: 'LINE_A',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                pst_details: [{ pst_name: 'ARKA TD 661', tap_position: 30, low_tap: 8, high_tap: 31 }],
+            };
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSimResult);
+
+            const mockSuperposition: CombinedAction = {
+                ...baseCombined,
+                action1_id: pstActionId,
+                estimated_max_rho: 0.80,
+                estimated_max_rho_line: 'LINE_B',
+            };
+            (api.computeSuperposition as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSuperposition);
+
+            const onUpdateCombinedEstimation = vi.fn();
+            const pstCombined: CombinedAction = {
+                ...baseCombined,
+                action1_id: pstActionId,
+            };
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [pstActionId]: {
+                        description_unitaire: 'Variation PST ARKA TD 661',
+                        rho_before: [1.1],
+                        rho_after: [0.95],
+                        max_rho: 0.95,
+                        max_rho_line: 'LINE_A',
+                        is_rho_reduction: true,
+                        action_topology: { ...emptyTopo, pst_tap: { 'ARKA TD 661': 29 } },
+                        pst_details: [{ pst_name: 'ARKA TD 661', tap_position: 29, low_tap: 8, high_tap: 31 }],
+                    } as ActionDetail,
+                },
+                combinedActions: { [pstPairId]: pstCombined },
+                onUpdateCombinedEstimation,
+            };
+            render(<ActionFeed {...props} />);
+
+            // Change tap and re-simulate
+            const tapInput = screen.getByTestId(`edit-tap-${pstActionId}`);
+            fireEvent.change(tapInput, { target: { value: '30' } });
+            fireEvent.click(screen.getByTestId(`resimulate-tap-${pstActionId}`));
+
+            await waitFor(() => {
+                expect(api.computeSuperposition).toHaveBeenCalledWith(
+                    pstActionId, otherActionId, 'LINE_1'
+                );
+            });
+
+            await waitFor(() => {
+                expect(onUpdateCombinedEstimation).toHaveBeenCalledWith(
+                    pstPairId,
+                    { estimated_max_rho: 0.80, estimated_max_rho_line: 'LINE_B' }
+                );
+            });
+        });
+
+        it('does not call computeSuperposition when no combined actions exist', async () => {
+            const mockSimResult = {
+                action_id: actionId,
+                description_unitaire: 'Load shedding on LOAD_X',
+                rho_before: [0.95],
+                rho_after: [0.60],
+                max_rho: 0.60,
+                max_rho_line: 'LINE_1',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 25.0 }],
+            };
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSimResult);
+
+            const onUpdateCombinedEstimation = vi.fn();
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [actionId]: {
+                        description_unitaire: 'Load shedding on LOAD_X',
+                        rho_before: [0.95],
+                        rho_after: [0.70],
+                        max_rho: 0.70,
+                        max_rho_line: 'LINE_1',
+                        is_rho_reduction: true,
+                        non_convergence: null,
+                        load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 42.5 }],
+                        action_topology: { ...emptyTopo, loads_p: { LOAD_X: 0.0 } },
+                    } as ActionDetail,
+                },
+                combinedActions: null,
+                onUpdateCombinedEstimation,
+            };
+            render(<ActionFeed {...props} />);
+
+            // Change MW and re-simulate
+            const mwInput = screen.getByTestId(`edit-mw-${actionId}`);
+            fireEvent.change(mwInput, { target: { value: '25' } });
+            fireEvent.click(screen.getByTestId(`resimulate-${actionId}`));
+
+            await waitFor(() => {
+                expect(api.simulateManualAction).toHaveBeenCalled();
+            });
+
+            // computeSuperposition should NOT be called
+            expect(api.computeSuperposition).not.toHaveBeenCalled();
+            expect(onUpdateCombinedEstimation).not.toHaveBeenCalled();
+        });
+
+        it('does not call onUpdateCombinedEstimation when computeSuperposition returns error', async () => {
+            const mockSimResult = {
+                action_id: actionId,
+                description_unitaire: 'Load shedding on LOAD_X',
+                rho_before: [0.95],
+                rho_after: [0.60],
+                max_rho: 0.60,
+                max_rho_line: 'LINE_1',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 25.0 }],
+            };
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSimResult);
+
+            const errorResult: CombinedAction = {
+                ...baseCombined,
+                error: 'Estimation failed',
+            };
+            (api.computeSuperposition as ReturnType<typeof vi.fn>).mockResolvedValueOnce(errorResult);
+
+            const onUpdateCombinedEstimation = vi.fn();
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [actionId]: {
+                        description_unitaire: 'Load shedding on LOAD_X',
+                        rho_before: [0.95],
+                        rho_after: [0.70],
+                        max_rho: 0.70,
+                        max_rho_line: 'LINE_1',
+                        is_rho_reduction: true,
+                        non_convergence: null,
+                        load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 42.5 }],
+                        action_topology: { ...emptyTopo, loads_p: { LOAD_X: 0.0 } },
+                    } as ActionDetail,
+                },
+                combinedActions: { [pairId]: baseCombined },
+                onUpdateCombinedEstimation,
+            };
+            render(<ActionFeed {...props} />);
+
+            const mwInput = screen.getByTestId(`edit-mw-${actionId}`);
+            fireEvent.change(mwInput, { target: { value: '25' } });
+            fireEvent.click(screen.getByTestId(`resimulate-${actionId}`));
+
+            await waitFor(() => {
+                expect(api.computeSuperposition).toHaveBeenCalled();
+            });
+
+            // onUpdateCombinedEstimation should NOT be called because of error
+            expect(onUpdateCombinedEstimation).not.toHaveBeenCalled();
+        });
+
+        it('refreshes multiple combined pairs when action appears in several combinations', async () => {
+            const thirdActionId = 'line_disco_2';
+            const pairId2 = `${actionId}+${thirdActionId}`;
+
+            const mockSimResult = {
+                action_id: actionId,
+                description_unitaire: 'Load shedding on LOAD_X',
+                rho_before: [0.95],
+                rho_after: [0.60],
+                max_rho: 0.60,
+                max_rho_line: 'LINE_1',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 25.0 }],
+            };
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockSimResult);
+
+            const mockSuper1: CombinedAction = { ...baseCombined, estimated_max_rho: 0.75, estimated_max_rho_line: 'LINE_2' };
+            const mockSuper2: CombinedAction = { ...baseCombined, action2_id: thirdActionId, estimated_max_rho: 0.80, estimated_max_rho_line: 'LINE_3' };
+            (api.computeSuperposition as ReturnType<typeof vi.fn>)
+                .mockResolvedValueOnce(mockSuper1)
+                .mockResolvedValueOnce(mockSuper2);
+
+            const onUpdateCombinedEstimation = vi.fn();
+            const combined2: CombinedAction = { ...baseCombined, action2_id: thirdActionId };
+            const props = {
+                ...defaultProps,
+                actions: {
+                    [actionId]: {
+                        description_unitaire: 'Load shedding on LOAD_X',
+                        rho_before: [0.95],
+                        rho_after: [0.70],
+                        max_rho: 0.70,
+                        max_rho_line: 'LINE_1',
+                        is_rho_reduction: true,
+                        non_convergence: null,
+                        load_shedding_details: [{ load_name: 'LOAD_X', voltage_level_id: 'VL_A', shedded_mw: 42.5 }],
+                        action_topology: { ...emptyTopo, loads_p: { LOAD_X: 0.0 } },
+                    } as ActionDetail,
+                },
+                combinedActions: { [pairId]: baseCombined, [pairId2]: combined2 },
+                onUpdateCombinedEstimation,
+            };
+            render(<ActionFeed {...props} />);
+
+            const mwInput = screen.getByTestId(`edit-mw-${actionId}`);
+            fireEvent.change(mwInput, { target: { value: '25' } });
+            fireEvent.click(screen.getByTestId(`resimulate-${actionId}`));
+
+            await waitFor(() => {
+                expect(api.computeSuperposition).toHaveBeenCalledTimes(2);
+            });
+
+            await waitFor(() => {
+                expect(onUpdateCombinedEstimation).toHaveBeenCalledTimes(2);
+                expect(onUpdateCombinedEstimation).toHaveBeenCalledWith(
+                    pairId, { estimated_max_rho: 0.75, estimated_max_rho_line: 'LINE_2' }
+                );
+                expect(onUpdateCombinedEstimation).toHaveBeenCalledWith(
+                    pairId2, { estimated_max_rho: 0.80, estimated_max_rho_line: 'LINE_3' }
                 );
             });
         });

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -907,9 +907,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
                                                                     // PST tap: read from cardEditTap (synchronized with action card)
-                                                                    const tapInfo = isPstType ? tapStartMap?.[item.actionId] : undefined;
+                                                                    // Tap info: prefer pst_details from computed action, fall back to tap_start from scores
+                                                                    const computedPst = isPstType ? actions[item.actionId]?.pst_details?.[0] : undefined;
+                                                                    const tapInfo = isPstType
+                                                                        ? (computedPst
+                                                                            ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
+                                                                            : tapStartMap?.[item.actionId] ?? null)
+                                                                        : undefined;
                                                                     const tapEditVal = cardEditTap[item.actionId];
-                                                                    const parsedTap = tapEditVal !== undefined ? parseInt(tapEditVal, 10) : null;
+                                                                    const effectiveTap = tapEditVal ?? (tapInfo ? String(tapInfo.tap) : undefined);
+                                                                    const parsedTap = effectiveTap !== undefined ? parseInt(effectiveTap, 10) : null;
                                                                     const isValidTap = parsedTap !== null && !isNaN(parsedTap) && (tapInfo?.low_tap == null || parsedTap >= tapInfo.low_tap) && (tapInfo?.high_tap == null || parsedTap <= tapInfo.high_tap);
                                                                     const canResimTap = isPstType && isComputed && isValidTap;
                                                                     return (
@@ -1017,8 +1024,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                         min={tapInfo?.low_tap ?? undefined}
                                                                                         max={tapInfo?.high_tap ?? undefined}
                                                                                         step={1}
-                                                                                        placeholder={tapInfo != null ? String(tapInfo.tap) : '0'}
-                                                                                        value={cardEditTap[item.actionId] ?? ''}
+                                                                                        value={cardEditTap[item.actionId] ?? (tapInfo ? String(tapInfo.tap) : '')}
                                                                                         onChange={(e) => setCardEditTap(prev => ({ ...prev, [item.actionId]: e.target.value }))}
                                                                                         style={{
                                                                                             width: '50px',

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -909,9 +909,6 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                     // PST tap: read from cardEditTap (synchronized with action card)
                                                                     // Tap Start: "previous tap" from action params (N-state), then tapStartMap, then computedPst
                                                                     const actionParams = isPstType ? typeData.params?.[item.actionId] : undefined;
-                                                                    if (isPstType && actionParams) {
-                                                                        console.log(`[PST tapInfo debug] actionId=${item.actionId} params keys:`, Object.keys(actionParams), 'values:', actionParams);
-                                                                    }
                                                                     // Try multiple key variants for the previous tap value
                                                                     const previousTap = actionParams
                                                                         ? (actionParams['previous tap'] ?? actionParams['previous_tap'] ?? actionParams['previousTap'] ??
@@ -935,11 +932,11 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                     ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
                                                                                     : null)
                                                                         : undefined;
-                                                                    if (isPstType) {
-                                                                        console.log(`[PST tapInfo debug] actionId=${item.actionId} previousTap=${previousTap} tapStartEntry=`, tapStartEntry, 'computedPst=', computedPst, '=> tapInfo=', tapInfo);
-                                                                    }
                                                                     const tapEditVal = cardEditTap[item.actionId];
-                                                                    const effectiveTap = tapEditVal ?? (tapInfo ? String(tapInfo.tap) : undefined);
+                                                                    // Target Tap default: user edit > simulated tap (from pst_details) > start tap
+                                                                    const simulatedTap = computedPst ? String(computedPst.tap_position) : undefined;
+                                                                    const defaultTap = simulatedTap ?? (tapInfo ? String(tapInfo.tap) : undefined);
+                                                                    const effectiveTap = tapEditVal ?? defaultTap;
                                                                     const parsedTap = effectiveTap !== undefined ? parseInt(effectiveTap, 10) : null;
                                                                     const isValidTap = parsedTap !== null && !isNaN(parsedTap) && (tapInfo?.low_tap == null || parsedTap >= tapInfo.low_tap) && (tapInfo?.high_tap == null || parsedTap <= tapInfo.high_tap);
                                                                     const canResimTap = isPstType && isComputed && isValidTap;
@@ -995,11 +992,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                                         Islanding: {actions[item.actionId].n_components} components
                                                                                                     </div>
                                                                                                 )}
-                                                                                                {Object.entries(typeData.params![item.actionId]).map(([k, v]) => (
-                                                                                                    <div key={k}>
-                                                                                                        <span style={{ color: '#adb5bd' }}>{k}:</span> {typeof v === 'object' ? JSON.stringify(v) : String(v)}
-                                                                                                    </div>
-                                                                                                ))}
+                                                                                                {Object.entries(typeData.params![item.actionId]).map(([k, v]) => {
+                                                                                                    // For PST: overlay current target tap on selected_pst_tap / target_tap fields
+                                                                                                    const isTargetTapKey = isPstType && (k === 'selected_pst_tap' || k.toLowerCase().includes('target') && k.toLowerCase().includes('tap'));
+                                                                                                    const displayVal = isTargetTapKey && effectiveTap !== undefined ? effectiveTap : (typeof v === 'object' ? JSON.stringify(v) : String(v));
+                                                                                                    return (
+                                                                                                        <div key={k}>
+                                                                                                            <span style={{ color: '#adb5bd' }}>{k}:</span> {displayVal}
+                                                                                                        </div>
+                                                                                                    );
+                                                                                                })}
                                                                                             </>
                                                                                         ))}
                                                                                         onMouseLeave={hideTooltip}
@@ -1048,7 +1050,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                         min={tapInfo?.low_tap ?? undefined}
                                                                                         max={tapInfo?.high_tap ?? undefined}
                                                                                         step={1}
-                                                                                        value={cardEditTap[item.actionId] ?? (tapInfo ? String(tapInfo.tap) : '')}
+                                                                                        value={cardEditTap[item.actionId] ?? (simulatedTap ?? (tapInfo ? String(tapInfo.tap) : ''))}
                                                                                         onChange={(e) => setCardEditTap(prev => ({ ...prev, [item.actionId]: e.target.value }))}
                                                                                         style={{
                                                                                             width: '50px',

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -239,7 +239,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
         return () => document.removeEventListener('mousedown', handler);
     }, [searchOpen]);
 
-    const handleAddAction = async (actionId: string, targetMw?: number) => {
+    const handleAddAction = async (actionId: string, targetMw?: number, targetTap?: number) => {
         const trimmedId = actionId.trim();
         if (!disconnectedElement) {
             setError('Select a contingency first.');
@@ -269,7 +269,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 }
             }
 
-            const result = await api.simulateManualAction(trimmedId, disconnectedElement, actionContent, linesOverloaded, targetMw);
+            const result = await api.simulateManualAction(trimmedId, disconnectedElement, actionContent, linesOverloaded, targetMw, targetTap);
             const detail: ActionDetail = {
                 description_unitaire: result.description_unitaire,
                 rho_before: result.rho_before,
@@ -865,6 +865,9 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                 const globalParams = isPerActionParams ? null : (paramsKeys.length > 0 ? typeData.params : null);
 
                                                 const isLsOrRcType = type === 'load_shedding' || type.includes('load_shedding') || type === 'renewable_curtailment' || type.includes('renewable_curtailment');
+                                                const isPstType = type === 'pst_tap_change' || type.includes('pst');
+                                                const hasEditableColumn = isLsOrRcType || isPstType;
+                                                const tapStartMap = isPstType ? (typeData as { tap_start?: Record<string, { pst_name: string; tap: number; low_tap: number | null; high_tap: number | null } | null> }).tap_start : undefined;
                                                 return (
                                                     <div key={type} style={{ marginBottom: '8px' }}>
                                                         <div style={{ fontSize: '11px', fontWeight: 600, color: '#0056b3', backgroundColor: '#e9ecef', padding: '2px 6px', borderRadius: '4px 4px 0 0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -889,10 +892,11 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                         <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', border: '1px solid #e9ecef', borderTop: 'none' }}>
                                                             <thead>
                                                                 <tr style={{ background: '#f8f9fa', borderBottom: '1px solid #ddd' }}>
-                                                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: isLsOrRcType ? '40%' : '55%' }}>Action</th>
-                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '15%' }}>MW Start</th>
+                                                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '40%' : '55%' }}>Action</th>
+                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '15%' }}>{isPstType ? 'Tap Start' : 'MW Start'}</th>
                                                                     {isLsOrRcType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}>Target MW</th>}
-                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: isLsOrRcType ? '15%' : '25%' }}>Score</th>
+                                                                    {isPstType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}>Target Tap</th>}
+                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: hasEditableColumn ? '15%' : '25%' }}>Score</th>
                                                                 </tr>
                                                             </thead>
                                                             <tbody>
@@ -902,6 +906,12 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                     const parsedTarget = targetVal !== undefined ? parseFloat(targetVal) : null;
                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
+                                                                    // PST tap: read from cardEditTap (synchronized with action card)
+                                                                    const tapInfo = isPstType ? tapStartMap?.[item.actionId] : undefined;
+                                                                    const tapEditVal = cardEditTap[item.actionId];
+                                                                    const parsedTap = tapEditVal !== undefined ? parseInt(tapEditVal, 10) : null;
+                                                                    const isValidTap = parsedTap !== null && !isNaN(parsedTap) && (tapInfo?.low_tap == null || parsedTap >= tapInfo.low_tap) && (tapInfo?.high_tap == null || parsedTap <= tapInfo.high_tap);
+                                                                    const canResimTap = isPstType && isComputed && isValidTap;
                                                                     return (
                                                                         <tr key={item.actionId}
                                                                             onClick={() => {
@@ -910,14 +920,19 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                     handleResimulate(item.actionId, parsedTarget!);
                                                                                     return;
                                                                                 }
+                                                                                if (canResimTap) {
+                                                                                    handleResimulateTap(item.actionId, parsedTap!);
+                                                                                    return;
+                                                                                }
                                                                                 if (isComputed) return;
                                                                                 const mw = isLsOrRcType && isValidTarget ? parsedTarget! : undefined;
-                                                                                handleAddAction(item.actionId, mw);
+                                                                                const tap = isPstType && isValidTap ? parsedTap! : undefined;
+                                                                                handleAddAction(item.actionId, mw, tap);
                                                                             }}
                                                                             style={{
                                                                                 borderBottom: '1px solid #eee',
-                                                                                cursor: (simulating || resimulating) ? 'wait' : (isComputed && !canResimulate) ? 'not-allowed' : 'pointer',
-                                                                                color: (isComputed && !canResimulate) ? '#888' : 'inherit',
+                                                                                cursor: (simulating || resimulating) ? 'wait' : (isComputed && !canResimulate && !canResimTap) ? 'not-allowed' : 'pointer',
+                                                                                color: (isComputed && !canResimulate && !canResimTap) ? '#888' : 'inherit',
                                                                                 opacity: (simulating === item.actionId || resimulating === item.actionId) ? 0.7 : 1,
                                                                                 background: (simulating === item.actionId || resimulating === item.actionId) ? '#e7f1ff' : 'transparent',
                                                                             }}>
@@ -960,8 +975,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                     >i</span>
                                                                                 )}
                                                                             </td>
-                                                                            <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: item.mwStart == null ? '#aaa' : '#333' }}>
-                                                                                {item.mwStart != null ? item.mwStart.toFixed(1) : 'N/A'}
+                                                                            <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: (isPstType ? tapInfo == null : item.mwStart == null) ? '#aaa' : '#333' }}>
+                                                                                {isPstType
+                                                                                    ? (tapInfo != null ? `${tapInfo.tap}` : 'N/A')
+                                                                                    : (item.mwStart != null ? item.mwStart.toFixed(1) : 'N/A')
+                                                                                }
+                                                                                {isPstType && tapInfo?.low_tap != null && tapInfo?.high_tap != null && (
+                                                                                    <span style={{ fontSize: '9px', color: '#7c3aed', marginLeft: '2px' }}>
+                                                                                        [{tapInfo.low_tap}..{tapInfo.high_tap}]
+                                                                                    </span>
+                                                                                )}
                                                                             </td>
                                                                             {isLsOrRcType && (
                                                                                 <td style={{ padding: '2px 4px', textAlign: 'right' }} onClick={(e) => e.stopPropagation()}>
@@ -980,6 +1003,29 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                             fontFamily: 'monospace',
                                                                                             padding: '2px 4px',
                                                                                             border: '1px solid #ccc',
+                                                                                            borderRadius: '3px',
+                                                                                            textAlign: 'right',
+                                                                                        }}
+                                                                                    />
+                                                                                </td>
+                                                                            )}
+                                                                            {isPstType && (
+                                                                                <td style={{ padding: '2px 4px', textAlign: 'right' }} onClick={(e) => e.stopPropagation()}>
+                                                                                    <input
+                                                                                        data-testid={`target-tap-${item.actionId}`}
+                                                                                        type="number"
+                                                                                        min={tapInfo?.low_tap ?? undefined}
+                                                                                        max={tapInfo?.high_tap ?? undefined}
+                                                                                        step={1}
+                                                                                        placeholder={tapInfo != null ? String(tapInfo.tap) : '0'}
+                                                                                        value={cardEditTap[item.actionId] ?? ''}
+                                                                                        onChange={(e) => setCardEditTap(prev => ({ ...prev, [item.actionId]: e.target.value }))}
+                                                                                        style={{
+                                                                                            width: '50px',
+                                                                                            fontSize: '11px',
+                                                                                            fontFamily: 'monospace',
+                                                                                            padding: '2px 4px',
+                                                                                            border: '1px solid #9333ea',
                                                                                             borderRadius: '3px',
                                                                                             textAlign: 'right',
                                                                                         }}

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -909,7 +909,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                     // PST tap: read from cardEditTap (synchronized with action card)
                                                                     // Tap Start: "previous tap" from action params (N-state), then tapStartMap, then computedPst
                                                                     const actionParams = isPstType ? typeData.params?.[item.actionId] : undefined;
-                                                                    const previousTap = actionParams?.['previous tap'] as number | undefined;
+                                                                    if (isPstType && actionParams) {
+                                                                        console.log(`[PST tapInfo debug] actionId=${item.actionId} params keys:`, Object.keys(actionParams), 'values:', actionParams);
+                                                                    }
+                                                                    // Try multiple key variants for the previous tap value
+                                                                    const previousTap = actionParams
+                                                                        ? (actionParams['previous tap'] ?? actionParams['previous_tap'] ?? actionParams['previousTap'] ??
+                                                                           // Fallback: find any key containing "previous" and "tap"
+                                                                           Object.entries(actionParams).find(([k]) => k.toLowerCase().includes('previous') && k.toLowerCase().includes('tap'))?.[1]
+                                                                          ) as number | undefined
+                                                                        : undefined;
                                                                     const tapStartEntry = isPstType ? tapStartMap?.[item.actionId] ?? null : undefined;
                                                                     const computedPst = isPstType ? actions[item.actionId]?.pst_details?.[0] : undefined;
                                                                     const tapInfo = isPstType
@@ -926,6 +935,9 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                                     ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
                                                                                     : null)
                                                                         : undefined;
+                                                                    if (isPstType) {
+                                                                        console.log(`[PST tapInfo debug] actionId=${item.actionId} previousTap=${previousTap} tapStartEntry=`, tapStartEntry, 'computedPst=', computedPst, '=> tapInfo=', tapInfo);
+                                                                    }
                                                                     const tapEditVal = cardEditTap[item.actionId];
                                                                     const effectiveTap = tapEditVal ?? (tapInfo ? String(tapInfo.tap) : undefined);
                                                                     const parsedTap = effectiveTap !== undefined ? parseInt(effectiveTap, 10) : null;

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -302,19 +302,32 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
 
     // Refresh combined estimations for all pairs that include the given action
     const refreshCombinedEstimations = async (actionId: string) => {
+        console.log('[refreshCombinedEstimations] called for:', actionId,
+            'combinedActions:', combinedActions ? Object.keys(combinedActions).length : null,
+            'disconnectedElement:', disconnectedElement,
+            'hasCallback:', !!onUpdateCombinedEstimation);
         if (!combinedActions || !disconnectedElement || !onUpdateCombinedEstimation) return;
         const relatedPairs = Object.entries(combinedActions).filter(([pairId]) => {
             const parts = pairId.split('+').map(p => p.trim());
             return parts.includes(actionId);
         });
+        console.log('[refreshCombinedEstimations] found', relatedPairs.length, 'related pairs:',
+            relatedPairs.map(([id]) => id));
         for (const [pairId] of relatedPairs) {
             const parts = pairId.split('+').map(p => p.trim());
             const [id1, id2] = parts;
             try {
                 const result = await api.computeSuperposition(id1, id2, disconnectedElement);
+                console.log('[refreshCombinedEstimations] superposition result for', pairId, ':', {
+                    error: result.error,
+                    estimated_max_rho: result.estimated_max_rho,
+                    max_rho: result.max_rho,
+                    max_rho_line: result.max_rho_line,
+                });
                 if (!result.error) {
                     const estRho = result.estimated_max_rho ?? result.max_rho;
                     const estLine = result.estimated_max_rho_line ?? result.max_rho_line;
+                    console.log('[refreshCombinedEstimations] updating pair', pairId, 'with estRho:', estRho, 'estLine:', estLine);
                     onUpdateCombinedEstimation(pairId, { estimated_max_rho: estRho, estimated_max_rho_line: estLine });
                 }
             } catch (e) {

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -87,6 +87,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     const [scoreTargetMw, setScoreTargetMw] = useState<Record<string, string>>({});
     // Per-action editable MW for action card re-simulation (keyed by actionId)
     const [cardEditMw, setCardEditMw] = useState<Record<string, string>>({});
+    // Per-action editable tap position for PST action re-simulation (keyed by actionId)
+    const [cardEditTap, setCardEditTap] = useState<Record<string, string>>({});
     const [resimulating, setResimulating] = useState<string | null>(null);
     const [dismissedRejectedWarning, setDismissedRejectedWarning] = useState(false);
     const [showActionDictWarning, setShowActionDictWarning] = useState(true);
@@ -281,6 +283,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 non_convergence: result.non_convergence,
                 load_shedding_details: result.load_shedding_details,
                 curtailment_details: result.curtailment_details,
+                pst_details: result.pst_details,
 
             };
             onManualActionAdded(trimmedId, detail, result.lines_overloaded || []);
@@ -316,6 +319,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 non_convergence: result.non_convergence,
                 load_shedding_details: result.load_shedding_details,
                 curtailment_details: result.curtailment_details,
+                pst_details: result.pst_details,
             };
             onManualActionAdded(actionId, newDetail, result.lines_overloaded || []);
             // Clear the edit input so it picks up the new shedded/curtailed MW from results
@@ -327,6 +331,44 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
             });
         } catch (e: unknown) {
             console.error('Re-simulation failed:', e);
+        } finally {
+            setResimulating(null);
+        }
+    };
+
+    // Re-simulate an existing PST action with a new tap position
+    const handleResimulateTap = async (actionId: string, newTap: number) => {
+        if (!disconnectedElement) return;
+        setResimulating(actionId);
+        try {
+            const detail = actions[actionId];
+            const actionContent = detail?.action_topology ? detail.action_topology as unknown as Record<string, unknown> : null;
+            const result = await api.simulateManualAction(actionId, disconnectedElement, actionContent, linesOverloaded, null, newTap);
+            const newDetail: ActionDetail = {
+                description_unitaire: result.description_unitaire,
+                rho_before: result.rho_before,
+                rho_after: result.rho_after,
+                max_rho: result.max_rho,
+                max_rho_line: result.max_rho_line,
+                is_rho_reduction: result.is_rho_reduction,
+                is_islanded: result.is_islanded,
+                n_components: result.n_components,
+                disconnected_mw: result.disconnected_mw,
+                non_convergence: result.non_convergence,
+                load_shedding_details: result.load_shedding_details,
+                curtailment_details: result.curtailment_details,
+                pst_details: result.pst_details,
+            };
+            onManualActionAdded(actionId, newDetail, result.lines_overloaded || []);
+            // Clear the edit input so it picks up the new tap from results
+            setCardEditTap(prev => {
+                if (!prev[actionId]) return prev;
+                const next = { ...prev };
+                delete next[actionId];
+                return next;
+            });
+        } catch (e: unknown) {
+            console.error('PST re-simulation failed:', e);
         } finally {
             setResimulating(null);
         }
@@ -524,6 +566,41 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                 }}
                                                 disabled={resimulating === id}
                                                 style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: '1px solid #0284c7', background: '#38bdf8', color: '#0c4a6e', cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
+                                            >
+                                                {resimulating === id ? 'Simulating...' : 'Re-simulate'}
+                                            </button>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                            {details.pst_details && details.pst_details.length > 0 && (
+                                <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: '#f3e8ff', color: '#6b21a8', padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: '1px solid #c084fc', fontWeight: 500 }}>
+                                    {details.pst_details.map((pst, i) => (
+                                        <div key={pst.pst_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
+                                            <span>PST <strong>{pst.pst_name}</strong> tap:</span>
+                                            <input
+                                                data-testid={`edit-tap-${id}`}
+                                                type="number"
+                                                min={pst.low_tap ?? undefined}
+                                                max={pst.high_tap ?? undefined}
+                                                step={1}
+                                                value={cardEditTap[id] ?? pst.tap_position}
+                                                onChange={(e) => setCardEditTap(prev => ({ ...prev, [id]: e.target.value }))}
+                                                style={{ width: '55px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: '1px solid #9333ea', borderRadius: '3px', textAlign: 'right' }}
+                                            />
+                                            {pst.low_tap != null && pst.high_tap != null && (
+                                                <span style={{ fontSize: '10px', color: '#7c3aed' }}>
+                                                    [{pst.low_tap}..{pst.high_tap}]
+                                                </span>
+                                            )}
+                                            <button
+                                                data-testid={`resimulate-tap-${id}`}
+                                                onClick={() => {
+                                                    const tapVal = parseInt(cardEditTap[id] ?? String(pst.tap_position), 10);
+                                                    if (!isNaN(tapVal)) handleResimulateTap(id, tapVal);
+                                                }}
+                                                disabled={resimulating === id}
+                                                style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: '1px solid #9333ea', background: '#c084fc', color: '#3b0764', cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
                                             >
                                                 {resimulating === id ? 'Simulating...' : 'Re-simulate'}
                                             </button>

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -907,16 +907,24 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
                                                                     // PST tap: read from cardEditTap (synchronized with action card)
-                                                                    // Tap Start = base N-state network tap from tapStartMap (scores)
-                                                                    // Bounds from tapStartMap, with computedPst as fallback
+                                                                    // Tap Start: "previous tap" from action params (N-state), then tapStartMap, then computedPst
+                                                                    const actionParams = isPstType ? typeData.params?.[item.actionId] : undefined;
+                                                                    const previousTap = actionParams?.['previous tap'] as number | undefined;
                                                                     const tapStartEntry = isPstType ? tapStartMap?.[item.actionId] ?? null : undefined;
                                                                     const computedPst = isPstType ? actions[item.actionId]?.pst_details?.[0] : undefined;
                                                                     const tapInfo = isPstType
-                                                                        ? (tapStartEntry
-                                                                            ? tapStartEntry
-                                                                            : computedPst
-                                                                                ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
-                                                                                : null)
+                                                                        ? (previousTap !== undefined
+                                                                            ? {
+                                                                                pst_name: tapStartEntry?.pst_name ?? computedPst?.pst_name ?? '',
+                                                                                tap: previousTap,
+                                                                                low_tap: tapStartEntry?.low_tap ?? computedPst?.low_tap ?? null,
+                                                                                high_tap: tapStartEntry?.high_tap ?? computedPst?.high_tap ?? null,
+                                                                            }
+                                                                            : tapStartEntry
+                                                                                ? tapStartEntry
+                                                                                : computedPst
+                                                                                    ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
+                                                                                    : null)
                                                                         : undefined;
                                                                     const tapEditVal = cardEditTap[item.actionId];
                                                                     const effectiveTap = tapEditVal ?? (tapInfo ? String(tapInfo.tap) : undefined);

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -39,6 +39,7 @@ interface ActionFeedProps {
     actionDictFileName?: string | null;
     actionDictStats?: { reco: number; disco: number; pst: number; open_coupling: number; close_coupling: number; total: number } | null;
     combinedActions: Record<string, CombinedAction> | null;
+    onUpdateCombinedEstimation?: (pairId: string, estimation: { estimated_max_rho: number; estimated_max_rho_line: string }) => void;
 }
 
 const ActionFeed: React.FC<ActionFeedProps> = ({
@@ -69,6 +70,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     actionDictFileName,
     actionDictStats,
     combinedActions,
+    onUpdateCombinedEstimation,
 }) => {
     const [searchOpen, setSearchOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
@@ -298,6 +300,29 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
         }
     };
 
+    // Refresh combined estimations for all pairs that include the given action
+    const refreshCombinedEstimations = async (actionId: string) => {
+        if (!combinedActions || !disconnectedElement || !onUpdateCombinedEstimation) return;
+        const relatedPairs = Object.entries(combinedActions).filter(([pairId]) => {
+            const parts = pairId.split('+').map(p => p.trim());
+            return parts.includes(actionId);
+        });
+        for (const [pairId] of relatedPairs) {
+            const parts = pairId.split('+').map(p => p.trim());
+            const [id1, id2] = parts;
+            try {
+                const result = await api.computeSuperposition(id1, id2, disconnectedElement);
+                if (!result.error) {
+                    const estRho = result.estimated_max_rho ?? result.max_rho;
+                    const estLine = result.estimated_max_rho_line ?? result.max_rho_line;
+                    onUpdateCombinedEstimation(pairId, { estimated_max_rho: estRho, estimated_max_rho_line: estLine });
+                }
+            } catch (e) {
+                console.error(`Failed to refresh estimation for pair ${pairId}:`, e);
+            }
+        }
+    };
+
     // Re-simulate an existing action with a new target MW value
     const handleResimulate = async (actionId: string, newTargetMw: number) => {
         if (!disconnectedElement) return;
@@ -329,6 +354,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 delete next[actionId];
                 return next;
             });
+            // Refresh combined estimations for pairs containing this action
+            refreshCombinedEstimations(actionId);
         } catch (e: unknown) {
             console.error('Re-simulation failed:', e);
         } finally {
@@ -367,6 +394,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 delete next[actionId];
                 return next;
             });
+            // Refresh combined estimations for pairs containing this action
+            refreshCombinedEstimations(actionId);
         } catch (e: unknown) {
             console.error('PST re-simulation failed:', e);
         } finally {

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -907,12 +907,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
                                                                     // PST tap: read from cardEditTap (synchronized with action card)
-                                                                    // Tap info: prefer pst_details from computed action, fall back to tap_start from scores
+                                                                    // Tap Start = base N-state network tap from tapStartMap (scores)
+                                                                    // Bounds from tapStartMap, with computedPst as fallback
+                                                                    const tapStartEntry = isPstType ? tapStartMap?.[item.actionId] ?? null : undefined;
                                                                     const computedPst = isPstType ? actions[item.actionId]?.pst_details?.[0] : undefined;
                                                                     const tapInfo = isPstType
-                                                                        ? (computedPst
-                                                                            ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
-                                                                            : tapStartMap?.[item.actionId] ?? null)
+                                                                        ? (tapStartEntry
+                                                                            ? tapStartEntry
+                                                                            : computedPst
+                                                                                ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
+                                                                                : null)
                                                                         : undefined;
                                                                     const tapEditVal = cardEditTap[item.actionId];
                                                                     const effectiveTap = tapEditVal ?? (tapInfo ? String(tapInfo.tap) : undefined);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -50,6 +50,12 @@ export interface CurtailmentDetail {
     voltage_level_id: string | null;
     curtailed_mw: number;
 }
+export interface PstDetail {
+    pst_name: string;
+    tap_position: number;
+    low_tap: number | null;
+    high_tap: number | null;
+}
 
 export interface ActionDetail {
     description_unitaire: string;
@@ -70,6 +76,7 @@ export interface ActionDetail {
     lines_overloaded_after?: string[];
     load_shedding_details?: LoadSheddingDetail[];
     curtailment_details?: CurtailmentDetail[];
+    pst_details?: PstDetail[];
 }
 
 export interface CombinedAction {
@@ -268,6 +275,7 @@ export interface SavedActionEntry {
     lines_overloaded_after?: string[];
     load_shedding_details?: LoadSheddingDetail[];
     curtailment_details?: CurtailmentDetail[];
+    pst_details?: PstDetail[];
     status: SavedActionStatus;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -101,7 +101,7 @@ export interface AnalysisResult {
     pdf_path: string | null;
     pdf_url: string | null;
     actions: Record<string, ActionDetail>;
-    action_scores?: Record<string, { scores: Record<string, number>; mw_start?: Record<string, number | null> }>;
+    action_scores?: Record<string, { scores: Record<string, number>; mw_start?: Record<string, number | null>; tap_start?: Record<string, { pst_name: string; tap: number; low_tap: number | null; high_tap: number | null } | null> }>;
     lines_overloaded: string[];
     combined_actions?: Record<string, CombinedAction>;
     message: string;

--- a/frontend/src/utils/sessionUtils.ts
+++ b/frontend/src/utils/sessionUtils.ts
@@ -130,6 +130,7 @@ export function buildSessionResult(input: SessionInput): SessionResult {
                         disconnected_mw: detail.disconnected_mw,
                         load_shedding_details: detail.load_shedding_details,
                         curtailment_details: detail.curtailment_details,
+                        pst_details: detail.pst_details,
                         status: {
                             is_selected: selectedActionIds.has(id),
                             // An action is "suggested" if the recommender ever returned it —

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -6024,9 +6024,16 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
                                                                                     // PST tap: read from cardEditTap (synchronized with action card)
-                                                                                    const tapInfo = isPstType ? (tapStartMap || {})[item.actionId] : undefined;
+                                                                                    // Tap info: prefer pst_details from computed action, fall back to tap_start from scores
+                                                                                    const computedPst = isPstType && isComputed ? result?.actions?.[item.actionId]?.pst_details?.[0] : undefined;
+                                                                                    const tapInfo = isPstType
+                                                                                        ? (computedPst
+                                                                                            ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
+                                                                                            : (tapStartMap || {})[item.actionId] || null)
+                                                                                        : undefined;
                                                                                     const tapEditVal = cardEditTap[item.actionId];
-                                                                                    const parsedTap = tapEditVal !== undefined ? parseInt(tapEditVal, 10) : null;
+                                                                                    const effectiveTap = tapEditVal != null ? tapEditVal : (tapInfo ? String(tapInfo.tap) : undefined);
+                                                                                    const parsedTap = effectiveTap !== undefined ? parseInt(effectiveTap, 10) : null;
                                                                                     const isValidTap = parsedTap !== null && !isNaN(parsedTap) && (tapInfo?.low_tap == null || parsedTap >= tapInfo.low_tap) && (tapInfo?.high_tap == null || parsedTap <= tapInfo.high_tap);
                                                                                     const canResimTap = isPstType && isComputed && isValidTap;
                                                                                     return (
@@ -6118,8 +6125,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                                         min={tapInfo?.low_tap != null ? tapInfo.low_tap : undefined}
                                                                                                         max={tapInfo?.high_tap != null ? tapInfo.high_tap : undefined}
                                                                                                         step={1}
-                                                                                                        placeholder={tapInfo != null ? String(tapInfo.tap) : '0'}
-                                                                                                        value={cardEditTap[item.actionId] != null ? cardEditTap[item.actionId] : ''}
+                                                                                                        value={cardEditTap[item.actionId] != null ? cardEditTap[item.actionId] : (tapInfo ? String(tapInfo.tap) : '')}
                                                                                                         onChange={(e) => setCardEditTap(prev => ({ ...prev, [item.actionId]: e.target.value }))}
                                                                                                         style={{
                                                                                                             width: '50px',

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -5982,6 +5982,9 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                 const isPerActionParams = paramsKeys.length > 0 && paramsKeys.some(k => scoresKeys.includes(k));
                                                                 const globalParams = isPerActionParams ? null : (paramsKeys.length > 0 ? typeData.params : null);
                                                                 const isLsOrRcType = type === 'load_shedding' || type.includes('load_shedding') || type === 'renewable_curtailment' || type.includes('renewable_curtailment');
+                                                                const isPstType = type === 'pst_tap_change' || type.includes('pst');
+                                                                const hasEditableColumn = isLsOrRcType || isPstType;
+                                                                const tapStartMap = isPstType ? typeData.tap_start : undefined;
 
                                                                 return (
                                                                     <div key={type} style={{ marginBottom: '8px' }}>
@@ -6006,10 +6009,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                         <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', border: '1px solid #e9ecef', borderTop: 'none' }}>
                                                                             <thead>
                                                                                 <tr style={{ background: '#f8f9fa', borderBottom: '1px solid #ddd' }}>
-                                                                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: isLsOrRcType ? '40%' : '55%' }}>Action</th>
-                                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '15%' }}>MW Start</th>
+                                                                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '40%' : '55%' }}>Action</th>
+                                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '15%' }}>{isPstType ? 'Tap Start' : 'MW Start'}</th>
                                                                                     {isLsOrRcType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}>Target MW</th>}
-                                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: isLsOrRcType ? '15%' : '25%' }}>Score</th>
+                                                                                    {isPstType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}>Target Tap</th>}
+                                                                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: hasEditableColumn ? '15%' : '25%' }}>Score</th>
                                                                                 </tr>
                                                                             </thead>
                                                                             <tbody>
@@ -6019,6 +6023,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                     const parsedTarget = targetVal !== undefined ? parseFloat(targetVal) : null;
                                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
+                                                                                    // PST tap: read from cardEditTap (synchronized with action card)
+                                                                                    const tapInfo = isPstType ? (tapStartMap || {})[item.actionId] : undefined;
+                                                                                    const tapEditVal = cardEditTap[item.actionId];
+                                                                                    const parsedTap = tapEditVal !== undefined ? parseInt(tapEditVal, 10) : null;
+                                                                                    const isValidTap = parsedTap !== null && !isNaN(parsedTap) && (tapInfo?.low_tap == null || parsedTap >= tapInfo.low_tap) && (tapInfo?.high_tap == null || parsedTap <= tapInfo.high_tap);
+                                                                                    const canResimTap = isPstType && isComputed && isValidTap;
                                                                                     return (
                                                                                         <tr key={item.actionId}
                                                                                             onClick={() => {
@@ -6027,14 +6037,18 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                                     handleResimulate(item.actionId, parsedTarget);
                                                                                                     return;
                                                                                                 }
+                                                                                                if (canResimTap) {
+                                                                                                    handleResimulateTap(item.actionId, parsedTap);
+                                                                                                    return;
+                                                                                                }
                                                                                                 if (isComputed) return;
                                                                                                 const mw = isLsOrRcType && isValidTarget ? parsedTarget : undefined;
                                                                                                 handleAddManualAction(item.actionId, mw);
                                                                                             }}
                                                                                             style={{
                                                                                                 borderBottom: '1px solid #eee',
-                                                                                                cursor: (simulatingActionId || resimulatingId) ? 'wait' : (isComputed && !canResimulate) ? 'not-allowed' : 'pointer',
-                                                                                                color: (isComputed && !canResimulate) ? '#888' : 'inherit',
+                                                                                                cursor: (simulatingActionId || resimulatingId) ? 'wait' : (isComputed && !canResimulate && !canResimTap) ? 'not-allowed' : 'pointer',
+                                                                                                color: (isComputed && !canResimulate && !canResimTap) ? '#888' : 'inherit',
                                                                                                 opacity: (simulatingActionId === item.actionId || resimulatingId === item.actionId) ? 0.7 : 1,
                                                                                                 background: (simulatingActionId === item.actionId || resimulatingId === item.actionId) ? '#e7f1ff' : 'transparent',
                                                                                             }}>
@@ -6064,8 +6078,16 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                                     >ⓘ</span>
                                                                                                 )}
                                                                                             </td>
-                                                                                            <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: item.mwStart == null ? '#aaa' : '#333' }}>
-                                                                                                {item.mwStart != null ? item.mwStart.toFixed(1) : 'N/A'}
+                                                                                            <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: (isPstType ? tapInfo == null : item.mwStart == null) ? '#aaa' : '#333' }}>
+                                                                                                {isPstType
+                                                                                                    ? (tapInfo != null ? String(tapInfo.tap) : 'N/A')
+                                                                                                    : (item.mwStart != null ? item.mwStart.toFixed(1) : 'N/A')
+                                                                                                }
+                                                                                                {isPstType && tapInfo && tapInfo.low_tap != null && tapInfo.high_tap != null && (
+                                                                                                    <span style={{ fontSize: '9px', color: '#7c3aed', marginLeft: '2px' }}>
+                                                                                                        [{tapInfo.low_tap}..{tapInfo.high_tap}]
+                                                                                                    </span>
+                                                                                                )}
                                                                                             </td>
                                                                                             {isLsOrRcType && (
                                                                                                 <td style={{ padding: '2px 4px', textAlign: 'right' }} onClick={(e) => e.stopPropagation()}>
@@ -6083,6 +6105,28 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                                             fontFamily: 'monospace',
                                                                                                             padding: '2px 4px',
                                                                                                             border: '1px solid #ccc',
+                                                                                                            borderRadius: '3px',
+                                                                                                            textAlign: 'right',
+                                                                                                        }}
+                                                                                                    />
+                                                                                                </td>
+                                                                                            )}
+                                                                                            {isPstType && (
+                                                                                                <td style={{ padding: '2px 4px', textAlign: 'right' }} onClick={(e) => e.stopPropagation()}>
+                                                                                                    <input
+                                                                                                        type="number"
+                                                                                                        min={tapInfo?.low_tap != null ? tapInfo.low_tap : undefined}
+                                                                                                        max={tapInfo?.high_tap != null ? tapInfo.high_tap : undefined}
+                                                                                                        step={1}
+                                                                                                        placeholder={tapInfo != null ? String(tapInfo.tap) : '0'}
+                                                                                                        value={cardEditTap[item.actionId] != null ? cardEditTap[item.actionId] : ''}
+                                                                                                        onChange={(e) => setCardEditTap(prev => ({ ...prev, [item.actionId]: e.target.value }))}
+                                                                                                        style={{
+                                                                                                            width: '50px',
+                                                                                                            fontSize: '11px',
+                                                                                                            fontFamily: 'monospace',
+                                                                                                            padding: '2px 4px',
+                                                                                                            border: '1px solid #9333ea',
                                                                                                             borderRadius: '3px',
                                                                                                             textAlign: 'right',
                                                                                                         }}

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -6051,7 +6051,10 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                                     : null)
                                                                                         : undefined;
                                                                                     const tapEditVal = cardEditTap[item.actionId];
-                                                                                    const effectiveTap = tapEditVal != null ? tapEditVal : (tapInfo ? String(tapInfo.tap) : undefined);
+                                                                                    // Target Tap default: user edit > simulated tap (from pst_details) > start tap
+                                                                                    const simulatedTap = computedPst ? String(computedPst.tap_position) : undefined;
+                                                                                    const defaultTap = simulatedTap != null ? simulatedTap : (tapInfo ? String(tapInfo.tap) : undefined);
+                                                                                    const effectiveTap = tapEditVal != null ? tapEditVal : defaultTap;
                                                                                     const parsedTap = effectiveTap !== undefined ? parseInt(effectiveTap, 10) : null;
                                                                                     const isValidTap = parsedTap !== null && !isNaN(parsedTap) && (tapInfo?.low_tap == null || parsedTap >= tapInfo.low_tap) && (tapInfo?.high_tap == null || parsedTap <= tapInfo.high_tap);
                                                                                     const canResimTap = isPstType && isComputed && isValidTap;
@@ -6093,12 +6096,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                                         onClick={(e) => e.stopPropagation()}
                                                                                                         onMouseEnter={(e) => showScoreTooltip(e, React.createElement(React.Fragment, null,
                                                                                                             React.createElement('div', { style: { fontWeight: 700, marginBottom: '2px', borderBottom: '1px solid #555', paddingBottom: '2px' } }, 'Parameters'),
-                                                                                                            ...Object.entries(typeData.params[item.actionId]).map(([k, v]) =>
-                                                                                                                React.createElement('div', { key: k },
+                                                                                                            ...Object.entries(typeData.params[item.actionId]).map(([k, v]) => {
+                                                                                                                const isTargetTapKey = isPstType && (k === 'selected_pst_tap' || (k.toLowerCase().includes('target') && k.toLowerCase().includes('tap')));
+                                                                                                                const displayVal = isTargetTapKey && effectiveTap !== undefined ? effectiveTap : (typeof v === 'object' ? JSON.stringify(v) : String(v));
+                                                                                                                return React.createElement('div', { key: k },
                                                                                                                     React.createElement('span', { style: { color: '#adb5bd' } }, k + ':'),
-                                                                                                                    ' ' + (typeof v === 'object' ? JSON.stringify(v) : String(v))
-                                                                                                                )
-                                                                                                            )
+                                                                                                                    ' ' + displayVal
+                                                                                                                );
+                                                                                                            })
                                                                                                         ))}
                                                                                                         onMouseLeave={hideScoreTooltip}
                                                                                                     >ⓘ</span>
@@ -6144,7 +6149,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                                         min={tapInfo?.low_tap != null ? tapInfo.low_tap : undefined}
                                                                                                         max={tapInfo?.high_tap != null ? tapInfo.high_tap : undefined}
                                                                                                         step={1}
-                                                                                                        value={cardEditTap[item.actionId] != null ? cardEditTap[item.actionId] : (tapInfo ? String(tapInfo.tap) : '')}
+                                                                                                        value={cardEditTap[item.actionId] != null ? cardEditTap[item.actionId] : (simulatedTap != null ? simulatedTap : (tapInfo ? String(tapInfo.tap) : ''))}
                                                                                                         onChange={(e) => setCardEditTap(prev => ({ ...prev, [item.actionId]: e.target.value }))}
                                                                                                         style={{
                                                                                                             width: '50px',

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -6024,16 +6024,24 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
                                                                                     // PST tap: read from cardEditTap (synchronized with action card)
-                                                                                    // Tap Start = base N-state network tap from tapStartMap (scores)
-                                                                                    // Bounds from tapStartMap, with computedPst as fallback
+                                                                                    // Tap Start: "previous tap" from action params (N-state), then tapStartMap, then computedPst
+                                                                                    const actionParams = isPstType ? (typeData.params || {})[item.actionId] : undefined;
+                                                                                    const previousTap = actionParams ? actionParams['previous tap'] : undefined;
                                                                                     const tapStartEntry = isPstType ? (tapStartMap || {})[item.actionId] || null : undefined;
                                                                                     const computedPst = isPstType && isComputed ? result?.actions?.[item.actionId]?.pst_details?.[0] : undefined;
                                                                                     const tapInfo = isPstType
-                                                                                        ? (tapStartEntry
-                                                                                            ? tapStartEntry
-                                                                                            : computedPst
-                                                                                                ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
-                                                                                                : null)
+                                                                                        ? (previousTap !== undefined
+                                                                                            ? {
+                                                                                                pst_name: (tapStartEntry || {}).pst_name || (computedPst || {}).pst_name || '',
+                                                                                                tap: previousTap,
+                                                                                                low_tap: (tapStartEntry || {}).low_tap != null ? tapStartEntry.low_tap : (computedPst || {}).low_tap != null ? computedPst.low_tap : null,
+                                                                                                high_tap: (tapStartEntry || {}).high_tap != null ? tapStartEntry.high_tap : (computedPst || {}).high_tap != null ? computedPst.high_tap : null,
+                                                                                            }
+                                                                                            : tapStartEntry
+                                                                                                ? tapStartEntry
+                                                                                                : computedPst
+                                                                                                    ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
+                                                                                                    : null)
                                                                                         : undefined;
                                                                                     const tapEditVal = cardEditTap[item.actionId];
                                                                                     const effectiveTap = tapEditVal != null ? tapEditVal : (tapInfo ? String(tapInfo.tap) : undefined);

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -3874,6 +3874,39 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 }
             };
 
+            // Refresh combined estimations for all pairs that include the given action
+            const refreshCombinedEstimations = async (actionId) => {
+                const combined = result && result.combined_actions;
+                if (!combined || !selectedBranch) return;
+                const relatedPairs = Object.entries(combined).filter(function([pairId]) {
+                    const parts = pairId.split('+').map(function(p) { return p.trim(); });
+                    return parts.indexOf(actionId) >= 0;
+                });
+                for (const [pairId] of relatedPairs) {
+                    const parts = pairId.split('+').map(function(p) { return p.trim(); });
+                    const id1 = parts[0];
+                    const id2 = parts[1];
+                    try {
+                        const res = await axios.post(API_BASE + '/api/compute-superposition', {
+                            action1_id: id1, action2_id: id2, disconnected_element: selectedBranch
+                        });
+                        const superResult = res.data;
+                        if (!superResult.error) {
+                            const estRho = superResult.estimated_max_rho != null ? superResult.estimated_max_rho : superResult.max_rho;
+                            const estLine = superResult.estimated_max_rho_line != null ? superResult.estimated_max_rho_line : superResult.max_rho_line;
+                            setResult(function(prev) {
+                                if (!prev || !prev.combined_actions || !prev.combined_actions[pairId]) return prev;
+                                var updated = Object.assign({}, prev.combined_actions);
+                                updated[pairId] = Object.assign({}, updated[pairId], { estimated_max_rho: estRho, estimated_max_rho_line: estLine });
+                                return Object.assign({}, prev, { combined_actions: updated });
+                            });
+                        }
+                    } catch (e) {
+                        console.error('Failed to refresh estimation for pair ' + pairId + ':', e);
+                    }
+                }
+            };
+
             // Re-simulate an existing action with a new target MW value
             const handleResimulate = async (actionId, newTargetMw) => {
                 if (!selectedBranch) return;
@@ -3922,6 +3955,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         delete next[actionId];
                         return next;
                     });
+                    // Refresh combined estimations for pairs containing this action
+                    refreshCombinedEstimations(actionId);
                 } catch (err) {
                     console.error('Re-simulation failed:', err);
                 } finally {
@@ -3977,6 +4012,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         delete next[actionId];
                         return next;
                     });
+                    // Refresh combined estimations for pairs containing this action
+                    refreshCombinedEstimations(actionId);
                 } catch (err) {
                     console.error('PST re-simulation failed:', err);
                 } finally {

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -6024,12 +6024,16 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                     const isValidTarget = parsedTarget !== null && !isNaN(parsedTarget) && parsedTarget >= 0 && (item.mwStart == null || parsedTarget <= item.mwStart);
                                                                                     const canResimulate = isLsOrRcType && isComputed && isValidTarget;
                                                                                     // PST tap: read from cardEditTap (synchronized with action card)
-                                                                                    // Tap info: prefer pst_details from computed action, fall back to tap_start from scores
+                                                                                    // Tap Start = base N-state network tap from tapStartMap (scores)
+                                                                                    // Bounds from tapStartMap, with computedPst as fallback
+                                                                                    const tapStartEntry = isPstType ? (tapStartMap || {})[item.actionId] || null : undefined;
                                                                                     const computedPst = isPstType && isComputed ? result?.actions?.[item.actionId]?.pst_details?.[0] : undefined;
                                                                                     const tapInfo = isPstType
-                                                                                        ? (computedPst
-                                                                                            ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
-                                                                                            : (tapStartMap || {})[item.actionId] || null)
+                                                                                        ? (tapStartEntry
+                                                                                            ? tapStartEntry
+                                                                                            : computedPst
+                                                                                                ? { pst_name: computedPst.pst_name, tap: computedPst.tap_position, low_tap: computedPst.low_tap, high_tap: computedPst.high_tap }
+                                                                                                : null)
                                                                                         : undefined;
                                                                                     const tapEditVal = cardEditTap[item.actionId];
                                                                                     const effectiveTap = tapEditVal != null ? tapEditVal : (tapInfo ? String(tapInfo.tap) : undefined);

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -3877,11 +3877,16 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             // Refresh combined estimations for all pairs that include the given action
             const refreshCombinedEstimations = async (actionId) => {
                 const combined = result && result.combined_actions;
+                console.log('[refreshCombinedEstimations] called for:', actionId,
+                    'combined:', combined ? Object.keys(combined).length : null,
+                    'selectedBranch:', selectedBranch);
                 if (!combined || !selectedBranch) return;
                 const relatedPairs = Object.entries(combined).filter(function([pairId]) {
                     const parts = pairId.split('+').map(function(p) { return p.trim(); });
                     return parts.indexOf(actionId) >= 0;
                 });
+                console.log('[refreshCombinedEstimations] found', relatedPairs.length, 'related pairs:',
+                    relatedPairs.map(function([id]) { return id; }));
                 for (const [pairId] of relatedPairs) {
                     const parts = pairId.split('+').map(function(p) { return p.trim(); });
                     const id1 = parts[0];
@@ -3891,9 +3896,16 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                             action1_id: id1, action2_id: id2, disconnected_element: selectedBranch
                         });
                         const superResult = res.data;
+                        console.log('[refreshCombinedEstimations] superposition result for', pairId, ':', {
+                            error: superResult.error,
+                            estimated_max_rho: superResult.estimated_max_rho,
+                            max_rho: superResult.max_rho,
+                            max_rho_line: superResult.max_rho_line,
+                        });
                         if (!superResult.error) {
                             const estRho = superResult.estimated_max_rho != null ? superResult.estimated_max_rho : superResult.max_rho;
                             const estLine = superResult.estimated_max_rho_line != null ? superResult.estimated_max_rho_line : superResult.max_rho_line;
+                            console.log('[refreshCombinedEstimations] updating pair', pairId, 'with estRho:', estRho, 'estLine:', estLine);
                             setResult(function(prev) {
                                 if (!prev || !prev.combined_actions || !prev.combined_actions[pairId]) return prev;
                                 var updated = Object.assign({}, prev.combined_actions);

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1851,6 +1851,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             const [scoreTargetMw, setScoreTargetMw] = useState({});
             // Per-action editable MW for action card re-simulation (keyed by actionId)
             const [cardEditMw, setCardEditMw] = useState({});
+            // Per-action editable tap position for PST action re-simulation (keyed by actionId)
+            const [cardEditTap, setCardEditTap] = useState({});
             const [resimulatingId, setResimulatingId] = useState(null);
             const searchDropdownRef = useRef(null);
             const searchInputRef = useRef(null);
@@ -2352,6 +2354,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                         disconnected_mw: detail.disconnected_mw,
                                         load_shedding_details: detail.load_shedding_details,
                                         curtailment_details: detail.curtailment_details,
+                                        pst_details: detail.pst_details,
                                         status: {
                                             is_selected: manualActionIds.has(id),
                                             is_suggested: suggestedByRecommenderIds.has(id),
@@ -2576,6 +2579,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                 n_components: entry.n_components,
                                 disconnected_mw: entry.disconnected_mw,
                                 load_shedding_details: entry.load_shedding_details,
+                                curtailment_details: entry.curtailment_details,
+                                pst_details: entry.pst_details,
                                 is_manual: entry.status.is_manually_simulated,
                             };
                             if (entry.status.is_selected) restoredSelected.add(id);
@@ -3833,6 +3838,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     disconnected_mw: detail.disconnected_mw,
                                     load_shedding_details: detail.load_shedding_details,
                                     curtailment_details: detail.curtailment_details,
+                                    pst_details: detail.pst_details,
                                     action_topology: detail.action_topology,
                                     non_convergence: detail.non_convergence,
                                     is_precomputed: isCombined ? true : (base.actions?.[actionId]?.is_precomputed || false)
@@ -3902,6 +3908,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     disconnected_mw: detail.disconnected_mw,
                                     load_shedding_details: detail.load_shedding_details,
                                     curtailment_details: detail.curtailment_details,
+                                    pst_details: detail.pst_details,
                                     action_topology: detail.action_topology,
                                     non_convergence: detail.non_convergence,
                                 }
@@ -3917,6 +3924,61 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     });
                 } catch (err) {
                     console.error('Re-simulation failed:', err);
+                } finally {
+                    setResimulatingId(null);
+                }
+            };
+
+            // Re-simulate an existing PST action with a new tap position
+            const handleResimulateTap = async (actionId, newTap) => {
+                if (!selectedBranch) return;
+                setResimulatingId(actionId);
+                try {
+                    const actionDetail = result?.actions?.[actionId];
+                    const actionContent = actionDetail?.action_topology || null;
+                    const res = await axios.post(API_BASE + '/api/simulate-manual-action', {
+                        action_id: actionId,
+                        disconnected_element: selectedBranch,
+                        action_content: actionContent,
+                        lines_overloaded: result?.lines_overloaded?.length > 0 ? result.lines_overloaded : null,
+                        target_tap: newTap,
+                    });
+                    const detail = res.data;
+                    setResult(prev => {
+                        const base = prev || { actions: {}, lines_overloaded: [] };
+                        return {
+                            ...base,
+                            actions: {
+                                ...(base.actions || {}),
+                                [actionId]: {
+                                    ...(base.actions?.[actionId] || {}),
+                                    description_unitaire: detail.description_unitaire,
+                                    rho_before: detail.rho_before,
+                                    rho_after: detail.rho_after,
+                                    max_rho: detail.max_rho,
+                                    max_rho_line: detail.max_rho_line,
+                                    is_rho_reduction: detail.is_rho_reduction,
+                                    is_islanded: detail.is_islanded,
+                                    n_components: detail.n_components,
+                                    disconnected_mw: detail.disconnected_mw,
+                                    load_shedding_details: detail.load_shedding_details,
+                                    curtailment_details: detail.curtailment_details,
+                                    pst_details: detail.pst_details,
+                                    action_topology: detail.action_topology,
+                                    non_convergence: detail.non_convergence,
+                                }
+                            }
+                        };
+                    });
+                    // Clear the edit input so it picks up the new tap from results
+                    setCardEditTap(prev => {
+                        if (!prev[actionId]) return prev;
+                        const next = { ...prev };
+                        delete next[actionId];
+                        return next;
+                    });
+                } catch (err) {
+                    console.error('PST re-simulation failed:', err);
                 } finally {
                     setResimulatingId(null);
                 }
@@ -4032,6 +4094,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     is_rho_reduction: detail.is_rho_reduction,
                                     load_shedding_details: detail.load_shedding_details,
                                     curtailment_details: detail.curtailment_details,
+                                    pst_details: detail.pst_details,
                                     action_topology: detail.action_topology,
                                     is_manual: true,
                                 }
@@ -4119,6 +4182,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     disconnected_mw: detail.disconnected_mw,
                                     load_shedding_details: detail.load_shedding_details,
                                     curtailment_details: detail.curtailment_details,
+                                    pst_details: detail.pst_details,
                                     action_topology: detail.action_topology,
                                     non_convergence: detail.non_convergence,
                                 }
@@ -5293,6 +5357,41 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                         }}
                                                         disabled={resimulatingId === id}
                                                         style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: '1px solid #0284c7', background: '#38bdf8', color: '#0c4a6e', cursor: resimulatingId === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
+                                                    >
+                                                        {resimulatingId === id ? 'Simulating...' : 'Re-simulate'}
+                                                    </button>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )
+                                }
+                                {
+                                    details.pst_details && details.pst_details.length > 0 && (
+                                        <div onClick={(e) => { e.stopPropagation(); e.preventDefault(); }} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: '#f3e8ff', color: '#6b21a8', padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: '1px solid #c084fc', fontWeight: 500 }}>
+                                            {details.pst_details.map((pst, i) => (
+                                                <div key={pst.pst_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
+                                                    <span>PST <strong>{pst.pst_name}</strong> tap:</span>
+                                                    <input
+                                                        type="number"
+                                                        min={pst.low_tap != null ? pst.low_tap : undefined}
+                                                        max={pst.high_tap != null ? pst.high_tap : undefined}
+                                                        step={1}
+                                                        value={cardEditTap[id] != null ? cardEditTap[id] : pst.tap_position}
+                                                        onChange={(e) => setCardEditTap(prev => ({ ...prev, [id]: e.target.value }))}
+                                                        style={{ width: '55px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: '1px solid #9333ea', borderRadius: '3px', textAlign: 'right' }}
+                                                    />
+                                                    {pst.low_tap != null && pst.high_tap != null && (
+                                                        <span style={{ fontSize: '10px', color: '#7c3aed' }}>
+                                                            [{pst.low_tap}..{pst.high_tap}]
+                                                        </span>
+                                                    )}
+                                                    <button
+                                                        onClick={() => {
+                                                            const tapVal = parseInt(cardEditTap[id] != null ? cardEditTap[id] : String(pst.tap_position), 10);
+                                                            if (!isNaN(tapVal)) handleResimulateTap(id, tapVal);
+                                                        }}
+                                                        disabled={resimulatingId === id}
+                                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: '1px solid #9333ea', background: '#c084fc', color: '#3b0764', cursor: resimulatingId === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
                                                     >
                                                         {resimulatingId === id ? 'Simulating...' : 'Re-simulate'}
                                                     </button>

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -6026,7 +6026,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                                     // PST tap: read from cardEditTap (synchronized with action card)
                                                                                     // Tap Start: "previous tap" from action params (N-state), then tapStartMap, then computedPst
                                                                                     const actionParams = isPstType ? (typeData.params || {})[item.actionId] : undefined;
-                                                                                    const previousTap = actionParams ? actionParams['previous tap'] : undefined;
+                                                                                    // Try multiple key variants for the previous tap value
+                                                                                    const previousTap = actionParams
+                                                                                        ? (actionParams['previous tap'] != null ? actionParams['previous tap']
+                                                                                           : actionParams['previous_tap'] != null ? actionParams['previous_tap']
+                                                                                           : actionParams['previousTap'] != null ? actionParams['previousTap']
+                                                                                           : (() => { const found = Object.entries(actionParams).find(([k]) => k.toLowerCase().includes('previous') && k.toLowerCase().includes('tap')); return found ? found[1] : undefined; })()
+                                                                                          )
+                                                                                        : undefined;
                                                                                     const tapStartEntry = isPstType ? (tapStartMap || {})[item.actionId] || null : undefined;
                                                                                     const computedPst = isPstType && isComputed ? result?.actions?.[item.actionId]?.pst_details?.[0] : undefined;
                                                                                     const tapInfo = isPstType


### PR DESCRIPTION
## Summary
This PR adds support for re-simulating Phase Shift Transformer (PST) actions with different tap positions. Users can now edit the tap position of PST actions and re-simulate them to see the impact on the grid, similar to the existing MW adjustment feature for load shedding/curtailment actions.

## Key Changes

### Backend (expert_backend)
- **New method `_compute_pst_details()`** in `recommender_service.py`: Extracts PST tap information from actions and retrieves tap bounds (low_tap, high_tap) from the network manager
- **Enhanced `simulate_manual_action()`**: Added `target_tap` parameter to support PST tap re-simulation with automatic clamping to valid bounds
- **PST details enrichment**: PST information is now computed and included in action enrichment pipeline, similar to load shedding and curtailment details
- **Updated API endpoint**: `ManualActionRequest` now accepts optional `target_tap` parameter

### Frontend (React/TypeScript)
- **New state management**: Added `cardEditTap` state to track per-action editable tap positions
- **New handler `handleResimulateTap()`**: Processes PST tap re-simulation requests and updates action results
- **UI component for PST details**: Displays PST name, current tap position, valid tap range, editable input field, and re-simulate button
- **Type definitions**: Added `PstDetail` interface with pst_name, tap_position, low_tap, and high_tap fields
- **API integration**: Extended `simulateManualAction()` to accept optional `targetTap` parameter

### Standalone Interface
- Mirrors all frontend changes for consistency in the standalone HTML interface
- Includes PST details display and re-simulation functionality

## Implementation Details
- PST tap bounds are retrieved from the network via `get_pst_tap_info()` to ensure valid ranges
- Tap values are automatically clamped to [low_tap, high_tap] during re-simulation
- The UI provides visual feedback with tap range display and disabled state during simulation
- Edit inputs are cleared after successful re-simulation to reflect updated results from the backend
- Consistent styling with existing load shedding/curtailment detail cards (purple theme)

https://claude.ai/code/session_01DuZKBaZ2wDnQFMd9bY3QWC