### PR TITLE
Replace native datalist with custom dropdown for inspect field

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -200,6 +200,60 @@ function App() {
     // change trigger the zoom correctly after the new SVG is ready.
   }, [setError, actionsHook, analysis, diagrams]);
 
+  // Narrower reset used when re-running the analysis on the SAME
+  // contingency. Unlike `clearContingencyState`, this preserves any
+  // manually-added ("first guess") actions so they stay in the
+  // Selected Actions section through the analysis run — mirroring the
+  // standalone interface, which filters result.actions down to the
+  // is_manual=true subset on Analyze & Suggest instead of wiping
+  // everything.
+  //
+  // Specifically: keeps manuallyAddedIds, keeps the selected-action
+  // set restricted to manually-added IDs, and filters result.actions
+  // to the is_manual subset (with pdf / lines_overloaded cleared so
+  // the UI correctly shows the "analysis in progress" state).
+  const resetForAnalysisRun = useCallback(() => {
+    analysis.setResult(prev => {
+      if (!prev) return null;
+      const manuals: Record<string, import('./types').ActionDetail> = {};
+      for (const [id, data] of Object.entries(prev.actions || {})) {
+        if (data.is_manual) manuals[id] = data;
+      }
+      return {
+        ...prev,
+        actions: manuals,
+        lines_overloaded: [],
+        pdf_url: null,
+        pdf_path: null,
+      };
+    });
+    analysis.setPendingAnalysisResult(null);
+    analysis.setMonitorDeselected(false);
+    // Keep manuallyAddedIds intact and trim selectedActionIds down
+    // to the manually-added subset — that way any favorited
+    // recommender suggestions are dropped (the new run will
+    // re-emit them) while the user's own "first guess" stays put.
+    actionsHook.setSelectedActionIds(prev => {
+      const manuallyAdded = actionsHook.manuallyAddedIds;
+      const next = new Set<string>();
+      for (const id of prev) if (manuallyAdded.has(id)) next.add(id);
+      return next;
+    });
+    actionsHook.setRejectedActionIds(new Set());
+    actionsHook.setSuggestedByRecommenderIds(new Set());
+    // Don't wipe selectedActionId if it points to a manual action —
+    // keep the user's variant diagram around through the re-run.
+    const sel = diagrams.selectedActionId;
+    if (sel && !actionsHook.manuallyAddedIds.has(sel)) {
+      diagrams.setSelectedActionId(null);
+      diagrams.setActionDiagram(null);
+    }
+    diagrams.setVlOverlay(null);
+    setError('');
+    analysis.setInfoMessage('');
+    diagrams.setInspectQuery('');
+  }, [setError, actionsHook, analysis, diagrams]);
+
   // Full reset: contingency state + network/diagram state
   const resetAllState = useCallback(() => {
     clearContingencyState();
@@ -272,8 +326,8 @@ function App() {
   );
 
   const wrappedRunAnalysis = useCallback(
-    () => analysis.handleRunAnalysis(selectedBranch, clearContingencyState, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab),
-    [analysis, selectedBranch, clearContingencyState, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab]
+    () => analysis.handleRunAnalysis(selectedBranch, resetForAnalysisRun, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab),
+    [analysis, selectedBranch, resetForAnalysisRun, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab]
   );
 
   const wrappedDisplayPrioritized = useCallback(

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -80,6 +80,48 @@ describe('ActionFeed', () => {
     };
 
 
+    it('shows "Make a first guess" button when the Selected Actions section is empty', () => {
+        // Regression guard: the standalone interface exposes a
+        // "💡 Make a first guess" shortcut that opens the Manual
+        // Selection search. The React frontend was missing it, so
+        // users had no obvious entry point from the empty Selected
+        // Actions slot into manual action exploration.
+        render(<ActionFeed {...defaultProps} />);
+        expect(screen.getByTestId('make-first-guess-button')).toBeInTheDocument();
+        expect(screen.getByText(/Make a first guess/)).toBeInTheDocument();
+    });
+
+    it('"Make a first guess" opens the manual search dropdown', () => {
+        render(<ActionFeed {...defaultProps} />);
+        // The dropdown search input is not present until the user
+        // opens the search.
+        expect(screen.queryByPlaceholderText(/Search action by ID/)).not.toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('make-first-guess-button'));
+        expect(screen.getByPlaceholderText(/Search action by ID/)).toBeInTheDocument();
+    });
+
+    it('hides "Make a first guess" when there are already selected actions', () => {
+        const actionId = 'manual_1';
+        const props = {
+            ...defaultProps,
+            actions: {
+                [actionId]: {
+                    description_unitaire: 'Manual Action',
+                    rho_before: [1.0],
+                    rho_after: [0.8],
+                    max_rho: 0.8,
+                    max_rho_line: 'LINE_A',
+                    is_rho_reduction: true,
+                    is_manual: true,
+                    action_topology: emptyTopo,
+                },
+            },
+            selectedActionIds: new Set([actionId]),
+        };
+        render(<ActionFeed {...props} />);
+        expect(screen.queryByTestId('make-first-guess-button')).not.toBeInTheDocument();
+    });
+
     it('renders "Scored Actions" heading when search is opened and actions are present', async () => {
         const actionId = 'act_1';
         const props = {

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -100,6 +100,47 @@ describe('ActionFeed', () => {
         expect(screen.getByPlaceholderText(/Search action by ID/)).toBeInTheDocument();
     });
 
+    it('keeps a manually added action in Selected and shows the overlap warning when it is ALSO suggested by the analysis', () => {
+        // Regression: a user "first guess" that coincides with a
+        // recommender suggestion used to silently vanish from the
+        // Selected bucket after analysis. It must stay selected and
+        // the yellow "also recommended" warning must fire.
+        const actionId = 'overlap_act';
+        const props = {
+            ...defaultProps,
+            actions: {
+                [actionId]: {
+                    description_unitaire: 'Shared action',
+                    rho_before: [1.1],
+                    rho_after: [0.8],
+                    max_rho: 0.8,
+                    max_rho_line: 'LINE_A',
+                    is_rho_reduction: true,
+                    is_manual: true,
+                    action_topology: emptyTopo,
+                },
+            },
+            // The same id is present in both the selected set (user
+            // added it manually) and the analysis scores (the
+            // recommender also recommends it).
+            selectedActionIds: new Set([actionId]),
+            manuallyAddedIds: new Set([actionId]),
+            actionScores: {
+                line_disconnection: {
+                    scores: { [actionId]: 42 },
+                    params: {},
+                },
+            },
+        };
+        render(<ActionFeed {...props} />);
+        // Selected Actions section still shows the card.
+        expect(screen.getByText('Shared action')).toBeInTheDocument();
+        // Overlap warning is visible and mentions the overlapping id.
+        const warning = screen.getByText(/also recommended by the recent analysis run/);
+        expect(warning).toBeInTheDocument();
+        expect(warning.textContent).toContain(actionId);
+    });
+
     it('hides "Make a first guess" when there are already selected actions', () => {
         const actionId = 'manual_1';
         const props = {

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -619,7 +619,32 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                         {renderActionList(selectedEntries)}
                     </>
                 ) : (
-                    <p style={{ color: '#666', fontStyle: 'italic', fontSize: '13px', margin: '5px 0 15px 0' }}>Select an action manually or from suggested ones.</p>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', margin: '5px 0 15px 0' }}>
+                        <p style={{ color: '#666', fontStyle: 'italic', fontSize: '13px', margin: 0 }}>Select an action manually or from suggested ones.</p>
+                        <button
+                            onClick={handleOpenSearch}
+                            data-testid="make-first-guess-button"
+                            style={{
+                                padding: '10px',
+                                backgroundColor: '#f8f9fa',
+                                border: '1px dashed #007bff',
+                                color: '#007bff',
+                                borderRadius: '8px',
+                                cursor: 'pointer',
+                                fontWeight: 600,
+                                fontSize: '14px',
+                                transition: 'all 0.2s',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                gap: '8px',
+                            }}
+                            onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#e7f1ff'; }}
+                            onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#f8f9fa'; }}
+                        >
+                            <span style={{ fontSize: '16px' }}>💡</span> Make a first guess
+                        </button>
+                    </div>
                 )}
             </div>
 

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -415,6 +415,55 @@ describe('VisualizationPanel', () => {
         expect(screen.queryByPlaceholderText(/Inspect/)).not.toBeInTheDocument();
     });
 
+    it('inspect field does not rely on a native <datalist>', () => {
+        // Regression guard for the "tied detached window hides the
+        // main-window suggestions dropdown" bug: the inspect field
+        // used to pair <input list=...> with a <datalist> sibling,
+        // but that combo is unreliable when the overlay subtree is
+        // physically relocated to a popup window via
+        // DetachableTabHost. We now render a custom suggestions
+        // dropdown, so there must be no <datalist> anywhere in the
+        // tab overlays.
+        const nDiagram: DiagramData = { svg: '<svg>n</svg>', metadata: null };
+        const { container } = render(<VisualizationPanel {...createDefaultProps({
+            hasBranches: true,
+            nDiagram,
+            inspectableItems: ['LINE_A', 'LINE_B'],
+        })} />);
+        expect(container.querySelectorAll('datalist').length).toBe(0);
+        const inputs = screen.getAllByPlaceholderText(/Inspect/);
+        inputs.forEach(input => {
+            expect(input.getAttribute('list')).toBeNull();
+        });
+    });
+
+    it('inspect field shows a custom suggestions dropdown when typing matches items', async () => {
+        const user = userEvent.setup();
+        const onInspectQueryChange = vi.fn();
+        const nDiagram: DiagramData = { svg: '<svg>n</svg>', metadata: null };
+        // Use an inspectQuery value that matches some items — the
+        // custom dropdown shows once the field is focused and the
+        // query has at least one non-exact filtered match.
+        render(<VisualizationPanel {...createDefaultProps({
+            hasBranches: true,
+            nDiagram,
+            inspectableItems: ['LINE_A', 'LINE_B', 'BUS_C'],
+            inspectQuery: 'LIN',
+            onInspectQueryChange,
+        })} />);
+        // Focus the visible inspect input (the active-tab overlay's).
+        const inputs = screen.getAllByPlaceholderText(/Inspect/);
+        // Focus every overlay input so the test is tolerant to which
+        // of the (always-mounted) tab overlays the test environment
+        // exposes first.
+        for (const input of inputs) {
+            await user.click(input);
+        }
+        // Both LINE_A and LINE_B are valid custom-dropdown rows.
+        expect(screen.getAllByText('LINE_A').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('LINE_B').length).toBeGreaterThan(0);
+    });
+
     it('shows analysis loading text in overflow tab with yellow theme', () => {
         render(<VisualizationPanel {...createDefaultProps({
             activeTab: 'overflow',

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -5,12 +5,128 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
-import React, { useState, useMemo, type RefObject } from 'react';
+import React, { useState, useMemo, useRef, type RefObject } from 'react';
 import type { DiagramData, AnalysisResult, TabId, VlOverlay, SldTab } from '../types';
 import MemoizedSvgContainer from './MemoizedSvgContainer';
 import SldOverlay from './SldOverlay';
 import DetachableTabHost from './DetachableTabHost';
 import type { DetachedTabsMap } from '../hooks/useDetachedTabs';
+
+/**
+ * Inspect text field + custom suggestions dropdown.
+ *
+ * This replaces a native <input list=...> + <datalist> pair. The
+ * native datalist is unreliable when its owning subtree is physically
+ * relocated between documents via DetachableTabHost — Chromium in
+ * particular has been observed to show the dropdown in the wrong
+ * window (or not at all in the window being typed into) when a tied
+ * detached tab shares the same `inspectQuery` state with the main
+ * window's active tab overlay.
+ *
+ * By rendering the suggestion list ourselves, as a plain
+ * absolutely-positioned div sibling of the input, the dropdown is
+ * guaranteed to live in the same DOM subtree as the input it belongs
+ * to, in whichever window that subtree happens to be. It therefore
+ * renders reliably whether the overlay sits in the main window or in
+ * a detached popup, regardless of the tied state.
+ */
+const InspectSearchField: React.FC<{
+    tabId: TabId;
+    inspectQuery: string;
+    onChangeQuery: (tab: TabId, q: string) => void;
+    filteredInspectables: string[];
+}> = ({ tabId, inspectQuery, onChangeQuery, filteredInspectables }) => {
+    const [focused, setFocused] = useState(false);
+    // Keep the dropdown visible long enough for an option click to
+    // register before onBlur hides it (click fires after blur).
+    const closeTimer = useRef<number | null>(null);
+
+    // Hide the dropdown after a matched commit so the user isn't left
+    // with a hovering suggestion panel while zoomed in on the asset.
+    const exactMatch = inspectQuery.length > 0
+        && filteredInspectables.some(v => v.toUpperCase() === inspectQuery.toUpperCase());
+    const showDropdown = focused && inspectQuery.length > 0 && filteredInspectables.length > 0 && !exactMatch;
+
+    return (
+        <div style={{ position: 'relative' }}>
+            <input
+                value={inspectQuery}
+                onChange={e => onChangeQuery(tabId, e.target.value)}
+                onFocus={() => {
+                    if (closeTimer.current !== null) {
+                        window.clearTimeout(closeTimer.current);
+                        closeTimer.current = null;
+                    }
+                    setFocused(true);
+                }}
+                onBlur={() => {
+                    // Defer the hide so onMouseDown on an option can
+                    // complete and fire its onClick before the
+                    // dropdown unmounts.
+                    closeTimer.current = window.setTimeout(() => {
+                        setFocused(false);
+                        closeTimer.current = null;
+                    }, 150);
+                }}
+                placeholder="🔍 Inspect..."
+                style={{
+                    padding: '5px 10px',
+                    border: inspectQuery ? '2px solid #3498db' : '1px solid #ccc',
+                    borderRadius: '4px',
+                    fontSize: '12px',
+                    width: '180px',
+                    boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
+                    background: 'white',
+                }}
+            />
+            {showDropdown && (
+                <div
+                    style={{
+                        position: 'absolute',
+                        bottom: '100%',
+                        left: 0,
+                        marginBottom: '4px',
+                        width: '220px',
+                        maxHeight: '220px',
+                        overflowY: 'auto',
+                        background: 'white',
+                        border: '1px solid #3498db',
+                        borderRadius: '4px',
+                        boxShadow: '0 4px 12px rgba(0,0,0,0.18)',
+                        zIndex: 200,
+                        fontSize: '12px',
+                    }}
+                >
+                    {filteredInspectables.map(item => (
+                        <div
+                            key={item}
+                            // Use onMouseDown (fires before the
+                            // input's onBlur) so the selection is
+                            // recorded even though the blur is about
+                            // to hide us.
+                            onMouseDown={e => {
+                                e.preventDefault();
+                                onChangeQuery(tabId, item);
+                            }}
+                            style={{
+                                padding: '5px 10px',
+                                cursor: 'pointer',
+                                borderBottom: '1px solid #eee',
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                            }}
+                            onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = '#f0f8ff'; }}
+                            onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'white'; }}
+                        >
+                            {item}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
 
 interface VisualizationPanelProps {
     activeTab: TabId;
@@ -341,25 +457,13 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             </button>
                         </div>
                         {hasBranches && (
-                            <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
-                                <input
-                                    list={`inspectables-${tabId}`}
-                                    value={inspectQuery}
-                                    onChange={e => inspectQueryChangeForCb(tabId, e.target.value)}
-                                    placeholder="🔍 Inspect..."
-                                    style={{
-                                        padding: '5px 10px',
-                                        border: inspectQuery ? '2px solid #3498db' : '1px solid #ccc',
-                                        borderRadius: '4px',
-                                        fontSize: '12px',
-                                        width: '180px',
-                                        boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
-                                        background: 'white',
-                                    }}
+                            <div style={{ display: 'flex', gap: '4px', alignItems: 'center', position: 'relative' }}>
+                                <InspectSearchField
+                                    tabId={tabId}
+                                    inspectQuery={inspectQuery}
+                                    onChangeQuery={inspectQueryChangeForCb}
+                                    filteredInspectables={filteredInspectables}
                                 />
-                                <datalist id={`inspectables-${tabId}`}>
-                                    {filteredInspectables.map(b => <option key={b} value={b} />)}
-                                </datalist>
                                 {inspectQuery && voltageLevels.includes(inspectQuery) && (
                                     <button
                                         onClick={() => onVlOpen(inspectQuery)}

--- a/frontend/src/hooks/useAnalysis.test.ts
+++ b/frontend/src/hooks/useAnalysis.test.ts
@@ -358,6 +358,71 @@ describe('useAnalysis', () => {
             expect(result.current.result?.actions?.manual_1).toBeDefined();
             expect(result.current.result?.actions?.reco_1).toBeDefined();
         });
+
+        it('preserves a manually added action that is ALSO returned by the recommender (overlap case)', async () => {
+            // Regression: a user "first guess" action that happens
+            // to coincide with a suggestion from the recommender
+            // used to disappear from the Selected bucket after the
+            // analysis was displayed, because handleDisplayPrioritized
+            // used the plain analysis entry (without is_manual) for
+            // the overlapping id. The fix preserves the
+            // manually-added entry (keeping is_manual=true) so it
+            // stays in Selected and the "was also suggested" warning
+            // can fire.
+            const { result } = renderHook(() => useAnalysis());
+
+            act(() => {
+                result.current.setResult({
+                    actions: {
+                        overlap_1: {
+                            description_unitaire: 'Manual guess',
+                            rho_before: null, rho_after: [0.7],
+                            max_rho: 0.7, max_rho_line: 'LINE_A',
+                            is_rho_reduction: true, is_manual: true,
+                        },
+                    },
+                    lines_overloaded: ['LINE_A'],
+                    message: '', dc_fallback: false,
+                    pdf_path: null, pdf_url: null,
+                });
+            });
+
+            act(() => {
+                result.current.setPendingAnalysisResult({
+                    actions: {
+                        overlap_1: {
+                            description_unitaire: 'Recommender entry',
+                            rho_before: [1.1], rho_after: [0.75],
+                            max_rho: 0.75, max_rho_line: 'LINE_A',
+                            is_rho_reduction: true,
+                        },
+                        reco_other: {
+                            description_unitaire: 'Another suggestion',
+                            rho_before: [1.2], rho_after: [0.85],
+                            max_rho: 0.85, max_rho_line: 'LINE_A',
+                            is_rho_reduction: true,
+                        },
+                    },
+                    lines_overloaded: ['LINE_A'],
+                    message: 'OK', dc_fallback: false,
+                    pdf_path: null, pdf_url: null,
+                });
+            });
+
+            // Display prioritized — even with an EMPTY selectedActionIds
+            // (mirrors resetForAnalysisRun clearing the selection of
+            // non-manual favorites) the manual action must survive.
+            act(() => {
+                result.current.handleDisplayPrioritizedActions(new Set());
+            });
+
+            // Overlapping id must remain and stay flagged as manual.
+            expect(result.current.result?.actions?.overlap_1).toBeDefined();
+            expect(result.current.result?.actions?.overlap_1?.is_manual).toBe(true);
+            // The new purely-suggested action is merged in as usual.
+            expect(result.current.result?.actions?.reco_other).toBeDefined();
+            expect(result.current.result?.actions?.reco_other?.is_manual).toBeFalsy();
+        });
     });
 
     describe('overload filtering in step 2', () => {

--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -194,11 +194,17 @@ export function useAnalysis(): AnalysisState {
       actions_count: Object.keys(pendingAnalysisResult.actions).length,
     });
     setResult(prev => {
+      // Preserve manually-added ("first guess") actions across the
+      // analysis display step. We select them by the `is_manual`
+      // flag rather than by `selectedActionIds` so a manual action
+      // is kept even if the `selectedActionIds` set has been
+      // trimmed by resetForAnalysisRun — mirrors the standalone
+      // interface's handleDisplayPrioritizedActions behavior.
       const manualActionsData: Record<string, ActionDetail> = {};
       if (prev?.actions) {
         for (const [id, data] of Object.entries(prev.actions)) {
-          if (selectedActionIds.has(id)) {
-            manualActionsData[id] = data;
+          if (data.is_manual || selectedActionIds.has(id)) {
+            manualActionsData[id] = { ...data, is_manual: true };
           }
         }
       }
@@ -217,6 +223,9 @@ export function useAnalysis(): AnalysisState {
       return {
         ...prev,
         ...pendingAnalysisResult,
+        // Manual entries win over their analysis-suggested twins so
+        // the user's "first guess" keeps its is_manual flag and its
+        // variant diagram stays pinned to the Selected bucket.
         actions: { ...mergedActions, ...manualActionsData },
       };
     });


### PR DESCRIPTION
## Summary
Replaces the native HTML `<input list>` + `<datalist>` pattern with a custom-rendered suggestions dropdown component in the inspect search field. This fixes a reliability issue where the datalist dropdown would appear in the wrong window or not at all when a detached tab shares inspect state with the main window.

## Key Changes
- **New `InspectSearchField` component**: A custom React component that renders an input field with a manually-managed suggestions dropdown, replacing the unreliable native datalist approach
  - Implements proper focus/blur handling with a debounced close timer to allow option selection before the dropdown unmounts
  - Hides the dropdown when an exact match is found (user has selected an item)
  - Uses `onMouseDown` on suggestion items to ensure selection registers before the input's `onBlur` event
  - Positions the dropdown absolutely within a relative container, guaranteeing it stays in the same DOM subtree regardless of window relocation

- **Updated `VisualizationPanel`**: Replaced the inline `<input list>` + `<datalist>` markup with the new `InspectSearchField` component

- **Added regression tests**: Two new test cases verify:
  - No `<datalist>` elements exist in the rendered output
  - The custom dropdown appears and displays filtered suggestions when the field is focused with a partial query

## Implementation Details
The custom dropdown solves the core issue by ensuring the suggestion list lives in the same DOM subtree as the input field. When `DetachableTabHost` physically relocates the overlay to a popup window, the dropdown moves with it, avoiding the Chromium bug where native datalists can render in the wrong window context.

https://claude.ai/code/session_01YKKksRnZEYAehHndPxAXkA