### PR TITLE
Add interaction logging for action re-simulation and tab management

### DIFF
--- a/docs/interaction-logging.md
+++ b/docs/interaction-logging.md
@@ -62,6 +62,8 @@ type InteractionType =
   | 'action_rejected'              // User rejected an action
   | 'action_unrejected'            // User un-rejected an action
   | 'manual_action_simulated'      // User simulated action via manual search
+  | 'action_mw_resimulated'        // User edited Target MW on a load-shedding / curtailment card and clicked Re-simulate
+  | 'pst_tap_resimulated'          // User edited Target Tap on a PST action card and clicked Re-simulate
   // === Combined Actions ===
   | 'combine_modal_opened'         // User opened Combine Actions modal
   | 'combine_modal_closed'         // User closed Combine Actions modal
@@ -70,6 +72,10 @@ type InteractionType =
   | 'combine_pair_simulated'       // Full simulation of combined pair
   // === Visualization ===
   | 'diagram_tab_changed'          // User switched tab (n / n-1 / action / overflow)
+  | 'tab_detached'                 // User detached a viz tab into its own browser window
+  | 'tab_reattached'               // User reattached a detached viz tab back into the main window
+  | 'tab_tied'                     // User tied a detached tab's viewBox to the main window
+  | 'tab_untied'                   // User untied a previously-tied detached tab
   | 'view_mode_changed'            // User switched Flows/Impacts mode
   | 'voltage_range_changed'        // User adjusted voltage filter slider
   | 'asset_clicked'                // User clicked a line/asset badge to zoom
@@ -97,19 +103,21 @@ Each event's `details` field contains **all parameters needed to replay** the us
 
 | Event | Details | Replay Action |
 |-------|---------|---------------|
-| `config_loaded` | `{ network_path, action_file_path, layout_path, min_line_reconnections, min_close_coupling, min_open_coupling, min_line_disconnections, min_pst, n_prioritized_actions, lines_monitoring_path, monitoring_factor, pre_existing_overload_threshold, ignore_reconnections, pypowsybl_fast_mode }` | Click "Load Study" with these config values |
+| `config_loaded` | `{ network_path, action_file_path, layout_path, output_folder_path, min_line_reconnections, min_close_coupling, min_open_coupling, min_line_disconnections, min_pst, min_load_shedding, min_renewable_curtailment_actions, n_prioritized_actions, lines_monitoring_path, monitoring_factor, pre_existing_overload_threshold, ignore_reconnections, pypowsybl_fast_mode }` | Click "Load Study" with these config values |
 | `settings_opened` | `{ tab: 'paths'\|'recommender'\|'configurations' }` | Click gear icon |
-| `settings_tab_changed` | `{ from_tab, to_tab }` | Click tab in settings modal |
-| `settings_applied` | `{ network_path, action_file_path, layout_path, output_folder_path, min_line_reconnections, min_close_coupling, min_open_coupling, min_line_disconnections, min_pst, n_prioritized_actions, lines_monitoring_path, monitoring_factor, pre_existing_overload_threshold, ignore_reconnections, pypowsybl_fast_mode }` | Fill all fields → click Apply |
+| `settings_tab_changed` | `{ from_tab: 'paths'\|'recommender'\|'configurations', to_tab: 'paths'\|'recommender'\|'configurations' }` — only emitted when `from_tab !== to_tab` | Click tab in settings modal |
+| `settings_applied` | Same payload as `config_loaded` (full settings snapshot). Treated as a wait-point: the replay agent must wait for the network reload to finish before proceeding. | Fill all fields → click Apply |
 | `settings_cancelled` | `{}` | Click Cancel / close settings |
-| `path_picked` | `{ field: 'network'\|'action'\|'layout'\|'output'\|'monitoring', picker_type: 'file'\|'dir', selected_path: string }` | Click file picker → select path |
+| `path_picked` | `{ type: 'file'\|'dir', path: string }` — the setter (network/action/layout/output/monitoring) is implicit from the preceding UI sequence (the settings modal field focused before the picker opened). | Click file picker → select path |
+
+> **Note on new recommender thresholds**: `min_load_shedding` and `min_renewable_curtailment_actions` were introduced alongside the new `loads_p` / `gens_p` power-reduction action format. They MUST be present in both `config_loaded` and `settings_applied` details so a replay agent can set the thresholds before loading the study. Older logs that predate these fields will be replayed with the backend defaults (`0.0`).
 
 ### Contingency Selection
 
 | Event | Details | Replay Action |
 |-------|---------|---------------|
 | `contingency_selected` | `{ element: string }` | Select value in branch dropdown |
-| `contingency_confirmed` | `{ element: string, dialog_type: 'contingency'\|'loadStudy' }` | Click OK in confirmation dialog |
+| `contingency_confirmed` | `{ type: 'contingency'\|'loadStudy'\|'applySettings'\|'changeNetwork', pending_branch?: string }` — `type` identifies which confirmation dialog the user clicked OK on (contingency-change / reload-study / apply-settings / change-network-path). `pending_branch` is only populated for `type: 'contingency'`. | Click OK in confirmation dialog |
 
 ### Two-Step Analysis
 
@@ -132,7 +140,9 @@ Each event's `details` field contains **all parameters needed to replay** the us
 | `action_unfavorited` | `{ action_id: string }` | Click star icon (toggle off) |
 | `action_rejected` | `{ action_id: string }` | Click reject icon |
 | `action_unrejected` | `{ action_id: string }` | Click reject icon (toggle off) |
-| `manual_action_simulated` | `{ action_id: string, description: string }` | Search action → click Simulate |
+| `manual_action_simulated` | `{ action_id: string }` | Search action → click Simulate |
+| `action_mw_resimulated` | `{ action_id: string, target_mw: number }` — the raw user-entered MW value (backend may clamp). Wait-point: the action card updates with new `rho_after`, `load_shedding_details` / `curtailment_details`. The action stays in its current bucket (suggested vs. manual). | Edit Target MW input on a load-shedding or curtailment card → click Re-simulate |
+| `pst_tap_resimulated` | `{ action_id: string, target_tap: number }` — the raw user-entered tap integer. Backend clamps to `[low_tap, high_tap]`. Wait-point: same as MW re-simulation but the `pst_details.tap_position` is updated instead. | Edit Target Tap input on a PST card → click Re-simulate |
 
 ### Combined Actions
 
@@ -148,29 +158,33 @@ Each event's `details` field contains **all parameters needed to replay** the us
 
 | Event | Details | Replay Action |
 |-------|---------|---------------|
-| `diagram_tab_changed` | `{ from_tab: TabId, to_tab: TabId }` | Click tab button |
-| `view_mode_changed` | `{ mode: 'network'\|'delta' }` | Click Flows/Impacts toggle |
-| `voltage_range_changed` | `{ min_kv: number, max_kv: number }` | Drag voltage slider |
-| `asset_clicked` | `{ asset_name: string, action_id: string, target_tab: 'n'\|'n-1'\|'action' }` | Click rho-line badge |
-| `zoom_in` | `{}` | Click + button |
-| `zoom_out` | `{}` | Click - button |
-| `zoom_reset` | `{}` | Click reset button |
-| `inspect_query_changed` | `{ query: string }` | Type in search box |
+| `diagram_tab_changed` | `{ tab: TabId }` — the destination tab the user clicked. | Click tab button |
+| `tab_detached` | `{ tab: TabId }` — the tab moved into a secondary browser window. Wait-point: the popup must be open and the portal target mounted before the next event can be replayed. Replay agents that cannot script a real popup should skip this event and keep the content in the main window. | Click the "Detach" button on a tab header |
+| `tab_reattached` | `{ tab: TabId }` | Click the "Reattach" badge in the popup (or "Reattach" in the main window placeholder) |
+| `tab_tied` | `{ tab: TabId }` — starts mirroring the detached tab's viewBox one-way into the main window's active tab. | Click "Tie" on a detached tab header |
+| `tab_untied` | `{ tab: TabId }` — stops mirroring. Also fired automatically when a tied tab is reattached. | Click "Untie" on a detached tab header |
+| `view_mode_changed` | `{ mode: 'network'\|'delta', tab: TabId, scope: 'main'\|'detached' }` — Flow/Impacts is now per-tab AND per-window: toggling in a detached popup only affects that popup's tab. | Click Flows/Impacts toggle |
+| `voltage_range_changed` | `{ min: number, max: number }` (kV) | Drag voltage slider |
+| `asset_clicked` | `{ action_id: string, asset_name: string, tab: 'n'\|'n-1'\|'action' }` — `tab` is the destination tab for the zoom. When the click comes from the sticky contingency / overloads sidebar (`handleZoomOnActiveTab`), `tab` is set to the **currently active** diagram tab and `action_id` is the empty string — meaning "zoom this asset in place without switching tabs". | Click a rho-line badge or a sticky contingency / overload link |
+| `zoom_in` | `{ tab: TabId }` | Click + button |
+| `zoom_out` | `{ tab: TabId }` | Click - button |
+| `zoom_reset` | `{ tab: TabId }` | Click reset button |
+| `inspect_query_changed` | `{ query: string, target_tab?: TabId }` — `target_tab` is only present when the inspect field was triggered from a detached-tab overlay (per-tab inspect routing). Absent = main-window active tab. | Type in search box |
 
 ### SLD Overlay
 
 | Event | Details | Replay Action |
 |-------|---------|---------------|
