### PR TITLE
Fix main window tab switching when action tab is detached

### DIFF
--- a/docs/detachable-viz-tabs.md
+++ b/docs/detachable-viz-tabs.md
@@ -49,6 +49,21 @@ which design decisions were made along the way.
 - Detach, reattach, tie and untie events are all recorded in the
   interaction log so that session replays can reproduce the operator's
   window layout AND any synchronisation they set up.
+- **Main-window tab is never disturbed by interactions targeting a
+  detached tab.** Clicking an action card, clicking an asset badge
+  inside an action card, clicking an overload badge targeting N / N-1,
+  or re-focusing an asset on the currently-selected action all keep
+  the main window on whatever tab the operator chose, as long as the
+  target tab lives in a detached popup. The detached popup still
+  receives the new diagram / zoom / focus via the shared React
+  subtree. See ["Main window stays steady on detached-tab
+  interactions"](#main-window-stays-steady-on-detached-tab-interactions)
+  for the full interaction contract.
+- **Action-tab zoom is preserved across action switches in a detached
+  popup**, exactly as it is when the Action tab is inline. Clicking a
+  different action card in the popup keeps the user's current
+  pan/zoom on the new action diagram instead of snapping to the N-1
+  viewBox. See ["Preserving action-tab zoom across action switches"](#preserving-action-tab-zoom-across-action-switches).
 
 ## Architecture
 
@@ -455,6 +470,188 @@ with the per-tab effective mode. Before this fix, Impacts mode
 never rendered inside a detached popup because the highlights
 effect only ran for the main window's active tab.
 
+## Main window stays steady on detached-tab interactions
+
+**Invariant** — if a user interaction targets a tab that currently
+lives in a detached popup, the main window's `activeTab` MUST NOT
+change. The interaction still takes effect (new diagram, new zoom
+focus, new selection), but it is routed through the shared React
+subtree / the detached popup's render path, while the main window
+keeps showing whatever tab the operator last chose (typically N or
+N-1 while working the detached Action popup).
+
+Before this invariant was enforced, every click on an action card
+(or on an asset badge inside one) flipped the main window to the
+Action tab — which then rendered only the "view is detached"
+placeholder over whatever N / N-1 diagram the operator was studying.
+The result was a jarring "main window blanks out every few seconds"
+experience for anyone using the detached Action popup alongside the
+main-window N-1 tab, exactly the dual-screen workflow this feature
+was built for. The symmetric versions of the same bug existed for the
+N and N-1 tabs (clicking an overload badge in the OverloadPanel).
+
+### Entry points covered
+
+The detached-tab guard applies uniformly at every entry point that
+used to call `setActiveTab(...)` in response to a user click:
+
+| Entry point | Location | Detached-guard behaviour |
+|---|---|---|
+| Clicking an action card in the ActionFeed | `useDiagrams.handleActionSelect` | When the action tab is detached, the selection, diagram fetch and zoom restore proceed as normal but `setActiveTab('action')` is skipped. |
+| Re-clicking the currently-selected action card (toggle deselect) | `useDiagrams.handleActionSelect` (toggle branch) | When the action tab is detached, the selection is cleared but `setActiveTab('n-1')` is skipped so the main window's N / N-1 view is not disturbed. |
+| Clicking an asset badge inside an action card (same action) | `useDiagrams.handleAssetClick` (`tab === 'action'`, same action) | When the action tab is detached, the inspect query + focus target are set on the action tab but `setActiveTab('action')` is skipped. |
+| Clicking an asset badge inside an action card (different action) | `useDiagrams.handleAssetClick` delegates to `handleActionSelectFn` | The delegation is unchanged; `handleActionSelect`'s own detached guard (row 1) then applies. |
+| Clicking an N-overload badge in the OverloadPanel | `useDiagrams.handleAssetClick` (`tab === 'n'`) | When the N tab is detached, `setActiveTab('n')` is skipped. |
+| Clicking an N-1-overload badge in the OverloadPanel | `useDiagrams.handleAssetClick` (`tab === 'n-1'`) | When the N-1 tab is detached, `setActiveTab('n-1')` is skipped. |
+
+**Inline behaviour is unchanged.** When the target tab is NOT
+detached, every entry point still force-switches `activeTab` exactly
+as before — that is the behaviour the operator expects when working
+entirely inside the main window. The guards are pure "don't disturb
+a popup-backed workflow" overrides and are never taken in the inline
+case.
+
+### Why the zoom / focus still lands on the correct (detached) tab
+
+`handleAssetClick` used to call `setInspectQuery(assetName)`, which
+drives the auto-zoom effect with a target tab of `activeTab` (the
+main window's current tab). That worked for the inline case
+specifically because the function was also calling `setActiveTab(tab)`
+— so `activeTab` was already `tab` by the time the auto-zoom effect
+ran.
+
+Removing the `setActiveTab` call would have broken the zoom: the
+auto-zoom would default to whatever the main-window tab was (N or
+N-1) and try to zoom the wrong SVG. The fix routes the inspect query
+through `setInspectQueryForTab(tab, assetName)` unconditionally. This
+records an explicit focus target in `inspectFocusTabRef` that the
+auto-zoom effect prefers over `activeTab`, so the zoom always lands
+on the correct SVG — whether that tab is inline or detached.
+
+### Implementation
+
+All guards live inside `useDiagrams.ts` and read the detached-tab
+state through a small ref mirror of the `detachedTabs` prop:
+
+```ts
+// useDiagrams.ts
+const detachedTabsRef = useRef(detachedTabs);
+useLayoutEffect(() => { detachedTabsRef.current = detachedTabs; }, [detachedTabs]);
+```
+
+`useLayoutEffect` keeps the ref in sync with the latest render
+**before** any subsequent callback runs, so the stable
+`useCallback`-wrapped handlers (`handleActionSelect`,
+`handleAssetClick`, ...) can read
+`detachedTabsRef.current?.[tab]` without having to declare
+`detachedTabs` in their dependency arrays — important because those
+callbacks are bound into `useMemo`-returned objects and re-binding
+them on every `detachedTabs` change would invalidate every downstream
+memo that depends on the hook's stable shape.
+
+`handleActionSelect` reads the ref once at the top:
+
+```ts
+const isActionDetached = !!detachedTabsRef.current?.['action'];
+...
+if (!isActionDetached) setActiveTab('action');   // select branch
+...
+if (!isActionDetached) setActiveTab('n-1');      // deselect branch
+```
+
+`handleAssetClick` reads it per `tab` argument:
+
+```ts
+setInspectQueryForTab(tab, assetName);
+const isTabDetached = !!detachedTabsRef.current?.[tab];
+if (tab === 'n') {
+    if (!isTabDetached) setActiveTab('n');
+} else if (tab === 'n-1') {
+    if (!isTabDetached) setActiveTab('n-1');
+} else if (actionId !== currentSelectedActionId) {
+    handleActionSelectFn(actionId);              // delegates
+} else {
+    if (!isTabDetached) setActiveTab('action');
+}
+```
+
+## Preserving action-tab zoom across action switches
+
+**Problem** — even with the detached-tab guard in place, clicking a
+different action card inside a detached Action popup used to snap
+the popup to the N-1 viewBox instead of preserving the operator's
+current zoom on the new action diagram. The attached (inline)
+behaviour has always preserved the zoom, so the detached case was a
+surprising divergence.
+
+**Root cause** — `useDiagrams` has a capture + restore pattern that
+preserves the action-tab viewBox across action switches:
+
+1. **Capture** (`handleActionSelect`): before triggering a new fetch,
+   save the current action viewBox into a ref
+   (`actionSyncSourceRef.current`).
+2. **Restore** (the "re-sync after action diagram loads" effect):
+   when the new action diagram loads, read the ref and re-apply it
+   via `actionPZ.setViewBox(captured)`, overriding the native viewBox
+   `usePanZoom` reset the pan/zoom to on every diagram load.
+
+Both halves of that pattern were gated on `activeTab === 'action'`:
+
+```ts
+// Capture
+actionSyncSourceRef.current =
+    (activeTabRef.current === 'action' ? actionPZ.viewBox : null)
+    || n1PZ.viewBox || nPZ.viewBox;
+
+// Restore
+useEffect(() => {
+    if (actionDiagram && activeTab === 'action' && actionSyncSourceRef.current) {
+        actionPZ.setViewBox(actionSyncSourceRef.current);
+        actionSyncSourceRef.current = null;
+    }
+}, [actionDiagram, activeTab, actionPZ]);
+```
+
+When the Action tab is detached, `activeTab` is NOT `'action'` — it
+is `'n'` or `'n-1'` (the main window's current tab). So the capture
+fell through to the `n1PZ.viewBox || nPZ.viewBox` fallback (capturing
+the wrong zoom) and the restore effect's guard was false (so the
+captured value, even if correct, was never re-applied). The popup
+therefore always snapped to the N / N-1 viewBox.
+
+**Fix** — both sides now treat "the action tab is currently showing
+the action diagram" as `activeTab === 'action' || isActionDetached`:
+
+```ts
+// Capture
+const actionTabShowsActionDiagram = activeTabRef.current === 'action' || isActionDetached;
+actionSyncSourceRef.current =
+    (actionTabShowsActionDiagram ? actionPZ.viewBox : null)
+    || n1PZ.viewBox || nPZ.viewBox;
+
+// Restore
+useEffect(() => {
+    const isActionDetached = !!detachedTabsRef.current?.['action'];
+    const captured = actionSyncSourceRef.current;
+    if (actionDiagram && captured && (activeTab === 'action' || isActionDetached)) {
+        actionPZ.setViewBox(captured);
+        actionSyncSourceRef.current = null;
+    }
+}, [actionDiagram, activeTab, actionPZ, detachedTabs]);
+```
+
+The restore effect also depends on `detachedTabs` so it re-runs when
+a tab transitions from inline to detached (or vice versa) while a
+capture is queued, keeping the guard honest.
+
+**First-action fallback still works.** If the operator detaches the
+Action tab before selecting any action, `actionPZ.viewBox` is still
+`null`. In that case the `||` chain falls through to
+`n1PZ.viewBox || nPZ.viewBox`, exactly like the inline case — so
+picking the first action syncs from the main-window N-1 / N viewBox.
+Only the "I already had an action zoomed in" case benefits from the
+fix.
+
 ## Bugs fixed in the second iteration
 
 The initial shipment (commit `ca80547`) worked visually but suffered
@@ -613,6 +810,34 @@ Vitest suites:
   directly (`document.body` children), because the overlay's
   DOM is imperatively relocated out of testing-library's
   container when the tab is detached.
+
+- **`frontend/src/hooks/useDiagrams.test.ts`** (+14 tests across
+  three describes) — regressions for the "main window stays steady
+  on detached-tab interactions" invariant and the "preserve
+  action-tab zoom across action switches" fix:
+
+  - `handleActionSelect respects detached action tab` (5 tests):
+    selecting a new action when the action tab is detached does
+    NOT switch `activeTab` to `'action'`; it still does when the
+    tab is inline (regression guard); the action variant diagram is
+    still fetched so the popup receives it; deselecting (re-clicking
+    the same card) while detached does NOT fall back to
+    `'n-1'`; still does when inline.
+  - `handleActionSelect preserves action-tab zoom when detached`
+    (3 tests): the captured viewBox is re-applied after the new
+    diagram loads in the detached case; the same holds for the
+    inline case (regression guard); the N-1 fallback still kicks in
+    when there is no prior action-tab viewBox to preserve.
+  - `handleAssetClick does not force activeTab onto detached tabs`
+    (6 tests): action-card asset click with action tab detached
+    stays on N-1; with action tab inline still switches to
+    `'action'`; N-overload badge click with N tab detached stays on
+    action; N-1-overload badge click with N-1 tab detached stays on
+    action; still switches to `'n-1'` when the N-1 tab is inline;
+    different-action asset click still delegates to
+    `handleActionSelectFn` (whose own detached guard is tested
+    above). Each test also checks `inspectQuery` is set so the
+    auto-zoom lands on the correct tab regardless of `activeTab`.
 
 ## Known limitations
 

--- a/frontend/src/App.contingency.test.tsx
+++ b/frontend/src/App.contingency.test.tsx
@@ -471,3 +471,90 @@ describe('Overload Clearing Logic', () => {
     });
   });
 });
