### PR TITLE
Add sticky contingency/overloads header with loading percentages

### DIFF
--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -124,7 +124,11 @@ class DiagramMixin:
 
         try:
             diagram = self._generate_diagram(n, voltage_level_ids=voltage_level_ids, depth=depth)
-            diagram["lines_overloaded"] = self._get_overloaded_lines(n, lines_we_care_about=self._get_lines_we_care_about())
+            names, rhos = self._get_overloaded_lines(
+                n, lines_we_care_about=self._get_lines_we_care_about(), with_rho=True
+            )
+            diagram["lines_overloaded"] = names
+            diagram["lines_overloaded_rho"] = rhos
             # Cache N-state element currents for N-1 comparison
             self._n_state_currents = self._get_element_max_currents(n)
             return diagram
@@ -188,9 +192,14 @@ class DiagramMixin:
 
             # Exclude pre-existing overloads (already overloaded in N) unless worsened
             n_state_currents = getattr(self, '_n_state_currents', None)
-            diagram["lines_overloaded"] = self._get_overloaded_lines(
-                n, n_state_currents=n_state_currents, lines_we_care_about=self._get_lines_we_care_about()
+            names, rhos = self._get_overloaded_lines(
+                n,
+                n_state_currents=n_state_currents,
+                lines_we_care_about=self._get_lines_we_care_about(),
+                with_rho=True,
             )
+            diagram["lines_overloaded"] = names
+            diagram["lines_overloaded_rho"] = rhos
             return diagram
         finally:
             n.set_working_variant(original_variant) # Restore original variant
@@ -466,7 +475,7 @@ class DiagramMixin:
                 logger.warning(f"Warning: Failed to load lines_we_care_about: {e}")
         return None
 
-    def _get_overloaded_lines(self, network, n_state_currents=None, lines_we_care_about=None):
+    def _get_overloaded_lines(self, network, n_state_currents=None, lines_we_care_about=None, with_rho=False):
         """Get overloaded lines and transformers.
 
         Args:
@@ -477,6 +486,13 @@ class DiagramMixin:
                 worsening threshold.
             lines_we_care_about: If provided, set of element IDs to monitor.
                 Only these elements are checked for overloads.
+            with_rho: If True, also return a parallel list of rho (I/limit ratio)
+                values aligned with the returned overloaded element names.
+
+        Returns:
+            list[str] of overloaded element IDs by default.
+            If ``with_rho`` is True, a tuple ``(names, rhos)`` where ``rhos`` is
+            a list of floats aligned with ``names``.
         """
         import numpy as np
         limits = network.get_operational_limits()
@@ -486,8 +502,9 @@ class DiagramMixin:
             limits = limits.reset_index()
             current_limits = limits[(limits['type'] == 'CURRENT') & (limits['acceptable_duration'] == -1)]
             limit_dict = dict(zip(current_limits['element_id'], current_limits['value']))
-        
+
         overloaded = []
+        overloaded_rho = []
         monitoring_factor = getattr(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95)
         worsening_threshold = getattr(config, 'PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD', 0.02)
         default_limit = 9999.0  # Same default as the recommender
@@ -498,12 +515,12 @@ class DiagramMixin:
                 # Skip elements not in the monitored set
                 if lines_we_care_about is not None and element_id not in lines_we_care_about:
                     continue
-                
+
                 limit = limit_dict.get(element_id)
                 if limit is None:
                     # No permanent limit found for this branch, skip monitoring
                     continue
-                    
+
                 i1 = row['i1']
                 i2 = row['i2']
                 if not np.isnan(i1) and not np.isnan(i2):
@@ -517,6 +534,10 @@ class DiagramMixin:
                                 if max_i <= n_max_i * (1 + worsening_threshold):
                                     continue
                         overloaded.append(element_id)
+                        overloaded_rho.append(float(max_i / limit) if limit else 0.0)
+
+        if with_rho:
+            return sanitize_for_json(overloaded), sanitize_for_json(overloaded_rho)
         return sanitize_for_json(overloaded)
 
     def _get_element_max_currents(self, network):

--- a/frontend/src/App.contingency.test.tsx
+++ b/frontend/src/App.contingency.test.tsx
@@ -397,26 +397,23 @@ describe('Overload Clearing Logic', () => {
     // VERIFY: N-1 diagram is STILL present in the panel
     expect(screen.getByTestId('visualization-panel')).toHaveAttribute('data-n1-diagram-present', 'true');
   });
-  it('verifies sidebar has unified scrollbar and no nested overflows', async () => {
+  it('pins contingency + overloads while only the action feed scrolls', async () => {
     await renderAndLoadStudy();
 
-    // The main sidebar container has the data-testid="sidebar"
+    // The sidebar itself no longer scrolls — it hosts a non-scrolling
+    // sticky header (contingency + overloads) and a scrolling body
+    // (the ActionFeed). Scrolling down in actions must leave the
+    // contingency and overload information fully visible.
     const sidebar = await screen.findByTestId('sidebar');
     expect(sidebar).toBeInTheDocument();
-    expect(sidebar).toHaveStyle({ overflowY: 'auto' });
+    expect(sidebar).toHaveStyle({ overflow: 'hidden' });
 
-    // Find the ActionFeed header within the sidebar
+    // The ActionFeed is inside a scrolling wrapper that takes the
+    // remaining sidebar height.
     const sidebarActionsHeader = await within(sidebar).findByTestId('action-feed-header');
-    
-    // ActionFeed wrapper should NOT have overflowY: auto
-    const actionFeedWrapper = sidebarActionsHeader.closest('div[style*="flex-shrink: 0"]');
-    expect(actionFeedWrapper).toBeInTheDocument();
-    expect(actionFeedWrapper).not.toHaveStyle({ overflowY: 'auto' });
-
-    // Internal ActionFeed root is the sibling of the header's container
-    const actionFeedRoot = sidebarActionsHeader.parentElement?.parentElement;
-    expect(actionFeedRoot).toBeInTheDocument();
-    expect(actionFeedRoot).not.toHaveStyle({ overflowY: 'auto' });
+    const scrollWrapper = sidebarActionsHeader.closest('div[style*="overflow-y: auto"]');
+    expect(scrollWrapper).toBeInTheDocument();
+    expect(scrollWrapper).toHaveStyle({ overflowY: 'auto' });
   });
 
   it('switches to overflow tab as soon as PDF event is received (regression test)', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import './App.css';
 import VisualizationPanel from './components/VisualizationPanel';
 import ActionFeed from './components/ActionFeed';
@@ -917,16 +917,100 @@ function App() {
 
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
         {/*
-          Sidebar layout: Contingency + Overloads N-1 are pinned as a
-          non-scrolling header block so the operator keeps sight of the
-          contingency and its overloads while scrolling through the
-          (potentially long) action list. Only the ActionFeed scrolls.
+          Sidebar layout:
+          - A COMPACT sticky strip at the top keeps only the
+            clickable fields of interest visible while scrolling
+            (selected contingency → zoom active tab; N-1 overloads →
+            jump to N-1 tab + zoom, same behavior as the old
+            "Loading Before" link on action cards).
+          - Everything else — the full Select Contingency card with
+            the search input, the Overloads panel with its warnings
+            and N/N-1 breakdown, and the ActionFeed — scrolls
+            together in a single column below, saving vertical space.
         */}
         <div data-testid="sidebar" style={{ width: '25%', background: '#eee', borderRight: '1px solid #ccc', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-          <div style={{ flexShrink: 0, padding: '15px 15px 0 15px', display: 'flex', flexDirection: 'column', gap: '15px' }}>
-            {/* Target Contingency selector */}
+          {(selectedBranch || (n1Diagram?.lines_overloaded?.length ?? 0) > 0) && (
+            <div
+              data-testid="sticky-feed-summary"
+              style={{
+                flexShrink: 0,
+                padding: '6px 12px',
+                background: '#f8f9fa',
+                borderBottom: '1px solid #ccc',
+                fontSize: '11px',
+                lineHeight: 1.5,
+                boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
+              }}
+            >
+              {selectedBranch && (
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
+                  <span style={{ color: '#555', fontWeight: 600, whiteSpace: 'nowrap' }}>🎯 Contingency:</span>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleZoomOnActiveTab(selectedBranch); }}
+                    title={`Zoom to ${selectedBranch} in the current diagram`}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      padding: 0,
+                      fontSize: '11px',
+                      color: '#1e40af',
+                      fontWeight: 600,
+                      textDecoration: 'underline dotted',
+                      wordBreak: 'break-word',
+                      textAlign: 'left',
+                    }}
+                  >
+                    🔍 {selectedBranch}
+                  </button>
+                </div>
+              )}
+              {(n1Diagram?.lines_overloaded?.length ?? 0) > 0 && (
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
+                  <span style={{ color: '#b91c1c', fontWeight: 600, whiteSpace: 'nowrap' }}>⚠️ N-1:</span>
+                  <span style={{ wordBreak: 'break-word' }}>
+                    {n1Diagram!.lines_overloaded!.map((name, i) => {
+                      const rho = n1Diagram!.lines_overloaded_rho?.[i];
+                      const rhoPct = rho != null && !Number.isNaN(rho) ? `${(rho * 100).toFixed(1)}%` : null;
+                      const isSelected = selectedOverloads?.has(name) ?? true;
+                      return (
+                        <React.Fragment key={name}>
+                          {i > 0 && ', '}
+                          <button
+                            onClick={(e) => { e.stopPropagation(); wrappedAssetClick('', name, 'n-1'); }}
+                            title={`Open N-1 tab and zoom to ${name}`}
+                            style={{
+                              background: 'none',
+                              border: 'none',
+                              cursor: 'pointer',
+                              padding: 0,
+                              fontSize: '11px',
+                              color: isSelected ? '#1e40af' : '#bdc3c7',
+                              fontWeight: isSelected ? 600 : 400,
+                              textDecoration: isSelected ? 'underline dotted' : 'none',
+                            }}
+                          >
+                            {name}
+                          </button>
+                          {rhoPct && (
+                            <span style={{ color: isSelected ? '#374151' : '#bdc3c7', marginLeft: '2px' }}>
+                              ({rhoPct})
+                            </span>
+                          )}
+                        </React.Fragment>
+                      );
+                    })}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+          <div style={{ flex: 1, overflowY: 'auto', padding: '15px', minHeight: 0, display: 'flex', flexDirection: 'column', gap: '15px' }}>
+            {/* Target Contingency selector — full card lives in the
+                scroll area so the compact sticky strip above stays
+                minimal. */}
             {branches.length > 0 && (
-              <div style={{ padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
+              <div style={{ flexShrink: 0, padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
                 <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>🎯 Select Contingency</label>
                 <input
                   list="contingencies"
@@ -938,50 +1022,29 @@ function App() {
                 <datalist id="contingencies">
                   {contingencyOptions}
                 </datalist>
-                {selectedBranch && (
-                  <div style={{ marginTop: '6px', fontSize: '11px', color: '#374151' }}>
-                    <span style={{ marginRight: '4px' }}>Selected:</span>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); handleZoomOnActiveTab(selectedBranch); }}
-                      title={`Zoom to ${selectedBranch} in the current diagram`}
-                      style={{
-                        background: 'none',
-                        border: 'none',
-                        cursor: 'pointer',
-                        padding: 0,
-                        fontSize: '11px',
-                        color: '#1e40af',
-                        fontWeight: 600,
-                        textDecoration: 'underline dotted',
-                      }}
-                    >
-                      🔍 {selectedBranch}
-                    </button>
-                  </div>
-                )}
               </div>
             )}
 
-            <OverloadPanel
-              nOverloads={nDiagram?.lines_overloaded || []}
-              n1Overloads={n1Diagram?.lines_overloaded || []}
-              nOverloadsRho={nDiagram?.lines_overloaded_rho}
-              n1OverloadsRho={n1Diagram?.lines_overloaded_rho}
-              onZoomToAsset={handleZoomOnActiveTab}
-              showMonitoringWarning={showMonitoringWarning}
-              monitoredLinesCount={monitoredLinesCount}
-              totalLinesCount={totalLinesCount}
-              monitoringFactor={monitoringFactor}
-              preExistingOverloadThreshold={preExistingOverloadThreshold}
-              onDismissWarning={handleDismissWarning}
-              onOpenSettings={handleOpenConfigSettings}
-              selectedOverloads={selectedOverloads}
-              onToggleOverload={analysis.handleToggleOverload}
-              monitorDeselected={monitorDeselected}
-              onToggleMonitorDeselected={handleToggleMonitorDeselected}
-            />
-          </div>
-          <div style={{ flex: 1, overflowY: 'auto', padding: '15px', minHeight: 0 }}>
+            <div style={{ flexShrink: 0 }}>
+              <OverloadPanel
+                nOverloads={nDiagram?.lines_overloaded || []}
+                n1Overloads={n1Diagram?.lines_overloaded || []}
+                nOverloadsRho={nDiagram?.lines_overloaded_rho}
+                n1OverloadsRho={n1Diagram?.lines_overloaded_rho}
+                onAssetClick={wrappedAssetClick as (actionId: string, assetName: string, tab?: 'n' | 'n-1') => void}
+                showMonitoringWarning={showMonitoringWarning}
+                monitoredLinesCount={monitoredLinesCount}
+                totalLinesCount={totalLinesCount}
+                monitoringFactor={monitoringFactor}
+                preExistingOverloadThreshold={preExistingOverloadThreshold}
+                onDismissWarning={handleDismissWarning}
+                onOpenSettings={handleOpenConfigSettings}
+                selectedOverloads={selectedOverloads}
+                onToggleOverload={analysis.handleToggleOverload}
+                monitorDeselected={monitorDeselected}
+                onToggleMonitorDeselected={handleToggleMonitorDeselected}
+              />
+            </div>
             <ActionFeed
               actions={result?.actions || {}}
               actionScores={result?.action_scores}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -341,6 +341,23 @@ function App() {
     [diagrams, wrappedActionSelect]
   );
 
+  // Zoom the currently-active diagram tab on a named asset without
+  // switching tabs. Used by the sticky Contingency and Overloads
+  // sections: operators want to keep the view they're on (N / N-1 /
+  // Action) and just focus the clicked line in place.
+  const handleZoomOnActiveTab = useCallback((assetName: string) => {
+    if (!assetName) return;
+    const tab = diagrams.activeTab;
+    if (tab === 'overflow') return;
+    interactionLogger.record('asset_clicked', { action_id: '', asset_name: assetName, tab });
+    // Update inspectQuery (so the inspect overlay, if open, reflects
+    // the focus) AND call zoomToElement directly — the auto-zoom effect
+    // skips no-op query changes, whereas we want re-clicking the same
+    // line to re-center the view.
+    diagrams.setInspectQueryForTab(tab, assetName);
+    diagrams.zoomToElement(assetName, tab);
+  }, [diagrams]);
+
   const saveParams = useMemo(() => ({
     networkPath, actionPath, layoutPath, outputFolderPath,
     minLineReconnections, minCloseCoupling, minOpenCoupling,
@@ -899,29 +916,58 @@ function App() {
       />
 
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-        <div data-testid="sidebar" style={{ width: '25%', background: '#eee', borderRight: '1px solid #ccc', display: 'flex', flexDirection: 'column', padding: '15px', gap: '15px', overflowY: 'auto' }}>
-          {/* Target Contingency selector */}
-          {branches.length > 0 && (
-            <div style={{ padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
-              <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>🎯 Select Contingency</label>
-              <input
-                list="contingencies"
-                value={selectedBranch}
-                onChange={handleContingencyChange}
-                placeholder="Search line/bus..."
-                style={{ width: '100%', padding: '7px 10px', border: '1px solid #ccc', borderRadius: '4px', boxSizing: 'border-box', fontSize: '0.85rem' }}
-              />
-              <datalist id="contingencies">
-                {contingencyOptions}
-              </datalist>
-            </div>
-          )}
+        {/*
+          Sidebar layout: Contingency + Overloads N-1 are pinned as a
+          non-scrolling header block so the operator keeps sight of the
+          contingency and its overloads while scrolling through the
+          (potentially long) action list. Only the ActionFeed scrolls.
+        */}
+        <div data-testid="sidebar" style={{ width: '25%', background: '#eee', borderRight: '1px solid #ccc', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          <div style={{ flexShrink: 0, padding: '15px 15px 0 15px', display: 'flex', flexDirection: 'column', gap: '15px' }}>
+            {/* Target Contingency selector */}
+            {branches.length > 0 && (
+              <div style={{ padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
+                <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>🎯 Select Contingency</label>
+                <input
+                  list="contingencies"
+                  value={selectedBranch}
+                  onChange={handleContingencyChange}
+                  placeholder="Search line/bus..."
+                  style={{ width: '100%', padding: '7px 10px', border: '1px solid #ccc', borderRadius: '4px', boxSizing: 'border-box', fontSize: '0.85rem' }}
+                />
+                <datalist id="contingencies">
+                  {contingencyOptions}
+                </datalist>
+                {selectedBranch && (
+                  <div style={{ marginTop: '6px', fontSize: '11px', color: '#374151' }}>
+                    <span style={{ marginRight: '4px' }}>Selected:</span>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); handleZoomOnActiveTab(selectedBranch); }}
+                      title={`Zoom to ${selectedBranch} in the current diagram`}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        padding: 0,
+                        fontSize: '11px',
+                        color: '#1e40af',
+                        fontWeight: 600,
+                        textDecoration: 'underline dotted',
+                      }}
+                    >
+                      🔍 {selectedBranch}
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
 
-          <div style={{ flexShrink: 0 }}>
             <OverloadPanel
               nOverloads={nDiagram?.lines_overloaded || []}
               n1Overloads={n1Diagram?.lines_overloaded || []}
-              onAssetClick={wrappedAssetClick as (actionId: string, assetName: string, tab?: 'n' | 'n-1') => void}
+              nOverloadsRho={nDiagram?.lines_overloaded_rho}
+              n1OverloadsRho={n1Diagram?.lines_overloaded_rho}
+              onZoomToAsset={handleZoomOnActiveTab}
               showMonitoringWarning={showMonitoringWarning}
               monitoredLinesCount={monitoredLinesCount}
               totalLinesCount={totalLinesCount}
@@ -935,7 +981,7 @@ function App() {
               onToggleMonitorDeselected={handleToggleMonitorDeselected}
             />
           </div>
-          <div style={{ flexShrink: 0 }}>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '15px', minHeight: 0 }}>
             <ActionFeed
               actions={result?.actions || {}}
               actionScores={result?.action_scores}

--- a/frontend/src/components/ActionCard.test.tsx
+++ b/frontend/src/components/ActionCard.test.tsx
@@ -108,6 +108,34 @@ describe('ActionCard', () => {
         expect(screen.queryByText('VIEWING')).not.toBeInTheDocument();
     });
 
+    it('renders the VIEWING marker as a vertical ribbon on the left edge', () => {
+        // The ribbon sits flush against the left border to free a full
+        // row of horizontal space inside the card header (long action
+        // IDs on a narrow sidebar).  It must be a sibling of the
+        // content column — not inside the header — and must use
+        // vertical writing mode.
+        render(<ActionCard {...defaultProps} isViewing={true} />);
+        const ribbon = screen.getByTestId('action-card-act_1-viewing-ribbon');
+        expect(ribbon).toBeInTheDocument();
+        expect(ribbon).toHaveTextContent('VIEWING');
+        expect(ribbon).toHaveStyle({ writingMode: 'vertical-rl' });
+
+        // And the inline top-right VIEWING pill is gone (the severity
+        // badge — "Solves overload" — is still rendered next to the
+        // title, but not the old rectangular "VIEWING" pill).
+        const card = screen.getByTestId('action-card-act_1');
+        const inlinePill = card.querySelectorAll('span');
+        const pillTexts = Array.from(inlinePill).map(el => el.textContent);
+        // The vertical ribbon is a <div>, not a <span>, so no <span>
+        // should contain exactly "VIEWING".
+        expect(pillTexts).not.toContain('VIEWING');
+    });
+
+    it('does not render the vertical ribbon when isViewing is false', () => {
+        render(<ActionCard {...defaultProps} isViewing={false} />);
+        expect(screen.queryByTestId('action-card-act_1-viewing-ribbon')).not.toBeInTheDocument();
+    });
+
     it('calls onActionSelect when card is clicked', () => {
         const onActionSelect = vi.fn();
         render(<ActionCard {...defaultProps} onActionSelect={onActionSelect} />);

--- a/frontend/src/components/ActionCard.test.tsx
+++ b/frontend/src/components/ActionCard.test.tsx
@@ -157,6 +157,43 @@ describe('ActionCard', () => {
         expect(screen.getAllByTitle('Zoom to LINE_A').length).toBeGreaterThan(0);
     });
 
+    it('clicks on the max-loading line name zoom the new worst line, not the pre-action overload', () => {
+        // Regression: the action re-distributes flows and the new worst
+        // line (LINE_B) is NOT in linesOverloaded (which reflects the
+        // pre-action N-1 overloads — only LINE_A here). Clicking
+        // "LINE_B" in the "Max loading: X% on LINE_B" row must zoom on
+        // LINE_B, not on any of the pre-action lines.
+        const onAssetClick = vi.fn();
+        const details: ActionDetail = {
+            ...baseDetails,
+            rho_before: [1.05],
+            rho_after: [0.72],     // LINE_A is now below the limit
+            max_rho: 0.967,        // but LINE_B (newly overloaded) peaks at 96.7%
+            max_rho_line: 'LINE_B',
+            is_rho_reduction: true,
+        };
+        render(
+            <ActionCard
+                {...defaultProps}
+                details={details}
+                linesOverloaded={['LINE_A']}
+                onAssetClick={onAssetClick}
+            />
+        );
+
+        // The displayed text must mention the new worst line
+        expect(screen.getByText('96.7%')).toBeInTheDocument();
+
+        // Click specifically the "on LINE_B" button inside the Max
+        // loading row — not the rho_after button (which would be on
+        // LINE_A) and not any sticky-panel button (not in this test).
+        const maxRhoButton = screen.getByTitle('Zoom to LINE_B');
+        fireEvent.click(maxRhoButton);
+
+        expect(onAssetClick).toHaveBeenCalledTimes(1);
+        expect(onAssetClick).toHaveBeenCalledWith('act_1', 'LINE_B', 'action');
+    });
+
     it('renders loading after rho section (loading before is shown in the sticky Overloads panel)', () => {
         render(<ActionCard {...defaultProps} />);
         expect(screen.queryByText(/Loading before/)).not.toBeInTheDocument();

--- a/frontend/src/components/ActionCard.test.tsx
+++ b/frontend/src/components/ActionCard.test.tsx
@@ -157,9 +157,9 @@ describe('ActionCard', () => {
         expect(screen.getAllByTitle('Zoom to LINE_A').length).toBeGreaterThan(0);
     });
 
-    it('renders loading before/after rho sections', () => {
+    it('renders loading after rho section (loading before is shown in the sticky Overloads panel)', () => {
         render(<ActionCard {...defaultProps} />);
-        expect(screen.getByText(/Loading before/)).toBeInTheDocument();
+        expect(screen.queryByText(/Loading before/)).not.toBeInTheDocument();
         expect(screen.getByText(/Loading after/)).toBeInTheDocument();
     });
 

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -331,7 +331,12 @@ const ActionCard: React.FC<ActionCardProps> = ({
             </div>
             <div style={{ fontSize: '12px', background: isViewing ? '#dce8f7' : '#f8f9fa', padding: '5px', marginTop: '5px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
                 <div>
-                    <div>Loading before: {renderRho(details.rho_before, id, 'n-1')}</div>
+                    {/*
+                      "Loading before" removed — the N-1 pre-action loading
+                      is already shown in the sticky Overloads N-1 section
+                      of the left feed, with percentages next to each
+                      overloaded line. No need to duplicate it per card.
+                    */}
                     <div>Loading after: {renderRho(details.rho_after, id, 'action')}</div>
                     {maxRhoPct != null && (
                         <div style={{ marginTop: '3px' }}>

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -191,13 +191,52 @@ const ActionCard: React.FC<ActionCardProps> = ({
                 background: (details.non_convergence || details.is_islanded) ? '#fff5f5' : (isViewing ? '#e7f1ff' : 'white'),
                 border: (details.non_convergence || details.is_islanded) ? '1px solid #dc3545' : '1px solid #ddd',
                 borderRadius: '8px',
-                padding: '10px',
                 marginBottom: '10px',
                 boxShadow: isViewing ? '0 0 0 2px rgba(0,123,255,0.3), 0 2px 8px rgba(0,0,0,0.15)' : '0 2px 4px rgba(0,0,0,0.1)',
                 borderLeft: `5px solid ${isViewing ? '#007bff' : sc.border}`,
                 cursor: 'pointer',
                 transition: 'all 0.15s ease',
+                display: 'flex',
+                alignItems: 'stretch',
+                overflow: 'hidden',
             }} onClick={() => onActionSelect(id)}>
+            {/*
+              When the card is the currently-viewed action, the
+              VIEWING marker is rendered as a vertical ribbon flush
+              against the left edge (between the colored border and
+              the content) — this frees up a full line of horizontal
+              space inside the header, which matters on a narrow
+              sidebar with long equipment IDs.
+
+              Implementation note: `writing-mode: vertical-rl` +
+              `transform: rotate(180deg)` yields bottom-to-top text
+              with letters rotated the "book-spine" way — the
+              cross-browser combination that works consistently on
+              Chromium / Firefox / Safari (unlike the newer
+              `sideways-lr`, which is still WebKit-patchy).
+            */}
+            {isViewing && (
+                <div
+                    data-testid={`action-card-${id}-viewing-ribbon`}
+                    style={{
+                        writingMode: 'vertical-rl',
+                        transform: 'rotate(180deg)',
+                        background: '#007bff',
+                        color: 'white',
+                        fontSize: '10px',
+                        fontWeight: 700,
+                        letterSpacing: '1.5px',
+                        padding: '8px 3px',
+                        textAlign: 'center',
+                        flexShrink: 0,
+                        userSelect: 'none',
+                    }}
+                    aria-label="Currently viewing this action"
+                >
+                    VIEWING
+                </div>
+            )}
+            <div style={{ flex: 1, padding: '10px', minWidth: 0 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <h4 style={{
                     margin: 0,
@@ -210,11 +249,6 @@ const ActionCard: React.FC<ActionCardProps> = ({
                     #{index + 1} {'\u2014'} {id}
                 </h4>
                 <div style={{ display: 'flex', gap: '5px', alignItems: 'center' }}>
-                    {isViewing && (
-                        <span style={{ fontSize: '10px', fontWeight: 600, padding: '2px 6px', borderRadius: '4px', background: '#007bff', color: 'white' }}>
-                            VIEWING
-                        </span>
-                    )}
                     <span style={{ fontSize: '11px', fontWeight: 600, padding: '2px 8px', borderRadius: '12px', background: sc.badgeBg, color: sc.badgeText }}>
                         {sc.label}
                     </span>
@@ -368,6 +402,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                     )}
                 </div>
             </div>
+            </div>{/* /content column */}
         </div>
     );
 };

--- a/frontend/src/components/OverloadPanel.test.tsx
+++ b/frontend/src/components/OverloadPanel.test.tsx
@@ -14,7 +14,7 @@ describe('OverloadPanel', () => {
     const defaultProps = {
         nOverloads: [] as string[],
         n1Overloads: [] as string[],
-        onZoomToAsset: vi.fn(),
+        onAssetClick: vi.fn(),
     };
 
     it('renders the Overloads heading', () => {
@@ -49,34 +49,34 @@ describe('OverloadPanel', () => {
         expect(screen.getByText('TRAFO_1')).toBeInTheDocument();
     });
 
-    it('calls onZoomToAsset with line name for N overloads', async () => {
+    it('calls onAssetClick with N tab for N overloads', async () => {
         const user = userEvent.setup();
-        const onZoomToAsset = vi.fn();
+        const onAssetClick = vi.fn();
         render(
             <OverloadPanel
                 {...defaultProps}
                 nOverloads={['LINE_A']}
-                onZoomToAsset={onZoomToAsset}
+                onAssetClick={onAssetClick}
             />
         );
 
         await user.click(screen.getByText('LINE_A'));
-        expect(onZoomToAsset).toHaveBeenCalledWith('LINE_A');
+        expect(onAssetClick).toHaveBeenCalledWith('', 'LINE_A', 'n');
     });
 
-    it('calls onZoomToAsset with line name for N-1 overloads', async () => {
+    it('calls onAssetClick with N-1 tab for N-1 overloads', async () => {
         const user = userEvent.setup();
-        const onZoomToAsset = vi.fn();
+        const onAssetClick = vi.fn();
         render(
             <OverloadPanel
                 {...defaultProps}
                 n1Overloads={['LINE_B']}
-                onZoomToAsset={onZoomToAsset}
+                onAssetClick={onAssetClick}
             />
         );
 
         await user.click(screen.getByText('LINE_B'));
-        expect(onZoomToAsset).toHaveBeenCalledWith('LINE_B');
+        expect(onAssetClick).toHaveBeenCalledWith('', 'LINE_B', 'n-1');
     });
 
     it('renders loading percentages next to overload names when rho is provided', () => {

--- a/frontend/src/components/OverloadPanel.test.tsx
+++ b/frontend/src/components/OverloadPanel.test.tsx
@@ -14,7 +14,7 @@ describe('OverloadPanel', () => {
     const defaultProps = {
         nOverloads: [] as string[],
         n1Overloads: [] as string[],
-        onAssetClick: vi.fn(),
+        onZoomToAsset: vi.fn(),
     };
 
     it('renders the Overloads heading', () => {
@@ -49,34 +49,48 @@ describe('OverloadPanel', () => {
         expect(screen.getByText('TRAFO_1')).toBeInTheDocument();
     });
 
-    it('calls onAssetClick with correct tab for N overloads', async () => {
+    it('calls onZoomToAsset with line name for N overloads', async () => {
         const user = userEvent.setup();
-        const onAssetClick = vi.fn();
+        const onZoomToAsset = vi.fn();
         render(
             <OverloadPanel
                 {...defaultProps}
                 nOverloads={['LINE_A']}
-                onAssetClick={onAssetClick}
+                onZoomToAsset={onZoomToAsset}
             />
         );
 
         await user.click(screen.getByText('LINE_A'));
-        expect(onAssetClick).toHaveBeenCalledWith('', 'LINE_A', 'n');
+        expect(onZoomToAsset).toHaveBeenCalledWith('LINE_A');
     });
 
-    it('calls onAssetClick with correct tab for N-1 overloads', async () => {
+    it('calls onZoomToAsset with line name for N-1 overloads', async () => {
         const user = userEvent.setup();
-        const onAssetClick = vi.fn();
+        const onZoomToAsset = vi.fn();
         render(
             <OverloadPanel
                 {...defaultProps}
                 n1Overloads={['LINE_B']}
-                onAssetClick={onAssetClick}
+                onZoomToAsset={onZoomToAsset}
             />
         );
 
         await user.click(screen.getByText('LINE_B'));
-        expect(onAssetClick).toHaveBeenCalledWith('', 'LINE_B', 'n-1');
+        expect(onZoomToAsset).toHaveBeenCalledWith('LINE_B');
+    });
+
+    it('renders loading percentages next to overload names when rho is provided', () => {
+        render(
+            <OverloadPanel
+                {...defaultProps}
+                nOverloads={['LINE_A']}
+                nOverloadsRho={[1.024]}
+                n1Overloads={['LINE_B']}
+                n1OverloadsRho={[1.1765]}
+            />
+        );
+        expect(screen.getByText('(102.4%)')).toBeInTheDocument();
+        expect(screen.getByText('(117.7%)')).toBeInTheDocument();
     });
 
     it('renders both N and N-1 overloads simultaneously', () => {

--- a/frontend/src/components/OverloadPanel.tsx
+++ b/frontend/src/components/OverloadPanel.tsx
@@ -10,7 +10,23 @@ import React from 'react';
 interface OverloadPanelProps {
     nOverloads: string[];
     n1Overloads: string[];
-    onAssetClick: (actionId: string, assetName: string, tab?: 'n' | 'n-1') => void;
+    /**
+     * Per-line loading ratios (aligned with `nOverloads`).
+     * Rendered as "(XX.X%)" after the line name.
+     */
+    nOverloadsRho?: number[];
+    /**
+     * Per-line loading ratios (aligned with `n1Overloads`).
+     * Rendered as "(XX.X%)" after the line name.
+     */
+    n1OverloadsRho?: number[];
+    /**
+     * Zoom the currently-active network visualization diagram on the
+     * clicked line. Unlike the old per-tab asset click, this keeps the
+     * user on whatever tab they're currently looking at — scanning
+     * overloads without jumping between N / N-1 / Action views.
+     */
+    onZoomToAsset: (assetName: string) => void;
     showMonitoringWarning?: boolean;
     monitoredLinesCount?: number;
     totalLinesCount?: number;
@@ -27,7 +43,9 @@ interface OverloadPanelProps {
 const OverloadPanel: React.FC<OverloadPanelProps> = ({
     nOverloads,
     n1Overloads,
-    onAssetClick,
+    nOverloadsRho,
+    n1OverloadsRho,
+    onZoomToAsset,
     showMonitoringWarning,
     monitoredLinesCount,
     totalLinesCount,
@@ -53,10 +71,14 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
         display: 'inline',
     };
 
-    const renderLinks = (lines: string[], tab: 'n' | 'n-1') => {
+    const formatRho = (v: number | undefined) =>
+        v == null || Number.isNaN(v) ? null : `${(v * 100).toFixed(1)}%`;
+
+    const renderLinks = (lines: string[], rhos: number[] | undefined, tab: 'n' | 'n-1') => {
         if (!lines || lines.length === 0) return <span style={{ color: '#888', fontStyle: 'italic' }}>None</span>;
         return lines.map((lineName, i) => {
             const isSelected = tab === 'n-1' ? (selectedOverloads?.has(lineName) ?? true) : true;
+            const rhoPct = formatRho(rhos?.[i]);
             return (
                 <React.Fragment key={i}>
                     {i > 0 && ', '}
@@ -67,19 +89,30 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                             fontWeight: isSelected ? 600 : 400,
                             textDecoration: isSelected ? 'underline dotted' : 'none'
                         }}
-                        title={tab === 'n-1' 
+                        title={tab === 'n-1'
                             ? (isSelected ? `Zoom to ${lineName} (Double-click to unselect)` : `Zoom to ${lineName} (Double-click to select)`)
                             : `Zoom to ${lineName}`}
-                        onClick={(e) => { e.stopPropagation(); onAssetClick('', lineName, tab); }}
-                        onDoubleClick={(e) => { 
+                        onClick={(e) => { e.stopPropagation(); onZoomToAsset(lineName); }}
+                        onDoubleClick={(e) => {
                             if (tab === 'n-1') {
-                                e.stopPropagation(); 
-                                onToggleOverload?.(lineName); 
+                                e.stopPropagation();
+                                onToggleOverload?.(lineName);
                             }
                         }}
                     >
                         {lineName}
                     </button>
+                    {rhoPct && (
+                        <span
+                            style={{
+                                color: isSelected ? '#374151' : '#bdc3c7',
+                                fontWeight: 500,
+                                marginLeft: '2px',
+                            }}
+                        >
+                            ({rhoPct})
+                        </span>
+                    )}
                 </React.Fragment>
             );
         });
@@ -142,7 +175,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                 }}>
                     <strong style={{ whiteSpace: 'nowrap' }}>N Overloads:</strong>
                     <div style={{ display: 'inline', wordBreak: 'break-word' }}>
-                        {renderLinks(nOverloads, 'n')}
+                        {renderLinks(nOverloads, nOverloadsRho, 'n')}
                     </div>
                 </div>
 
@@ -200,7 +233,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                         </label>
                     )}
                     <span style={{ wordBreak: 'break-word' }}>
-                        {renderLinks(n1Overloads, 'n-1')}
+                        {renderLinks(n1Overloads, n1OverloadsRho, 'n-1')}
                     </span>
                 </div>
             </div>

--- a/frontend/src/components/OverloadPanel.tsx
+++ b/frontend/src/components/OverloadPanel.tsx
@@ -21,12 +21,13 @@ interface OverloadPanelProps {
      */
     n1OverloadsRho?: number[];
     /**
-     * Zoom the currently-active network visualization diagram on the
-     * clicked line. Unlike the old per-tab asset click, this keeps the
-     * user on whatever tab they're currently looking at — scanning
-     * overloads without jumping between N / N-1 / Action views.
+     * Clicking an overloaded line switches to the matching diagram
+     * tab (N for N-overloads, N-1 for N-1-overloads) and zooms on
+     * the element — mirroring the old "Loading Before" behavior on
+     * action cards so the operator lands directly on the relevant
+     * network state.
      */
-    onZoomToAsset: (assetName: string) => void;
+    onAssetClick: (actionId: string, assetName: string, tab?: 'n' | 'n-1') => void;
     showMonitoringWarning?: boolean;
     monitoredLinesCount?: number;
     totalLinesCount?: number;
@@ -45,7 +46,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
     n1Overloads,
     nOverloadsRho,
     n1OverloadsRho,
-    onZoomToAsset,
+    onAssetClick,
     showMonitoringWarning,
     monitoredLinesCount,
     totalLinesCount,
@@ -92,7 +93,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                         title={tab === 'n-1'
                             ? (isSelected ? `Zoom to ${lineName} (Double-click to unselect)` : `Zoom to ${lineName} (Double-click to select)`)
                             : `Zoom to ${lineName}`}
-                        onClick={(e) => { e.stopPropagation(); onZoomToAsset(lineName); }}
+                        onClick={(e) => { e.stopPropagation(); onAssetClick('', lineName, tab); }}
                         onDoubleClick={(e) => {
                             if (tab === 'n-1') {
                                 e.stopPropagation();

--- a/frontend/src/hooks/useDiagrams.test.ts
+++ b/frontend/src/hooks/useDiagrams.test.ts
@@ -7,8 +7,20 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useDiagrams } from './useDiagrams';
+import { useDiagrams, computeKnownItemsSet } from './useDiagrams';
+import type { MetadataIndex, NodeMeta, EdgeMeta } from '../types';
 import { interactionLogger } from '../utils/interactionLogger';
+
+const makeIndex = (nodes: string[], edges: string[]): MetadataIndex => ({
+    nodesByEquipmentId: new Map<string, NodeMeta>(
+        nodes.map(id => [id, { equipmentId: id, svgId: `svg-${id}`, x: 0, y: 0 }]),
+    ),
+    nodesBySvgId: new Map(),
+    edgesByEquipmentId: new Map<string, EdgeMeta>(
+        edges.map(id => [id, { equipmentId: id, svgId: `svg-${id}`, node1: 'n1', node2: 'n2' }]),
+    ),
+    edgesByNode: new Map(),
+});
 
 // Mock the api module
 vi.mock('../api', () => ({
@@ -291,5 +303,56 @@ describe('useDiagrams — interaction logging', () => {
             rerender({ dt: {} });
             expect(result.current.nSvgContainerRef).toBe(nRef);
         });
+    });
+});
+
+describe('computeKnownItemsSet — auto-zoom guard', () => {
+    it('includes branches and voltage levels', () => {
+        const set = computeKnownItemsSet(['BRANCH_A', 'BRANCH_B'], ['VL1', 'VL2'], []);
+        expect(set.has('BRANCH_A')).toBe(true);
+        expect(set.has('BRANCH_B')).toBe(true);
+        expect(set.has('VL1')).toBe(true);
+        expect(set.has('VL2')).toBe(true);
+    });
+
+    it('still rejects partial / unknown text so typed-input guard works', () => {
+        const set = computeKnownItemsSet(['BRANCH_A'], ['VL1'], []);
+        expect(set.has('BRAN')).toBe(false);
+        expect(set.has('UNKNOWN_LINE')).toBe(false);
+    });
+
+    it('includes equipment IDs from metadata edge indices', () => {
+        // A line that is NOT in the disconnectable branches list
+        // (e.g. an action reshuffles flows and a different line
+        // becomes the new max_rho line) must still be zoomable via
+        // an explicit asset click.
+        const actionMeta = makeIndex([], ['CHALOL31LOUHA']);
+        const set = computeKnownItemsSet(['BEONL31CPVAN'], [], [null, null, actionMeta]);
+        expect(set.has('BEONL31CPVAN')).toBe(true);
+        expect(set.has('CHALOL31LOUHA')).toBe(true);
+    });
+
+    it('includes equipment IDs from metadata node indices', () => {
+        const nMeta = makeIndex(['VL_FOO'], []);
+        const set = computeKnownItemsSet([], [], [nMeta]);
+        expect(set.has('VL_FOO')).toBe(true);
+    });
+
+    it('is the union of branches, voltageLevels and every provided index', () => {
+        const nMeta = makeIndex(['NODE_N'], ['EDGE_N']);
+        const n1Meta = makeIndex(['NODE_N1'], ['EDGE_N1']);
+        const actionMeta = makeIndex(['NODE_A'], ['EDGE_A']);
+        const set = computeKnownItemsSet(
+            ['BRANCH_X'], ['VL_X'], [nMeta, n1Meta, actionMeta],
+        );
+        for (const k of ['BRANCH_X', 'VL_X', 'NODE_N', 'EDGE_N', 'NODE_N1', 'EDGE_N1', 'NODE_A', 'EDGE_A']) {
+            expect(set.has(k)).toBe(true);
+        }
+    });
+
+    it('tolerates null / undefined metadata indices', () => {
+        expect(() => computeKnownItemsSet([], [], [null, undefined, null])).not.toThrow();
+        const set = computeKnownItemsSet(['BRANCH_A'], [], [null]);
+        expect(set.has('BRANCH_A')).toBe(true);
     });
 });

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -17,6 +17,41 @@ import type { DiagramData, ViewBox, MetadataIndex, TabId, VlOverlay, SldTab, Ana
 import { interactionLogger } from '../utils/interactionLogger';
 import { useSldOverlay } from './useSldOverlay';
 
+/**
+ * Compute the set of equipment IDs the auto-zoom effect is allowed to
+ * target. Includes:
+ *
+ *  - `branches` — disconnectable N-1 targets (so typing "LIN"
+ *    in the inspect input is rejected until the user commits a full
+ *    equipment name).
+ *  - `voltageLevels` — same rationale.
+ *  - Every equipment ID present in any loaded NAD metadata index
+ *    (nodes + edges), which is what makes explicit asset clicks
+ *    work for elements that are NOT in the disconnectable branch
+ *    list — for instance, an action's re-distributed `max_rho_line`
+ *    (a line that is newly overloaded after a remedial action but is
+ *    not itself a contingency target).  Without these extra entries
+ *    the effect would reject the click and leave the diagram centered
+ *    on whatever element was zoomed last (typically the previous
+ *    pre-action overload), giving the impression that the
+ *    Max-loading link is "stuck".
+ *
+ * Exported for tests; consumed internally by {@link useDiagrams}.
+ */
+export function computeKnownItemsSet(
+  branches: string[],
+  voltageLevels: string[],
+  indices: (MetadataIndex | null | undefined)[],
+): Set<string> {
+  const s = new Set<string>([...branches, ...voltageLevels]);
+  for (const idx of indices) {
+    if (!idx) continue;
+    for (const k of idx.edgesByEquipmentId.keys()) s.add(k);
+    for (const k of idx.nodesByEquipmentId.keys()) s.add(k);
+  }
+  return s;
+}
+
 export interface DiagramsState {
   // Tab
   activeTab: TabId;
@@ -576,10 +611,11 @@ export function useDiagrams(
     [branches, voltageLevels]
   );
 
-  // Set for O(1) lookup used by the zoom guard
-  const knownItemsSet = useMemo(() =>
-    new Set([...branches, ...voltageLevels]),
-    [branches, voltageLevels]
+  // Set for O(1) lookup used by the zoom guard.  See
+  // `computeKnownItemsSet` for the why.
+  const knownItemsSet = useMemo(
+    () => computeKnownItemsSet(branches, voltageLevels, [nMetaIndex, n1MetaIndex, actionMetaIndex]),
+    [branches, voltageLevels, nMetaIndex, n1MetaIndex, actionMetaIndex],
   );
 
   // ===== Voltage Range Filter =====

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -123,6 +123,13 @@ export interface DiagramData {
     asset_deltas?: Record<string, AssetDelta>;
     originalViewBox?: ViewBox | null;
     lines_overloaded?: string[];
+    /**
+     * Parallel to `lines_overloaded`: the per-element loading ratio
+     * (max|i|/permanent_limit, so a value > 1.0 means the branch is
+     * above its limit). Displayed in the Overloads feed as "(XX.X%)"
+     * alongside the line name. Missing for older session dumps.
+     */
+    lines_overloaded_rho?: number[];
 }
 
 export interface FlowDelta {

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -70,18 +70,26 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             background: #eee;
             border-right: 1px solid #ccc;
             /*
-              The Contingency + Overloads N-1 sections must stay visible
-              when scrolling through actions, so the sidebar itself no
-              longer scrolls — its inner `.action-feed-scroll` does.
+              A COMPACT sticky strip at the top keeps only the
+              clickable fields of interest visible (selected
+              contingency + N-1 overloads).  Everything else —
+              full Select Contingency card, full Overloads panel,
+              ActionFeed — scrolls together in `.action-feed-scroll`
+              to save vertical space.
             */
             display: flex;
             flex-direction: column;
             overflow: hidden;
         }
 
-        .action-feed-sticky {
+        .action-feed-sticky-summary {
             flex-shrink: 0;
-            padding: 15px 15px 0 15px;
+            padding: 6px 12px;
+            background: #f8f9fa;
+            border-bottom: 1px solid #ccc;
+            font-size: 11px;
+            line-height: 1.5;
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
         }
 
         .action-feed-scroll {
@@ -5812,25 +5820,56 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 
                     <div className="main-content">
                         <div className="action-feed">
-                            <div className="action-feed-sticky">
-                            {/* Target Contingency selector */}
-                            {branches.length > 0 && (
-                                <div style={{ marginBottom: '10px', padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
-                                    <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>🎯 Select Contingency</label>
-                                    <input list="contingencies" value={selectedBranch} onChange={e => { const val = e.target.value; if (branches.includes(val)) interactionLogger.record('contingency_selected', { element: val }); setSelectedBranch(val); }} placeholder="Search line/bus..." style={{ width: '100%', padding: '7px 10px', border: '1px solid #ccc', borderRadius: '4px', boxSizing: 'border-box', fontSize: '0.85rem' }} />
-                                    <datalist id="contingencies">{contingencyOptions}</datalist>
+                            {(selectedBranch || (n1Diagram && n1Diagram.lines_overloaded && n1Diagram.lines_overloaded.length > 0)) && (
+                                <div className="action-feed-sticky-summary">
                                     {selectedBranch && (
-                                        <div style={{ marginTop: '6px', fontSize: '11px', color: '#374151' }}>
-                                            <span style={{ marginRight: '4px' }}>Selected:</span>
+                                        <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
+                                            <span style={{ color: '#555', fontWeight: 600, whiteSpace: 'nowrap' }}>🎯 Contingency:</span>
                                             <button
                                                 onClick={(e) => { e.stopPropagation(); zoomOnActiveTab(selectedBranch); }}
                                                 title={`Zoom to ${selectedBranch} in the current diagram`}
-                                                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '11px', color: '#1e40af', fontWeight: 600, textDecoration: 'underline dotted' }}
+                                                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '11px', color: '#1e40af', fontWeight: 600, textDecoration: 'underline dotted', textAlign: 'left' }}
                                             >
                                                 🔍 {selectedBranch}
                                             </button>
                                         </div>
                                     )}
+                                    {n1Diagram && n1Diagram.lines_overloaded && n1Diagram.lines_overloaded.length > 0 && (
+                                        <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
+                                            <span style={{ color: '#b91c1c', fontWeight: 600, whiteSpace: 'nowrap' }}>⚠️ N-1:</span>
+                                            <span style={{ wordBreak: 'break-word' }}>
+                                                {n1Diagram.lines_overloaded.map((lvl, i) => {
+                                                    const isSelected = selectedOverloads.has(lvl);
+                                                    const rho = n1Diagram.lines_overloaded_rho && n1Diagram.lines_overloaded_rho[i];
+                                                    const rhoPct = (rho != null && !Number.isNaN(rho)) ? `${(rho * 100).toFixed(1)}%` : null;
+                                                    return (
+                                                        <React.Fragment key={lvl}>
+                                                            {i > 0 && ', '}
+                                                            <button
+                                                                onClick={(e) => { e.stopPropagation(); handleAssetClick(null, lvl, 'n-1'); }}
+                                                                title={`Open N-1 tab and zoom to ${lvl}`}
+                                                                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '11px', color: isSelected ? '#1e40af' : '#bdc3c7', fontWeight: isSelected ? 600 : 400, textDecoration: isSelected ? 'underline dotted' : 'none' }}
+                                                            >
+                                                                {lvl}
+                                                            </button>
+                                                            {rhoPct && <span style={{ color: isSelected ? '#374151' : '#bdc3c7', marginLeft: '2px' }}>({rhoPct})</span>}
+                                                        </React.Fragment>
+                                                    );
+                                                })}
+                                            </span>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                            <div className="action-feed-scroll">
+                            {/* Target Contingency selector — full card lives in the
+                                scroll area so the compact sticky strip above stays
+                                minimal. */}
+                            {branches.length > 0 && (
+                                <div style={{ marginBottom: '10px', padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
+                                    <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>🎯 Select Contingency</label>
+                                    <input list="contingencies" value={selectedBranch} onChange={e => { const val = e.target.value; if (branches.includes(val)) interactionLogger.record('contingency_selected', { element: val }); setSelectedBranch(val); }} placeholder="Search line/bus..." style={{ width: '100%', padding: '7px 10px', border: '1px solid #ccc', borderRadius: '4px', boxSizing: 'border-box', fontSize: '0.85rem' }} />
+                                    <datalist id="contingencies">{contingencyOptions}</datalist>
                                 </div>
                             )}
 
@@ -5874,7 +5913,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                     return (
                                                         <React.Fragment key={lvl}>
                                                             {i > 0 && ', '}
-                                                            <button onClick={() => zoomOnActiveTab(lvl)} title={`Zoom to ${lvl}`} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: 'inherit', color: '#1e40af', fontWeight: 600, textDecoration: 'underline dotted' }}>{lvl}</button>
+                                                            <button onClick={() => handleAssetClick(null, lvl, 'n')} title={`Open N tab and zoom to ${lvl}`} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: 'inherit', color: '#1e40af', fontWeight: 600, textDecoration: 'underline dotted' }}>{lvl}</button>
                                                             {rhoPct && <span style={{ color: '#374151', fontWeight: 500, marginLeft: '2px' }}>({rhoPct})</span>}
                                                         </React.Fragment>
                                                     );
@@ -5948,7 +5987,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                         <React.Fragment key={lvl}>
                                                             {i > 0 && ', '}
                                                             <button
-                                                                onClick={(e) => { e.stopPropagation(); zoomOnActiveTab(lvl); }}
+                                                                onClick={(e) => { e.stopPropagation(); handleAssetClick(null, lvl, 'n-1'); }}
                                                                 onDoubleClick={(e) => {
                                                                     e.stopPropagation();
                                                                     const next = new Set(selectedOverloads);
@@ -5969,7 +6008,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                                     textDecoration: isSelected ? 'underline dotted' : 'none',
                                                                     display: 'inline'
                                                                 }}
-                                                                title={isSelected ? `Zoom to ${lvl} (Double-click to unselect)` : `Zoom to ${lvl} (Double-click to select)`}
+                                                                title={isSelected ? `Open N-1 tab and zoom to ${lvl} (Double-click to unselect)` : `Open N-1 tab and zoom to ${lvl} (Double-click to select)`}
                                                             >
                                                                 {lvl}
                                                             </button>
@@ -5984,8 +6023,6 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     </div>
                                 </div>
                             </div>
-                            </div>{/* /.action-feed-sticky */}
-                            <div className="action-feed-scroll">
 
                             <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px', position: 'relative' }}>
                                 <h3 style={{ margin: 0, flex: 1 }}>Simulated Actions</h3>

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -5287,8 +5287,33 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                 borderTop: (details.non_convergence || details.is_islanded) ? '1px solid #f8d7da' : 'none',
                                 borderBottom: (details.non_convergence || details.is_islanded) ? '1px solid #f8d7da' : 'none',
                                 boxShadow: isSelected ? '0 0 0 2px rgba(0,123,255,0.3), 0 2px 8px rgba(0,0,0,0.15)' : '0 2px 4px rgba(0,0,0,0.1)',
-                                transition: 'all 0.15s ease'
+                                transition: 'all 0.15s ease',
+                                /* Flex row so the VIEWING ribbon can sit
+                                   flush against the left edge. Padding is
+                                   moved to the inner content column. */
+                                padding: 0,
+                                display: 'flex',
+                                alignItems: 'stretch',
+                                overflow: 'hidden'
                             }}>
+                                {isSelected && (
+                                    <div style={{
+                                        writingMode: 'vertical-rl',
+                                        transform: 'rotate(180deg)',
+                                        background: '#007bff',
+                                        color: 'white',
+                                        fontSize: '10px',
+                                        fontWeight: 700,
+                                        letterSpacing: '1.5px',
+                                        padding: '8px 3px',
+                                        textAlign: 'center',
+                                        flexShrink: 0,
+                                        userSelect: 'none'
+                                    }}>
+                                        VIEWING
+                                    </div>
+                                )}
+                                <div style={{ flex: 1, padding: '10px', minWidth: 0 }}>
                                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px' }}>
                                     <h4 style={{
                                         margin: 0,
@@ -5298,11 +5323,6 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                         overflowWrap: 'anywhere'
                                     }}>#{index + 1} — {id}</h4>
                                     <div style={{ display: 'flex', gap: '5px', alignItems: 'center' }}>
-                                        {isSelected && (
-                                            <span style={{ fontSize: '10px', fontWeight: 600, padding: '2px 6px', borderRadius: '4px', background: '#007bff', color: 'white' }}>
-                                                VIEWING
-                                            </span>
-                                        )}
                                         <span style={{ fontSize: '11px', fontWeight: 600, padding: '2px 8px', borderRadius: '12px', background: sc.badgeBg, color: sc.badgeText }}>
                                             {sc.label}
                                         </span>
@@ -5543,6 +5563,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                         )}
                                     </div>
                                 </div>
+                                </div>{/* /content column */}
                             </div >
                         );
                     });

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -69,8 +69,26 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             width: 25%;
             background: #eee;
             border-right: 1px solid #ccc;
-            padding: 15px;
+            /*
+              The Contingency + Overloads N-1 sections must stay visible
+              when scrolling through actions, so the sidebar itself no
+              longer scrolls — its inner `.action-feed-scroll` does.
+            */
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .action-feed-sticky {
+            flex-shrink: 0;
+            padding: 15px 15px 0 15px;
+        }
+
+        .action-feed-scroll {
+            flex: 1 1 auto;
+            min-height: 0;
             overflow-y: auto;
+            padding: 15px;
         }
 
         .visualization {
@@ -3018,6 +3036,19 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 }
             };
 
+            // ===== Zoom on active tab =====
+            // Used by the sticky Contingency and Overloads sections: the
+            // operator wants to keep the current diagram view (N / N-1 /
+            // Action) and just focus the clicked asset in place rather
+            // than jumping tabs.
+            const zoomOnActiveTab = (assetName) => {
+                if (!assetName) return;
+                const tab = activeTabRef.current;
+                if (tab === 'overflow') return;
+                interactionLogger.record('asset_clicked', { asset_name: assetName, action_id: '', target_tab: tab });
+                setInspectQuery(assetName);
+            };
+
             // ===== VL Double-Click → Single Line Diagram overlay =====
             const handleVlDoubleClick = async (actionId, vlName) => {
                 setOverlayTransform({ scale: 1, tx: 0, ty: 0 });
@@ -5471,7 +5502,9 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                 }
                                 <div style={{ fontSize: '12px', background: isSelected ? '#dce8f7' : '#f8f9fa', padding: '5px', marginTop: '5px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
                                     <div>
-                                        <div>Loading before: {renderRho(details.rho_before, 'n-1')}</div>
+                                        {/* "Loading before" removed: the N-1 pre-action loading is
+                                             already shown in the sticky Overloads N-1 section, with
+                                             percentages next to each overloaded line. */}
                                         <div>Loading after: {renderRho(details.rho_after, 'action')}</div>
                                         {maxRhoPct != null && (
                                             <div style={{ marginTop: '3px' }}>
@@ -5779,12 +5812,25 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 
                     <div className="main-content">
                         <div className="action-feed">
+                            <div className="action-feed-sticky">
                             {/* Target Contingency selector */}
                             {branches.length > 0 && (
                                 <div style={{ marginBottom: '10px', padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
                                     <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>🎯 Select Contingency</label>
                                     <input list="contingencies" value={selectedBranch} onChange={e => { const val = e.target.value; if (branches.includes(val)) interactionLogger.record('contingency_selected', { element: val }); setSelectedBranch(val); }} placeholder="Search line/bus..." style={{ width: '100%', padding: '7px 10px', border: '1px solid #ccc', borderRadius: '4px', boxSizing: 'border-box', fontSize: '0.85rem' }} />
                                     <datalist id="contingencies">{contingencyOptions}</datalist>
+                                    {selectedBranch && (
+                                        <div style={{ marginTop: '6px', fontSize: '11px', color: '#374151' }}>
+                                            <span style={{ marginRight: '4px' }}>Selected:</span>
+                                            <button
+                                                onClick={(e) => { e.stopPropagation(); zoomOnActiveTab(selectedBranch); }}
+                                                title={`Zoom to ${selectedBranch} in the current diagram`}
+                                                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '11px', color: '#1e40af', fontWeight: 600, textDecoration: 'underline dotted' }}
+                                            >
+                                                🔍 {selectedBranch}
+                                            </button>
+                                        </div>
+                                    )}
                                 </div>
                             )}
 
@@ -5822,12 +5868,17 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                         <strong style={{ whiteSpace: 'nowrap' }}>N Overloads:</strong>
                                         <div style={{ display: 'inline', wordBreak: 'break-word' }}>
                                             {nDiagram && nDiagram.lines_overloaded && nDiagram.lines_overloaded.length > 0 ? (
-                                                nDiagram.lines_overloaded.map((lvl, i) => (
-                                                    <React.Fragment key={lvl}>
-                                                        {i > 0 && ', '}
-                                                        <button onClick={() => handleAssetClick(null, lvl, 'n')} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: 'inherit', color: '#1e40af', fontWeight: 600, textDecoration: 'underline dotted' }}>{lvl}</button>
-                                                    </React.Fragment>
-                                                ))
+                                                nDiagram.lines_overloaded.map((lvl, i) => {
+                                                    const rho = nDiagram.lines_overloaded_rho && nDiagram.lines_overloaded_rho[i];
+                                                    const rhoPct = (rho != null && !Number.isNaN(rho)) ? `${(rho * 100).toFixed(1)}%` : null;
+                                                    return (
+                                                        <React.Fragment key={lvl}>
+                                                            {i > 0 && ', '}
+                                                            <button onClick={() => zoomOnActiveTab(lvl)} title={`Zoom to ${lvl}`} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: 'inherit', color: '#1e40af', fontWeight: 600, textDecoration: 'underline dotted' }}>{lvl}</button>
+                                                            {rhoPct && <span style={{ color: '#374151', fontWeight: 500, marginLeft: '2px' }}>({rhoPct})</span>}
+                                                        </React.Fragment>
+                                                    );
+                                                })
                                             ) : (
                                                 <span style={{ color: '#888', fontStyle: 'italic' }}>None</span>
                                             )}
@@ -5891,11 +5942,13 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                             {n1Diagram && n1Diagram.lines_overloaded && n1Diagram.lines_overloaded.length > 0 ? (
                                                 n1Diagram.lines_overloaded.map((lvl, i) => {
                                                     const isSelected = selectedOverloads.has(lvl);
+                                                    const rho = n1Diagram.lines_overloaded_rho && n1Diagram.lines_overloaded_rho[i];
+                                                    const rhoPct = (rho != null && !Number.isNaN(rho)) ? `${(rho * 100).toFixed(1)}%` : null;
                                                     return (
                                                         <React.Fragment key={lvl}>
                                                             {i > 0 && ', '}
                                                             <button
-                                                                onClick={(e) => { e.stopPropagation(); handleAssetClick(null, lvl, 'n-1'); }}
+                                                                onClick={(e) => { e.stopPropagation(); zoomOnActiveTab(lvl); }}
                                                                 onDoubleClick={(e) => {
                                                                     e.stopPropagation();
                                                                     const next = new Set(selectedOverloads);
@@ -5920,6 +5973,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                             >
                                                                 {lvl}
                                                             </button>
+                                                            {rhoPct && <span style={{ color: isSelected ? '#374151' : '#bdc3c7', fontWeight: 500, marginLeft: '2px' }}>({rhoPct})</span>}
                                                         </React.Fragment>
                                                     );
                                                 })
@@ -5930,6 +5984,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     </div>
                                 </div>
                             </div>
+                            </div>{/* /.action-feed-sticky */}
+                            <div className="action-feed-scroll">
 
                             <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px', position: 'relative' }}>
                                 <h3 style={{ margin: 0, flex: 1 }}>Simulated Actions</h3>
@@ -6535,6 +6591,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     {scoreTooltip.content}
                                 </div>
                             )}
+                            </div>{/* /.action-feed-scroll */}
                         </div>
                         <div className="visualization" style={{ display: 'flex', flexDirection: 'column' }}>
                             {/* Tab bar — all 4 tabs always visible; unavailable ones dimmed/italic with placeholder tooltips */}


### PR DESCRIPTION
## Summary
This PR introduces a compact sticky header in the sidebar that keeps the selected contingency and N-1 overloads visible while scrolling through the action feed. It also adds loading ratio (rho) percentages next to overloaded lines throughout the UI, and removes the redundant "Loading before" display from individual action cards.

## Key Changes

- **Sticky Contingency & Overloads Header**: Added a non-scrolling sticky strip at the top of the sidebar that displays:
  - The selected contingency as a clickable button that zooms to it in the current diagram tab (without switching tabs)
  - N-1 overloaded lines with their loading percentages, clickable to switch to N-1 tab and zoom
  - This keeps critical information visible while scrolling through actions

- **Loading Ratio Display**: 
  - Backend now returns `lines_overloaded_rho` (per-element I/limit ratios) alongside `lines_overloaded` names
  - Frontend displays these as "(XX.X%)" next to each overloaded line in the Overloads panel, sticky header, and action cards
  - Rho values are aligned with element names for consistent rendering

- **New `handleZoomOnActiveTab` Handler**: Allows zooming to an asset in the current diagram without switching tabs, used by the sticky contingency button and overload links

- **Sidebar Layout Restructuring**:
  - Sidebar now uses flexbox with `overflow: hidden` to prevent nested scrollbars
  - Sticky summary strip (`flex-shrink: 0`) stays fixed at top
  - Scrollable content area below contains the full Select Contingency card, Overloads panel, and ActionFeed
  - Unified scrollbar for the entire feed area

- **Removed Redundant "Loading Before"**: Deleted the "Loading before" line from individual action cards since this information is now prominently displayed in the sticky N-1 overloads section

- **Updated OverloadPanel Component**: Added `nOverloadsRho` and `n1OverloadsRho` props to render loading percentages; improved documentation of the asset click behavior

- **Test Updates**: Updated tests to verify the new sticky header layout and rho percentage rendering

## Implementation Details

- The sticky header conditionally renders only when there's a selected contingency or N-1 overloads, minimizing visual clutter
- Overload links in the sticky header use `wrappedAssetClick` for N-1 (switches tabs) vs `handleZoomOnActiveTab` for contingency (stays on current tab)
- Backend `_get_overloaded_lines()` method now supports `with_rho=True` parameter to return both names and rho values as a tuple
- Rho formatting is consistent across all UI surfaces: `(rho * 100).toFixed(1) + '%'`
- Selected overloads in N-1 are visually emphasized with darker text and underlines; deselected ones are grayed out

https://claude.ai/code/session_01JpNKJ8NCyrv4erGkKBp2Nz