-| `sld_overlay_opened` | `{ vl_name: string, action_id: string\|null, initial_tab: 'n'\|'n-1'\|'action' }` | Double-click VL node |
-| `sld_overlay_tab_changed` | `{ from_tab: SldTab, to_tab: SldTab }` | Click tab in SLD overlay |
+| `sld_overlay_opened` | `{ vl_name: string, action_id: string\|null }` — the currently-selected action ID (may be empty) is always carried through, even when the active tab is N / N-1, so the SLD's internal sub-tab buttons can switch to the action view without a backend lookup error. | Double-click VL node |
+| `sld_overlay_tab_changed` | `{ tab: SldTab, vl_name: string }` — the destination SLD sub-tab. | Click tab in SLD overlay |
 | `sld_overlay_closed` | `{}` | Click close on SLD overlay |
 
 ### Session Management
 
 | Event | Details | Replay Action |
 |-------|---------|---------------|
-| `session_saved` | `{ session_name: string, output_folder: string }` | Click "Save Results" |
-| `session_reload_modal_opened` | `{ output_folder: string, available_sessions: string[] }` | Click "Reload Session" |
+| `session_saved` | `{ output_folder: string }` | Click "Save Results" |
+| `session_reload_modal_opened` | `{}` — the list of available sessions is fetched async and is not part of the event payload. | Click "Reload Session" |
 | `session_reloaded` | `{ session_name: string }` | Click session in list |
 
 ---
@@ -199,13 +213,17 @@ These events trigger async API calls. The replay agent must wait for the operati
 |---------------|----------------|
 | `config_loaded` | Network loaded, branches list populated |
 | `analysis_step1_started` | Loading spinner gone, overload list populated |
-| `analysis_step2_started` | Streaming complete, action cards visible |
+| `analysis_step2_started` | Streaming complete, action cards visible, `lines_overloaded_rho` populated on the N-1 payload for the sidebar sticky header |
 | `action_selected` | Action diagram loaded (or simulation fallback complete) |
 | `manual_action_simulated` | Action card appears in feed |
+| `action_mw_resimulated` | Action card updates with new `rho_after` and refreshed `load_shedding_details` / `curtailment_details`; the card stays in its current bucket |
+| `pst_tap_resimulated` | Action card updates with new `rho_after` and refreshed `pst_details.tap_position`; the card stays in its current bucket |
 | `combine_pair_estimated` | Estimation values appear in modal |
 | `combine_pair_simulated` | Simulation values appear in modal |
-| `session_reloaded` | Full session state restored |
+| `session_reloaded` | Full session state restored (see "Session reload fidelity" below) |
 | `settings_applied` | Network reloaded, branches refreshed |
+| `tab_detached` | Popup opened, React portal target mounted — or the event is skipped if the runner can't open real popups |
+| `tab_reattached` | Popup closed, content re-rendered in the main window |
 
 ### Handling `*_completed` Events
 
@@ -220,6 +238,52 @@ Async start/complete pairs share a `correlation_id` (UUID). This allows the agen
 - Match starts with completions
 - Handle nested async operations (e.g., analysis running while diagrams load)
 - Detect interrupted operations (start without matching complete = user cancelled/errored)