+
+// Regression: when the user selects a contingency, the N-1 diagram comes
+// back from the backend with `lines_overloaded` already populated. Those
+// overloaded lines must be picked up by the app state IMMEDIATELY — and
+// fed into the highlight pipeline — without waiting for the user to run
+// "Analyze & Suggest". The previous implementation only sourced highlight
+// data from `result.lines_overloaded` (set post-analysis), so the orange
+// halos never appeared on the freshly-loaded N-1 view. The pure
+// computation that selects which lines to highlight is unit-tested in
+// `src/utils/overloadHighlights.test.ts`. The integration assertions
+// here verify the data flows through App state into the panels that
+// drive that computation, even before any analysis has run.
+describe('N-1 overload state is populated before action analysis', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    Object.values(mockApi).forEach(m => {
+      if (vi.isMockFunction(m)) m.mockReset();
+    });
+    mockApi.updateConfig.mockResolvedValue({ monitored_lines_count: 10, total_lines_count: 10 });
+    mockApi.getBranches.mockResolvedValue(['BRANCH_A', 'BRANCH_B', 'BRANCH_C']);
+    mockApi.getVoltageLevels.mockResolvedValue(['VL1', 'VL2']);
+    mockApi.getNominalVoltages.mockResolvedValue({ mapping: {}, unique_kv: [63, 225] });
+    mockApi.getNetworkDiagram.mockResolvedValue({ svg: '<svg></svg>', metadata: null });
+    mockApi.getN1Diagram.mockResolvedValue({ svg: '<svg></svg>', metadata: null, lines_overloaded: [] });
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('exposes N-1 overloads + a default selection set as soon as the N-1 diagram loads (no analysis yet)', async () => {
+    mockApi.getN1Diagram.mockResolvedValueOnce({
+      svg: '<svg></svg>',
+      metadata: null,
+      lines_overloaded: ['LINE_OL_A', 'LINE_OL_B'],
+    });
+
+    await renderAndLoadStudy();
+    await selectBranch('BRANCH_A');
+
+    // The OverloadPanel reflects the two overloads from the N-1
+    // diagram fetch — and they are auto-selected so the
+    // computeN1OverloadHighlights helper will return them as the
+    // highlight set on the very next render of the N-1 tab.
+    await waitFor(() => {
+      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '2');
+      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '2');
+    });
+
+    // No analysis was run, so the ActionFeed sees zero result-side
+    // overloads. The N-1 highlight pipeline must therefore use the
+    // n1Diagram fallback (covered by the unit tests on the helper).
+    expect(screen.getByTestId('action-feed')).toHaveAttribute('data-ol-count', '0');
+  });
+
+  it('replaces the overload selection when switching contingencies without running analysis', async () => {
+    mockApi.getN1Diagram.mockResolvedValueOnce({
+      svg: '<svg></svg>',
+      metadata: null,
+      lines_overloaded: ['LINE_OL_A', 'LINE_OL_B'],
+    });
+
+    await renderAndLoadStudy();
+    await selectBranch('BRANCH_A');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '2');
+    });
+
+    mockApi.getN1Diagram.mockResolvedValueOnce({
+      svg: '<svg></svg>',
+      metadata: null,
+      lines_overloaded: ['LINE_OL_C'],
+    });
+
+    const input = screen.getByPlaceholderText('Search line/bus...');
+    await act(async () => {
+      await userEvent.clear(input);
+      await userEvent.type(input, 'BRANCH_B');
+    });
+
+    await waitFor(() => {
+      expect(mockApi.getN1Diagram).toHaveBeenCalledWith('BRANCH_B');
+      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '1');
+      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '1');
+    });
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import ConfirmationDialog from './components/modals/ConfirmationDialog';
 import type { ConfirmDialogState } from './components/modals/ConfirmationDialog';
 import { api } from './api';
 import { applyOverloadedHighlights, applyDeltaVisuals, applyActionTargetHighlights, applyContingencyHighlight, processSvg } from './utils/svgUtils';