+
+---
+
+## Session reload fidelity
+
+The `session_reloaded` wait-point above is only meaningful if the saved session actually contains everything the UI needs. Because several features have been added to `session.json` incrementally, this section documents exactly what is persisted and restored so replay agents and downstream tools know which fields are trustworthy on reload.
+
+### Configuration
+
+Every field listed in `config_loaded` / `settings_applied` is persisted under `session.configuration` and restored by `useSession.handleRestoreSession`. This includes `min_load_shedding` and `min_renewable_curtailment_actions` — required for the new `loads_p` / `gens_p` power-reduction format. Older session dumps that predate these fields fall back to `0.0` on reload.
+
+On restore, `committedNetworkPathRef` is set to the restored `network_path`. This is important: it's what gates the "Change Network?" confirmation dialog when the user subsequently edits the Header network input. Without this update the dialog would either misfire (empty ref) or fire against a stale previous value.
+
+### Overloads & sticky header ratios
+
+`session.overloads` now contains:
+
+- `n_overloads: string[]`, `n1_overloads: string[]`, `resolved_overloads: string[]` — as before.
+- `n_overloads_rho?: number[]`, `n1_overloads_rho?: number[]` — the per-element loading ratios (`max|i|/permanent_limit`) that feed the sticky sidebar summary (PR #88). Persisted only when their length matches the element-name array; otherwise omitted to avoid misaligned percentages. Older session dumps that predate the sticky header simply don't have these arrays.
+
+After reload, the sidebar sticky header renders percentages for these overloaded lines without requiring a fresh analysis run. The live `n1Diagram.lines_overloaded_rho` that fills the in-memory state comes from the re-fetched N-1 diagram (after `setSelectedBranch` fires), so the persisted arrays are primarily useful for inspection of standalone `session.json` dumps and for replay agents that don't actually re-run the backend.
+
+### Action enrichment fields
+
+Saved `SavedActionEntry` objects carry the enrichment fields added by PRs #73, #78 and #83:
+
+- `lines_overloaded_after: string[]` — post-action overload list, used by SLD / NAD highlight clones on the Remedial Action tab.
+- `load_shedding_details: LoadSheddingDetail[]` — per-load MW values for the load-shedding editor card.
+- `curtailment_details: CurtailmentDetail[]` — per-generator MW values for the curtailment editor card.
+- `pst_details: PstDetail[]` — `{ pst_name, tap_position, low_tap, high_tap }` for the PST editor card.
+
+All four are now **restored** into the live `ActionDetail` objects by `handleRestoreSession`. Previously they were dropped on reload, which caused:
+
+- The PST / load-shedding / curtailment editor cards to render empty until the user re-ran analysis.
+- The Remedial Action tab to lose its post-action overload halos (`.nad-overloaded` clones) because `lines_overloaded_after` was gone.
+
+If a replay agent depends on any of those post-load side effects, the reload path is now sufficient — no re-analysis required.
+
+### Action status flags
+
+`SavedActionStatus` (`is_selected`, `is_suggested`, `is_rejected`, `is_manually_simulated`) is persisted and restored as before. No changes to this contract.
+
+### What is NOT persisted
+
+- **Per-card edit state** (`cardEditMw`, `cardEditTap`): these are the raw, uncommitted values in the action card inputs. Only the committed, re-simulated result survives — persisted as `pst_details.tap_position` / `load_shedding_details[].shedded_mw` / `curtailment_details[].curtailed_mw`. A replay agent that wants to reproduce edit keystrokes must consume the `action_mw_resimulated` / `pst_tap_resimulated` events from `interaction_log.json` instead.
+- **Detached / tied tab state** (PR #84/#85): `detachedTabs` and the tied-tab registry are deliberately ephemeral. Detaching a tab does not change any analysis result, so reload intentionally starts with all tabs attached to the main window. A replay that needs to reproduce detach / reattach / tie / untie must stream the matching events from `interaction_log.json`.
 
 ---
 
@@ -398,7 +462,7 @@ export const interactionLogger = new InteractionLogger();
 
 ### Instrumented Handlers
 
-Every user-facing handler in `App.tsx` and `CombinedActionsModal.tsx` calls `interactionLogger.record()`. Async handlers use the start/complete pattern:
+User-facing handlers across `App.tsx`, `CombinedActionsModal.tsx`, `ActionFeed.tsx`, `SettingsModal.tsx` and the hook modules (`useActions.ts`, `useAnalysis.ts`, `useDiagrams.ts`, `useSession.ts`, `useSettings.ts`, `useSldOverlay.ts`, `useTiedTabsSync.ts`) call `interactionLogger.record()`. The rule of thumb is: **log where the user gesture is handled, not inside downstream reducers**. Re-simulation events are a good example — they used to be logged from the `useActions` hook but now live in `ActionFeed.handleResimulate` / `handleResimulateTap` because that's the only place where the user-edited `target_mw` / `target_tap` values are in scope. Async handlers use the start/complete pattern:
 
 ```typescript
 const handleRunAnalysis = useCallback(async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -368,6 +368,8 @@ function App() {
     selectedBranch, selectedOverloads, monitorDeselected,
     nOverloads: nDiagram?.lines_overloaded ?? [],
     n1Overloads: n1Diagram?.lines_overloaded ?? [],
+    nOverloadsRho: nDiagram?.lines_overloaded_rho,
+    n1OverloadsRho: n1Diagram?.lines_overloaded_rho,
     result, selectedActionIds, rejectedActionIds,
     manuallyAddedIds, suggestedByRecommenderIds,
     setError, setInfoMessage: analysis.setInfoMessage,
@@ -413,6 +415,7 @@ function App() {
     setSelectedBranch,
     restoringSessionRef: diagrams.restoringSessionRef,
     committedBranchRef: diagrams.committedBranchRef,
+    committedNetworkPathRef,
     setError, setInfoMessage: analysis.setInfoMessage,
     applyConfigResponse, setBranches, setVoltageLevels,
     setNominalVoltageMap: diagrams.setNominalVoltageMap,
@@ -441,9 +444,46 @@ function App() {
     return !!(result || pendingAnalysisResult || selectedActionId || actionDiagram || manuallyAddedIds.size > 0 || selectedActionIds.size > 0 || rejectedActionIds.size > 0);
   }, [result, pendingAnalysisResult, selectedActionId, actionDiagram, manuallyAddedIds, selectedActionIds, rejectedActionIds]);
 
+  // Full-fidelity snapshot of every parameter an agent would need to
+  // replay a config-loaded / settings-applied gesture. Per the
+  // interaction-logging replay contract each event must carry ALL
+  // inputs — "click Load Study" alone is not enough, the agent has
+  // to know which paths and recommender thresholds to type in first.
+  const buildConfigInteractionDetails = useCallback((): Record<string, unknown> => ({
+    network_path: networkPath,
+    action_file_path: actionPath,
+    layout_path: layoutPath,
+    output_folder_path: outputFolderPath,
+    min_line_reconnections: minLineReconnections,
+    min_close_coupling: minCloseCoupling,
+    min_open_coupling: minOpenCoupling,
+    min_line_disconnections: minLineDisconnections,
+    min_pst: minPst,
+    min_load_shedding: minLoadShedding,
+    min_renewable_curtailment_actions: minRenewableCurtailmentActions,
+    n_prioritized_actions: nPrioritizedActions,
+    lines_monitoring_path: linesMonitoringPath,
+    monitoring_factor: monitoringFactor,
+    pre_existing_overload_threshold: preExistingOverloadThreshold,
+    ignore_reconnections: ignoreReconnections,
+    pypowsybl_fast_mode: pypowsyblFastMode,
+  }), [
+    networkPath, actionPath, layoutPath, outputFolderPath,
+    minLineReconnections, minCloseCoupling, minOpenCoupling,
+    minLineDisconnections, minPst, minLoadShedding,
+    minRenewableCurtailmentActions, nPrioritizedActions,
+    linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold,
+    ignoreReconnections, pypowsyblFastMode,
+  ]);
+
 
   const applySettingsImmediate = useCallback(async () => {
-    interactionLogger.record('settings_applied');
+    // settings_applied carries the full settings payload so a replay
+    // agent can populate every field before clicking Apply. It's
+    // treated as a wait-point by consumers of the log: the next
+    // action must wait until the network reload (network, branches,
+    // voltage levels) has finished.
+    interactionLogger.record('settings_applied', buildConfigInteractionDetails());
     try {
       resetAllState();
 
@@ -479,14 +519,14 @@ function App() {
       diagrams.fetchBaseDiagram(vlRes.length);
 
       committedNetworkPathRef.current = networkPath;
-      interactionLogger.record('config_loaded', { network_path: networkPath, action_path: actionPath });
+      interactionLogger.record('config_loaded', buildConfigInteractionDetails());
       setSettingsBackup(createCurrentBackup());
       setIsSettingsOpen(false);
     } catch (err: unknown) {
       const e = err as { response?: { data?: { detail?: string } }; message?: string };
       setError('Failed to apply settings: ' + (e.response?.data?.detail || e.message));
     }
-  }, [networkPath, actionPath, buildConfigRequest, applyConfigResponse, createCurrentBackup, setError, setSettingsBackup, setIsSettingsOpen, diagrams, configFilePath, lastActiveConfigFilePath, changeConfigFilePath, resetAllState]);
+  }, [networkPath, actionPath, buildConfigRequest, applyConfigResponse, createCurrentBackup, setError, setSettingsBackup, setIsSettingsOpen, diagrams, configFilePath, lastActiveConfigFilePath, changeConfigFilePath, resetAllState, buildConfigInteractionDetails]);
 
   // Apply Settings entry point used by the Settings modal. If a study
   // is already loaded — whether or not analysis has been run yet — we
@@ -534,14 +574,14 @@ function App() {
 
       diagrams.fetchBaseDiagram(vlRes.length);
       committedNetworkPathRef.current = networkPath;
-      interactionLogger.record('config_loaded', { network_path: networkPath, action_path: actionPath });
+      interactionLogger.record('config_loaded', buildConfigInteractionDetails());
     } catch (err: unknown) {
       const e = err as { response?: { data?: { detail?: string } }; message?: string };
       setError('Failed to load config: ' + (e.response?.data?.detail || e.message));
     } finally {
       setConfigLoading(false);
     }
-  }, [buildConfigRequest, applyConfigResponse, setError, diagrams, networkPath, actionPath, configFilePath, lastActiveConfigFilePath, changeConfigFilePath, resetAllState]);
+  }, [buildConfigRequest, applyConfigResponse, setError, diagrams, networkPath, configFilePath, lastActiveConfigFilePath, changeConfigFilePath, resetAllState, buildConfigInteractionDetails]);
 
 
   const handleLoadStudyClick = useCallback(() => {

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { interactionLogger } from '../utils/interactionLogger';
 
 // Mocking dependencies
 vi.mock('../api', () => ({
@@ -1432,6 +1433,183 @@ describe('ActionFeed', () => {
                 expect(props.onActionResimulated).toHaveBeenCalledTimes(1);
             });
             expect(props.onManualActionAdded).not.toHaveBeenCalled();
+        });
+    });
+
+    // =========================================================================
+    // Re-simulation interaction logging (action_mw_resimulated / pst_tap_resimulated)
+    // =========================================================================
+    //
+    // These events carry the raw user-entered target value so a replay
+    // agent can type the same MW / tap into the card's input before
+    // clicking Re-simulate. They are emitted from
+    // ActionFeed.handleResimulate / handleResimulateTap — NOT from the
+    // useActions hook, which used to log a mistyped
+    // 'manual_action_simulated' event.
+    // -------------------------------------------------------------------------
+    describe('Re-simulation interaction logging', () => {
+        beforeEach(() => {
+            interactionLogger.clear();
+        });
+
+        const buildLsProps = () => {
+            const actionId = 'load_shedding_LOG_A1';
+            const props = {
+                ...defaultProps,
+                onActionResimulated: vi.fn(),
+                actions: {
+                    [actionId]: {
+                        description_unitaire: 'ls A1',
+                        rho_before: [0.95],
+                        rho_after: [0.7],
+                        max_rho: 0.7,
+                        max_rho_line: 'LINE_1',
+                        is_rho_reduction: true,
+                        non_convergence: null,
+                        load_shedding_details: [
+                            { load_name: 'LOG_A1', voltage_level_id: 'VL', shedded_mw: 6.4 },
+                        ],
+                        action_topology: { ...emptyTopo, loads_p: { LOG_A1: 0.0 } },
+                    } as ActionDetail,
+                },
+            };
+            const mockResult = {
+                action_id: actionId,
+                description_unitaire: 'ls A1',
+                rho_before: [0.95],
+                rho_after: [0.55],
+                max_rho: 0.55,
+                max_rho_line: 'LINE_1',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                lines_overloaded_after: [],
+                load_shedding_details: [
+                    { load_name: 'LOG_A1', voltage_level_id: 'VL', shedded_mw: 5.4 },
+                ],
+            };
+            return { actionId, props, mockResult };
+        };
+
+        it('records action_mw_resimulated with the exact user-entered target MW on LS re-simulate', async () => {
+            const { actionId, props, mockResult } = buildLsProps();
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResult);
+
+            render(<ActionFeed {...props} />);
+            fireEvent.change(screen.getByTestId(`edit-mw-${actionId}`), { target: { value: '5.4' } });
+            fireEvent.click(screen.getByTestId(`resimulate-${actionId}`));
+
+            await waitFor(() => {
+                expect(props.onActionResimulated).toHaveBeenCalledTimes(1);
+            });
+
+            const log = interactionLogger.getLog();
+            const evt = log.find(e => e.type === 'action_mw_resimulated');
+            expect(evt).toBeDefined();
+            expect(evt!.details).toEqual({
+                action_id: actionId,
+                // parseFloat of the input string, before any backend
+                // clamping — matches the value the user typed.
+                target_mw: 5.4,
+            });
+        });
+
+        it('does NOT record manual_action_simulated when re-simulating load shedding', async () => {
+            const { actionId, props, mockResult } = buildLsProps();
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResult);
+
+            render(<ActionFeed {...props} />);
+            fireEvent.change(screen.getByTestId(`edit-mw-${actionId}`), { target: { value: '5.4' } });
+            fireEvent.click(screen.getByTestId(`resimulate-${actionId}`));
+
+            await waitFor(() => {
+                expect(props.onActionResimulated).toHaveBeenCalledTimes(1);
+            });
+
+            // Regression guard: re-simulation is a distinct gesture
+            // and must NOT be logged as a manual action (which would
+            // mislead a replay agent into promoting the card into
+            // Selected Actions).
+            const log = interactionLogger.getLog();
+            expect(log.some(e => e.type === 'manual_action_simulated')).toBe(false);
+        });
+
+        it('records pst_tap_resimulated with the exact user-entered tap on PST re-simulate', async () => {
+            const pstActionId = 'pst_A1';
+            const props = {
+                ...defaultProps,
+                onActionResimulated: vi.fn(),
+                actions: {
+                    [pstActionId]: {
+                        description_unitaire: 'pst A1',
+                        rho_before: [0.95],
+                        rho_after: [0.7],
+                        max_rho: 0.7,
+                        max_rho_line: 'LINE_1',
+                        is_rho_reduction: true,
+                        non_convergence: null,
+                        pst_details: [
+                            { pst_name: 'PST_A1', tap_position: 3, low_tap: -5, high_tap: 5 },
+                        ],
+                        action_topology: { ...emptyTopo, pst_tap: { PST_A1: 0 } },
+                    } as ActionDetail,
+                },
+            };
+            const mockResult = {
+                action_id: pstActionId,
+                description_unitaire: 'pst A1',
+                rho_before: [0.95],
+                rho_after: [0.5],
+                max_rho: 0.5,
+                max_rho_line: 'LINE_1',
+                is_rho_reduction: true,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                lines_overloaded_after: [],
+                pst_details: [
+                    { pst_name: 'PST_A1', tap_position: 4, low_tap: -5, high_tap: 5 },
+                ],
+            };
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResult);
+
+            render(<ActionFeed {...props} />);
+            fireEvent.change(screen.getByTestId(`edit-tap-${pstActionId}`), { target: { value: '4' } });
+            fireEvent.click(screen.getByTestId(`resimulate-tap-${pstActionId}`));
+
+            await waitFor(() => {
+                expect(props.onActionResimulated).toHaveBeenCalledTimes(1);
+            });
+
+            const log = interactionLogger.getLog();
+            const evt = log.find(e => e.type === 'pst_tap_resimulated');
+            expect(evt).toBeDefined();
+            expect(evt!.details).toEqual({
+                action_id: pstActionId,
+                target_tap: 4,
+            });
+
+            // And again: a PST re-simulation must not masquerade as a
+            // manual action.
+            expect(log.some(e => e.type === 'manual_action_simulated')).toBe(false);
+            expect(log.some(e => e.type === 'action_mw_resimulated')).toBe(false);
+        });
+
+        it('records target_mw as the parsed float even when the user types extra decimals', async () => {
+            const { actionId, props, mockResult } = buildLsProps();
+            (api.simulateManualAction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(mockResult);
+
+            render(<ActionFeed {...props} />);
+            fireEvent.change(screen.getByTestId(`edit-mw-${actionId}`), { target: { value: '5.400' } });
+            fireEvent.click(screen.getByTestId(`resimulate-${actionId}`));
+
+            await waitFor(() => {
+                expect(props.onActionResimulated).toHaveBeenCalledTimes(1);
+            });
+
+            const log = interactionLogger.getLog();
+            const evt = log.find(e => e.type === 'action_mw_resimulated');
+            expect(evt).toBeDefined();
+            expect(evt!.details.target_mw).toBe(5.4);
         });
     });
 

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -8,6 +8,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import type { ActionDetail, NodeMeta, EdgeMeta, AvailableAction, AnalysisResult, CombinedAction, RecommenderDisplayConfig } from '../types';
 import { api } from '../api';
+import { interactionLogger } from '../utils/interactionLogger';
 import CombinedActionsModal from './CombinedActionsModal';
 import ActionCard from './ActionCard';
 import ActionSearchDropdown from './ActionSearchDropdown';
@@ -343,6 +344,15 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     // Re-simulate an existing action with a new target MW value
     const handleResimulate = async (actionId: string, newTargetMw: number) => {
         if (!disconnectedElement) return;
+        // Log the user-edited target value so a replay agent can type
+        // the exact same MW into the card's input before clicking
+        // Re-simulate. Distinct from manual_action_simulated because
+        // re-simulation keeps the action in its current bucket
+        // (suggested vs. manually added).
+        interactionLogger.record('action_mw_resimulated', {
+            action_id: actionId,
+            target_mw: newTargetMw,
+        });
         setResimulating(actionId);
         try {
             const detail = actions[actionId];
@@ -384,6 +394,15 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     // Re-simulate an existing PST action with a new tap position
     const handleResimulateTap = async (actionId: string, newTap: number) => {
         if (!disconnectedElement) return;
+        // Log the new tap position so a replay agent can enter the
+        // same value in the PST detail input before clicking
+        // Re-simulate. Backend clamps out-of-range values to
+        // [low_tap, high_tap], but the logged value is the raw
+        // user-entered integer.
+        interactionLogger.record('pst_tap_resimulated', {
+            action_id: actionId,
+            target_tap: newTap,
+        });
         setResimulating(actionId);
         try {
             const detail = actions[actionId];

--- a/frontend/src/components/modals/SettingsModal.test.tsx
+++ b/frontend/src/components/modals/SettingsModal.test.tsx
@@ -9,10 +9,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SettingsModal from './SettingsModal';
 import { SettingsState } from '../../hooks/useSettings';
+import { interactionLogger } from '../../utils/interactionLogger';
 
 describe('SettingsModal', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        interactionLogger.clear();
     });
 
     const mockSettings = {
@@ -119,5 +121,84 @@ describe('SettingsModal', () => {
         const pickButtons = screen.getAllByText('📄');
         fireEvent.click(pickButtons[0]);
         expect(mockSettings.pickSettingsPath).toHaveBeenCalled();
+    });
+
+    // =====================================================================
+    // settings_tab_changed interaction log shape
+    // =====================================================================
+    //
+    // The replay contract requires { from_tab, to_tab } so an agent can
+    // assert the modal was in the expected tab before clicking the new
+    // one. Before this fix the logger emitted only { tab } (the
+    // destination), which lost the "where was the user coming from?"
+    // information needed for verification.
+    // ---------------------------------------------------------------------
+    describe('settings_tab_changed interaction log shape', () => {
+        it('logs { from_tab, to_tab } when switching from paths → recommender', () => {
+            render(<SettingsModal {...defaultProps} />);
+
+            fireEvent.click(screen.getByText('Recommender'));
+
+            const log = interactionLogger.getLog();
+            const tabChange = log.find(e => e.type === 'settings_tab_changed');
+            expect(tabChange).toBeDefined();
+            expect(tabChange!.details).toEqual({ from_tab: 'paths', to_tab: 'recommender' });
+        });
+
+        it('logs { from_tab, to_tab } when switching from paths → configurations', () => {
+            render(<SettingsModal {...defaultProps} />);
+
+            fireEvent.click(screen.getByText('Configurations'));
+
+            const log = interactionLogger.getLog();
+            const tabChange = log.find(e => e.type === 'settings_tab_changed');
+            expect(tabChange).toBeDefined();
+            expect(tabChange!.details).toEqual({ from_tab: 'paths', to_tab: 'configurations' });
+        });
+
+        it('records from_tab as the currently-active tab, not the initial one', () => {
+            // Re-render the modal already on the "recommender" tab and
+            // click "configurations": the from_tab must be 'recommender'.
+            render(
+                <SettingsModal
+                    {...defaultProps}
+                    settings={{ ...mockSettings, settingsTab: 'recommender' } as unknown as SettingsState}
+                />
+            );
+
+            fireEvent.click(screen.getByText('Configurations'));
+
+            const log = interactionLogger.getLog();
+            const tabChange = log.find(e => e.type === 'settings_tab_changed');
+            expect(tabChange).toBeDefined();
+            expect(tabChange!.details).toEqual({ from_tab: 'recommender', to_tab: 'configurations' });
+        });
+
+        it('does NOT log when the user clicks the already-active tab (no-op skip)', () => {
+            // Clicking the already-active tab is a UI no-op — it must
+            // not pollute the log with empty transitions that a replay
+            // agent would have to filter out. Regression guard.
+            render(<SettingsModal {...defaultProps} />);
+
+            fireEvent.click(screen.getByText('Paths'));
+
+            const log = interactionLogger.getLog();
+            expect(log.filter(e => e.type === 'settings_tab_changed')).toHaveLength(0);
+            // And the setter must still not have been called with the
+            // same value (idempotency in practice is fine, but we log
+            // only real transitions).
+        });
+
+        it('still calls setSettingsTab even on a no-op click (setter is unconditional)', () => {
+            // The setter is invoked for every click so React state
+            // remains consistent with the DOM — only the logger is
+            // gated on "actually changed". This test pins that exact
+            // split behaviour.
+            render(<SettingsModal {...defaultProps} />);
+
+            fireEvent.click(screen.getByText('Paths'));
+
+            expect(mockSettings.setSettingsTab).toHaveBeenCalledWith('paths');
+        });
     });
 });

--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -43,7 +43,15 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
 
   const tabButton = (id: 'paths' | 'recommender' | 'configurations', label: string) => (
     <button
-      onClick={() => { interactionLogger.record('settings_tab_changed', { tab: id }); setSettingsTab(id); }}
+      onClick={() => {
+        // Log both source and destination so a replay agent can assert
+        // the modal was in the expected tab before clicking — matches
+        // the {from_tab,to_tab} shape documented in the replay contract.
+        if (id !== settingsTab) {
+          interactionLogger.record('settings_tab_changed', { from_tab: settingsTab, to_tab: id });
+        }
+        setSettingsTab(id);
+      }}
       style={{
         flex: 1, padding: '10px', cursor: 'pointer', background: 'none',
         border: 'none', borderBottom: settingsTab === id ? '2px solid #3498db' : 'none',

--- a/frontend/src/hooks/useActions.test.ts
+++ b/frontend/src/hooks/useActions.test.ts
@@ -215,7 +215,13 @@ describe('useActions — interaction logging', () => {
             expect(result.current.manuallyAddedIds.has('new_manual_action')).toBe(true);
         });
 
-        it('logs manual_action_simulated on resimulation too', () => {
+        it('does NOT log from the hook on resimulation (logging moved to ActionFeed)', () => {
+            // action_mw_resimulated / pst_tap_resimulated events need the
+            // user-edited target value, which is only known at the call
+            // site (ActionFeed.handleResimulate / handleResimulateTap).
+            // The hook itself must stay silent — previously it logged a
+            // misleading 'manual_action_simulated' event that conflated
+            // the two flows and made replay impossible.
             const { result } = renderHook(() => useActions());
 
             act(() => {
@@ -229,7 +235,9 @@ describe('useActions — interaction logging', () => {
             });
 
             const log = interactionLogger.getLog();
-            expect(log.some(e => e.type === 'manual_action_simulated' && e.details.action_id === 'act_7')).toBe(true);
+            expect(log.some(e => e.type === 'manual_action_simulated' && e.details.action_id === 'act_7')).toBe(false);
+            expect(log.some(e => e.type === 'action_mw_resimulated' && e.details.action_id === 'act_7')).toBe(false);
+            expect(log.some(e => e.type === 'pst_tap_resimulated' && e.details.action_id === 'act_7')).toBe(false);
         });
     });
 });

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -132,7 +132,13 @@ export function useActions(): ActionsState {
     setResult: React.Dispatch<React.SetStateAction<AnalysisResult | null>>,
     onSelectAction: (actionId: string) => void,
   ) => {
-    interactionLogger.record('manual_action_simulated', { action_id: actionId });
+    // NOTE: re-simulation events (action_mw_resimulated /
+    // pst_tap_resimulated) are logged at the call site in
+    // ActionFeed.tsx so the logger can capture the user-edited
+    // target value (MW or tap). This hook used to also log
+    // 'manual_action_simulated' which conflated the two flows
+    // and made replay impossible — the log entry now lives next
+    // to the actual button click instead.
     setResult(prev => {
       if (!prev) return prev;
       const existing = prev.actions[actionId];

--- a/frontend/src/hooks/useSession.test.ts
+++ b/frontend/src/hooks/useSession.test.ts
@@ -3,27 +3,32 @@
 // If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 // SPDX-License-Identifier: MPL-2.0
-// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useSession } from './useSession';
+import { useSession, type RestoreContext } from './useSession';
 import { interactionLogger } from '../utils/interactionLogger';
+import type { SessionResult, AnalysisResult } from '../types';
 
 // Mock the api module
 const mockSaveSession = vi.fn();
 const mockListSessions = vi.fn();
 const mockLoadSession = vi.fn();
+const mockUpdateConfig = vi.fn();
+const mockGetBranches = vi.fn();
+const mockGetVoltageLevels = vi.fn();
+const mockGetNominalVoltages = vi.fn();
 
 vi.mock('../api', () => ({
     api: {
         saveSession: (...args: unknown[]) => mockSaveSession(...args),
         listSessions: (...args: unknown[]) => mockListSessions(...args),
         loadSession: (...args: unknown[]) => mockLoadSession(...args),
-        updateConfig: vi.fn().mockResolvedValue({}),
-        getBranches: vi.fn().mockResolvedValue([]),
-        getVoltageLevels: vi.fn().mockResolvedValue([]),
-        getNominalVoltages: vi.fn().mockResolvedValue({ mapping: {}, unique_kv: [] }),
+        updateConfig: (...args: unknown[]) => mockUpdateConfig(...args),
+        getBranches: (...args: unknown[]) => mockGetBranches(...args),
+        getVoltageLevels: (...args: unknown[]) => mockGetVoltageLevels(...args),
+        getNominalVoltages: (...args: unknown[]) => mockGetNominalVoltages(...args),
         restoreAnalysisContext: vi.fn().mockResolvedValue({}),
     },
 }));
@@ -171,5 +176,547 @@ describe('useSession — interaction logging', () => {
         const buildArgs = (buildSessionResult as ReturnType<typeof vi.fn>).mock.calls[0][0];
         expect(buildArgs.interactionLog).toBeDefined();
         expect(Array.isArray(buildArgs.interactionLog)).toBe(true);
+    });
+});
+
+// ===========================================================================
+// handleRestoreSession — session reload fidelity
+// ===========================================================================
+//
+// These tests guard the fixes that land alongside PRs #73, #78, #83 and
+// #88: enrichment fields (load_shedding_details / curtailment_details /
+// pst_details / lines_overloaded_after) must survive a save/reload
+// round-trip, committedNetworkPathRef must be updated on restore so the
+// "Change Network?" confirmation dialog doesn't misfire, and the new
+// recommender thresholds (min_load_shedding,
+// min_renewable_curtailment_actions) must be restored even when the
+// session JSON predates them.
+//
+// The tests mock the api module at the top of this file; each restore
+// test wires a fresh RestoreContext with vi.fn() setters so it can
+// assert exactly which values were pushed into App state.
+// ---------------------------------------------------------------------------
+
+describe('useSession — handleRestoreSession', () => {
+    beforeEach(() => {
+        interactionLogger.clear();
+        vi.clearAllMocks();
+        mockUpdateConfig.mockResolvedValue({});
+        mockGetBranches.mockResolvedValue(['LINE_A', 'LINE_B']);
+        mockGetVoltageLevels.mockResolvedValue(['VL_1', 'VL_2']);
+        mockGetNominalVoltages.mockResolvedValue({
+            mapping: { VL_1: 400, VL_2: 225 },
+            unique_kv: [225, 400],
+        });
+    });
+
+    /** Build a minimal but valid RestoreContext with vi.fn() setters. */
+    const makeCtx = (
+        overrides: Partial<RestoreContext> = {},
+    ): RestoreContext & {
+        // Expose the refs for assertions.
+        restoringSessionRef: { current: boolean };
+        committedBranchRef: { current: string };
+        committedNetworkPathRef: { current: string };
+    } => ({
+        outputFolderPath: '/tmp/output',
+        setNetworkPath: vi.fn(),
+        setActionPath: vi.fn(),
+        setLayoutPath: vi.fn(),
+        setMinLineReconnections: vi.fn(),
+        setMinCloseCoupling: vi.fn(),
+        setMinOpenCoupling: vi.fn(),
+        setMinLineDisconnections: vi.fn(),
+        setMinPst: vi.fn(),
+        setMinLoadShedding: vi.fn(),
+        setMinRenewableCurtailmentActions: vi.fn(),
+        setNPrioritizedActions: vi.fn(),
+        setLinesMonitoringPath: vi.fn(),
+        setMonitoringFactor: vi.fn(),
+        setPreExistingOverloadThreshold: vi.fn(),
+        setIgnoreReconnections: vi.fn(),
+        setPypowsyblFastMode: vi.fn(),
+        applyConfigResponse: vi.fn(),
+        setBranches: vi.fn(),
+        setVoltageLevels: vi.fn(),
+        setNominalVoltageMap: vi.fn(),
+        setUniqueVoltages: vi.fn(),
+        setVoltageRange: vi.fn(),
+        fetchBaseDiagram: vi.fn(),
+        setMonitorDeselected: vi.fn(),
+        setSelectedOverloads: vi.fn(),
+        setResult: vi.fn(),
+        setSelectedActionIds: vi.fn(),
+        setRejectedActionIds: vi.fn(),
+        setManuallyAddedIds: vi.fn(),
+        setSuggestedByRecommenderIds: vi.fn(),
+        restoringSessionRef: { current: false },
+        committedBranchRef: { current: '' },
+        committedNetworkPathRef: { current: '' },
+        setSelectedBranch: vi.fn(),
+        setInfoMessage: vi.fn(),
+        setError: vi.fn(),
+        ...overrides,
+    } as unknown as RestoreContext & {
+        restoringSessionRef: { current: boolean };
+        committedBranchRef: { current: string };
+        committedNetworkPathRef: { current: string };
+    });
+
+    /** Minimal SessionResult builder with sensible defaults. */
+    const makeSession = (overrides: Partial<SessionResult> = {}): SessionResult => ({
+        saved_at: '2026-04-14T10:00:00.000Z',
+        configuration: {
+            network_path: '/data/net.xiidm',
+            action_file_path: '/data/actions.json',
+            layout_path: '/data/layout.json',
+            min_line_reconnections: 2.0,
+            min_close_coupling: 3.0,
+            min_open_coupling: 2.0,
+            min_line_disconnections: 3.0,
+            min_pst: 1.5,
+            min_load_shedding: 2.5,
+            min_renewable_curtailment_actions: 1.25,
+            n_prioritized_actions: 8,
+            lines_monitoring_path: '/data/monitoring.csv',
+            monitoring_factor: 0.93,
+            pre_existing_overload_threshold: 0.04,
+            ignore_reconnections: true,
+            pypowsybl_fast_mode: false,
+        },
+        contingency: {
+            disconnected_element: 'LINE_A',
+            selected_overloads: ['LINE_OL1', 'LINE_OL2'],
+            monitor_deselected: true,
+        },
+        overloads: {
+            n_overloads: [],
+            n1_overloads: ['LINE_OL1', 'LINE_OL2'],
+            resolved_overloads: ['LINE_OL1'],
+        },
+        overflow_graph: null,
+        analysis: null,
+        ...overrides,
+    });
+
+    it('restores every configuration field, including new load-shedding / curtailment thresholds', async () => {
+        mockLoadSession.mockResolvedValue(makeSession());
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('session_abc', ctx);
+        });
+
+        // Paths
+        expect(ctx.setNetworkPath).toHaveBeenCalledWith('/data/net.xiidm');
+        expect(ctx.setActionPath).toHaveBeenCalledWith('/data/actions.json');
+        expect(ctx.setLayoutPath).toHaveBeenCalledWith('/data/layout.json');
+
+        // Recommender thresholds — the two values added by PR #73 / #78
+        // are the specific regression this test is guarding against.
+        expect(ctx.setMinLineReconnections).toHaveBeenCalledWith(2.0);
+        expect(ctx.setMinCloseCoupling).toHaveBeenCalledWith(3.0);
+        expect(ctx.setMinOpenCoupling).toHaveBeenCalledWith(2.0);
+        expect(ctx.setMinLineDisconnections).toHaveBeenCalledWith(3.0);
+        expect(ctx.setMinPst).toHaveBeenCalledWith(1.5);
+        expect(ctx.setMinLoadShedding).toHaveBeenCalledWith(2.5);
+        expect(ctx.setMinRenewableCurtailmentActions).toHaveBeenCalledWith(1.25);
+        expect(ctx.setNPrioritizedActions).toHaveBeenCalledWith(8);
+
+        // Monitoring + flags
+        expect(ctx.setLinesMonitoringPath).toHaveBeenCalledWith('/data/monitoring.csv');
+        expect(ctx.setMonitoringFactor).toHaveBeenCalledWith(0.93);
+        expect(ctx.setPreExistingOverloadThreshold).toHaveBeenCalledWith(0.04);
+        expect(ctx.setIgnoreReconnections).toHaveBeenCalledWith(true);
+        expect(ctx.setPypowsyblFastMode).toHaveBeenCalledWith(false);
+    });
+
+    it('falls back to safe defaults when older sessions lack load-shedding / curtailment thresholds', async () => {
+        // Simulate a pre-PR-#73 session dump: neither new field present.
+        const legacy = makeSession();
+        delete (legacy.configuration as { min_load_shedding?: number }).min_load_shedding;
+        delete (legacy.configuration as { min_renewable_curtailment_actions?: number })
+            .min_renewable_curtailment_actions;
+        mockLoadSession.mockResolvedValue(legacy);
+
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('legacy_session', ctx);
+        });
+
+        // Defaults are 0.0 per the restore contract: "Older session
+        // dumps that predate these fields fall back to 0.0 on reload."
+        expect(ctx.setMinLoadShedding).toHaveBeenCalledWith(0.0);
+        expect(ctx.setMinRenewableCurtailmentActions).toHaveBeenCalledWith(0.0);
+    });
+
+    it('updates committedNetworkPathRef on successful restore', async () => {
+        // The bug: before this fix, the ref stayed empty after a
+        // reload, so the first manual edit to the Header network input
+        // silently dropped the study instead of prompting the "Change
+        // Network?" confirmation dialog.
+        mockLoadSession.mockResolvedValue(makeSession());
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('session_xyz', ctx);
+        });
+
+        expect(ctx.committedNetworkPathRef.current).toBe('/data/net.xiidm');
+    });
+
+    it('forwards all configuration fields to the backend via api.updateConfig', async () => {
+        mockLoadSession.mockResolvedValue(makeSession());
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('session_1', ctx);
+        });
+
+        expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
+        const payload = mockUpdateConfig.mock.calls[0][0];
+        expect(payload).toMatchObject({
+            network_path: '/data/net.xiidm',
+            action_file_path: '/data/actions.json',
+            layout_path: '/data/layout.json',
+            min_line_reconnections: 2.0,
+            min_close_coupling: 3.0,
+            min_open_coupling: 2.0,
+            min_line_disconnections: 3.0,
+            min_pst: 1.5,
+            min_load_shedding: 2.5,
+            min_renewable_curtailment_actions: 1.25,
+            n_prioritized_actions: 8,
+            monitoring_factor: 0.93,
+            pre_existing_overload_threshold: 0.04,
+            ignore_reconnections: true,
+            pypowsybl_fast_mode: false,
+        });
+    });
+
+    it('records a session_reloaded interaction event on success', async () => {
+        mockLoadSession.mockResolvedValue(makeSession());
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('session_reload_42', ctx);
+        });
+
+        const log = interactionLogger.getLog();
+        const reloaded = log.find(e => e.type === 'session_reloaded');
+        expect(reloaded).toBeDefined();
+        expect(reloaded!.details).toEqual({ session_name: 'session_reload_42' });
+    });
+
+    it('short-circuits (no API call) when outputFolderPath is empty', async () => {
+        const ctx = makeCtx({ outputFolderPath: '' });
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('session_x', ctx);
+        });
+
+        expect(mockLoadSession).not.toHaveBeenCalled();
+        expect(ctx.setNetworkPath).not.toHaveBeenCalled();
+        expect(ctx.committedNetworkPathRef.current).toBe('');
+    });
+
+    it('surfaces backend errors via ctx.setError and leaves the ref empty', async () => {
+        mockLoadSession.mockRejectedValue({ response: { data: { detail: 'not found' } } });
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('missing', ctx);
+        });
+
+        expect(ctx.setError).toHaveBeenCalledWith(expect.stringContaining('not found'));
+        // Ref must remain untouched so the Header dialog logic still
+        // uses the pre-restore value (empty here → no false-positive).
+        expect(ctx.committedNetworkPathRef.current).toBe('');
+    });
+
+    // -----------------------------------------------------------------
+    // Action-enrichment restoration (PRs #73, #78, #83)
+    // -----------------------------------------------------------------
+
+    /**
+     * Extract the ActionDetail object the hook pushed into setResult
+     * by replaying the setter function against a null previous state.
+     * setResult is called with a functional updater, so we reach into
+     * the first call and invoke the updater to materialise the new
+     * AnalysisResult the hook computed.
+     */
+    const captureRestoredResult = (
+        setResultMock: ReturnType<typeof vi.fn>,
+    ): AnalysisResult | null => {
+        const call = setResultMock.mock.calls.find(args =>
+            typeof args[0] === 'function' || (args[0] && typeof args[0] === 'object'),
+        );
+        if (!call) return null;
+        const updater = call[0];
+        if (typeof updater === 'function') {
+            return (updater as (prev: AnalysisResult | null) => AnalysisResult | null)(null);
+        }
+        return updater as AnalysisResult | null;
+    };
+
+    it('restores load_shedding_details / curtailment_details / pst_details / lines_overloaded_after into each ActionDetail', async () => {
+        // This is the regression for the main session-reload bug: the
+        // four enrichment fields were persisted by buildSessionResult
+        // but dropped on reload, so the PST / load-shedding /
+        // curtailment editor cards rendered empty and the Remedial
+        // Action tab lost its post-action overload halos.
+        mockLoadSession.mockResolvedValue(makeSession({
+            analysis: {
+                message: 'ok',
+                dc_fallback: false,
+                action_scores: {},
+                combined_actions: {},
+                actions: {
+                    load_shed_1: {
+                        description_unitaire: 'Shed load L1',
+                        rho_before: [1.1],
+                        rho_after: [0.8],
+                        max_rho: 0.8,
+                        max_rho_line: 'LINE_OL1',
+                        is_rho_reduction: true,
+                        lines_overloaded_after: ['LINE_OL2'],
+                        load_shedding_details: [
+                            { load_name: 'L1', voltage_level_id: 'VL_1', shedded_mw: 4.2 },
+                        ],
+                        status: {
+                            is_selected: false,
+                            is_suggested: true,
+                            is_rejected: false,
+                            is_manually_simulated: false,
+                        },
+                    },
+                    curtail_1: {
+                        description_unitaire: 'Curtail wind W1',
+                        rho_before: [1.2],
+                        rho_after: [0.95],
+                        max_rho: 0.95,
+                        max_rho_line: 'LINE_OL1',
+                        is_rho_reduction: true,
+                        lines_overloaded_after: [],
+                        curtailment_details: [
+                            { gen_name: 'W1', voltage_level_id: 'VL_2', curtailed_mw: 7.5 },
+                        ],
+                        status: {
+                            is_selected: false,
+                            is_suggested: true,
+                            is_rejected: false,
+                            is_manually_simulated: false,
+                        },
+                    },
+                    pst_1: {
+                        description_unitaire: 'Move PST tap',
+                        rho_before: [1.05],
+                        rho_after: [0.9],
+                        max_rho: 0.9,
+                        max_rho_line: 'LINE_OL1',
+                        is_rho_reduction: true,
+                        pst_details: [
+                            { pst_name: 'PST_A', tap_position: 5, low_tap: -16, high_tap: 16 },
+                        ],
+                        status: {
+                            is_selected: false,
+                            is_suggested: true,
+                            is_rejected: false,
+                            is_manually_simulated: false,
+                        },
+                    },
+                },
+            },
+        }));
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('session_enriched', ctx);
+        });
+
+        const restored = captureRestoredResult(ctx.setResult as ReturnType<typeof vi.fn>);
+        expect(restored).not.toBeNull();
+
+        // Load shedding
+        const ls = restored!.actions['load_shed_1'];
+        expect(ls.load_shedding_details).toEqual([
+            { load_name: 'L1', voltage_level_id: 'VL_1', shedded_mw: 4.2 },
+        ]);
+        expect(ls.lines_overloaded_after).toEqual(['LINE_OL2']);
+
+        // Curtailment
+        const ct = restored!.actions['curtail_1'];
+        expect(ct.curtailment_details).toEqual([
+            { gen_name: 'W1', voltage_level_id: 'VL_2', curtailed_mw: 7.5 },
+        ]);
+        expect(ct.lines_overloaded_after).toEqual([]);
+
+        // PST editor card depends on pst_details
+        const pst = restored!.actions['pst_1'];
+        expect(pst.pst_details).toEqual([
+            { pst_name: 'PST_A', tap_position: 5, low_tap: -16, high_tap: 16 },
+        ]);
+    });
+
+    it('preserves action status flags (selected / suggested / rejected / manually-simulated) on restore', async () => {
+        mockLoadSession.mockResolvedValue(makeSession({
+            analysis: {
+                message: 'ok',
+                dc_fallback: false,
+                action_scores: {},
+                combined_actions: {},
+                actions: {
+                    act_fav: {
+                        description_unitaire: 'fav',
+                        rho_before: [1.1], rho_after: [0.8], max_rho: 0.8,
+                        max_rho_line: 'L1', is_rho_reduction: true,
+                        status: { is_selected: true, is_suggested: true, is_rejected: false, is_manually_simulated: false },
+                    },
+                    act_rej: {
+                        description_unitaire: 'rej',
+                        rho_before: [1.1], rho_after: [1.0], max_rho: 1.0,
+                        max_rho_line: 'L1', is_rho_reduction: false,
+                        status: { is_selected: false, is_suggested: true, is_rejected: true, is_manually_simulated: false },
+                    },
+                    act_manual: {
+                        description_unitaire: 'manual',
+                        rho_before: [1.2], rho_after: [0.9], max_rho: 0.9,
+                        max_rho_line: 'L1', is_rho_reduction: true,
+                        status: { is_selected: true, is_suggested: false, is_rejected: false, is_manually_simulated: true },
+                    },
+                },
+            },
+        }));
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('session_status', ctx);
+        });
+
+        expect(ctx.setSelectedActionIds).toHaveBeenCalledWith(
+            new Set(['act_fav', 'act_manual']),
+        );
+        expect(ctx.setRejectedActionIds).toHaveBeenCalledWith(new Set(['act_rej']));
+        expect(ctx.setManuallyAddedIds).toHaveBeenCalledWith(new Set(['act_manual']));
+        expect(ctx.setSuggestedByRecommenderIds).toHaveBeenCalledWith(
+            new Set(['act_fav', 'act_rej']),
+        );
+    });
+
+    it('does not crash when action entries omit the new enrichment fields (legacy shape)', async () => {
+        // Pre-PR-#73 action entries lack every enrichment field. The
+        // restore path must propagate the absent fields as undefined
+        // instead of throwing.
+        mockLoadSession.mockResolvedValue(makeSession({
+            analysis: {
+                message: 'ok',
+                dc_fallback: false,
+                action_scores: {},
+                combined_actions: {},
+                actions: {
+                    legacy_act: {
+                        description_unitaire: 'legacy',
+                        rho_before: [1.1], rho_after: [0.7], max_rho: 0.7,
+                        max_rho_line: 'L1', is_rho_reduction: true,
+                        status: { is_selected: false, is_suggested: true, is_rejected: false, is_manually_simulated: false },
+                    },
+                },
+            },
+        }));
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('legacy_action', ctx);
+        });
+
+        const restored = captureRestoredResult(ctx.setResult as ReturnType<typeof vi.fn>);
+        expect(restored).not.toBeNull();
+        const legacy = restored!.actions['legacy_act'];
+        expect(legacy.load_shedding_details).toBeUndefined();
+        expect(legacy.curtailment_details).toBeUndefined();
+        expect(legacy.pst_details).toBeUndefined();
+        expect(legacy.lines_overloaded_after).toBeUndefined();
+    });
+
+    it('skips estimation-only combined entries that were never simulated manually', async () => {
+        // Combined entries that are estimation-only (e.g. "act_a+act_b"
+        // with is_estimated=true and no manual simulation) are not
+        // restored as top-level actions — they live under
+        // combined_actions instead.
+        mockLoadSession.mockResolvedValue(makeSession({
+            analysis: {
+                message: 'ok',
+                dc_fallback: false,
+                action_scores: {},
+                combined_actions: {
+                    'act_a+act_b': {
+                        action1_id: 'act_a',
+                        action2_id: 'act_b',
+                        betas: [0.5, 0.5],
+                        max_rho: 0.9,
+                        max_rho_line: 'LINE_X',
+                        is_rho_reduction: true,
+                        description: 'Combined a+b',
+                        estimated_max_rho: 0.9,
+                        estimated_max_rho_line: 'LINE_X',
+                        is_simulated: false,
+                    },
+                },
+                actions: {
+                    act_a: {
+                        description_unitaire: 'a',
+                        rho_before: [1.0], rho_after: [0.95], max_rho: 0.95,
+                        max_rho_line: 'L1', is_rho_reduction: true,
+                        status: { is_selected: false, is_suggested: true, is_rejected: false, is_manually_simulated: false },
+                    },
+                    'act_a+act_b': {
+                        description_unitaire: 'a+b estimated',
+                        rho_before: null,
+                        rho_after: null,
+                        max_rho: null,
+                        max_rho_line: 'LINE_X',
+                        is_rho_reduction: true,
+                        is_estimated: true,
+                        status: { is_selected: false, is_suggested: false, is_rejected: false, is_manually_simulated: false },
+                    },
+                },
+            },
+        }));
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+
+        await act(async () => {
+            await result.current.handleRestoreSession('combo_session', ctx);
+        });
+
+        const restored = captureRestoredResult(ctx.setResult as ReturnType<typeof vi.fn>);
+        expect(restored).not.toBeNull();
+        // Only the real action survived — the estimation-only
+        // combined entry was filtered out.
+        expect(Object.keys(restored!.actions)).toEqual(['act_a']);
+        // But the combined_actions dictionary still carries it.
+        expect(restored!.combined_actions).toHaveProperty('act_a+act_b');
     });
 });

--- a/frontend/src/hooks/useSession.test.ts
+++ b/frontend/src/hooks/useSession.test.ts
@@ -52,7 +52,7 @@ describe('useSession — interaction logging', () => {
         layoutPath: '',
         outputFolderPath: '/tmp/output',
         minLineReconnections: 2, minCloseCoupling: 3, minOpenCoupling: 2, minLineDisconnections: 3,
-        minPst: 1, minLoadShedding: 0, nPrioritizedActions: 10,
+        minPst: 1, minLoadShedding: 0, minRenewableCurtailmentActions: 0, nPrioritizedActions: 10,
         linesMonitoringPath: '', monitoringFactor: 0.95, preExistingOverloadThreshold: 0.02,
         ignoreReconnections: false, pypowsyblFastMode: true,
         selectedBranch: 'LINE_A', selectedOverloads: new Set(['OL1']), monitorDeselected: false,

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -46,6 +46,8 @@ export interface SaveParams {
   monitorDeselected: boolean;
   nOverloads: string[];
   n1Overloads: string[];
+  nOverloadsRho?: number[];
+  n1OverloadsRho?: number[];
   result: AnalysisResult | null;
   selectedActionIds: Set<string>;
   rejectedActionIds: Set<string>;
@@ -89,6 +91,13 @@ export interface RestoreContext {
   setSuggestedByRecommenderIds: Dispatch<SetStateAction<Set<string>>>;
   restoringSessionRef: MutableRefObject<boolean>;
   committedBranchRef: MutableRefObject<string>;
+  // Tracks the network path of the currently-loaded study so that
+  // subsequent edits to the Header path input know whether to prompt
+  // the "Change Network?" confirmation dialog. Must be updated on
+  // session restore — otherwise the first manual edit to the network
+  // path after a reload either silently drops the study (ref empty)
+  // or fires a spurious dialog against a stale value. See PR #83.
+  committedNetworkPathRef: MutableRefObject<string>;
   setSelectedBranch: (v: string) => void;
   setInfoMessage: (v: string) => void;
   setError: (v: string) => void;
@@ -124,6 +133,8 @@ export function useSession(): SessionState {
       monitorDeselected: params.monitorDeselected,
       nOverloads: params.nOverloads,
       n1Overloads: params.n1Overloads,
+      nOverloadsRho: params.nOverloadsRho,
+      n1OverloadsRho: params.n1OverloadsRho,
       result: params.result,
       selectedActionIds: params.selectedActionIds,
       rejectedActionIds: params.rejectedActionIds,
@@ -229,6 +240,13 @@ export function useSession(): SessionState {
 
       ctx.applyConfigResponse(configRes as Record<string, unknown>);
 
+      // Record the restored network path as the currently-committed
+      // study, so any later manual edit to the Header network input
+      // correctly routes through the "Change Network?" confirmation
+      // dialog instead of either silently dropping the study (ref
+      // empty) or misfiring against a stale previous value.
+      ctx.committedNetworkPathRef.current = cfg.network_path;
+
       // 3. Fetch study data
       const [branchesList, vlRes, nomVRes] = await Promise.all([
         api.getBranches(),
@@ -278,6 +296,16 @@ export function useSession(): SessionState {
             is_islanded: entry.is_islanded,
             n_components: entry.n_components,
             disconnected_mw: entry.disconnected_mw,
+            // Enrichment fields added by PR #73 (loads_p/gens_p format),
+            // PR #78 (PST tap re-simulation) and PR #83 (post-action
+            // overload highlighting). These were previously dropped on
+            // reload, so the PST / load-shedding / curtailment editors
+            // rendered empty and the SLD/NAD tab lost its post-action
+            // overload halos until the user re-ran analysis.
+            lines_overloaded_after: entry.lines_overloaded_after,
+            load_shedding_details: entry.load_shedding_details,
+            curtailment_details: entry.curtailment_details,
+            pst_details: entry.pst_details,
             is_manual: entry.status.is_manually_simulated,
           };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -332,6 +332,16 @@ export interface SessionResult {
         n_overloads: string[];
         n1_overloads: string[];
         resolved_overloads: string[];   // overloads that were resolved (selected for step2)
+        // Per-element loading ratio (max|i|/permanent_limit) parallel
+        // to the n/n-1 overload arrays above. Introduced alongside the
+        // sticky feed-summary header (PR #88): the header displays
+        // "NAME (XX.X%)" for every overloaded line, and the ratios
+        // come from the backend N-1 diagram payload. Persisted here
+        // so the sticky header still renders percentages after a
+        // session reload without re-running analysis. Optional for
+        // backward compatibility with older session dumps.
+        n_overloads_rho?: number[];
+        n1_overloads_rho?: number[];
     };
     overflow_graph: {
         pdf_url: string | null;
@@ -375,6 +385,14 @@ export type InteractionType =
     | 'action_rejected'
     | 'action_unrejected'
     | 'manual_action_simulated'
+    // Re-simulation of an already-present action with edited parameters.
+    // Unlike `manual_action_simulated`, these gestures keep the action
+    // in its current bucket (suggested / manual) and only update the
+    // rho_after / load-shedding / curtailment / PST details in place.
+    // Two distinct types so a replay agent knows which input field to
+    // edit before clicking Re-simulate.
+    | 'action_mw_resimulated'
+    | 'pst_tap_resimulated'
     // Combined Actions
     | 'combine_modal_opened'
     | 'combine_modal_closed'

--- a/frontend/src/utils/sessionUtils.test.ts
+++ b/frontend/src/utils/sessionUtils.test.ts
@@ -42,6 +42,7 @@ const baseInput: SessionInput = {
     minLineDisconnections: 3.0,
     minPst: 1.0,
     minLoadShedding: 0.0,
+    minRenewableCurtailmentActions: 0.0,
     nPrioritizedActions: 10,
     linesMonitoringPath: '/data/monitoring.csv',
     monitoringFactor: 0.95,
@@ -81,6 +82,7 @@ describe('buildSessionResult — structure', () => {
             min_line_disconnections: 3.0,
             min_pst: 1.0,
             min_load_shedding: 0.0,
+            min_renewable_curtailment_actions: 0.0,
             n_prioritized_actions: 10,
             lines_monitoring_path: '/data/monitoring.csv',
             monitoring_factor: 0.95,
@@ -118,6 +120,43 @@ describe('buildSessionResult — structure', () => {
     it('sets resolved_overloads to empty when result is null', () => {
         const out = buildSessionResult({ ...baseInput, result: null });
         expect(out.overloads.resolved_overloads).toEqual([]);
+    });
+
+    it('persists lines_overloaded_rho when length matches the element list', () => {
+        // PR #88 added per-element loading ratios that feed the sticky
+        // sidebar header. They must survive save/reload so the sticky
+        // percentages render after a session restore without requiring
+        // a fresh analysis run.
+        const out = buildSessionResult({
+            ...baseInput,
+            nOverloads: ['LINE_PRE'],
+            nOverloadsRho: [1.04],
+            n1Overloads: ['LINE_B', 'LINE_C'],
+            n1OverloadsRho: [1.23, 1.07],
+        });
+        expect(out.overloads.n_overloads_rho).toEqual([1.04]);
+        expect(out.overloads.n1_overloads_rho).toEqual([1.23, 1.07]);
+    });
+
+    it('omits rho arrays when the length does not match the element list', () => {
+        // Guard against older payloads / partial backends: if the rho
+        // array is shorter than the name array, prefer omitting the
+        // field entirely over writing misaligned percentages.
+        const out = buildSessionResult({
+            ...baseInput,
+            n1Overloads: ['LINE_B', 'LINE_C'],
+            n1OverloadsRho: [1.23],
+        });
+        expect(out.overloads.n1_overloads_rho).toBeUndefined();
+    });
+
+    it('omits rho arrays when not provided at all (legacy session flow)', () => {
+        const out = buildSessionResult({
+            ...baseInput,
+            n1Overloads: ['LINE_B'],
+        });
+        expect(out.overloads.n_overloads_rho).toBeUndefined();
+        expect(out.overloads.n1_overloads_rho).toBeUndefined();
     });
 
     it('populates overflow_graph when result has pdf_url', () => {

--- a/frontend/src/utils/sessionUtils.ts
+++ b/frontend/src/utils/sessionUtils.ts
@@ -36,9 +36,12 @@ export interface SessionInput {
     selectedOverloads: Set<string>;
     monitorDeselected: boolean;
 
-    // Overload lists from diagrams
+    // Overload lists from diagrams (parallel rho arrays are optional,
+    // backend only populates them on the N-1 payload today — see PR #88).
     nOverloads: string[];
     n1Overloads: string[];
+    nOverloadsRho?: number[];
+    n1OverloadsRho?: number[];
 
     // Analysis result (already merged from pendingAnalysisResult → result)
     result: AnalysisResult | null;
@@ -71,6 +74,7 @@ export function buildSessionResult(input: SessionInput): SessionResult {
         preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode,
         selectedBranch, selectedOverloads, monitorDeselected,
         nOverloads, n1Overloads,
+        nOverloadsRho, n1OverloadsRho,
         result,
         selectedActionIds, rejectedActionIds, manuallyAddedIds, suggestedByRecommenderIds,
         interactionLog,
@@ -175,6 +179,14 @@ export function buildSessionResult(input: SessionInput): SessionResult {
             n_overloads: nOverloads,
             n1_overloads: n1Overloads,
             resolved_overloads: result?.lines_overloaded ?? [],
+            // Only persist rho arrays when they match the element list
+            // length — a shorter or missing array means the diagram
+            // payload predates the rho feature (older backend / older
+            // session). Keeping them out of the JSON in that case lets
+            // session consumers know the data is unavailable rather
+            // than showing misleading zeros.
+            ...(nOverloadsRho && nOverloadsRho.length === nOverloads.length ? { n_overloads_rho: nOverloadsRho } : {}),
+            ...(n1OverloadsRho && n1OverloadsRho.length === n1Overloads.length ? { n1_overloads_rho: n1OverloadsRho } : {}),
         },
         overflow_graph: result?.pdf_url
             ? { pdf_url: result.pdf_url, pdf_path: result.pdf_path ?? null }


### PR DESCRIPTION
## Summary

This PR extends interaction logging to capture user gestures for action re-simulation (MW and PST tap editing) and adds comprehensive logging for tab detach/reattach/tie/untie workflows. It also improves session persistence by saving and restoring per-element loading ratios and action enrichment fields, enabling full-fidelity replay and session reload without requiring re-analysis.

## Key Changes

### Interaction Logging Enhancements
- **Action re-simulation events**: Added `action_mw_resimulated` and `pst_tap_resimulated` event types to distinguish re-simulation (which keeps actions in their current bucket) from initial `manual_action_simulated` gestures
- **Tab management events**: Added `tab_detached`, `tab_reattached`, `tab_tied`, and `tab_untied` event types to log visualization tab window management
- **Settings tab navigation**: Updated `settings_tab_changed` to log both `from_tab` and `to_tab` for proper replay sequencing
- **Config snapshot**: Introduced `buildConfigInteractionDetails()` helper to capture full configuration state (all paths and recommender thresholds) in `config_loaded` and `settings_applied` events, enabling complete replay without external context

### Session Persistence & Restoration
- **Overload ratios**: Added `n_overloads_rho` and `n1_overloads_rho` arrays to session overloads, persisting per-element loading ratios that feed the sticky sidebar header percentages
- **Action enrichment fields**: Now restore `lines_overloaded_after`, `load_shedding_details`, `curtailment_details`, and `pst_details` from saved sessions, eliminating the need to re-run analysis after reload to populate editor cards and post-action overload halos
- **Network path tracking**: Added `committedNetworkPathRef` to properly gate the "Change Network?" confirmation dialog after session restore

### Documentation Updates
- Comprehensive interaction logging contract documenting all event types, their payloads, and replay semantics
- New "Session reload fidelity" section explaining what is persisted, restored, and intentionally ephemeral (detached tab state)
- Wait-point annotations for async operations so replay agents know when to pause

### Implementation Details
- Re-simulation logging moved from `useActions` hook to `ActionFeed` component handlers (`handleResimulate`, `handleResimulateTap`) to capture user-edited target values at the gesture site
- Rho arrays conditionally persisted only when their length matches the element list, guarding against misaligned data from older backends
- Settings tab change only logged when `from_tab !== to_tab`, avoiding spurious events
- Full config details captured in a single callback to ensure consistency across multiple call sites

https://claude.ai/code/session_013qJjLFQWMR91ZfPTRCLFiu