+import { computeN1OverloadHighlights } from './utils/overloadHighlights';
 import type { ActionDetail, TabId, RecommenderDisplayConfig } from './types';
 import { useSettings } from './hooks/useSettings';
 import { useActions } from './hooks/useActions';
@@ -749,6 +750,22 @@ function App() {
     const effectiveMode = mode ?? viewModeForTab(tab);
     const overloadedLines = result?.lines_overloaded || [];
 
+    // For the N-1 tab, the overloads are known as soon as the N-1
+    // diagram comes back from the backend (`n1Diagram.lines_overloaded`)
+    // — well before any action analysis has run. Falling back to that
+    // list lets the orange overload halos show up immediately on the
+    // N-1 view, matching the standalone interface and what the user
+    // expects to see right after picking a contingency. Once analysis
+    // runs and `result.lines_overloaded` becomes available, we use that.
+    // In both cases the user's selected-overload set (from the
+    // Overloads panel) further filters the list down. Extracted to a
+    // pure helper for unit testing.
+    const n1OverloadedLines = computeN1OverloadHighlights(
+      overloadedLines,
+      n1Diagram?.lines_overloaded,
+      selectedOverloads,
+    );
+
     if (tab === 'n-1') {
       if (diagrams.n1SvgContainerRef.current) {
         // IMPORTANT: run highlight CLONES before applyDeltaVisuals.
@@ -768,8 +785,8 @@ function App() {
         // the action redistributes flows AND which lines are still
         // (or newly) overloaded; suppressing the halos in delta mode
         // hides exactly that information.
-        if (diagrams.n1MetaIndex && overloadedLines.length > 0) {
-          applyOverloadedHighlights(diagrams.n1SvgContainerRef.current, diagrams.n1MetaIndex, overloadedLines);
+        if (diagrams.n1MetaIndex && n1OverloadedLines.length > 0) {
+          applyOverloadedHighlights(diagrams.n1SvgContainerRef.current, diagrams.n1MetaIndex, n1OverloadedLines);
         }
         applyContingencyHighlight(diagrams.n1SvgContainerRef.current, diagrams.n1MetaIndex, selectedBranch);
         applyDeltaVisuals(diagrams.n1SvgContainerRef.current, n1Diagram, diagrams.n1MetaIndex, effectiveMode === 'delta');
@@ -823,7 +840,7 @@ function App() {
       // layer.
       applyDeltaVisuals(diagrams.actionSvgContainerRef.current, actionDiagram, diagrams.actionMetaIndex, effectiveMode === 'delta');
     }
-  }, [n1Diagram, actionDiagram, result, selectedActionId, selectedBranch, diagrams, monitoringFactor, viewModeForTab]);
+  }, [n1Diagram, actionDiagram, result, selectedActionId, selectedBranch, diagrams, monitoringFactor, viewModeForTab, selectedOverloads]);
 
   useEffect(() => {
     const isTabSwitch = prevHighlightTabRef.current !== activeTab;
@@ -858,7 +875,7 @@ function App() {
     } else {
       applyAll();
     }
-  }, [nDiagram, n1Diagram, actionDiagram, diagrams.nMetaIndex, diagrams.n1MetaIndex, diagrams.actionMetaIndex, result, selectedActionId, actionViewMode, detachedViewModes, detachedTabs, activeTab, selectedBranch, applyHighlightsForTab]);
+  }, [nDiagram, n1Diagram, actionDiagram, diagrams.nMetaIndex, diagrams.n1MetaIndex, diagrams.actionMetaIndex, result, selectedActionId, actionViewMode, detachedViewModes, detachedTabs, activeTab, selectedBranch, selectedOverloads, applyHighlightsForTab]);
 
   // ===== Extracted JSX callbacks (stable references for React.memo) =====
 

--- a/frontend/src/hooks/useDiagrams.test.ts
+++ b/frontend/src/hooks/useDiagrams.test.ts
@@ -531,6 +531,142 @@ describe('useDiagrams — interaction logging', () => {
             });
         });
 
+        // Any interaction targeting a tab that is currently detached
+        // must leave the main window's `activeTab` alone. In particular,
+        // clicking an asset button inside an action card (or an N / N-1
+        // overload badge) used to force the main window to switch to
+        // that tab — for a detached tab, that means the main window
+        // goes from N or N-1 to the blank "Detached" placeholder every
+        // time. The fix routes the auto-zoom via `setInspectQueryForTab`
+        // (so the zoom still lands on the detached tab) while skipping
+        // the `setActiveTab` call for any detached target.
+        describe('handleAssetClick does not force activeTab onto detached tabs', () => {
+            it('does NOT switch activeTab to "action" when clicking an asset on the already-selected action card while the action tab is detached', () => {
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { action: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                // Main window on N-1, action tab in popup showing 'act_1'.
+                act(() => { result.current.setActiveTab('n-1'); });
+                act(() => { result.current.setSelectedActionId('act_1'); });
+                rerender({ dt: { action: { window: {}, mountNode: document.createElement('div') } } });
+
+                // User clicks an asset badge inside the act_1 card.
+                act(() => {
+                    result.current.handleAssetClick('act_1', 'LINE_XY', 'action', 'act_1', vi.fn());
+                });
+
+                // Main-window activeTab unchanged.
+                expect(result.current.activeTab).toBe('n-1');
+                // And the inspect query is set (drives the auto-zoom
+                // on the detached action tab).
+                expect(result.current.inspectQuery).toBe('LINE_XY');
+            });
+
+            it('still switches activeTab to "action" when clicking an asset on the already-selected action and the action tab is NOT detached', () => {
+                const { result } = renderHook(() => useDiagrams([], [], '', {}));
+
+                act(() => { result.current.setSelectedActionId('act_1'); });
+                act(() => { result.current.setActiveTab('n-1'); });
+
+                act(() => {
+                    result.current.handleAssetClick('act_1', 'LINE_XY', 'action', 'act_1', vi.fn());
+                });
+
+                // No detachment → main window follows the click.
+                expect(result.current.activeTab).toBe('action');
+                expect(result.current.inspectQuery).toBe('LINE_XY');
+            });
+
+            it('does NOT switch activeTab to "n" when clicking an asset targeting a detached N tab', () => {
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { n: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                act(() => { result.current.setActiveTab('action'); });
+                rerender({ dt: { n: { window: {}, mountNode: document.createElement('div') } } });
+
+                act(() => {
+                    result.current.handleAssetClick('', 'LINE_N', 'n', null, vi.fn());
+                });
+
+                expect(result.current.activeTab).toBe('action');
+                expect(result.current.inspectQuery).toBe('LINE_N');
+            });
+
+            it('does NOT switch activeTab to "n-1" when clicking an asset targeting a detached N-1 tab', () => {
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { 'n-1': { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                act(() => { result.current.setActiveTab('action'); });
+                act(() => { result.current.setSelectedActionId('act_1'); });
+                rerender({ dt: { 'n-1': { window: {}, mountNode: document.createElement('div') } } });
+
+                act(() => {
+                    result.current.handleAssetClick('', 'LINE_N1', 'n-1', 'act_1', vi.fn());
+                });
+
+                expect(result.current.activeTab).toBe('action');
+                expect(result.current.inspectQuery).toBe('LINE_N1');
+            });
+
+            it('still switches activeTab to "n-1" when clicking an asset targeting an INLINE N-1 tab', () => {
+                const { result } = renderHook(() => useDiagrams([], [], '', {}));
+
+                act(() => { result.current.setActiveTab('action'); });
+
+                act(() => {
+                    result.current.handleAssetClick('', 'LINE_N1', 'n-1', null, vi.fn());
+                });
+
+                expect(result.current.activeTab).toBe('n-1');
+            });
+
+            it('still forwards to handleActionSelect (which has its own detached guard) when clicking an asset on a DIFFERENT action while the action tab is detached', () => {
+                const handleActionSelectFn = vi.fn();
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { action: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                act(() => { result.current.setSelectedActionId('act_prev'); });
+                act(() => { result.current.setActiveTab('n-1'); });
+                rerender({ dt: { action: { window: {}, mountNode: document.createElement('div') } } });
+
+                act(() => {
+                    result.current.handleAssetClick('act_new', 'LINE_X', 'action', 'act_prev', handleActionSelectFn);
+                });
+
+                // The different-action branch delegates to the caller
+                // (wrappedActionSelect → handleActionSelect), NOT to
+                // setActiveTab directly. The detached-guard for the
+                // activeTab switch lives in handleActionSelect itself
+                // (tested elsewhere in this file).
+                expect(handleActionSelectFn).toHaveBeenCalledWith('act_new');
+                expect(result.current.activeTab).toBe('n-1');
+            });
+        });
+
         it('re-renders with a new detachedTabs map without losing state', () => {
             // Start with no detached tabs.
             const { result, rerender } = renderHook(

--- a/frontend/src/hooks/useDiagrams.test.ts
+++ b/frontend/src/hooks/useDiagrams.test.ts
@@ -404,6 +404,133 @@ describe('useDiagrams — interaction logging', () => {
             });
         });
 
+        // When the action tab is detached into a popup, clicking another
+        // action card must preserve the pan/zoom the user had on the
+        // previous action — same behaviour as the inline (attached) case.
+        // The capture + restore pattern in handleActionSelect / the re-sync
+        // effect were previously gated on `activeTab === 'action'`, which
+        // is FALSE for the detached case (the main window is on N or N-1),
+        // so the viewBox fell through to the N-1 / N viewBox fallback and
+        // the popup snapped to a completely different zoom every time the
+        // user clicked a different action card.
+        describe('handleActionSelect preserves action-tab zoom when detached', () => {
+            const zoomedVb = { x: 10, y: 20, w: 50, h: 40 };
+
+            it('keeps the previous action-tab viewBox after switching actions (detached case)', async () => {
+                const { api } = await import('../api');
+                // Return a new SVG with a native viewBox so usePanZoom's
+                // sync effect actively tries to reset to it — this
+                // mirrors real diagram loads and makes the test
+                // observably exercise the capture+restore path (if the
+                // restore were missing, viewBox would end up as the
+                // native one, not `zoomedVb`).
+                vi.mocked(api.getActionVariantDiagram).mockResolvedValueOnce({
+                    svg: '<svg viewBox="0 0 1000 800"></svg>',
+                    metadata: null,
+                });
+
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { action: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                // User parked the main window on N-1; the action tab
+                // lives in a popup and currently shows 'act_prev' at a
+                // zoomed-in viewBox.
+                act(() => { result.current.setActiveTab('n-1'); });
+                act(() => { result.current.setSelectedActionId('act_prev'); });
+                act(() => { result.current.actionPZ.setViewBox(zoomedVb); });
+                rerender({ dt: { action: { window: {}, mountNode: document.createElement('div') } } });
+                expect(result.current.actionPZ.viewBox).toEqual(zoomedVb);
+
+                // User clicks a different action card in the popup.
+                // handleActionSelect must capture the current action
+                // viewBox (zoomedVb) into actionSyncSourceRef and
+                // re-apply it after the new diagram loads — so the
+                // popup stays exactly where it was.
+                await act(async () => {
+                    await result.current.handleActionSelect('act_next', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                expect(result.current.selectedActionId).toBe('act_next');
+                // Main window stayed on N-1 (covered by a previous test,
+                // but double-checked here as the precondition for the
+                // zoom-preserve branch).
+                expect(result.current.activeTab).toBe('n-1');
+                // The captured viewBox was re-applied — NOT the native
+                // one from the freshly loaded SVG.
+                expect(result.current.actionPZ.viewBox).toEqual(zoomedVb);
+            });
+
+            it('still preserves the action-tab viewBox across action switches when the action tab is inline (attached case)', async () => {
+                const { api } = await import('../api');
+                vi.mocked(api.getActionVariantDiagram).mockResolvedValueOnce({
+                    svg: '<svg viewBox="0 0 1000 800"></svg>',
+                    metadata: null,
+                });
+
+                const { result } = renderHook(() => useDiagrams([], [], '', {}));
+
+                // User is on the action tab inline, zoomed into
+                // 'act_prev'.
+                act(() => { result.current.setActiveTab('action'); });
+                act(() => { result.current.setSelectedActionId('act_prev'); });
+                act(() => { result.current.actionPZ.setViewBox(zoomedVb); });
+                expect(result.current.actionPZ.viewBox).toEqual(zoomedVb);
+
+                // Click a different action card.
+                await act(async () => {
+                    await result.current.handleActionSelect('act_next', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                // Sanity: this is the long-standing attached-case
+                // behaviour. Regression guard for it.
+                expect(result.current.selectedActionId).toBe('act_next');
+                expect(result.current.activeTab).toBe('action');
+                expect(result.current.actionPZ.viewBox).toEqual(zoomedVb);
+            });
+
+            it('falls back to the N-1 viewBox when selecting an action with no prior action-tab viewBox (detached case)', async () => {
+                const { api } = await import('../api');
+                vi.mocked(api.getActionVariantDiagram).mockResolvedValueOnce({
+                    svg: '<svg viewBox="0 0 1000 800"></svg>',
+                    metadata: null,
+                });
+
+                const n1Vb = { x: 100, y: 200, w: 300, h: 400 };
+
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { action: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                // Main window on N-1 with a viewBox, action tab
+                // detached but the user has NOT yet selected an
+                // action — so actionPZ.viewBox is still null.
+                act(() => { result.current.setActiveTab('n-1'); });
+                act(() => { result.current.n1PZ.setViewBox(n1Vb); });
+                rerender({ dt: { action: { window: {}, mountNode: document.createElement('div') } } });
+                expect(result.current.actionPZ.viewBox).toBeNull();
+
+                // Picking the first action in the detached popup
+                // should fall back to the N-1 viewBox (the standard
+                // "sync across tabs" behaviour, unchanged by this fix).
+                await act(async () => {
+                    await result.current.handleActionSelect('act_first', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                expect(result.current.actionPZ.viewBox).toEqual(n1Vb);
+            });
+        });
+
         it('re-renders with a new detachedTabs map without losing state', () => {
             // Start with no detached tabs.
             const { result, rerender } = renderHook(

--- a/frontend/src/hooks/useDiagrams.test.ts
+++ b/frontend/src/hooks/useDiagrams.test.ts
@@ -285,6 +285,125 @@ describe('useDiagrams — interaction logging', () => {
             }
         });
 
+        // When the action tab is detached into a popup, selecting an
+        // action card must NOT switch the main window's activeTab to
+        // 'action'. The popup gets the new diagram via the existing
+        // render path; the main window stays on whatever tab the user
+        // had open (typically N or N-1). Without this guard the main
+        // window blanks out into the "Detached" placeholder every time
+        // the user clicks a different action card. (Sync window/zoom
+        // view fix.)
+        describe('handleActionSelect respects detached action tab', () => {
+            it('does NOT switch activeTab to "action" when the action tab is detached', async () => {
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { action: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                // User parked the main window on the N-1 tab while the
+                // action tab is open in a popup.
+                act(() => { result.current.setActiveTab('n-1'); });
+                expect(result.current.activeTab).toBe('n-1');
+
+                // Re-render with the same detached map so the ref mirror
+                // is up-to-date before the callback fires.
+                rerender({ dt: { action: { window: {}, mountNode: document.createElement('div') } } });
+
+                await act(async () => {
+                    await result.current.handleActionSelect('act_42', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                // selection moved, but main-window activeTab is unchanged.
+                expect(result.current.selectedActionId).toBe('act_42');
+                expect(result.current.activeTab).toBe('n-1');
+            });
+
+            it('still switches activeTab to "action" when the action tab is NOT detached', async () => {
+                const { result } = renderHook(() => useDiagrams([], [], '', {}));
+
+                act(() => { result.current.setActiveTab('n-1'); });
+                expect(result.current.activeTab).toBe('n-1');
+
+                await act(async () => {
+                    await result.current.handleActionSelect('act_99', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                expect(result.current.selectedActionId).toBe('act_99');
+                expect(result.current.activeTab).toBe('action');
+            });
+
+            it('still fetches the action variant diagram when the action tab is detached', async () => {
+                const { api } = await import('../api');
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { action: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                act(() => { result.current.setActiveTab('n'); });
+                rerender({ dt: { action: { window: {}, mountNode: document.createElement('div') } } });
+                vi.mocked(api.getActionVariantDiagram).mockClear();
+
+                await act(async () => {
+                    await result.current.handleActionSelect('act_77', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                // The popup-rendered tab still needs the new diagram, so
+                // the fetch must fire even though the main window did not
+                // switch to the action tab.
+                expect(api.getActionVariantDiagram).toHaveBeenCalledWith('act_77');
+                // And the main window stays on N.
+                expect(result.current.activeTab).toBe('n');
+            });
+
+            it('does NOT switch main window to "n-1" on deselect when action tab is detached', async () => {
+                const { result, rerender } = renderHook(
+                    ({ dt }: { dt: Record<string, unknown> }) => useDiagrams([], [], '', dt),
+                    {
+                        initialProps: {
+                            dt: { action: { window: {}, mountNode: document.createElement('div') } } as Record<string, unknown>,
+                        },
+                    },
+                );
+
+                // User is on the N tab in the main window; action tab
+                // detached and showing 'act_1'.
+                act(() => { result.current.setSelectedActionId('act_1'); });
+                act(() => { result.current.setActiveTab('n'); });
+                rerender({ dt: { action: { window: {}, mountNode: document.createElement('div') } } });
+
+                // Re-clicking the same card toggles deselect.
+                await act(async () => {
+                    await result.current.handleActionSelect('act_1', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                // Selection cleared, but main-window tab is unchanged.
+                expect(result.current.selectedActionId).toBe(null);
+                expect(result.current.activeTab).toBe('n');
+            });
+
+            it('still falls back to "n-1" on deselect when action tab is NOT detached', async () => {
+                const { result } = renderHook(() => useDiagrams([], [], '', {}));
+
+                act(() => { result.current.setSelectedActionId('act_1'); });
+                act(() => { result.current.setActiveTab('action'); });
+
+                await act(async () => {
+                    await result.current.handleActionSelect('act_1', null, '', 0, vi.fn(), vi.fn());
+                });
+
+                expect(result.current.selectedActionId).toBe(null);
+                expect(result.current.activeTab).toBe('n-1');
+            });
+        });
+
         it('re-renders with a new detachedTabs map without losing state', () => {
             // Start with no detached tabs.
             const { result, rerender } = renderHook(

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -525,17 +525,38 @@ export function useDiagrams(
     handleActionSelectFn: (actionId: string | null) => void,
   ) => {
     interactionLogger.record('asset_clicked', { action_id: actionId, asset_name: assetName, tab });
-    setInspectQuery(assetName);
+    // Route the auto-zoom to the clicked tab explicitly — the
+    // auto-zoom effect reads `inspectFocusTabRef` and falls back to
+    // `activeTab` only when no explicit target is set. Routing here
+    // is what lets the zoom happen on the correct (detached) tab
+    // even when we DO NOT switch the main window's `activeTab`.
+    setInspectQueryForTab(tab, assetName);
+
+    // A tab that lives in a detached popup must NOT force the main
+    // window's `activeTab` — doing so blanks whatever tab the user
+    // had open and replaces it with the "Detached" placeholder. The
+    // detached popup is already re-rendering the correct diagram via
+    // the shared React subtree, so we just update inspect state and
+    // leave `activeTab` alone.
+    const isTabDetached = !!detachedTabsRef.current?.[tab];
+
     if (tab === 'n') {
-      setActiveTab('n');
+      if (!isTabDetached) setActiveTab('n');
     } else if (tab === 'n-1') {
-      setActiveTab('n-1');
+      if (!isTabDetached) setActiveTab('n-1');
     } else if (actionId !== currentSelectedActionId) {
+      // Selecting a different action card. `handleActionSelect`
+      // already has its own detached-tab guard (it refrains from
+      // switching activeTab to 'action' when the tab is detached),
+      // so we just forward the call.
       handleActionSelectFn(actionId);
     } else {
-      setActiveTab('action');
+      // Same action, user is re-focusing an asset within it. Only
+      // force `activeTab` to 'action' when the tab is inline — for
+      // the detached case we keep the main window where it is.
+      if (!isTabDetached) setActiveTab('action');
     }
-  }, []);
+  }, [setInspectQueryForTab]);
 
   // ===== Zoom to Element =====
   // Accepts an optional `targetTab` so an in-tab inspect overlay can

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -220,6 +220,17 @@ export function useDiagrams(
     activeTab === 'action' || !!detachedTabs?.['action'],
   );
 
+  // Ref mirror of the `detachedTabs` map so stable callbacks (notably
+  // `handleActionSelect`) can read the latest detached state without
+  // having to be re-bound on every map change. This is the same pattern
+  // used for `activeTabRef` above. When the action tab is detached, the
+  // selecting-an-action flow must NOT switch the main window's active
+  // tab to 'action' — the main window should keep showing whatever tab
+  // the user had open (typically N or N-1), and only the popup gets the
+  // updated diagram.
+  const detachedTabsRef = useRef<Partial<Record<TabId, unknown>> | undefined>(detachedTabs);
+  useLayoutEffect(() => { detachedTabsRef.current = detachedTabs; }, [detachedTabs]);
+
   // Zoom state
   const lastZoomState = useRef({ query: '', branch: '' });
   const actionSyncSourceRef = useRef<ViewBox | null>(null);
@@ -290,11 +301,20 @@ export function useDiagrams(
     setError: (v: string) => void,
     force: boolean = false,
   ) => {
+    const isActionDetached = !!detachedTabsRef.current?.['action'];
+
     if (!force && actionId === selectedActionId) {
       interactionLogger.record('action_deselected', { action_id: actionId });
       setSelectedActionId(null);
       setActionDiagram(null);
-      setActiveTab('n-1');
+      // Only fall back to the N-1 tab in the main window when the
+      // action tab is currently inline (i.e. the user was actually
+      // looking at the action tab in the main window). When the
+      // action tab is detached into a popup, the main window is
+      // already showing N or N-1 and must not be force-switched.
+      if (!isActionDetached) {
+        setActiveTab('n-1');
+      }
       return;
     }
 
@@ -310,7 +330,14 @@ export function useDiagrams(
     if (actionId === null) return;
 
     setActionDiagramLoading(true);
-    setActiveTab('action');
+    // Switching the main window's activeTab to 'action' would blank the
+    // current N or N-1 view and replace it with the "Detached" placeholder.
+    // When the action tab lives in a popup, keep the main window where the
+    // user left it and let the popup pick up the new diagram via its
+    // existing render path.
+    if (!isActionDetached) {
+      setActiveTab('action');
+    }
     try {
       const res = await api.getActionVariantDiagram(actionId);
       const { svg, viewBox } = processSvg(res.svg, voltageLevelsLength);

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -318,8 +318,20 @@ export function useDiagrams(
       return;
     }
 
+    // Preserve the current viewBox across action switches. When the
+    // action tab is inline in the main window, `activeTab === 'action'`
+    // tells us the user is currently looking at the action diagram and
+    // `actionPZ.viewBox` is the right source. When the action tab is
+    // DETACHED into a popup, `activeTab` is 'n' or 'n-1' (the main
+    // window's current tab) but the popup is still showing the action
+    // diagram — so `actionPZ.viewBox` is STILL the correct source and
+    // we must use it even though `activeTab` is not 'action'. Without
+    // this branch, clicking a different action card in a detached
+    // popup would snap the popup back to the N / N-1 viewBox instead
+    // of preserving the zoom the user had on the previous action.
+    const actionTabShowsActionDiagram = activeTabRef.current === 'action' || isActionDetached;
     actionSyncSourceRef.current =
-      (activeTabRef.current === 'action' ? actionPZ.viewBox : null)
+      (actionTabShowsActionDiagram ? actionPZ.viewBox : null)
       || n1PZ.viewBox || nPZ.viewBox;
 
     if (actionId !== null) {
@@ -488,13 +500,21 @@ export function useDiagrams(
     else if (activeTab === 'action') actionPZ.setViewBox(sourceVB);
   }, [activeTab, nPZ, n1PZ, actionPZ]);
 
-  // Re-sync after action diagram loads
+  // Re-sync after action diagram loads. Fires when the action tab is
+  // currently inline in the main window OR detached into a popup —
+  // both cases need the captured viewBox to be re-applied over the
+  // native one usePanZoom resets to on every new diagram load.
+  // Without the detached branch, switching actions inside a detached
+  // popup would lose the user's zoom every time (see
+  // handleActionSelect for the capture side of the same pattern).
   useEffect(() => {
-    if (actionDiagram && activeTab === 'action' && actionSyncSourceRef.current) {
-      actionPZ.setViewBox(actionSyncSourceRef.current);
+    const isActionDetached = !!detachedTabsRef.current?.['action'];
+    const captured = actionSyncSourceRef.current;
+    if (actionDiagram && captured && (activeTab === 'action' || isActionDetached)) {
+      actionPZ.setViewBox(captured);
       actionSyncSourceRef.current = null;
     }
-  }, [actionDiagram, activeTab, actionPZ]);
+  }, [actionDiagram, activeTab, actionPZ, detachedTabs]);
 
   // ===== Asset Click =====
   const handleAssetClick = useCallback((

--- a/frontend/src/utils/overloadHighlights.test.ts
+++ b/frontend/src/utils/overloadHighlights.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { describe, it, expect } from 'vitest';
+import { computeN1OverloadHighlights } from './overloadHighlights';
+
+describe('computeN1OverloadHighlights', () => {
+    // Regression: N-1 overload halos must appear on the N-1 tab as
+    // soon as the contingency diagram comes back from the backend —
+    // before any "Analyze & Suggest" run. The previous implementation
+    // sourced the highlight list strictly from `result.lines_overloaded`
+    // (only populated post-analysis), so the orange halos never showed
+    // up on the freshly-loaded N-1 view. The fix adds a fallback to
+    // `n1Diagram.lines_overloaded`, which is the early source.
+
+    it('falls back to the N-1 diagram overloads when no analysis result is available yet', () => {
+        const result = computeN1OverloadHighlights(
+            null,                              // no analysis result yet
+            ['LINE_OL_A', 'LINE_OL_B'],        // straight from the N-1 fetch
+            new Set(),                         // user has not narrowed the selection
+        );
+        expect(result).toEqual(['LINE_OL_A', 'LINE_OL_B']);
+    });
+
+    it('also falls back when the analysis-result overloads array is empty', () => {
+        const result = computeN1OverloadHighlights(
+            [],                                // analysis ran but found nothing
+            ['LINE_OL_A'],                     // n1Diagram still has overloads
+            new Set(),
+        );
+        expect(result).toEqual(['LINE_OL_A']);
+    });
+
+    it('uses the analysis-result overloads when populated (they override the n1Diagram fallback)', () => {
+        const result = computeN1OverloadHighlights(
+            ['LINE_AFTER_ANALYSIS'],
+            ['LINE_OL_A', 'LINE_OL_B'],
+            new Set(),
+        );
+        expect(result).toEqual(['LINE_AFTER_ANALYSIS']);
+    });
+
+    it('filters the source list down to user-selected overloads when the selection set is non-empty', () => {
+        const result = computeN1OverloadHighlights(
+            null,
+            ['LINE_OL_A', 'LINE_OL_B', 'LINE_OL_C'],
+            new Set(['LINE_OL_B']),
+        );
+        expect(result).toEqual(['LINE_OL_B']);
+    });
+
+    it('treats an empty selection set as "no explicit selection yet" (highlight everything)', () => {
+        const result = computeN1OverloadHighlights(
+            null,
+            ['LINE_OL_A', 'LINE_OL_B'],
+            new Set(),
+        );
+        expect(result).toEqual(['LINE_OL_A', 'LINE_OL_B']);
+    });
+
+    it('returns an empty list when both sources are empty', () => {
+        expect(computeN1OverloadHighlights(null, null, new Set())).toEqual([]);
+        expect(computeN1OverloadHighlights([], [], new Set())).toEqual([]);
+        expect(computeN1OverloadHighlights(undefined, undefined, new Set())).toEqual([]);
+    });
+
+    it('returns an empty list when the user selection has no intersection with the source overloads', () => {
+        const result = computeN1OverloadHighlights(
+            null,
+            ['LINE_OL_A'],
+            new Set(['LINE_NOT_IN_LIST']),
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('respects user selection even after analysis result populates', () => {
+        const result = computeN1OverloadHighlights(
+            ['LINE_OL_A', 'LINE_OL_B'],
+            ['LINE_OL_A', 'LINE_OL_B', 'LINE_OL_C'],
+            new Set(['LINE_OL_A']),
+        );
+        expect(result).toEqual(['LINE_OL_A']);
+    });
+});

--- a/frontend/src/utils/overloadHighlights.ts
+++ b/frontend/src/utils/overloadHighlights.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+/**
+ * Compute the list of overloaded line IDs that should receive an
+ * orange halo on the N-1 tab.
+ *
+ * Source priority:
+ *   1. `analysisOverloads` — populated once an action analysis has run
+ *      (`result.lines_overloaded`). When non-empty, this list wins.
+ *   2. `n1DiagramOverloads` — what the backend reports along with the
+ *      N-1 diagram fetch (`n1Diagram.lines_overloaded`). This is the
+ *      EARLY source: it is available as soon as the user picks a
+ *      contingency, so the orange halos must show up immediately on
+ *      the N-1 view — without waiting for the user to run "Analyze &
+ *      Suggest". The previous implementation forgot this fallback,
+ *      which made the N-1 overload halos disappear until after a
+ *      remedial-action simulation had populated `result`.
+ *
+ * In both cases the user's `selectedOverloads` set (from the Overloads
+ * panel) further filters the list down — when the set is empty the
+ * filter is a no-op (empty selection means "no explicit selection
+ * yet", not "highlight nothing").
+ */
+export function computeN1OverloadHighlights(
+  analysisOverloads: string[] | undefined | null,
+  n1DiagramOverloads: string[] | undefined | null,
+  selectedOverloads: Set<string>,
+): string[] {
+  const source = (analysisOverloads && analysisOverloads.length > 0)
+    ? analysisOverloads
+    : (n1DiagramOverloads || []);
+  if (selectedOverloads.size === 0) return [...source];
+  return source.filter(name => selectedOverloads.has(name));
+}


### PR DESCRIPTION
## Summary
When the action tab is detached into a popup window, selecting an action card in the popup should not switch the main window's active tab to 'action'. This prevents the main window from blanking out and showing the "Detached" placeholder every time the user clicks a different action card in the popup.

## Key Changes
- Added `detachedTabsRef` to track the current detached tabs state in a stable ref, allowing callbacks to read the latest detached state without re-binding
- Modified `handleActionSelect` to check if the action tab is detached before switching the main window's active tab
  - When detached: skips `setActiveTab('action')` so the main window stays on its current tab (N or N-1)
  - When not detached: maintains existing behavior of switching to the action tab
- Modified deselect logic in `handleActionSelect` to only fall back to 'n-1' when the action tab is inline
  - When detached: skips the fallback so the main window keeps showing whatever tab the user had open
  - When not detached: maintains existing behavior of switching to 'n-1'
- The popup still receives the updated diagram via the existing render path regardless of detached state

## Implementation Details
- Uses the same ref pattern as `activeTabRef` to maintain a stable reference to `detachedTabs` without triggering callback re-binds
- The action variant diagram fetch still occurs in both cases (detached and inline) to ensure the popup gets the updated diagram
- Comprehensive test coverage added to verify behavior in both detached and inline scenarios, including selection, deselection, and diagram fetching

https://claude.ai/code/session_01VSVgi5jnBmHLrjb1XZuM9Y