### PR TITLE
Add action-overview diagram with interactive pins for remedial actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,14 +41,17 @@ Co-Study4Grid/
 │       │   ├── sessionUtils.ts       # Session snapshot building (buildSessionResult)
 │       │   ├── sessionUtils.test.ts  # Unit tests for session serialization
 │       │   ├── interactionLogger.ts  # Singleton interaction event logger (replay-ready)
-│       │   └── interactionLogger.test.ts # Unit tests for interaction logger
+│       │   ├── interactionLogger.test.ts # Unit tests for interaction logger
+│       │   └── popoverPlacement.ts   # Pure helpers for pin-popover positioning
 │       └── components/
 │           ├── Header.tsx              # Top bar: logo, network path input, Load/Save/Reload/Settings buttons
 │           ├── Header.test.tsx         # Unit tests for Header
-│           ├── ActionFeed.tsx          # Prioritized action results display with search/filter
-│           ├── VisualizationPanel.tsx  # SVG diagram rendering (NAD + SLD overlay)
-│           ├── OverloadPanel.tsx       # Two-step analysis: detect → select → resolve
-│           ├── CombinedActionsModal.tsx # Superposition pair computation modal
+│           ├── ActionFeed.tsx              # Prioritized action results display with search/filter + auto-scroll on selection
+│           ├── ActionOverviewDiagram.tsx  # N-1 NAD with pin overlay (overview of all actions)
+│           ├── ActionCardPopover.tsx      # Shared floating ActionCard wrapper (pin click preview)
+│           ├── VisualizationPanel.tsx     # SVG diagram rendering (NAD + SLD overlay)
+│           ├── OverloadPanel.tsx          # Two-step analysis: detect → select → resolve
+│           ├── CombinedActionsModal.tsx   # Superposition pair computation modal
 │           └── modals/
 │               ├── SettingsModal.tsx           # 3-tab settings dialog (paths, recommender, config)
 │               ├── SettingsModal.test.tsx      # Unit tests for SettingsModal
@@ -207,7 +210,7 @@ npm run test         # Run Vitest test suite
 - **Load**: `POST /api/load-session` reads `session.json` -> frontend restores all state without re-simulating actions
 - **Output folder**: `<output_folder>/costudy4grid_session_<contingency>_<timestamp>/` contains `session.json` + overflow PDF
 - **Interaction logging**: Every user interaction is logged as a timestamped, replay-ready event via `interactionLogger`. Saved as `interaction_log.json` alongside `session.json`.
-- See `docs/save-results.md` for session save/load and `docs/interaction-logging.md` for the replay contract
+- See `docs/save-results.md` for session save/load, `docs/interaction-logging.md` for the replay contract, and `docs/action-overview-diagram.md` for the Remedial Action overview (pin overlay on N-1 network)
 
 ### SVG Visualization (standalone_interface.html)
 The standalone interface includes advanced SVG rendering for pypowsybl network-area diagrams:

--- a/docs/action-overview-diagram.md
+++ b/docs/action-overview-diagram.md
@@ -1,0 +1,184 @@
+# Action Overview Diagram
+
+## Overview
+
+The Remedial Action tab now hosts an **action-overview diagram** when no action card is selected. It renders the post-contingency (N-1) Network Area Diagram as a dimmed background and overlays **Google-Maps-style pins** — one per prioritised remedial action — anchored on the grid asset each action targets. The operator can see all suggested actions at a glance, single-click a pin to preview the full action card, or double-click to drill down into the action-variant network diagram.
+
+When any action card IS selected (either via the sidebar feed or by double-clicking a pin), the overview folds away and the existing action-variant diagram + highlights take over. The operator can return to the overview by clicking the deselect chip in the tab label ("Remedial Action: **\<action-id\> ✕**").
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Tab bar                                                 │
+│  [Network (N)]  [Contingency (N-1)]  [Remedial action: overview]  [Overflow] │
+├──────────────────────────────────────────────────────────┤
+│                                                          │
+│   Background: N-1 NAD (dimmed)                           │
+│                                                          │
+│         ┌──────┐                                         │
+│         │ 73%  │   ← green pin (solves overload)         │
+│         └──┬───┘                                         │
+│            │ points at line mid-point                     │
+│         ┌──────┐                                         │
+│         │ 99%  │   ← red pin (still overloaded)          │
+│         └──┬───┘                                         │
+│            │                                             │
+│   Zoom: +  Fit  -                                        │
+│   🔍 Focus asset...                                      │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Visual stack
+
+The SVG layers are ordered as follows (back to front):
+
+| Layer | Content | Opacity | Purpose |
+|---|---|---|---|
+| 1. `.nad-overview-highlight-layer` | Clone of contingency + overloaded edges | 1.0 | Matches N-1 tab halos (yellow contingency, orange overloads) |
+| 2. Original NAD content | All voltage-level nodes, edges, labels | 1.0 | The actual network diagram |
+| 3. `.nad-overview-dim-rect` | White `<rect>` covering the entire viewBox | 0.65 | Dims the network + highlight halos so pins pop |
+| 4. `.nad-action-overview-pins` | Google-Maps teardrop pins | 1.0 | One pin per action, severity-coloured, labelled with max loading % |
+
+Highlights are placed **behind** the NAD content (same background-layer pattern as the N-1 tab) so the halo peeks out around the line strokes. The dim rect sits on top of both, and pins ride above everything.
+
+### Why a `<rect>` instead of `<g opacity>`?
+
+Earlier iterations wrapped the NAD children in a `<g opacity="0.35">`. On large grids (11k+ elements) this caused Chrome's Layerize compositor step to create individual layers for every child element — a ~25-31 second penalty. The `<rect>` overlay achieves the same dim effect at zero compositing cost because the browser only needs to paint one extra element.
+
+---
+
+## Pin anatomy
+
+Each pin is an SVG `<g>` with the following structure:
+
+```
+<g class="nad-action-overview-pin" transform="translate(x y)" data-action-id="...">
+  <g class="nad-action-overview-pin-body" transform="scale(k)">
+    <title>action id — description — max loading XX.X%</title>
+    <path d="M ... A ... L 0 0 Z"  fill="#28a745"  stroke="none" />   ← teardrop
+    <circle cx="0" cy="..." r="..."  fill="#fff" fill-opacity="0.92" /> ← inner disc
+    <text fill="#1f2937" font-weight="800">73%</text>                   ← label
+  </g>
+</g>
+```
+
+### Severity palette
+
+Mirrors the `ActionCard` sidebar palette exactly:
+
+| Severity | Fill colour | Condition |
+|---|---|---|
+| green | `#28a745` | `max_rho ≤ monitoringFactor - 0.05` |
+| orange | `#f0ad4e` | `monitoringFactor - 0.05 < max_rho ≤ monitoringFactor` |
+| red | `#dc3545` | `max_rho > monitoringFactor` |
+| grey | `#9ca3af` | Load-flow divergent or islanding detected |
+
+The label text always uses dark slate `#1f2937` for contrast on both the white inner disc and the coloured teardrop.
+
+### Pin sizing
+
+Base radius is read from the first VL circle in the SVG (`svg.querySelector('.nad-vl-nodes circle[r]').r`), so pins match voltage-level glyphs at normal zoom. A **screen-constant floor** (`PIN_MIN_SCREEN_RADIUS_PX = 22px`) is enforced: as the operator zooms out, `rescaleActionOverviewPins` upscales the `.nad-action-overview-pin-body` `scale()` transform so pins stay at least 22 screen pixels tall. An additional floor of 1/50th of the viewBox extent prevents pins from shrinking below a minimum proportion of the diagram.
+
+The rescaler is driven by a `MutationObserver` on the SVG's `viewBox` attribute, rAF-throttled to avoid forced layouts during rapid wheel-zoom bursts (the source of the "Page ne répondant pas" lag on large grids).
+
+### Pin anchor resolution
+
+For each action, the anchor position is resolved in this order:
+
+1. **Line / PST target** → mid-point of the edge's two node endpoints (via `getActionTargetLines`)
+2. **Voltage-level target** → node (x, y) coordinate (via `getActionTargetVoltageLevels`)
+3. **Fallback: `max_rho_line`** → mid-point of the line that carries the highest loading after the action
+
+Actions whose asset cannot be located in the metadata are silently skipped.
+
+---
+
+## Interactions
+
+### Auto-zoom on open
+
+When the overview becomes visible, it computes a **fit rectangle** that encloses:
+- the contingency edge endpoints,
+- all overloaded-line edge endpoints,
+- every pin position,
+
+padded by 5% on each side. This rectangle is set as the initial `viewBox` via `usePanZoom` so the operator always opens on a meaningful frame.
+
+The fit rectangle is recomputed when `(n1MetaIndex, contingency, overloadedLines, pins)` changes, and re-asserted when the overview re-appears after a round-trip through the action drill-down view (tracked via `wasVisibleRef`).
+
+### Pan, zoom, and inspect
+
+The overview mounts its own `usePanZoom` instance (independent from the N-1 and action tabs):
+- **Wheel zoom** + **drag pan**: handled by the hook's event listeners, active only when `visible && svgReady`.
+- **Zoom +/−/Fit buttons**: rendered in the bottom-left control cluster. Fit restores the auto-fit rectangle and clears the `lastFocusedRef` so a subsequent asset focus works on the same id.
+- **Inspect search field**: local to the overview. Typing / selecting an equipment id pans and zooms onto it via `computeEquipmentFitRect`. The focus is "consume-once" (mirrors `useDiagrams`'s `lastZoomState` pattern) so wheel-zoom after an asset focus does NOT snap back.
+
+### Single-click on a pin → card popover
+
+A single click (deferred by 250ms to distinguish from double-click) opens a floating **ActionCardPopover** anchored near the pin. The popover renders the **same `ActionCard` component** the sidebar feed uses (see [Card sharing](#card-sharing) below).
+
+Popover placement is computed by `utils/popoverPlacement.ts`:
+- **Vertical**: below the pin if there's room, above if not (uses CSS `bottom` for above-placement so the bottom edge anchors at the pin regardless of popover height).
+- **Horizontal**: left-aligned if pin is in the left viewport third, right-aligned if in the right third, centred otherwise. Always clamped to viewport edges.
+
+Dismissed on: Escape, outside click, the ✕ button, card body click, or when `visible` flips false.
+
+### Double-click on a pin → drill-down
+
+A double-click (detected via the browser's click + dblclick sequence; the 250ms single-click timer is cancelled) calls `onActionSelect(actionId)`. This:
+
+1. Closes any open popover.
+2. Triggers the existing action-select flow in `useDiagrams` → fetches the action-variant NAD → folds the overview away.
+3. Scrolls the sidebar feed to centre the matching card via `ActionFeed`'s `scrollIntoView({ block: 'center' })` effect.
+
+### Returning to the overview
+
+When the action-variant diagram is showing, the tab label reads **"Remedial Action: \<chip\>"** where `<chip>` is a pink clickable badge around the action id with a ✕ circle. Clicking the chip calls `onActionSelect(null)` and the overview re-opens with its last fit rectangle.
+
+---
+
+## Card sharing
+
+Both the sidebar feed and the pin-click popover render the **same `ActionCard` component** from `components/ActionCard.tsx`. The popover-specific chrome (floating frame, close button, shadow, no-op stubs for re-simulate/edit controls) is encapsulated in `components/ActionCardPopover.tsx`, so adding or renaming a field on `ActionCard` only requires updating two call-sites (the feed render + the popover wrapper), never parallel implementations.
+
+---
+
+## Files
+
+| File | Responsibility |
+|---|---|
+| `components/ActionOverviewDiagram.tsx` | Main component: SVG injection, dim rect, highlights, pins, pan/zoom, popover state |
+| `components/ActionCardPopover.tsx` | Shared floating ActionCard wrapper (chrome + no-op stubs) |
+| `utils/svgUtils.ts` | Helpers: `buildActionOverviewPins`, `applyActionOverviewPins`, `applyActionOverviewHighlights`, `rescaleActionOverviewPins`, `computeActionOverviewFitRect`, `computeEquipmentFitRect` |
+| `utils/popoverPlacement.ts` | Pure helpers: `decidePopoverPlacement`, `computePopoverStyle` |
+| `components/VisualizationPanel.tsx` | Mounts overview in the action tab's `DetachableTabHost`; renders the deselect chip in the tab label |
+| `App.tsx` | Wires `n1MetaIndex`, `onActionSelect`, `onActionFavorite`, `onActionReject`, `selectedActionIds`, `rejectedActionIds`, `monitoringFactor` through to `VisualizationPanel` |
+| `components/ActionFeed.tsx` | `scrollIntoView` effect on `selectedActionId` change |
+| `App.css` | `.nad-overview-dimmed`, `.nad-action-overview-pin`, `.nad-action-overview-container` styles |
+
+---
+
+## Test coverage
+
+| Test file | Cases | Covers |
+|---|---|---|
+| `utils/svgUtils.test.ts` | `buildActionOverviewPins` (8), `applyActionOverviewPins` (12), `applyActionOverviewHighlights` (8), `rescaleActionOverviewPins` (6), `computeActionOverviewFitRect` (5), `computeEquipmentFitRect` (4) | Pin resolution, severity, label, palette, idempotence, click semantics, mousedown stopPropagation, no-outline, dark label text, highlight cloning + ordering, pin rescale + rAF throttle, fit-rect geometry |
+| `components/ActionOverviewDiagram.test.tsx` | 40 | SVG injection, dim rect, pins + palette, no-outline, anchor positions, double-click → onActionSelect, auto-fit, legend, pin count, visibility toggle, empty states, zoom +/−/Fit, inspect asset-focus + sticking regression, popover open/close/Escape/card-body-activate/placement, highlights ordering + refresh, pin rescale + rAF throttle |
+| `components/ActionCardPopover.test.tsx` | 8 | Shared ActionCard rendering, extraDataAttributes forwarding, custom testId, close ✕, stopPropagation, card-body activation, no-op stubs |
+| `utils/popoverPlacement.test.ts` | 16 | Vertical + horizontal placement rules, top/bottom/left anchoring, viewport clamping, end-to-end corner cases |
+| `components/VisualizationPanel.test.tsx` | 4 | Deselect chip render, click calls onActionSelect(null), Enter/Space keyboard, no chip when no action selected |
+| `components/ActionFeed.test.tsx` | 3 | scrollIntoView called on selection, not called when null, re-scrolls on change |
+
+---
+
+## Performance notes
+
+| Concern | Mitigation |
+|---|---|
+| SVG injection on large grids (>10k elements) | Pre-parsed via `DOMParser` in a `useMemo`, injected with `replaceChildren()` — zero double-parse |
+| Dim layer compositing (Chrome Layerize) | Single `<rect>` overlay instead of `<g opacity>` wrapper — avoids per-child layer creation (~25s savings on 11k-element NADs) |
+| Highlight CTM reads | Batched: `cachedLayerCTM` is computed once per `applyActionOverviewHighlights` call, not per-clone |
+| Pin rescale during wheel-zoom | `MutationObserver` + `requestAnimationFrame` throttle — at most one `getScreenCTM`-equivalent per frame. The rescaler now reads `viewBox` + `clientWidth` directly (pure math) instead of calling `getScreenCTM()` to avoid forced layouts entirely |
+| ID-map lookups | `getIdMap` uses a `WeakMap` cache keyed on the container element, invalidated only when the SVG content changes |

--- a/docs/action-overview-diagram.md
+++ b/docs/action-overview-diagram.md
@@ -43,9 +43,14 @@ The SVG layers are ordered as follows (back to front):
 
 Highlights are placed **behind** the NAD content (same background-layer pattern as the N-1 tab) so the halo peeks out around the line strokes. The dim rect sits on top of both, and pins ride above everything.
 
-### Why a `<rect>` instead of `<g opacity>`?
+### Why a `<rect>` instead of `<g opacity>` or CSS opacity?
 
-Earlier iterations wrapped the NAD children in a `<g opacity="0.35">`. On large grids (11k+ elements) this caused Chrome's Layerize compositor step to create individual layers for every child element — a ~25-31 second penalty. The `<rect>` overlay achieves the same dim effect at zero compositing cost because the browser only needs to paint one extra element.
+Earlier iterations tried two approaches that both failed on large grids (11k+ elements, ~43k SVG children):
+
+1. **SVG transparency group** (`<g opacity="0.35">`): Forces Chrome to rasterise every child into an intermediate buffer before compositing — ~31s Layerize penalty.
+2. **CSS per-child opacity** (`.nad-overview-dimmed > * { opacity: 0.35 }`): Each child element with `opacity < 1` creates its own stacking context — ~25s Layerize penalty.
+
+The single white `<rect>` overlay (`opacity: 0.65`) achieves the same dim effect at zero compositing cost because the browser only needs to paint one extra element with no stacking contexts.
 
 ---
 
@@ -164,7 +169,7 @@ Both the sidebar feed and the pin-click popover render the **same `ActionCard` c
 
 | Test file | Cases | Covers |
 |---|---|---|
-| `utils/svgUtils.test.ts` | `buildActionOverviewPins` (8), `applyActionOverviewPins` (12), `applyActionOverviewHighlights` (8), `rescaleActionOverviewPins` (6), `computeActionOverviewFitRect` (5), `computeEquipmentFitRect` (4) | Pin resolution, severity, label, palette, idempotence, click semantics, mousedown stopPropagation, no-outline, dark label text, highlight cloning + ordering, pin rescale + rAF throttle, fit-rect geometry |
+| `utils/svgUtils.test.ts` | `buildActionOverviewPins` (8), `applyActionOverviewPins` (12), `applyActionOverviewHighlights` (10), `rescaleActionOverviewPins` (6), `computeActionOverviewFitRect` (5), `computeEquipmentFitRect` (4) | Pin resolution, severity, label, palette, idempotence, click semantics, mousedown stopPropagation, no-outline, dark label text, highlight cloning + background-layer ordering (behind NAD content) + idempotent re-insertion at SVG start, pin rescale + rAF throttle + viewBox-fraction floor, fit-rect geometry |
 | `components/ActionOverviewDiagram.test.tsx` | 40 | SVG injection, dim rect, pins + palette, no-outline, anchor positions, double-click → onActionSelect, auto-fit, legend, pin count, visibility toggle, empty states, zoom +/−/Fit, inspect asset-focus + sticking regression, popover open/close/Escape/card-body-activate/placement, highlights ordering + refresh, pin rescale + rAF throttle |
 | `components/ActionCardPopover.test.tsx` | 8 | Shared ActionCard rendering, extraDataAttributes forwarding, custom testId, close ✕, stopPropagation, card-body activation, no-op stubs |
 | `utils/popoverPlacement.test.ts` | 16 | Vertical + horizontal placement rules, top/bottom/left anchoring, viewport clamping, end-to-end corner cases |
@@ -178,7 +183,7 @@ Both the sidebar feed and the pin-click popover render the **same `ActionCard` c
 | Concern | Mitigation |
 |---|---|
 | SVG injection on large grids (>10k elements) | Pre-parsed via `DOMParser` in a `useMemo`, injected with `replaceChildren()` — zero double-parse |
-| Dim layer compositing (Chrome Layerize) | Single `<rect>` overlay instead of `<g opacity>` wrapper — avoids per-child layer creation (~25s savings on 11k-element NADs) |
+| Dim layer compositing (Chrome Layerize) | Single `<rect>` overlay instead of `<g opacity>` wrapper or CSS per-child `opacity` — both alternatives force Chrome to create individual composite layers for every child element (~25-31s Layerize penalty on 11k-element NADs). The `<rect>` approach has zero stacking-context cost. |
 | Highlight CTM reads | Batched: `cachedLayerCTM` is computed once per `applyActionOverviewHighlights` call, not per-clone |
 | Pin rescale during wheel-zoom | `MutationObserver` + `requestAnimationFrame` throttle — at most one `getScreenCTM`-equivalent per frame. The rescaler now reads `viewBox` + `clientWidth` directly (pure math) instead of calling `getScreenCTM()` to avoid forced layouts entirely |
 | ID-map lookups | `getIdMap` uses a `WeakMap` cache keyed on the container element, invalidated only when the SVG content changes |

--- a/docs/interaction-logging.md
+++ b/docs/interaction-logging.md
@@ -83,6 +83,16 @@ type InteractionType =
   | 'zoom_out'                     // User clicked zoom-out button
   | 'zoom_reset'                   // User clicked zoom reset button
   | 'inspect_query_changed'        // User typed in search/inspect box
+  // === Action Overview Diagram ===
+  | 'overview_shown'               // Overview view became visible (no card selected)
+  | 'overview_hidden'              // Overview view hidden (card selected / tab switched)
+  | 'overview_pin_clicked'         // Single-click on a pin → popover opened
+  | 'overview_pin_double_clicked'  // Double-click on a pin → action drill-down activated
+  | 'overview_popover_closed'      // Popover dismissed (✕ / Escape / outside-click / drill-down)
+  | 'overview_zoom_in'             // User clicked overview zoom-in button
+  | 'overview_zoom_out'            // User clicked overview zoom-out button
+  | 'overview_zoom_fit'            // User clicked overview "Fit" button
+  | 'overview_inspect_changed'     // User focused or cleared an asset in the overview inspect search
   // === SLD Overlay ===
   | 'sld_overlay_opened'           // User double-clicked VL to open SLD
   | 'sld_overlay_tab_changed'      // User switched SLD tab (n / n-1 / action)
@@ -170,6 +180,20 @@ Each event's `details` field contains **all parameters needed to replay** the us
 | `zoom_out` | `{ tab: TabId }` | Click - button |
 | `zoom_reset` | `{ tab: TabId }` | Click reset button |
 | `inspect_query_changed` | `{ query: string, target_tab?: TabId }` — `target_tab` is only present when the inspect field was triggered from a detached-tab overlay (per-tab inspect routing). Absent = main-window active tab. | Type in search box |
+
+### Action Overview Diagram
+
+| Event | Details | Replay Action |
+|-------|---------|---------------|
+| `overview_shown` | `{ has_pins: boolean, pin_count: number }` — the overview became visible (no card selected). `pin_count` is 0 before the first analysis runs. | Switch to the Remedial Action tab with no card selected, or deselect a card. |
+| `overview_hidden` | `{}` — the overview was folded away because a card was selected or the tab was switched. | Select an action card (double-click pin, click card body, etc.). |
+| `overview_pin_clicked` | `{ action_id: string }` — a single click opened the floating ActionCard popover next to the pin. | Click a pin once (popover preview). |
+| `overview_pin_double_clicked` | `{ action_id: string }` — a double-click activated the full action drill-down view (the action-variant diagram replaces the overview in the tab). Cancels any pending single-click popover. | Double-click a pin. |
+| `overview_popover_closed` | `{ reason: 'close_button' \| 'escape' \| 'outside_click' }` — the popover was dismissed. Drill-down activation fires `overview_pin_double_clicked` instead (no popover-close event in that case). | Close the popover via ✕, Escape, or clicking outside. |
+| `overview_zoom_in` | `{}` | Click the overview `+` zoom button. |
+| `overview_zoom_out` | `{}` | Click the overview `-` zoom button. |
+| `overview_zoom_fit` | `{}` — resets the viewBox to the auto-fit rectangle (contingency + overloads + pins). | Click the overview `Fit` button. |
+| `overview_inspect_changed` | `{ query: string, action: 'focus' \| 'cleared' }` — `focus` means the typed query matched an exact equipment id and the view zoomed onto it. `cleared` means the query was emptied and the view returned to the fit rectangle. Intermediate keystrokes that don't match are not logged. | Type in the overview inspect field or clear it. |
 
 ### SLD Overlay
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -503,13 +503,6 @@ circle.nad-highlight {
 .nad-action-overview-pin:hover > path {
     stroke-width: 2.5;
 }
-.nad-action-overview-container {
-    /* Promote to its own composite layer so toggling visibility
-       is a compositor-only repaint (~1ms) instead of a full
-       re-rasterise of the 11k-element SVG subtree (~11s). */
-    will-change: visibility;
-    transform: translateZ(0);
-}
 .nad-action-overview-container svg {
     display: block;
     /* Trade anti-aliasing quality for rendering speed.  On a

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -504,9 +504,12 @@ circle.nad-highlight {
     stroke-width: 2.5;
 }
 /* The dim effect is achieved by a single white <rect> with
-   opacity 0.65 inserted ABOVE the NAD content but BELOW the
-   highlight and pin layers — no per-child opacity or stacking
-   contexts needed.  See ActionOverviewDiagram.tsx preparedSvg. */
+   opacity 0.65 inserted ABOVE the NAD content.  Highlights are
+   inserted at the START of the SVG (behind NAD content), matching
+   the N-1 tab's background-layer pattern.  Pins sit on top.
+   Visual stack: highlights → NAD content → dim rect → pins.
+   No per-child opacity or stacking contexts needed.
+   See ActionOverviewDiagram.tsx preparedSvg. */
 .nad-action-overview-container svg {
     display: block;
     /* Trade anti-aliasing quality for rendering speed.  On a

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -503,6 +503,18 @@ circle.nad-highlight {
 .nad-action-overview-pin:hover > path {
     stroke-width: 2.5;
 }
+.nad-action-overview-container {
+    /* Promote to its own composite layer so toggling visibility
+       is a compositor-only repaint (~1ms) instead of a full
+       re-rasterise of the 11k-element SVG subtree (~11s). */
+    will-change: visibility;
+    transform: translateZ(0);
+}
 .nad-action-overview-container svg {
     display: block;
+    /* Trade anti-aliasing quality for rendering speed.  On a
+       10k+ element power-grid NAD the difference can be several
+       seconds of paint time. */
+    shape-rendering: optimizeSpeed;
+    text-rendering: optimizeSpeed;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -489,3 +489,20 @@ circle.nad-highlight {
     background: rgba(220, 220, 220, 0.95);
     color: #333;
 }
+/* ============================================================
+   Action-overview pins (Remedial Action tab, no card selected)
+   ============================================================ */
+.nad-action-overview-pin {
+    transition: transform 0.15s ease;
+    transform-box: fill-box;
+    transform-origin: center bottom;
+}
+.nad-action-overview-pin:hover {
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.35));
+}
+.nad-action-overview-pin:hover > path {
+    stroke-width: 2.5;
+}
+.nad-action-overview-container svg {
+    display: block;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -503,6 +503,22 @@ circle.nad-highlight {
 .nad-action-overview-pin:hover > path {
     stroke-width: 2.5;
 }
+/* Dim the original network content in the action overview WITHOUT
+   creating an SVG transparency group (which forces Chrome to
+   rasterize all ~43k elements into an intermediate buffer — the
+   "Layerize" step that takes ~31s on large grids).
+
+   Instead, we target each direct child of the SVG that is NOT one
+   of our overlay layers (highlights / pins).  Each child gets its
+   own simple opacity — no intermediate buffer needed. */
+.nad-overview-dimmed > :not(.nad-overview-highlight-layer):not(.nad-action-overview-pins) {
+    opacity: 0.35;
+}
+/* Ensure overlay layers stay fully opaque above the dimmed network. */
+.nad-overview-dimmed > .nad-overview-highlight-layer,
+.nad-overview-dimmed > .nad-action-overview-pins {
+    opacity: 1;
+}
 .nad-action-overview-container svg {
     display: block;
     /* Trade anti-aliasing quality for rendering speed.  On a

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -503,22 +503,10 @@ circle.nad-highlight {
 .nad-action-overview-pin:hover > path {
     stroke-width: 2.5;
 }
-/* Dim the original network content in the action overview WITHOUT
-   creating an SVG transparency group (which forces Chrome to
-   rasterize all ~43k elements into an intermediate buffer — the
-   "Layerize" step that takes ~31s on large grids).
-
-   Instead, we target each direct child of the SVG that is NOT one
-   of our overlay layers (highlights / pins).  Each child gets its
-   own simple opacity — no intermediate buffer needed. */
-.nad-overview-dimmed > :not(.nad-overview-highlight-layer):not(.nad-action-overview-pins) {
-    opacity: 0.35;
-}
-/* Ensure overlay layers stay fully opaque above the dimmed network. */
-.nad-overview-dimmed > .nad-overview-highlight-layer,
-.nad-overview-dimmed > .nad-action-overview-pins {
-    opacity: 1;
-}
+/* The dim effect is achieved by a single white <rect> with
+   opacity 0.65 inserted ABOVE the NAD content but BELOW the
+   highlight and pin layers — no per-child opacity or stacking
+   contexts needed.  See ActionOverviewDiagram.tsx preparedSvg. */
 .nad-action-overview-container svg {
     display: block;
     /* Trade anti-aliasing quality for rendering speed.  On a

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1183,6 +1183,10 @@ function App() {
             onToggleTabTie={toggleTabTie}
             n1MetaIndex={diagrams.n1MetaIndex}
             onActionSelect={wrappedActionSelect}
+            onActionFavorite={wrappedActionFavorite}
+            onActionReject={actionsHook.handleActionReject}
+            selectedActionIds={selectedActionIds}
+            rejectedActionIds={rejectedActionIds}
             monitoringFactor={monitoringFactor}
           />
         </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1181,6 +1181,9 @@ function App() {
             onFocusDetachedTab={focusDetachedTab}
             isTabTied={isTabTied}
             onToggleTabTie={toggleTabTie}
+            n1MetaIndex={diagrams.n1MetaIndex}
+            onActionSelect={wrappedActionSelect}
+            monitoringFactor={monitoringFactor}
           />
         </div>
       </div>

--- a/frontend/src/components/ActionCardPopover.test.tsx
+++ b/frontend/src/components/ActionCardPopover.test.tsx
@@ -1,0 +1,139 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import ActionCardPopover from './ActionCardPopover';
+import type { ActionDetail } from '../types';
+
+const makeDetails = (overrides: Partial<ActionDetail> = {}): ActionDetail => ({
+    description_unitaire: 'shed load X',
+    rho_before: null,
+    rho_after: null,
+    max_rho: 0.88,
+    max_rho_line: 'LINE_A',
+    is_rho_reduction: true,
+    ...overrides,
+});
+
+const defaultProps = () => ({
+    actionId: 'act_1',
+    details: makeDetails(),
+    index: 0,
+    style: { position: 'fixed' as const, top: 100, left: 100 },
+    linesOverloaded: ['LINE_A'],
+    monitoringFactor: 0.95,
+    metaIndex: null,
+    onActivateAction: vi.fn(),
+    onClose: vi.fn(),
+});
+
+describe('ActionCardPopover', () => {
+    afterEach(() => cleanup());
+
+    it('renders the shared ActionCard for the given action id', () => {
+        const { getByTestId } = render(<ActionCardPopover {...defaultProps()} />);
+        // ActionCard's test id pattern proves the popover delegates
+        // visuals to the SAME component the sidebar feed uses.
+        expect(getByTestId('action-card-act_1')).toBeInTheDocument();
+    });
+
+    it('forwards the extra data attributes onto the popover root', () => {
+        const { getByTestId } = render(
+            <ActionCardPopover
+                {...defaultProps()}
+                extraDataAttributes={{
+                    'data-place-above': 'true',
+                    'data-horizontal-align': 'end',
+                }}
+            />,
+        );
+        const root = getByTestId('action-card-popover');
+        expect(root.getAttribute('data-place-above')).toBe('true');
+        expect(root.getAttribute('data-horizontal-align')).toBe('end');
+    });
+
+    it('respects a custom testId', () => {
+        const { getByTestId, queryByTestId } = render(
+            <ActionCardPopover {...defaultProps()} testId="my-custom-popover" />,
+        );
+        expect(getByTestId('my-custom-popover')).toBeInTheDocument();
+        expect(getByTestId('my-custom-popover-close')).toBeInTheDocument();
+        expect(queryByTestId('action-card-popover')).toBeNull();
+    });
+
+    it('clicking the close ✕ invokes onClose', () => {
+        const onClose = vi.fn();
+        const { getByTestId } = render(<ActionCardPopover {...defaultProps()} onClose={onClose} />);
+        fireEvent.click(getByTestId('action-card-popover-close'));
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('mousedown inside the popover does NOT bubble (outside-click guard)', () => {
+        const onMouseDown = vi.fn();
+        const { getByTestId } = render(
+            <div onMouseDown={onMouseDown}>
+                <ActionCardPopover {...defaultProps()} />
+            </div>,
+        );
+        fireEvent.mouseDown(getByTestId('action-card-popover'));
+        // stopPropagation on the popover means the outer
+        // listener should never fire.
+        expect(onMouseDown).not.toHaveBeenCalled();
+    });
+
+    it('clicking the card body closes the popover AND activates the action', () => {
+        const onActivateAction = vi.fn();
+        const onClose = vi.fn();
+        const { getByTestId } = render(
+            <ActionCardPopover
+                {...defaultProps()}
+                onActivateAction={onActivateAction}
+                onClose={onClose}
+            />,
+        );
+        fireEvent.click(getByTestId('action-card-act_1'));
+        expect(onActivateAction).toHaveBeenCalledWith('act_1');
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT call onActivateAction when ActionCard fires a null selection (deselect)', () => {
+        // ActionCard.onActionSelect may receive null when the
+        // user toggles off a card — we should still close the
+        // popover but NOT activate anything downstream.
+        const onActivateAction = vi.fn();
+        const onClose = vi.fn();
+        const { getByTestId } = render(
+            <ActionCardPopover
+                {...defaultProps()}
+                onActivateAction={onActivateAction}
+                onClose={onClose}
+            />,
+        );
+        // Simulate the user clicking the reject button — this
+        // path calls onActionReject and not onActionSelect in
+        // ActionCard, so nothing should activate.
+        fireEvent.click(getByTestId('action-card-act_1'));
+        // Body click activates once (sanity check)
+        expect(onActivateAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-ops gracefully when optional callbacks are omitted', () => {
+        // When onActionFavorite / onActionReject are undefined,
+        // internal stubs keep ActionCard happy.
+        const { getByTestId } = render(
+            <ActionCardPopover
+                {...defaultProps()}
+                onActionFavorite={undefined}
+                onActionReject={undefined}
+            />,
+        );
+        // Rendering should not throw
+        expect(getByTestId('action-card-act_1')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/ActionCardPopover.tsx
+++ b/frontend/src/components/ActionCardPopover.tsx
@@ -1,0 +1,179 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import React, { useCallback, type CSSProperties, type Ref } from 'react';
+import type { ActionDetail, MetadataIndex } from '../types';
+import ActionCard from './ActionCard';
+
+/**
+ * Floating ActionCard popover — shared between the action
+ * overview view (single-click on a pin) and any future callsite
+ * that needs a read-only-ish "peek" at an action's details
+ * without opening the full drill-down diagram.
+ *
+ * The popover intentionally reuses the SAME `ActionCard`
+ * component that the sidebar feed renders, so card visuals,
+ * severity palette, badge resolution and tooltip text all stay
+ * in lock-step with the feed — we only need to change the
+ * component in ONE place. Re-simulate / edit controls are wired
+ * to no-op stubs because the popover is a preview, not an
+ * editor; callers that need those interactions should open the
+ * drill-down view (which is what a double-click on the pin
+ * already does).
+ *
+ * The chrome (floating card frame + close button) is owned by
+ * this component so every callsite gets identical affordances.
+ */
+interface ActionCardPopoverProps {
+    actionId: string;
+    details: ActionDetail;
+    /** Visual index shown in the card header (e.g. "#3"). */
+    index: number;
+    /**
+     * Absolute-positioning style (including `position: fixed`,
+     * top/bottom/left/right anchors). Typically produced by
+     * `utils/popoverPlacement.computePopoverStyle` so the
+     * popover lands next to the anchor element.
+     */
+    style: CSSProperties;
+    /** Overloaded lines used for the "Loading after" rendering. */
+    linesOverloaded: readonly string[];
+    /** Monitoring factor — drives the severity badge. */
+    monitoringFactor: number;
+    /** N-1 metadata index used by badge resolution. */
+    metaIndex: MetadataIndex | null;
+    /** Selected-action set (for the card's `isSelected` styling). */
+    selectedActionIds?: Set<string>;
+    /** Rejected-action set (for the card's `isRejected` styling). */
+    rejectedActionIds?: Set<string>;
+    /**
+     * Called when the user activates the card (clicks the card
+     * body or the dedicated "view" affordance). Parent typically
+     * closes the popover and switches to the action drill-down
+     * view.
+     */
+    onActivateAction: (actionId: string) => void;
+    /** Toggle favourite status. */
+    onActionFavorite?: (actionId: string) => void;
+    /** Reject the action. */
+    onActionReject?: (actionId: string) => void;
+    /** Close the popover. */
+    onClose: () => void;
+    /**
+     * Optional ref on the popover root so the parent can detect
+     * outside clicks.
+     */
+    popoverRef?: Ref<HTMLDivElement>;
+    /**
+     * Optional test id on the popover root (defaults to
+     * "action-card-popover"). Kept overridable so multiple
+     * callsites can disambiguate their popovers in tests.
+     */
+    testId?: string;
+    /**
+     * Optional data-attributes to forward onto the popover root —
+     * used by `ActionOverviewDiagram` to record the placement
+     * decision on the DOM for its unit tests.
+     */
+    extraDataAttributes?: Record<string, string>;
+}
+
+const NOOP = () => { /* intentional no-op */ };
+
+const ActionCardPopover: React.FC<ActionCardPopoverProps> = ({
+    actionId,
+    details,
+    index,
+    style,
+    linesOverloaded,
+    monitoringFactor,
+    metaIndex,
+    selectedActionIds,
+    rejectedActionIds,
+    onActivateAction,
+    onActionFavorite,
+    onActionReject,
+    onClose,
+    popoverRef,
+    testId = 'action-card-popover',
+    extraDataAttributes,
+}) => {
+    // Wrap the "activate the action" intent so both the card
+    // body click and any future explicit affordance flow through
+    // the same path — and the popover always auto-dismisses.
+    const handleActivate = useCallback((id: string | null) => {
+        onClose();
+        if (id) onActivateAction(id);
+    }, [onActivateAction, onClose]);
+
+    return (
+        <div
+            ref={popoverRef}
+            data-testid={testId}
+            data-action-id={actionId}
+            {...(extraDataAttributes ?? {})}
+            style={{
+                ...style,
+                background: 'white',
+                border: '1px solid #cbd5e1',
+                borderRadius: 8,
+                boxShadow: '0 10px 24px rgba(0, 0, 0, 0.25)',
+                zIndex: 300,
+            }}
+            onMouseDown={e => e.stopPropagation()}
+        >
+            <button
+                data-testid={`${testId}-close`}
+                onClick={onClose}
+                title="Close"
+                style={{
+                    position: 'absolute',
+                    top: 6,
+                    right: 8,
+                    zIndex: 2,
+                    background: 'white',
+                    border: '1px solid #cbd5e1',
+                    borderRadius: '50%',
+                    width: 22,
+                    height: 22,
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    color: '#475569',
+                    boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+                    lineHeight: 1,
+                }}
+            >
+                {'\u2715'}
+            </button>
+            <ActionCard
+                id={actionId}
+                details={details}
+                index={index}
+                isViewing={false}
+                isSelected={selectedActionIds?.has(actionId) ?? false}
+                isRejected={rejectedActionIds?.has(actionId) ?? false}
+                linesOverloaded={Array.from(linesOverloaded)}
+                monitoringFactor={monitoringFactor}
+                nodesByEquipmentId={metaIndex?.nodesByEquipmentId ?? null}
+                edgesByEquipmentId={metaIndex?.edgesByEquipmentId ?? null}
+                cardEditMw={{}}
+                cardEditTap={{}}
+                resimulating={null}
+                onActionSelect={handleActivate}
+                onActionFavorite={onActionFavorite ?? NOOP}
+                onActionReject={onActionReject ?? NOOP}
+                onAssetClick={NOOP}
+                onCardEditMwChange={NOOP}
+                onCardEditTapChange={NOOP}
+                onResimulate={NOOP}
+                onResimulateTap={NOOP}
+            />
+        </div>
+    );
+};
+
+export default React.memo(ActionCardPopover);

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -2416,4 +2416,84 @@ describe('ActionFeed', () => {
             });
         });
     });
+
+    describe('auto-scroll on selectedActionId change', () => {
+        // The action feed mounts a useEffect that scrolls the
+        // currently-viewed card into view whenever
+        // `selectedActionId` flips. This is what lets a
+        // double-click on a pin in the action overview center
+        // the matching card in the sidebar without the operator
+        // having to scroll.
+
+        const makeProps = (overrides: Partial<typeof defaultProps> = {}) => ({
+            ...defaultProps,
+            actions: {
+                'act_a': {
+                    description_unitaire: 'A',
+                    rho_before: null,
+                    rho_after: null,
+                    max_rho: 0.5,
+                    max_rho_line: 'LINE_1',
+                    is_rho_reduction: true,
+                    action_topology: emptyTopo,
+                },
+                'act_b': {
+                    description_unitaire: 'B',
+                    rho_before: null,
+                    rho_after: null,
+                    max_rho: 0.6,
+                    max_rho_line: 'LINE_1',
+                    is_rho_reduction: true,
+                    action_topology: emptyTopo,
+                },
+                'act_c': {
+                    description_unitaire: 'C',
+                    rho_before: null,
+                    rho_after: null,
+                    max_rho: 0.7,
+                    max_rho_line: 'LINE_1',
+                    is_rho_reduction: true,
+                    action_topology: emptyTopo,
+                },
+            },
+            ...overrides,
+        });
+
+        beforeEach(() => {
+            // jsdom doesn't implement scrollIntoView; stub it
+            // so the effect can call it without throwing.
+            Element.prototype.scrollIntoView = vi.fn() as unknown as Element['scrollIntoView'];
+        });
+
+        it('calls scrollIntoView on the matching card when selectedActionId changes', async () => {
+            const { rerender } = render(<ActionFeed {...makeProps()} />);
+            // Switch to selecting act_b
+            rerender(<ActionFeed {...makeProps({ selectedActionId: 'act_b' })} />);
+            // Wait one rAF for the deferred scroll to fire
+            await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+            const card = screen.getByTestId('action-card-act_b');
+            expect(card.scrollIntoView).toHaveBeenCalledWith(
+                expect.objectContaining({ block: 'center' })
+            );
+        });
+
+        it('does NOT scroll when selectedActionId is null', async () => {
+            const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView');
+            render(<ActionFeed {...makeProps()} />);
+            await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+            expect(scrollSpy).not.toHaveBeenCalled();
+        });
+
+        it('re-scrolls on each selectedActionId change', async () => {
+            const { rerender } = render(<ActionFeed {...makeProps({ selectedActionId: 'act_a' })} />);
+            await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+            const cardA = screen.getByTestId('action-card-act_a');
+            expect(cardA.scrollIntoView).toHaveBeenCalled();
+
+            rerender(<ActionFeed {...makeProps({ selectedActionId: 'act_c' })} />);
+            await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+            const cardC = screen.getByTestId('action-card-act_c');
+            expect(cardC.scrollIntoView).toHaveBeenCalled();
+        });
+    });
 });

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -482,6 +482,45 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
         return sortedActionEntries.filter(([id]) => !selectedActionIds.has(id) && !rejectedActionIds.has(id));
     }, [sortedActionEntries, selectedActionIds, rejectedActionIds, analysisLoading]);
 
+    // When an action becomes the currently-viewed one (typically
+    // after the user double-clicks a pin in the action overview
+    // diagram, or clicks an action card body), scroll the
+    // sidebar so the matching card is centred in the viewport.
+    // Without this, double-clicking a pin can activate an action
+    // that is many cards down the feed and the operator has to
+    // hunt for it manually.
+    //
+    // Implementation note: we look up the card by its existing
+    // `data-testid="action-card-${id}"` attribute and call
+    // `scrollIntoView({ block: 'center' })`. The browser walks
+    // up to the nearest scrollable ancestor (the sidebar's
+    // overflow-y: auto wrapper in App.tsx) and scrolls that.
+    //
+    // Wrapped in a rAF so the scroll runs after the matching
+    // card has had a chance to mount/move in response to the
+    // selection change in the same render cycle.
+    useEffect(() => {
+        if (!selectedActionId) return;
+        let cancelled = false;
+        const rafId = requestAnimationFrame(() => {
+            if (cancelled) return;
+            const el = document.querySelector(
+                `[data-testid="action-card-${CSS.escape(selectedActionId)}"]`,
+            );
+            if (el && typeof (el as HTMLElement).scrollIntoView === 'function') {
+                (el as HTMLElement).scrollIntoView({
+                    block: 'center',
+                    inline: 'nearest',
+                    behavior: 'smooth',
+                });
+            }
+        });
+        return () => {
+            cancelled = true;
+            cancelAnimationFrame(rafId);
+        };
+    }, [selectedActionId]);
+
     const rejectedEntries = useMemo(() => {
         return sortedActionEntries.filter(([id]) => rejectedActionIds.has(id));
     }, [sortedActionEntries, rejectedActionIds]);

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -419,10 +419,12 @@ describe('ActionOverviewDiagram', () => {
             // fast-path DOM writes and verifies the rescaler reacts.
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg') as unknown as SVGGraphicsElement;
+            const svgContainer = container.querySelector('.nad-action-overview-container')!;
 
-            // Mock getScreenCTM to return a tiny ratio so the rescaler
-            // upscales the body well above scale(1).
-            svg.getScreenCTM = (() => ({ a: 0.1, b: 0, c: 0, d: 0.1, e: 0, f: 0 })) as unknown as SVGGraphicsElement['getScreenCTM'];
+            // Mock clientWidth so the viewBox-based pxPerSvgUnit
+            // calculation yields 0.1 (clientWidth / viewBoxWidth).
+            // viewBox will be "0 0 99999 99999", so clientWidth = 9999.9
+            Object.defineProperty(svgContainer, 'clientWidth', { value: 9999.9, configurable: true });
 
             // Mutate the viewBox — the MutationObserver schedules
             // a rAF, so we wait one animation frame to read the
@@ -449,10 +451,11 @@ describe('ActionOverviewDiagram', () => {
 
         it('does not upscale pins when VL circles are already big enough on screen', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
-            const svg = container.querySelector('.nad-action-overview-container svg') as unknown as SVGGraphicsElement;
-            // pxPerSvgUnit=2 → VL circle with r=40 = 80 screen px,
-            // well above the 22-px floor. No rescale needed.
-            svg.getScreenCTM = (() => ({ a: 2, b: 0, c: 0, d: 2, e: 0, f: 0 })) as unknown as SVGGraphicsElement['getScreenCTM'];
+            const svgContainer = container.querySelector('.nad-action-overview-container')!;
+            const svg = svgContainer.querySelector('svg') as unknown as SVGGraphicsElement;
+            // viewBox "0 0 100 100", clientWidth=200 → pxPerSvgUnit=2
+            // → VL circle with r=40 = 80 screen px, well above the 22-px floor.
+            Object.defineProperty(svgContainer, 'clientWidth', { value: 200, configurable: true });
             (svg as unknown as SVGSVGElement).setAttribute('viewBox', '0 0 100 100');
 
             return new Promise<void>(resolve => {

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -53,9 +53,14 @@ const makeAction = (overrides: Partial<ActionDetail> = {}): ActionDetail => ({
 
 // A minimal NAD-like SVG background — the test component
 // parses this via innerHTML and queries for the injected pin
-// layer. We keep it tiny so the assertions stay focussed.
+// layer. Includes a `.nad-vl-nodes circle[r="40"]` so the pin
+// sizing logic (which reads the VL circle radius) has something
+// realistic to latch on.
 const makeN1Diagram = (): DiagramData => ({
-    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-50 -50 700 700"></svg>',
+    svg:
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-50 -50 700 700">' +
+        '  <g class="nad-vl-nodes"><circle r="40"/></g>' +
+        '</svg>',
     metadata: null,
     lines_overloaded: ['LINE_B'],
     lines_overloaded_rho: [1.03],
@@ -121,7 +126,9 @@ describe('ActionOverviewDiagram', () => {
 
     it('draws pins WITHOUT a stroke outline', () => {
         const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
-        const paths = container.querySelectorAll('g.nad-action-overview-pin > path');
+        // path lives inside the inner .nad-action-overview-pin-body
+        // wrapper so the rescaler can upscale it on unzoom.
+        const paths = container.querySelectorAll('g.nad-action-overview-pin path');
         expect(paths.length).toBeGreaterThan(0);
         paths.forEach(p => {
             expect(p.getAttribute('stroke')).toBe('none');
@@ -131,7 +138,7 @@ describe('ActionOverviewDiagram', () => {
 
     it('each pin displays the rounded max loading as its label', () => {
         const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
-        const texts = Array.from(container.querySelectorAll('g.nad-action-overview-pin > text'))
+        const texts = Array.from(container.querySelectorAll('g.nad-action-overview-pin text'))
             .map(t => t.textContent);
         // 0.5 → "50%", 1.1 → "110%"
         expect(texts).toEqual(expect.arrayContaining(['50%', '110%']));
@@ -343,6 +350,76 @@ describe('ActionOverviewDiagram', () => {
             fireEvent.change(input, { target: { value: 'VL_FAR' } });
             const focusedVb2 = svg.getAttribute('viewBox')!;
             expect(focusedVb2).toBe(focusedVb1);
+        });
+    });
+
+    describe('pin sizing and screen-constant rescaling', () => {
+        it('sizes pins from the VL circle radius (40 in the fixture)', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            // The teardrop path uses the VL circle radius R=40
+            // from makeN1Diagram(), so the arc command must
+            // reference "A 40 40" in its `d` attribute.
+            const path = container.querySelector('g.nad-action-overview-pin path');
+            expect(path).not.toBeNull();
+            expect(path!.getAttribute('d')).toContain('A 40 40');
+        });
+
+        it('wraps every pin glyph in a rescalable .nad-action-overview-pin-body', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const bodies = container.querySelectorAll('g.nad-action-overview-pin-body');
+            expect(bodies.length).toBe(2);
+            // Outer translate stays clean, body carries the scale.
+            bodies.forEach(b => {
+                expect(b.getAttribute('transform')).toMatch(/^scale\(/);
+            });
+        });
+
+        it('rescales pins when the svg viewBox attribute changes', () => {
+            // MutationObserver on the svg's viewBox attribute is
+            // what keeps pins screen-constant during wheel/drag.
+            // Directly mutating viewBox here simulates usePanZoom's
+            // fast-path DOM writes and verifies the rescaler reacts.
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg') as unknown as SVGGraphicsElement;
+
+            // Mock getScreenCTM to return a tiny ratio so the rescaler
+            // upscales the body well above scale(1).
+            svg.getScreenCTM = (() => ({ a: 0.1, b: 0, c: 0, d: 0.1, e: 0, f: 0 })) as unknown as SVGGraphicsElement['getScreenCTM'];
+
+            // Mutate the viewBox — MutationObserver fires on the
+            // next microtask, so flush with a manual wait.
+            (svg as unknown as SVGSVGElement).setAttribute('viewBox', '0 0 99999 99999');
+
+            return new Promise<void>(resolve => {
+                // MutationObserver callbacks are scheduled as microtasks
+                queueMicrotask(() => {
+                    const body = container.querySelector('g.nad-action-overview-pin-body')!;
+                    const match = body.getAttribute('transform')!.match(/^scale\(([0-9.]+)\)$/);
+                    expect(match).not.toBeNull();
+                    const scale = parseFloat(match![1]);
+                    // pxPerSvgUnit=0.1, MIN_SCREEN_RADIUS_PX=22,
+                    // baseR=40 → effectiveR=max(40, 220)=220 → scale=5.5
+                    expect(scale).toBeCloseTo(220 / 40, 2);
+                    resolve();
+                });
+            });
+        });
+
+        it('does not upscale pins when VL circles are already big enough on screen', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg') as unknown as SVGGraphicsElement;
+            // pxPerSvgUnit=2 → VL circle with r=40 = 80 screen px,
+            // well above the 22-px floor. No rescale needed.
+            svg.getScreenCTM = (() => ({ a: 2, b: 0, c: 0, d: 2, e: 0, f: 0 })) as unknown as SVGGraphicsElement['getScreenCTM'];
+            (svg as unknown as SVGSVGElement).setAttribute('viewBox', '0 0 100 100');
+
+            return new Promise<void>(resolve => {
+                queueMicrotask(() => {
+                    const body = container.querySelector('g.nad-action-overview-pin-body')!;
+                    expect(body.getAttribute('transform')).toBe('scale(1)');
+                    resolve();
+                });
+            });
         });
     });
 });

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -437,8 +437,9 @@ describe('ActionOverviewDiagram', () => {
                         expect(match).not.toBeNull();
                         const scale = parseFloat(match![1]);
                         // pxPerSvgUnit=0.1, MIN_SCREEN_RADIUS_PX=22,
-                        // baseR=40 → effectiveR=max(40, 220)=220 → scale=5.5
-                        expect(scale).toBeCloseTo(220 / 40, 2);
+                        // baseR=40, viewBoxMinR=99999/50≈2000
+                        // effectiveR=max(40, 220, 2000)=2000 → scale≈50
+                        expect(scale).toBeCloseTo(99999 / 50 / 40, 1);
                         resolve();
                     });
                 });
@@ -524,14 +525,17 @@ describe('ActionOverviewDiagram', () => {
             expect(pinLayer).not.toBeNull();
         });
 
-        it('places highlight layer BEFORE pins in document order', () => {
+        it('places highlight layer AFTER dim rect and BEFORE pins in document order', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
-            const directGs = Array.from(svg.children) as Element[];
-            const highlightIdx = directGs.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
-            const pinIdx = directGs.findIndex(c => c.classList.contains('nad-action-overview-pins'));
+            const children = Array.from(svg.children);
+            const dimIdx = children.findIndex(c => c.classList.contains('nad-overview-dim-rect'));
+            const highlightIdx = children.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+            const pinIdx = children.findIndex(c => c.classList.contains('nad-action-overview-pins'));
+            expect(dimIdx).toBeGreaterThan(-1);
             expect(highlightIdx).toBeGreaterThan(-1);
             expect(pinIdx).toBeGreaterThan(-1);
+            expect(dimIdx).toBeLessThan(highlightIdx);
             expect(highlightIdx).toBeLessThan(pinIdx);
         });
 
@@ -589,7 +593,7 @@ describe('ActionOverviewDiagram', () => {
             expect(pinLayer).not.toBeNull();
         });
 
-        it('dim rect is placed BEFORE highlights and pins in document order', () => {
+        it('visual stack order: NAD content → dim rect → highlights → pins', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
             const children = Array.from(svg.children);
@@ -599,6 +603,7 @@ describe('ActionOverviewDiagram', () => {
             expect(dimIdx).toBeGreaterThan(-1);
             expect(highlightIdx).toBeGreaterThan(-1);
             expect(pinIdx).toBeGreaterThan(-1);
+            // Dim rect after NAD content, highlights above dim, pins last
             expect(dimIdx).toBeLessThan(highlightIdx);
             expect(highlightIdx).toBeLessThan(pinIdx);
         });

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -1,0 +1,348 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import ActionOverviewDiagram from './ActionOverviewDiagram';
+import type { ActionDetail, DiagramData, EdgeMeta, MetadataIndex, NodeMeta } from '../types';
+
+// ------------------------------------------------------------
+// Test fixtures
+//
+// A 4-node square with an extra isolated VL, mirrored from the
+// svgUtils action-overview test fixture so the expected pin
+// anchors and fit rectangles stay consistent between the two
+// test suites.
+// ------------------------------------------------------------
+const makeMetaIndex = (): MetadataIndex => {
+    const nodes: NodeMeta[] = [
+        { equipmentId: 'VL_N1', svgId: 'svg-n1', x: 0, y: 0 },
+        { equipmentId: 'VL_N2', svgId: 'svg-n2', x: 100, y: 0 },
+        { equipmentId: 'VL_N3', svgId: 'svg-n3', x: 0, y: 100 },
+        { equipmentId: 'VL_N4', svgId: 'svg-n4', x: 100, y: 100 },
+        { equipmentId: 'VL_FAR', svgId: 'svg-far', x: 500, y: 500 },
+    ];
+    const edges: EdgeMeta[] = [
+        { equipmentId: 'LINE_A', svgId: 'svg-line-a', node1: 'svg-n1', node2: 'svg-n2' },
+        { equipmentId: 'LINE_B', svgId: 'svg-line-b', node1: 'svg-n2', node2: 'svg-n4' },
+        { equipmentId: 'LINE_C', svgId: 'svg-line-c', node1: 'svg-n1', node2: 'svg-n3' },
+        { equipmentId: 'LINE_D', svgId: 'svg-line-d', node1: 'svg-n3', node2: 'svg-n4' },
+    ];
+    return {
+        nodesByEquipmentId: new Map(nodes.map(n => [n.equipmentId, n] as const)),
+        nodesBySvgId: new Map(nodes.map(n => [n.svgId, n] as const)),
+        edgesByEquipmentId: new Map(edges.map(e => [e.equipmentId, e] as const)),
+        edgesByNode: new Map(),
+    };
+};
+
+const makeAction = (overrides: Partial<ActionDetail> = {}): ActionDetail => ({
+    description_unitaire: 'test action',
+    rho_before: null,
+    rho_after: null,
+    max_rho: null,
+    max_rho_line: '',
+    is_rho_reduction: false,
+    ...overrides,
+});
+
+// A minimal NAD-like SVG background — the test component
+// parses this via innerHTML and queries for the injected pin
+// layer. We keep it tiny so the assertions stay focussed.
+const makeN1Diagram = (): DiagramData => ({
+    svg: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-50 -50 700 700"></svg>',
+    metadata: null,
+    lines_overloaded: ['LINE_B'],
+    lines_overloaded_rho: [1.03],
+});
+
+const makeActions = (): Record<string, ActionDetail> => ({
+    'disco_LINE_A': makeAction({
+        action_topology: {
+            lines_ex_bus: { LINE_A: -1 },
+            lines_or_bus: { LINE_A: -1 },
+            gens_bus: {},
+            loads_bus: {},
+        },
+        max_rho: 0.5, // green
+        max_rho_line: 'LINE_D',
+    }),
+    'coupling_VL_FAR': makeAction({
+        description_unitaire: "Ouverture du poste 'VL_FAR'",
+        max_rho: 1.1, // red
+        max_rho_line: 'LINE_B',
+    }),
+});
+
+const defaultProps = () => ({
+    n1Diagram: makeN1Diagram(),
+    n1MetaIndex: makeMetaIndex(),
+    actions: makeActions(),
+    monitoringFactor: 0.95,
+    onActionSelect: vi.fn(),
+    contingency: 'LINE_C' as string | null,
+    overloadedLines: ['LINE_B'] as readonly string[],
+    inspectableItems: ['LINE_A', 'LINE_B', 'LINE_C', 'LINE_D', 'VL_N1', 'VL_FAR'],
+    visible: true,
+});
+
+describe('ActionOverviewDiagram', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('injects the N-1 SVG as background into its own container', () => {
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        // The overview SVG (from innerHTML injection) should live
+        // inside the nad-action-overview-container div.
+        const host = container.querySelector('.nad-action-overview-container');
+        expect(host).not.toBeNull();
+        const svg = host!.querySelector('svg');
+        expect(svg).not.toBeNull();
+        // width/height are normalised to fill the container
+        expect(svg!.getAttribute('width')).toBe('100%');
+        expect(svg!.getAttribute('height')).toBe('100%');
+        expect(svg!.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet');
+    });
+
+    it('renders one pin per simulated action using the severity palette', () => {
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        const pins = container.querySelectorAll('g.nad-action-overview-pin');
+        expect(pins.length).toBe(2);
+        const fills = Array.from(pins).map(p => p.querySelector('path')?.getAttribute('fill'));
+        // disco_LINE_A: rho=0.5 → green; coupling_VL_FAR: rho=1.1 → red
+        expect(fills).toEqual(expect.arrayContaining(['#28a745', '#dc3545']));
+    });
+
+    it('draws pins WITHOUT a stroke outline', () => {
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        const paths = container.querySelectorAll('g.nad-action-overview-pin > path');
+        expect(paths.length).toBeGreaterThan(0);
+        paths.forEach(p => {
+            expect(p.getAttribute('stroke')).toBe('none');
+            expect(p.hasAttribute('stroke-width')).toBe(false);
+        });
+    });
+
+    it('each pin displays the rounded max loading as its label', () => {
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        const texts = Array.from(container.querySelectorAll('g.nad-action-overview-pin > text'))
+            .map(t => t.textContent);
+        // 0.5 → "50%", 1.1 → "110%"
+        expect(texts).toEqual(expect.arrayContaining(['50%', '110%']));
+    });
+
+    it('pin anchors on the asset highlighted by the corresponding card', () => {
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        const groups = Array.from(container.querySelectorAll('g.nad-action-overview-pin'));
+        const byId = Object.fromEntries(groups.map(g => [
+            g.getAttribute('data-action-id'),
+            g.getAttribute('transform'),
+        ]));
+        // disco_LINE_A anchors on LINE_A midpoint (50, 0)
+        expect(byId['disco_LINE_A']).toBe('translate(50 0)');
+        // coupling_VL_FAR anchors on the VL node (500, 500)
+        expect(byId['coupling_VL_FAR']).toBe('translate(500 500)');
+    });
+
+    it('clicking a pin invokes onActionSelect with its id', () => {
+        const onActionSelect = vi.fn();
+        const { container } = render(
+            <ActionOverviewDiagram {...defaultProps()} onActionSelect={onActionSelect} />,
+        );
+        const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+        expect(pin).not.toBeNull();
+        fireEvent.click(pin!);
+        expect(onActionSelect).toHaveBeenCalledWith('disco_LINE_A');
+    });
+
+    it('auto-zooms to the fit rectangle on mount', () => {
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        // Fit rect unions:
+        //   contingency LINE_C:  (0,0)..(0,100)
+        //   overload   LINE_B:   (100,0)..(100,100)
+        //   pins:                (50, 0), (500, 500)
+        // Raw bbox = [0..500, 0..500] → 5% pad → [-25..525, -25..525]
+        // So w=550, h=550, x=-25, y=-25.
+        const svg = container.querySelector('.nad-action-overview-container svg');
+        const vb = svg!.getAttribute('viewBox')!;
+        const parts = vb.split(/\s+/).map(parseFloat);
+        expect(parts[0]).toBeCloseTo(-25, 0);
+        expect(parts[1]).toBeCloseTo(-25, 0);
+        expect(parts[2]).toBeCloseTo(550, 0);
+        expect(parts[3]).toBeCloseTo(550, 0);
+    });
+
+    it('renders severity legend (Solves overload / Low margin / Still overloaded / Divergent)', () => {
+        const { getByText } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        expect(getByText('Solves overload')).toBeInTheDocument();
+        expect(getByText('Low margin')).toBeInTheDocument();
+        expect(getByText('Still overloaded')).toBeInTheDocument();
+        expect(getByText('Divergent / islanded')).toBeInTheDocument();
+    });
+
+    it('shows the pin count in the header', () => {
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        expect(container.textContent).toContain('2 pins on the N-1 network');
+    });
+
+    it('hides itself when visible=false', () => {
+        const { container } = render(
+            <ActionOverviewDiagram {...defaultProps()} visible={false} />,
+        );
+        const root = container.querySelector('[data-testid="action-overview-diagram"]') as HTMLElement;
+        expect(root.style.display).toBe('none');
+    });
+
+    it('shows the "no analysis yet" empty state when there are no actions', () => {
+        const { getByText } = render(
+            <ActionOverviewDiagram {...defaultProps()} actions={{}} />,
+        );
+        expect(getByText(/Run.*Analyze.*Suggest/)).toBeInTheDocument();
+    });
+
+    it('shows the "no background" empty state when no N-1 diagram is loaded', () => {
+        const { getByText } = render(
+            <ActionOverviewDiagram {...defaultProps()} n1Diagram={null} />,
+        );
+        expect(getByText(/Load a contingency first/)).toBeInTheDocument();
+    });
+
+    describe('local zoom controls', () => {
+        it('clicking "+" shrinks the viewBox around its centre', () => {
+            const { container, getByTitle } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const before = svg.getAttribute('viewBox')!.split(/\s+/).map(parseFloat);
+            fireEvent.click(getByTitle('Zoom In'));
+            const after = svg.getAttribute('viewBox')!.split(/\s+/).map(parseFloat);
+            // Width shrinks by 0.8×
+            expect(after[2]).toBeCloseTo(before[2] * 0.8, 1);
+            expect(after[3]).toBeCloseTo(before[3] * 0.8, 1);
+        });
+
+        it('clicking "-" grows the viewBox around its centre', () => {
+            const { container, getByTitle } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const before = svg.getAttribute('viewBox')!.split(/\s+/).map(parseFloat);
+            fireEvent.click(getByTitle('Zoom Out'));
+            const after = svg.getAttribute('viewBox')!.split(/\s+/).map(parseFloat);
+            expect(after[2]).toBeCloseTo(before[2] * 1.25, 1);
+            expect(after[3]).toBeCloseTo(before[3] * 1.25, 1);
+        });
+
+        it('Fit button restores the auto-fit rectangle after panning', () => {
+            const { container, getByTitle } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const fit = svg.getAttribute('viewBox')!;
+            fireEvent.click(getByTitle('Zoom In'));
+            expect(svg.getAttribute('viewBox')).not.toBe(fit);
+            fireEvent.click(getByTitle(/Reset view/i));
+            expect(svg.getAttribute('viewBox')).toBe(fit);
+        });
+    });
+
+    describe('asset-focus inspect search', () => {
+        beforeEach(() => {
+            // `usePanZoom` debounces the React commit through setTimeout;
+            // use fake timers so the tests can deterministically flush
+            // any pending commits.
+            vi.useFakeTimers();
+        });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('typing an exact equipment id zooms onto it', () => {
+            const { container, getByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const fitVb = svg.getAttribute('viewBox')!;
+
+            const input = getByTestId('overview-inspect-input') as HTMLInputElement;
+            fireEvent.change(input, { target: { value: 'VL_FAR' } });
+
+            const focused = svg.getAttribute('viewBox')!;
+            expect(focused).not.toBe(fitVb);
+            // VL_FAR is a single-point → expanded to 150x150 around (500, 500)
+            const parts = focused.split(/\s+/).map(parseFloat);
+            expect(parts[0]).toBeCloseTo(500 - 75 - 150 * 0.35, 0);
+            expect(parts[1]).toBeCloseTo(500 - 75 - 150 * 0.35, 0);
+        });
+
+        it('does NOT re-focus on the same asset after the user zooms out (regression)', () => {
+            // This is the "sticking" bug: after focusing on an asset,
+            // unzooming used to re-run the effect and snap back onto
+            // the asset. The fix is `lastFocusedRef` — here we assert
+            // that a subsequent zoom-out is preserved.
+            const { container, getByTitle, getByTestId } = render(
+                <ActionOverviewDiagram {...defaultProps()} />,
+            );
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const input = getByTestId('overview-inspect-input') as HTMLInputElement;
+
+            // Focus on VL_FAR
+            fireEvent.change(input, { target: { value: 'VL_FAR' } });
+            const focusedVb = svg.getAttribute('viewBox')!;
+
+            // Zoom out — this changes pz.viewBox and therefore the
+            // memoised pz object identity, which previously caused
+            // the inspect effect to re-fire and snap back onto VL_FAR.
+            fireEvent.click(getByTitle('Zoom Out'));
+            // Flush any pending rAF / setTimeout commits
+            act(() => { vi.runAllTimers(); });
+
+            const afterZoomOut = svg.getAttribute('viewBox')!;
+            expect(afterZoomOut).not.toBe(focusedVb);
+
+            // One more zoom-out: the view should continue to widen,
+            // NOT snap back onto the asset.
+            const afterPrevZoom = svg.getAttribute('viewBox')!;
+            fireEvent.click(getByTitle('Zoom Out'));
+            act(() => { vi.runAllTimers(); });
+            const afterZoomOut2 = svg.getAttribute('viewBox')!;
+            expect(afterZoomOut2).not.toBe(afterPrevZoom);
+            expect(afterZoomOut2).not.toBe(focusedVb);
+        });
+
+        it('clearing the inspect query returns the view to the auto-fit rectangle', () => {
+            const { container, getByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const fitVb = svg.getAttribute('viewBox')!;
+
+            const input = getByTestId('overview-inspect-input') as HTMLInputElement;
+            fireEvent.change(input, { target: { value: 'VL_FAR' } });
+            expect(svg.getAttribute('viewBox')).not.toBe(fitVb);
+
+            fireEvent.change(input, { target: { value: '' } });
+            expect(svg.getAttribute('viewBox')).toBe(fitVb);
+        });
+
+        it('Fit button re-enables focusing on the same asset again', () => {
+            // After a Fit reset, typing the same asset id should
+            // focus again — the reset clears `lastFocusedRef` so the
+            // consume-once guard no longer swallows the re-entry.
+            const { container, getByTitle, getByTestId } = render(
+                <ActionOverviewDiagram {...defaultProps()} />,
+            );
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const input = getByTestId('overview-inspect-input') as HTMLInputElement;
+
+            fireEvent.change(input, { target: { value: 'VL_FAR' } });
+            const focusedVb1 = svg.getAttribute('viewBox')!;
+
+            // Back to fit
+            fireEvent.click(getByTitle(/Reset view/i));
+            fireEvent.change(input, { target: { value: '' } });
+
+            // Re-type the same asset id — should focus again, NOT
+            // silently skip because the ref remembered it.
+            fireEvent.change(input, { target: { value: 'VL_FAR' } });
+            const focusedVb2 = svg.getAttribute('viewBox')!;
+            expect(focusedVb2).toBe(focusedVb1);
+        });
+    });
+});

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -491,7 +491,7 @@ describe('ActionOverviewDiagram', () => {
             expect(layer!.querySelector('.nad-overloaded')).not.toBeNull();
         });
 
-        it('places the highlight layer ABOVE the dim layer (not inside it)', () => {
+        it('places the highlight layer NEXT TO (not inside) the dim layer', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
             const dim = svg.querySelector(':scope > g.nad-overview-dim-layer');
@@ -504,15 +504,23 @@ describe('ActionOverviewDiagram', () => {
             expect(dim!.contains(highlightLayer!)).toBe(false);
         });
 
-        it('places the highlight layer BELOW the pin layer in document order', () => {
+        it('places the highlight layer BEFORE the dim layer in document order (background like N-1 tab)', () => {
+            // Regression guard: the highlight clones must render
+            // BEHIND the dimmed network so the halo peeks out
+            // around the line strokes, mirroring the
+            // `#nad-background-layer` placement on the N-1 tab.
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
             const directGs = Array.from(svg.children) as Element[];
             const highlightIdx = directGs.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+            const dimIdx = directGs.findIndex(c => c.classList.contains('nad-overview-dim-layer'));
             const pinIdx = directGs.findIndex(c => c.classList.contains('nad-action-overview-pins'));
             expect(highlightIdx).toBeGreaterThan(-1);
+            expect(dimIdx).toBeGreaterThan(-1);
             expect(pinIdx).toBeGreaterThan(-1);
-            expect(highlightIdx).toBeLessThan(pinIdx);
+            // Order: highlights → dim → pins
+            expect(highlightIdx).toBeLessThan(dimIdx);
+            expect(dimIdx).toBeLessThan(pinIdx);
         });
 
         it('refreshes highlights when contingency changes', () => {
@@ -670,6 +678,54 @@ describe('ActionOverviewDiagram', () => {
 
             rerender(<ActionOverviewDiagram {...defaultProps()} visible={false} />);
             expect(queryByTestId('action-overview-popover')).toBeNull();
+        });
+
+        it('records data-place-above and data-horizontal-align attributes from the placement helper', async () => {
+            // Stub getBoundingClientRect on the pin so the click
+            // handler captures a known screen position.  We pin
+            // it to the bottom-right corner of the viewport
+            // (1024x768 in jsdom by default) so the placement
+            // helper picks above + end.
+            const { container, getByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]') as SVGGElement;
+            pin.getBoundingClientRect = (() => ({
+                left: 900, right: 920,
+                top: 700, bottom: 720,
+                width: 20, height: 20,
+                x: 900, y: 700,
+                toJSON: () => ({}),
+            })) as unknown as SVGGElement['getBoundingClientRect'];
+
+            fireEvent.click(pin);
+            act(() => { vi.advanceTimersByTime(300); });
+
+            const popover = getByTestId('action-overview-popover');
+            expect(popover.getAttribute('data-place-above')).toBe('true');
+            expect(popover.getAttribute('data-horizontal-align')).toBe('end');
+            // Above placement → uses CSS `bottom`, not `top`.
+            expect(popover.style.bottom).not.toBe('');
+            expect(popover.style.top).toBe('');
+        });
+
+        it('renders the popover BELOW the pin when the pin is in the top of the viewport', async () => {
+            const { container, getByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]') as SVGGElement;
+            pin.getBoundingClientRect = (() => ({
+                left: 100, right: 120,
+                top: 50, bottom: 70,
+                width: 20, height: 20,
+                x: 100, y: 50,
+                toJSON: () => ({}),
+            })) as unknown as SVGGElement['getBoundingClientRect'];
+
+            fireEvent.click(pin);
+            act(() => { vi.advanceTimersByTime(300); });
+
+            const popover = getByTestId('action-overview-popover');
+            expect(popover.getAttribute('data-place-above')).toBe('false');
+            expect(popover.getAttribute('data-horizontal-align')).toBe('start');
+            expect(popover.style.top).not.toBe('');
+            expect(popover.style.bottom).toBe('');
         });
     });
 });

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -236,13 +236,26 @@ describe('ActionOverviewDiagram', () => {
         expect(container.textContent).toContain('2 pins on the N-1 network');
     });
 
-    it('hides itself when visible=false', () => {
+    it('hides itself when visible=false (before first show: display:none)', () => {
         const { container } = render(
             <ActionOverviewDiagram {...defaultProps()} visible={false} />,
         );
         const root = container.querySelector('[data-testid="action-overview-diagram"]') as HTMLElement;
-        // Uses visibility:hidden (not display:none) so the SVG stays
-        // in its composite layer and tab-switching is instant.
+        // Before the component has ever been visible, it uses
+        // display:none for zero rendering cost.
+        expect(root.style.display).toBe('none');
+        expect(root.style.pointerEvents).toBe('none');
+    });
+
+    it('uses visibility:hidden after first show (keeps composite layer)', () => {
+        const { container, rerender } = render(
+            <ActionOverviewDiagram {...defaultProps()} visible={true} />,
+        );
+        // Show it once, then hide — should switch to visibility:hidden
+        // so the painted SVG stays in its GPU layer for instant re-show.
+        rerender(<ActionOverviewDiagram {...defaultProps()} visible={false} />);
+        const root = container.querySelector('[data-testid="action-overview-diagram"]') as HTMLElement;
+        expect(root.style.display).toBe('flex');
         expect(root.style.visibility).toBe('hidden');
         expect(root.style.pointerEvents).toBe('none');
     });

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, cleanup, act } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import ActionOverviewDiagram from './ActionOverviewDiagram';
+import { interactionLogger } from '../utils/interactionLogger';
 import type { ActionDetail, DiagramData, EdgeMeta, MetadataIndex, NodeMeta } from '../types';
 
 // ------------------------------------------------------------
@@ -768,6 +769,103 @@ describe('ActionOverviewDiagram', () => {
             expect(popover.getAttribute('data-horizontal-align')).toBe('start');
             expect(popover.style.top).not.toBe('');
             expect(popover.style.bottom).toBe('');
+        });
+    });
+
+    describe('interaction logging', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+            interactionLogger.clear();
+        });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        const lastLog = (type: string) =>
+            interactionLogger.getLog().filter(e => e.type === type).pop();
+
+        it('logs overview_shown when the component becomes visible', () => {
+            render(<ActionOverviewDiagram {...defaultProps()} />);
+            expect(lastLog('overview_shown')).toBeDefined();
+            expect(lastLog('overview_shown')!.details).toHaveProperty('pin_count');
+        });
+
+        it('logs overview_hidden when visible flips false', () => {
+            const { rerender } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            rerender(<ActionOverviewDiagram {...defaultProps()} visible={false} />);
+            expect(lastLog('overview_hidden')).toBeDefined();
+        });
+
+        it('logs overview_pin_clicked on single-click (after the delay)', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+            const entry = lastLog('overview_pin_clicked');
+            expect(entry).toBeDefined();
+            expect(entry!.details.action_id).toBe('disco_LINE_A');
+        });
+
+        it('logs overview_pin_double_clicked on double-click', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            fireEvent.click(pin!);
+            fireEvent.doubleClick(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+            const entry = lastLog('overview_pin_double_clicked');
+            expect(entry).toBeDefined();
+            expect(entry!.details.action_id).toBe('disco_LINE_A');
+            // The single-click should NOT have been logged (cancelled by dblclick)
+            expect(lastLog('overview_pin_clicked')).toBeUndefined();
+        });
+
+        it('logs overview_popover_closed with reason on close button', () => {
+            const { container, getByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+            fireEvent.click(getByTestId('action-overview-popover-close'));
+            const entry = lastLog('overview_popover_closed');
+            expect(entry).toBeDefined();
+            expect(entry!.details.reason).toBe('close_button');
+        });
+
+        it('logs overview_popover_closed with reason "escape" on Escape key', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+            act(() => { document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })); });
+            expect(lastLog('overview_popover_closed')!.details.reason).toBe('escape');
+        });
+
+        it('logs overview_zoom_in / overview_zoom_out / overview_zoom_fit on button clicks', () => {
+            const { getByTitle } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            fireEvent.click(getByTitle('Zoom In'));
+            expect(lastLog('overview_zoom_in')).toBeDefined();
+            fireEvent.click(getByTitle('Zoom Out'));
+            expect(lastLog('overview_zoom_out')).toBeDefined();
+            fireEvent.click(getByTitle(/Reset view/i));
+            expect(lastLog('overview_zoom_fit')).toBeDefined();
+        });
+
+        it('logs overview_inspect_changed when an exact equipment match is typed', () => {
+            const { getByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const input = getByTestId('overview-inspect-input') as HTMLInputElement;
+            fireEvent.change(input, { target: { value: 'VL_FAR' } });
+            const entry = lastLog('overview_inspect_changed');
+            expect(entry).toBeDefined();
+            expect(entry!.details).toEqual({ query: 'VL_FAR', action: 'focus' });
+        });
+
+        it('logs overview_inspect_changed with action "cleared" when query is cleared', () => {
+            const { getByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const input = getByTestId('overview-inspect-input') as HTMLInputElement;
+            fireEvent.change(input, { target: { value: 'VL_FAR' } });
+            fireEvent.change(input, { target: { value: '' } });
+            const entry = lastLog('overview_inspect_changed');
+            expect(entry!.details.action).toBe('cleared');
         });
     });
 });

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -53,13 +53,23 @@ const makeAction = (overrides: Partial<ActionDetail> = {}): ActionDetail => ({
 
 // A minimal NAD-like SVG background — the test component
 // parses this via innerHTML and queries for the injected pin
-// layer. Includes a `.nad-vl-nodes circle[r="40"]` so the pin
-// sizing logic (which reads the VL circle radius) has something
-// realistic to latch on.
+// layer. Includes:
+//  - `.nad-vl-nodes circle[r="40"]` so the pin sizing logic
+//    (which reads the VL circle radius) has something realistic
+//    to latch on
+//  - `<g id="svg-line-X">` stubs for every line referenced by
+//    the metadata index so `applyActionOverviewHighlights` can
+//    locate and clone the contingency / overload edges.
 const makeN1Diagram = (): DiagramData => ({
     svg:
         '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-50 -50 700 700">' +
         '  <g class="nad-vl-nodes"><circle r="40"/></g>' +
+        '  <g class="nad-edges">' +
+        '    <g id="svg-line-a"><line x1="0" y1="0" x2="100" y2="0"/></g>' +
+        '    <g id="svg-line-b"><line x1="100" y1="0" x2="100" y2="100"/></g>' +
+        '    <g id="svg-line-c"><line x1="0" y1="0" x2="0" y2="100"/></g>' +
+        '    <g id="svg-line-d"><line x1="0" y1="100" x2="100" y2="100"/></g>' +
+        '  </g>' +
         '</svg>',
     metadata: null,
     lines_overloaded: ['LINE_B'],
@@ -389,21 +399,25 @@ describe('ActionOverviewDiagram', () => {
             // upscales the body well above scale(1).
             svg.getScreenCTM = (() => ({ a: 0.1, b: 0, c: 0, d: 0.1, e: 0, f: 0 })) as unknown as SVGGraphicsElement['getScreenCTM'];
 
-            // Mutate the viewBox — MutationObserver fires on the
-            // next microtask, so flush with a manual wait.
+            // Mutate the viewBox — the MutationObserver schedules
+            // a rAF, so we wait one animation frame to read the
+            // committed scale.
             (svg as unknown as SVGSVGElement).setAttribute('viewBox', '0 0 99999 99999');
 
             return new Promise<void>(resolve => {
-                // MutationObserver callbacks are scheduled as microtasks
+                // First a microtask flush to let MO deliver its records,
+                // then a rAF to let the throttled rescaler run.
                 queueMicrotask(() => {
-                    const body = container.querySelector('g.nad-action-overview-pin-body')!;
-                    const match = body.getAttribute('transform')!.match(/^scale\(([0-9.]+)\)$/);
-                    expect(match).not.toBeNull();
-                    const scale = parseFloat(match![1]);
-                    // pxPerSvgUnit=0.1, MIN_SCREEN_RADIUS_PX=22,
-                    // baseR=40 → effectiveR=max(40, 220)=220 → scale=5.5
-                    expect(scale).toBeCloseTo(220 / 40, 2);
-                    resolve();
+                    requestAnimationFrame(() => {
+                        const body = container.querySelector('g.nad-action-overview-pin-body')!;
+                        const match = body.getAttribute('transform')!.match(/^scale\(([0-9.]+)\)$/);
+                        expect(match).not.toBeNull();
+                        const scale = parseFloat(match![1]);
+                        // pxPerSvgUnit=0.1, MIN_SCREEN_RADIUS_PX=22,
+                        // baseR=40 → effectiveR=max(40, 220)=220 → scale=5.5
+                        expect(scale).toBeCloseTo(220 / 40, 2);
+                        resolve();
+                    });
                 });
             });
         });
@@ -418,11 +432,101 @@ describe('ActionOverviewDiagram', () => {
 
             return new Promise<void>(resolve => {
                 queueMicrotask(() => {
-                    const body = container.querySelector('g.nad-action-overview-pin-body')!;
-                    expect(body.getAttribute('transform')).toBe('scale(1)');
-                    resolve();
+                    requestAnimationFrame(() => {
+                        const body = container.querySelector('g.nad-action-overview-pin-body')!;
+                        expect(body.getAttribute('transform')).toBe('scale(1)');
+                        resolve();
+                    });
                 });
             });
+        });
+
+        it('rAF-throttles rescale: many viewBox mutations in a row trigger AT MOST one rescale per animation frame', () => {
+            // Regression guard for the "Page ne répondant pas" lag:
+            // the wheel-zoom path in usePanZoom mutates the viewBox
+            // many times per frame; without rAF batching that would
+            // call getScreenCTM (a forced layout) on every mutation
+            // and freeze the page on large grids.
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg') as unknown as SVGGraphicsElement;
+            let ctmCalls = 0;
+            svg.getScreenCTM = (() => {
+                ctmCalls += 1;
+                return { a: 0.5, b: 0, c: 0, d: 0.5, e: 0, f: 0 };
+            }) as unknown as SVGGraphicsElement['getScreenCTM'];
+
+            // Reset the counter — initial pin mount + dim wrap may
+            // have invoked getScreenCTM already; we only care about
+            // the burst that follows the rapid viewBox writes.
+            ctmCalls = 0;
+
+            // Simulate a wheel-zoom burst: 20 viewBox writes in a row.
+            for (let i = 1; i <= 20; i++) {
+                (svg as unknown as SVGSVGElement).setAttribute('viewBox', `0 0 ${1000 + i} ${1000 + i}`);
+            }
+
+            return new Promise<void>(resolve => {
+                queueMicrotask(() => {
+                    requestAnimationFrame(() => {
+                        // Even though we wrote viewBox 20 times, the
+                        // throttled rescaler should have run AT MOST
+                        // once for that frame (and called getScreenCTM
+                        // exactly once inside that single rescale).
+                        expect(ctmCalls).toBeLessThanOrEqual(1);
+                        resolve();
+                    });
+                });
+            });
+        });
+    });
+
+    describe('contingency + overload highlights', () => {
+        it('renders contingency + overload highlight clones via applyActionOverviewHighlights', () => {
+            // The fixture sets contingency='LINE_C' and overloadedLines=['LINE_B'].
+            // Both must produce a clone inside the .nad-overview-highlight-layer.
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const layer = container.querySelector('.nad-overview-highlight-layer');
+            expect(layer).not.toBeNull();
+            expect(layer!.querySelector('.nad-contingency-highlight')).not.toBeNull();
+            expect(layer!.querySelector('.nad-overloaded')).not.toBeNull();
+        });
+
+        it('places the highlight layer ABOVE the dim layer (not inside it)', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const dim = svg.querySelector(':scope > g.nad-overview-dim-layer');
+            const highlightLayer = svg.querySelector(':scope > g.nad-overview-highlight-layer');
+            expect(dim).not.toBeNull();
+            expect(highlightLayer).not.toBeNull();
+            // Highlight layer must NOT be a descendant of the dim
+            // group — otherwise its halos would inherit the 0.35
+            // opacity and become invisible.
+            expect(dim!.contains(highlightLayer!)).toBe(false);
+        });
+
+        it('places the highlight layer BELOW the pin layer in document order', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const directGs = Array.from(svg.children) as Element[];
+            const highlightIdx = directGs.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+            const pinIdx = directGs.findIndex(c => c.classList.contains('nad-action-overview-pins'));
+            expect(highlightIdx).toBeGreaterThan(-1);
+            expect(pinIdx).toBeGreaterThan(-1);
+            expect(highlightIdx).toBeLessThan(pinIdx);
+        });
+
+        it('refreshes highlights when contingency changes', () => {
+            const { container, rerender } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const layer1 = container.querySelector('.nad-overview-highlight-layer');
+            expect(layer1).not.toBeNull();
+            // Change contingency to a non-resolvable id — the
+            // highlight layer should be wiped (1 contingency lost),
+            // leaving only the overload clone.
+            rerender(<ActionOverviewDiagram {...defaultProps()} contingency={null} />);
+            const layer2 = container.querySelector('.nad-overview-highlight-layer');
+            expect(layer2).not.toBeNull();
+            expect(layer2!.querySelector('.nad-contingency-highlight')).toBeNull();
+            expect(layer2!.querySelector('.nad-overloaded')).not.toBeNull();
         });
     });
 

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -157,14 +157,17 @@ describe('ActionOverviewDiagram', () => {
         expect(byId['coupling_VL_FAR']).toBe('translate(500 500)');
     });
 
-    it('clicking a pin invokes onActionSelect with its id', () => {
+    it('double-clicking a pin invokes onActionSelect with its id (drill-down path)', () => {
+        // Semantics changed in the click-vs-dblclick split:
+        //  - single-click → opens the popover (separate test below)
+        //  - double-click → selects the action (this test)
         const onActionSelect = vi.fn();
         const { container } = render(
             <ActionOverviewDiagram {...defaultProps()} onActionSelect={onActionSelect} />,
         );
         const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
         expect(pin).not.toBeNull();
-        fireEvent.click(pin!);
+        fireEvent.doubleClick(pin!);
         expect(onActionSelect).toHaveBeenCalledWith('disco_LINE_A');
     });
 
@@ -420,6 +423,149 @@ describe('ActionOverviewDiagram', () => {
                     resolve();
                 });
             });
+        });
+    });
+
+    describe('dim background layer', () => {
+        it('wraps existing SVG children in a .nad-overview-dim-layer <g>', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const dim = container.querySelector('.nad-action-overview-container svg > g.nad-overview-dim-layer');
+            expect(dim).not.toBeNull();
+            // The VL nodes group from the test fixture should now be INSIDE the dim group
+            expect(dim!.querySelector('.nad-vl-nodes')).not.toBeNull();
+        });
+
+        it('applies an opacity attribute below 1 on the dim layer', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const dim = container.querySelector('g.nad-overview-dim-layer');
+            expect(dim).not.toBeNull();
+            const opacity = parseFloat(dim!.getAttribute('opacity') || '1');
+            expect(opacity).toBeGreaterThan(0);
+            expect(opacity).toBeLessThan(1);
+        });
+
+        it('pin layer is a SIBLING of the dim layer (full opacity on top)', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const dim = svg.querySelector(':scope > g.nad-overview-dim-layer');
+            const pinLayer = svg.querySelector(':scope > g.nad-action-overview-pins');
+            expect(dim).not.toBeNull();
+            expect(pinLayer).not.toBeNull();
+            // Pin layer must NOT be inside the dim wrapper.
+            expect(dim!.contains(pinLayer!)).toBe(false);
+        });
+    });
+
+    describe('click popover (single-click on pin)', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('opens an ActionCard popover on single-click (after the single-click delay)', async () => {
+            const { container, queryByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            // Before clicking, no popover is mounted.
+            expect(queryByTestId('action-overview-popover')).toBeNull();
+
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            // The click action is deferred — popover is NOT up yet.
+            expect(queryByTestId('action-overview-popover')).toBeNull();
+
+            // Advance the single-click delay + flush React batching.
+            act(() => { vi.advanceTimersByTime(300); });
+
+            const popover = queryByTestId('action-overview-popover');
+            expect(popover).not.toBeNull();
+            expect(popover!.getAttribute('data-action-id')).toBe('disco_LINE_A');
+            // The popover embeds the real ActionCard for this id.
+            expect(popover!.querySelector('[data-testid="action-card-disco_LINE_A"]')).not.toBeNull();
+        });
+
+        it('does NOT open the popover when the user double-clicks the same pin', async () => {
+            const onActionSelect = vi.fn();
+            const { container, queryByTestId } = render(
+                <ActionOverviewDiagram {...defaultProps()} onActionSelect={onActionSelect} />,
+            );
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            // Simulate the real browser sequence: click, click, dblclick.
+            fireEvent.click(pin!);
+            fireEvent.click(pin!);
+            fireEvent.doubleClick(pin!);
+            act(() => { vi.advanceTimersByTime(500); });
+
+            expect(queryByTestId('action-overview-popover')).toBeNull();
+            expect(onActionSelect).toHaveBeenCalledWith('disco_LINE_A');
+        });
+
+        it('closes the popover when the ✕ button is clicked', async () => {
+            const { container, getByTestId, queryByTestId } = render(
+                <ActionOverviewDiagram {...defaultProps()} />,
+            );
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+
+            expect(queryByTestId('action-overview-popover')).not.toBeNull();
+            fireEvent.click(getByTestId('action-overview-popover-close'));
+            expect(queryByTestId('action-overview-popover')).toBeNull();
+        });
+
+        it('closes the popover when Escape is pressed', async () => {
+            const { container, queryByTestId } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+
+            expect(queryByTestId('action-overview-popover')).not.toBeNull();
+            act(() => {
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+            });
+            expect(queryByTestId('action-overview-popover')).toBeNull();
+        });
+
+        it('clicking inside the popover does NOT dismiss it (stopPropagation)', async () => {
+            const { container, getByTestId, queryByTestId } = render(
+                <ActionOverviewDiagram {...defaultProps()} />,
+            );
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+
+            const popover = getByTestId('action-overview-popover');
+            fireEvent.mouseDown(popover);
+            expect(queryByTestId('action-overview-popover')).not.toBeNull();
+        });
+
+        it('clicking the ActionCard body inside the popover activates the drill-down and closes the popover', async () => {
+            const onActionSelect = vi.fn();
+            const { container, getByTestId, queryByTestId } = render(
+                <ActionOverviewDiagram {...defaultProps()} onActionSelect={onActionSelect} />,
+            );
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+
+            const card = getByTestId('action-card-disco_LINE_A');
+            fireEvent.click(card);
+            expect(onActionSelect).toHaveBeenCalledWith('disco_LINE_A');
+            // Popover should have been cleared as part of the activation flow.
+            expect(queryByTestId('action-overview-popover')).toBeNull();
+        });
+
+        it('does not render the popover when the overview is hidden', async () => {
+            const { container, rerender, queryByTestId } = render(
+                <ActionOverviewDiagram {...defaultProps()} />,
+            );
+            const pin = container.querySelector('g.nad-action-overview-pin[data-action-id="disco_LINE_A"]');
+            fireEvent.click(pin!);
+            act(() => { vi.advanceTimersByTime(300); });
+            expect(queryByTestId('action-overview-popover')).not.toBeNull();
+
+            rerender(<ActionOverviewDiagram {...defaultProps()} visible={false} />);
+            expect(queryByTestId('action-overview-popover')).toBeNull();
         });
     });
 });

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -125,6 +125,31 @@ describe('ActionOverviewDiagram', () => {
         expect(svg!.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet');
     });
 
+    it('wraps existing SVG children in a .nad-overview-dim-layer via pre-parse (replaceChildren path)', () => {
+        // Regression: the preparedSvg useMemo wraps children in a
+        // dim-layer off-DOM before replaceChildren injects them —
+        // verify the dim layer exists and has the right opacity.
+        const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+        const host = container.querySelector('.nad-action-overview-container');
+        const dimLayer = host!.querySelector('svg > g.nad-overview-dim-layer');
+        expect(dimLayer).not.toBeNull();
+        expect(dimLayer!.getAttribute('opacity')).toBe('0.35');
+        // The original SVG content (edges, VL nodes) should be
+        // INSIDE the dim layer, not at the SVG root.
+        expect(dimLayer!.querySelector('.nad-edges')).not.toBeNull();
+        expect(dimLayer!.querySelector('.nad-vl-nodes')).not.toBeNull();
+    });
+
+    it('clears the container when n1Diagram becomes null', () => {
+        const props = defaultProps();
+        const { container, rerender } = render(<ActionOverviewDiagram {...props} />);
+        const host = container.querySelector('.nad-action-overview-container')!;
+        expect(host.querySelector('svg')).not.toBeNull();
+
+        rerender(<ActionOverviewDiagram {...props} n1Diagram={null as unknown as DiagramData} />);
+        expect(host.querySelector('svg')).toBeNull();
+    });
+
     it('renders one pin per simulated action using the severity palette', () => {
         const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
         const pins = container.querySelectorAll('g.nad-action-overview-pin');

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -236,28 +236,12 @@ describe('ActionOverviewDiagram', () => {
         expect(container.textContent).toContain('2 pins on the N-1 network');
     });
 
-    it('hides itself when visible=false (before first show: display:none)', () => {
+    it('hides itself when visible=false', () => {
         const { container } = render(
             <ActionOverviewDiagram {...defaultProps()} visible={false} />,
         );
         const root = container.querySelector('[data-testid="action-overview-diagram"]') as HTMLElement;
-        // Before the component has ever been visible, it uses
-        // display:none for zero rendering cost.
         expect(root.style.display).toBe('none');
-        expect(root.style.pointerEvents).toBe('none');
-    });
-
-    it('uses visibility:hidden after first show (keeps composite layer)', () => {
-        const { container, rerender } = render(
-            <ActionOverviewDiagram {...defaultProps()} visible={true} />,
-        );
-        // Show it once, then hide — should switch to visibility:hidden
-        // so the painted SVG stays in its GPU layer for instant re-show.
-        rerender(<ActionOverviewDiagram {...defaultProps()} visible={false} />);
-        const root = container.querySelector('[data-testid="action-overview-diagram"]') as HTMLElement;
-        expect(root.style.display).toBe('flex');
-        expect(root.style.visibility).toBe('hidden');
-        expect(root.style.pointerEvents).toBe('none');
     });
 
     it('shows the "no analysis yet" empty state when there are no actions', () => {

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -125,15 +125,12 @@ describe('ActionOverviewDiagram', () => {
         expect(svg!.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet');
     });
 
-    it('adds nad-overview-dimmed CSS class to the SVG for dimming (no opacity group)', () => {
-        // The old approach wrapped children in <g opacity="0.35"> which
-        // created an SVG transparency group — Chrome had to rasterize
-        // all ~43k elements into an intermediate buffer (Layerize: 31s).
-        // Now we use a CSS class instead — no stacking context.
+    it('marks the SVG with nad-overview-dimmed class and inserts a dim rect overlay', () => {
         const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
         const host = container.querySelector('.nad-action-overview-container');
         const svg = host!.querySelector('svg');
         expect(svg!.classList.contains('nad-overview-dimmed')).toBe(true);
+        expect(svg!.querySelector('rect.nad-overview-dim-rect')).not.toBeNull();
         // Original SVG content stays at the SVG root (no wrapper group).
         expect(svg!.querySelector('.nad-edges')).not.toBeNull();
         expect(svg!.querySelector('.nad-vl-nodes')).not.toBeNull();
@@ -553,16 +550,36 @@ describe('ActionOverviewDiagram', () => {
         });
     });
 
-    describe('dim background (CSS class, no opacity group)', () => {
-        it('applies nad-overview-dimmed class instead of wrapping in an opacity group', () => {
+    describe('dim background (rect overlay, no opacity group or per-child opacity)', () => {
+        it('inserts a white dim rect overlay instead of wrapping in an opacity group or using CSS per-child opacity', () => {
             // The old <g opacity="0.35"> wrapper created an SVG
-            // transparency group that caused a 31s Layerize on large
-            // grids.  Now we use a CSS class instead.
+            // transparency group (Layerize: 31s). CSS per-child
+            // opacity still created stacking contexts (25s). Now we
+            // use a single white <rect> overlay — zero stacking contexts.
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
-            expect(svg.classList.contains('nad-overview-dimmed')).toBe(true);
+            const dimRect = svg.querySelector('rect.nad-overview-dim-rect');
+            expect(dimRect).not.toBeNull();
+            expect(dimRect!.getAttribute('fill')).toBe('white');
+            expect(dimRect!.getAttribute('opacity')).toBe('0.65');
+            expect(dimRect!.getAttribute('pointer-events')).toBe('none');
             // No <g> opacity wrapper should exist.
             expect(svg.querySelector('g.nad-overview-dim-layer')).toBeNull();
+        });
+
+        it('dim rect covers the viewBox with margin', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const dimRect = svg.querySelector('rect.nad-overview-dim-rect')!;
+            // viewBox="-50 -50 700 700", margin = 700 * 0.1 = 70
+            const x = parseFloat(dimRect.getAttribute('x')!);
+            const y = parseFloat(dimRect.getAttribute('y')!);
+            const w = parseFloat(dimRect.getAttribute('width')!);
+            const h = parseFloat(dimRect.getAttribute('height')!);
+            expect(x).toBeCloseTo(-50 - 70, 0);
+            expect(y).toBeCloseTo(-50 - 70, 0);
+            expect(w).toBeCloseTo(700 + 140, 0);
+            expect(h).toBeCloseTo(700 + 140, 0);
         });
 
         it('pin layer is a direct child of the SVG (not nested)', () => {
@@ -570,6 +587,20 @@ describe('ActionOverviewDiagram', () => {
             const svg = container.querySelector('.nad-action-overview-container svg')!;
             const pinLayer = svg.querySelector(':scope > g.nad-action-overview-pins');
             expect(pinLayer).not.toBeNull();
+        });
+
+        it('dim rect is placed BEFORE highlights and pins in document order', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
+            const children = Array.from(svg.children);
+            const dimIdx = children.findIndex(c => c.classList.contains('nad-overview-dim-rect'));
+            const highlightIdx = children.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+            const pinIdx = children.findIndex(c => c.classList.contains('nad-action-overview-pins'));
+            expect(dimIdx).toBeGreaterThan(-1);
+            expect(highlightIdx).toBeGreaterThan(-1);
+            expect(pinIdx).toBeGreaterThan(-1);
+            expect(dimIdx).toBeLessThan(highlightIdx);
+            expect(highlightIdx).toBeLessThan(pinIdx);
         });
     });
 

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -241,7 +241,10 @@ describe('ActionOverviewDiagram', () => {
             <ActionOverviewDiagram {...defaultProps()} visible={false} />,
         );
         const root = container.querySelector('[data-testid="action-overview-diagram"]') as HTMLElement;
-        expect(root.style.display).toBe('none');
+        // Uses visibility:hidden (not display:none) so the SVG stays
+        // in its composite layer and tab-switching is instant.
+        expect(root.style.visibility).toBe('hidden');
+        expect(root.style.pointerEvents).toBe('none');
     });
 
     it('shows the "no analysis yet" empty state when there are no actions', () => {

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -525,17 +525,18 @@ describe('ActionOverviewDiagram', () => {
             expect(pinLayer).not.toBeNull();
         });
 
-        it('places highlight layer AFTER dim rect and BEFORE pins in document order', () => {
+        it('places highlight layer BEFORE NAD content (at SVG start) and BEFORE dim rect and pins', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
             const children = Array.from(svg.children);
-            const dimIdx = children.findIndex(c => c.classList.contains('nad-overview-dim-rect'));
             const highlightIdx = children.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+            const dimIdx = children.findIndex(c => c.classList.contains('nad-overview-dim-rect'));
             const pinIdx = children.findIndex(c => c.classList.contains('nad-action-overview-pins'));
-            expect(dimIdx).toBeGreaterThan(-1);
             expect(highlightIdx).toBeGreaterThan(-1);
+            expect(dimIdx).toBeGreaterThan(-1);
             expect(pinIdx).toBeGreaterThan(-1);
-            expect(dimIdx).toBeLessThan(highlightIdx);
+            // Highlights at start, before everything else
+            expect(highlightIdx).toBeLessThan(dimIdx);
             expect(highlightIdx).toBeLessThan(pinIdx);
         });
 
@@ -593,19 +594,19 @@ describe('ActionOverviewDiagram', () => {
             expect(pinLayer).not.toBeNull();
         });
 
-        it('visual stack order: NAD content → dim rect → highlights → pins', () => {
+        it('visual stack order: highlights → NAD content → dim rect → pins', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
             const children = Array.from(svg.children);
-            const dimIdx = children.findIndex(c => c.classList.contains('nad-overview-dim-rect'));
             const highlightIdx = children.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+            const dimIdx = children.findIndex(c => c.classList.contains('nad-overview-dim-rect'));
             const pinIdx = children.findIndex(c => c.classList.contains('nad-action-overview-pins'));
-            expect(dimIdx).toBeGreaterThan(-1);
             expect(highlightIdx).toBeGreaterThan(-1);
+            expect(dimIdx).toBeGreaterThan(-1);
             expect(pinIdx).toBeGreaterThan(-1);
-            // Dim rect after NAD content, highlights above dim, pins last
-            expect(dimIdx).toBeLessThan(highlightIdx);
-            expect(highlightIdx).toBeLessThan(pinIdx);
+            // Highlights first (behind NAD), dim rect after NAD, pins last
+            expect(highlightIdx).toBeLessThan(dimIdx);
+            expect(dimIdx).toBeLessThan(pinIdx);
         });
     });
 

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -125,19 +125,18 @@ describe('ActionOverviewDiagram', () => {
         expect(svg!.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet');
     });
 
-    it('wraps existing SVG children in a .nad-overview-dim-layer via pre-parse (replaceChildren path)', () => {
-        // Regression: the preparedSvg useMemo wraps children in a
-        // dim-layer off-DOM before replaceChildren injects them —
-        // verify the dim layer exists and has the right opacity.
+    it('adds nad-overview-dimmed CSS class to the SVG for dimming (no opacity group)', () => {
+        // The old approach wrapped children in <g opacity="0.35"> which
+        // created an SVG transparency group — Chrome had to rasterize
+        // all ~43k elements into an intermediate buffer (Layerize: 31s).
+        // Now we use a CSS class instead — no stacking context.
         const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
         const host = container.querySelector('.nad-action-overview-container');
-        const dimLayer = host!.querySelector('svg > g.nad-overview-dim-layer');
-        expect(dimLayer).not.toBeNull();
-        expect(dimLayer!.getAttribute('opacity')).toBe('0.35');
-        // The original SVG content (edges, VL nodes) should be
-        // INSIDE the dim layer, not at the SVG root.
-        expect(dimLayer!.querySelector('.nad-edges')).not.toBeNull();
-        expect(dimLayer!.querySelector('.nad-vl-nodes')).not.toBeNull();
+        const svg = host!.querySelector('svg');
+        expect(svg!.classList.contains('nad-overview-dimmed')).toBe(true);
+        // Original SVG content stays at the SVG root (no wrapper group).
+        expect(svg!.querySelector('.nad-edges')).not.toBeNull();
+        expect(svg!.querySelector('.nad-vl-nodes')).not.toBeNull();
     });
 
     it('clears the container when n1Diagram becomes null', () => {
@@ -519,36 +518,24 @@ describe('ActionOverviewDiagram', () => {
             expect(layer!.querySelector('.nad-overloaded')).not.toBeNull();
         });
 
-        it('places the highlight layer NEXT TO (not inside) the dim layer', () => {
+        it('highlight and pin layers are direct children of the SVG', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
-            const dim = svg.querySelector(':scope > g.nad-overview-dim-layer');
             const highlightLayer = svg.querySelector(':scope > g.nad-overview-highlight-layer');
-            expect(dim).not.toBeNull();
+            const pinLayer = svg.querySelector(':scope > g.nad-action-overview-pins');
             expect(highlightLayer).not.toBeNull();
-            // Highlight layer must NOT be a descendant of the dim
-            // group — otherwise its halos would inherit the 0.35
-            // opacity and become invisible.
-            expect(dim!.contains(highlightLayer!)).toBe(false);
+            expect(pinLayer).not.toBeNull();
         });
 
-        it('places the highlight layer BEFORE the dim layer in document order (background like N-1 tab)', () => {
-            // Regression guard: the highlight clones must render
-            // BEHIND the dimmed network so the halo peeks out
-            // around the line strokes, mirroring the
-            // `#nad-background-layer` placement on the N-1 tab.
+        it('places highlight layer BEFORE pins in document order', () => {
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
             const directGs = Array.from(svg.children) as Element[];
             const highlightIdx = directGs.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
-            const dimIdx = directGs.findIndex(c => c.classList.contains('nad-overview-dim-layer'));
             const pinIdx = directGs.findIndex(c => c.classList.contains('nad-action-overview-pins'));
             expect(highlightIdx).toBeGreaterThan(-1);
-            expect(dimIdx).toBeGreaterThan(-1);
             expect(pinIdx).toBeGreaterThan(-1);
-            // Order: highlights → dim → pins
-            expect(highlightIdx).toBeLessThan(dimIdx);
-            expect(dimIdx).toBeLessThan(pinIdx);
+            expect(highlightIdx).toBeLessThan(pinIdx);
         });
 
         it('refreshes highlights when contingency changes', () => {
@@ -566,33 +553,23 @@ describe('ActionOverviewDiagram', () => {
         });
     });
 
-    describe('dim background layer', () => {
-        it('wraps existing SVG children in a .nad-overview-dim-layer <g>', () => {
-            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
-            const dim = container.querySelector('.nad-action-overview-container svg > g.nad-overview-dim-layer');
-            expect(dim).not.toBeNull();
-            // The VL nodes group from the test fixture should now be INSIDE the dim group
-            expect(dim!.querySelector('.nad-vl-nodes')).not.toBeNull();
-        });
-
-        it('applies an opacity attribute below 1 on the dim layer', () => {
-            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
-            const dim = container.querySelector('g.nad-overview-dim-layer');
-            expect(dim).not.toBeNull();
-            const opacity = parseFloat(dim!.getAttribute('opacity') || '1');
-            expect(opacity).toBeGreaterThan(0);
-            expect(opacity).toBeLessThan(1);
-        });
-
-        it('pin layer is a SIBLING of the dim layer (full opacity on top)', () => {
+    describe('dim background (CSS class, no opacity group)', () => {
+        it('applies nad-overview-dimmed class instead of wrapping in an opacity group', () => {
+            // The old <g opacity="0.35"> wrapper created an SVG
+            // transparency group that caused a 31s Layerize on large
+            // grids.  Now we use a CSS class instead.
             const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
             const svg = container.querySelector('.nad-action-overview-container svg')!;
-            const dim = svg.querySelector(':scope > g.nad-overview-dim-layer');
+            expect(svg.classList.contains('nad-overview-dimmed')).toBe(true);
+            // No <g> opacity wrapper should exist.
+            expect(svg.querySelector('g.nad-overview-dim-layer')).toBeNull();
+        });
+
+        it('pin layer is a direct child of the SVG (not nested)', () => {
+            const { container } = render(<ActionOverviewDiagram {...defaultProps()} />);
+            const svg = container.querySelector('.nad-action-overview-container svg')!;
             const pinLayer = svg.querySelector(':scope > g.nad-action-overview-pins');
-            expect(dim).not.toBeNull();
             expect(pinLayer).not.toBeNull();
-            // Pin layer must NOT be inside the dim wrapper.
-            expect(dim!.contains(pinLayer!)).toBe(false);
         });
     });
 

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -1,0 +1,194 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import type { ActionDetail, DiagramData, MetadataIndex } from '../types';
+import { applyActionOverviewPins, buildActionOverviewPins } from '../utils/svgUtils';
+
+/**
+ * Action-overview diagram.
+ *
+ * When the Remedial Action tab is opened without any action card
+ * selected, this view is rendered inside that tab. It shows the
+ * N-1 NAD as an immutable background and overlays one Google-Maps
+ * style pin per prioritised action, anchored on the asset the
+ * corresponding action card highlights in its badges.
+ *
+ * Design notes:
+ *  - We deliberately do NOT reuse `actionSvgContainerRef` /
+ *    `actionPZ` from useDiagrams because those are tied to the
+ *    post-action diagram. Mixing the two would blur the
+ *    "overview vs drill-down" distinction and force us to
+ *    invalidate the action diagram state on every pin refresh.
+ *  - We DO re-use the N-1 metadata index (same positions that
+ *    drive `applyActionTargetHighlights`), so a pin and the
+ *    yellow halo for the same asset share one source of truth.
+ *  - The view is pan/zoom-less by default — the pins already
+ *    act as the overview; a user who wants to drill in clicks
+ *    a pin (or the corresponding card) and gets the detailed
+ *    action diagram that already supports zoom.
+ */
+interface ActionOverviewDiagramProps {
+    n1Diagram: DiagramData | null;
+    n1MetaIndex: MetadataIndex | null;
+    actions: Record<string, ActionDetail> | undefined;
+    monitoringFactor: number;
+    /** Invoked when a pin is clicked — wired to the existing action-select flow. */
+    onActionSelect: (actionId: string) => void;
+    visible: boolean;
+}
+
+const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
+    n1Diagram,
+    n1MetaIndex,
+    actions,
+    monitoringFactor,
+    onActionSelect,
+    visible,
+}) => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    // Build the pin list — pure, memo-able, independent from DOM.
+    const pins = useMemo(() => {
+        if (!n1MetaIndex || !actions) return [];
+        return buildActionOverviewPins(actions, n1MetaIndex, monitoringFactor);
+    }, [n1MetaIndex, actions, monitoringFactor]);
+
+    // Inject / re-inject the N-1 SVG into our own container whenever
+    // the source SVG string changes. Using innerHTML (instead of
+    // mutating the shared parsed SVG from useDiagrams) guarantees we
+    // get a standalone DOM subtree — the N-1 tab's own container is
+    // untouched and keeps its viewBox / zoom state.
+    useLayoutEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+        if (!n1Diagram?.svg) {
+            container.innerHTML = '';
+            return;
+        }
+        container.innerHTML = n1Diagram.svg;
+        const svg = container.querySelector('svg');
+        if (svg) {
+            // Make the SVG fill the container — the existing
+            // diagram SVGs embed their viewBox, so width/height
+            // 100% lets the browser handle the fit.
+            svg.setAttribute('width', '100%');
+            svg.setAttribute('height', '100%');
+            svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+            (svg as SVGSVGElement).style.width = '100%';
+            (svg as SVGSVGElement).style.height = '100%';
+        }
+    }, [n1Diagram?.svg]);
+
+    // (Re)apply pins whenever the underlying SVG or pin list changes.
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+        applyActionOverviewPins(container, pins, onActionSelect);
+    }, [pins, onActionSelect, n1Diagram?.svg]);
+
+    const hasAnyAction = !!actions && Object.keys(actions).length > 0;
+    const noBackground = !n1Diagram?.svg;
+
+    return (
+        <div
+            data-testid="action-overview-diagram"
+            style={{
+                position: 'absolute',
+                inset: 0,
+                display: visible ? 'flex' : 'none',
+                flexDirection: 'column',
+                background: 'white',
+                // Sit above the hidden MemoizedSvgContainer for
+                // actionDiagram (which stays mounted to preserve
+                // zoom state) so clicks land on the overview.
+                zIndex: 15,
+            }}
+        >
+            {/* Header strip — mirrors the severity legend used by
+                the cards so the operator understands the colour
+                encoding at a glance. */}
+            <div
+                style={{
+                    flexShrink: 0,
+                    padding: '8px 14px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: '10px',
+                    fontSize: '12px',
+                    background: '#f8fafc',
+                    borderBottom: '1px solid #e2e8f0',
+                    color: '#334155',
+                }}
+            >
+                <div style={{ fontWeight: 700 }}>
+                    {'\uD83D\uDCCD Remedial actions overview'}
+                    {hasAnyAction && (
+                        <span style={{ marginLeft: 8, fontWeight: 400, color: '#64748b' }}>
+                            {pins.length} pin{pins.length === 1 ? '' : 's'} on the N-1 network
+                        </span>
+                    )}
+                </div>
+                <div style={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+                    <Legend color="#28a745" label="Solves overload" />
+                    <Legend color="#f0ad4e" label="Low margin" />
+                    <Legend color="#dc3545" label="Still overloaded" />
+                    <Legend color="#9ca3af" label="Divergent / islanded" />
+                </div>
+            </div>
+            <div
+                ref={containerRef}
+                className="svg-container nad-action-overview-container"
+                style={{
+                    flex: 1,
+                    overflow: 'hidden',
+                    position: 'relative',
+                }}
+            />
+            {noBackground && (
+                <div style={{
+                    position: 'absolute', inset: 0, top: 40,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: '#999', fontStyle: 'italic', textAlign: 'center', padding: '40px',
+                    pointerEvents: 'none',
+                }}>
+                    Load a contingency first, then run the analysis to populate this overview.
+                </div>
+            )}
+            {!noBackground && !hasAnyAction && (
+                <div style={{
+                    position: 'absolute', inset: 0, top: 40,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    color: '#999', fontStyle: 'italic', textAlign: 'center', padding: '40px',
+                    pointerEvents: 'none',
+                }}>
+                    Run &ldquo;Analyze &amp; Suggest&rdquo; to see prioritised remedial actions as pins on the network.
+                </div>
+            )}
+        </div>
+    );
+};
+
+const Legend: React.FC<{ color: string; label: string }> = ({ color, label }) => (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <span
+            aria-hidden
+            style={{
+                display: 'inline-block',
+                width: 10,
+                height: 10,
+                borderRadius: '50%',
+                background: color,
+                border: '1px solid #1f2937',
+            }}
+        />
+        <span style={{ color: '#475569' }}>{label}</span>
+    </span>
+);
+
+export default React.memo(ActionOverviewDiagram);

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -17,6 +17,12 @@ import {
 } from '../utils/svgUtils';
 import { usePanZoom } from '../hooks/usePanZoom';
 import ActionCard from './ActionCard';
+import {
+    POPOVER_WIDTH,
+    POPOVER_MAX_HEIGHT,
+    decidePopoverPlacement,
+    computePopoverStyle,
+} from '../utils/popoverPlacement';
 
 /**
  * Action-overview diagram.
@@ -213,14 +219,29 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // anchored next to the pin in screen coordinates; double-click
     // activates the full action drill-down view (see
     // `handlePinDoubleClick`) and closes the popover.
+    //
+    // Placement is computed at click time from the pin's screen
+    // position relative to the viewport. The popover may sit
+    // ABOVE or BELOW the pin (whichever side has more room) and
+    // is horizontally aligned LEFT-of, CENTERED-on, or RIGHT-of
+    // the pin to avoid clipping at the visualisation panel
+    // edges. See `decidePopoverPlacement` for the rules.
     const [popoverPin, setPopoverPin] = useState<{
         id: string;
         screenX: number;
         screenY: number;
+        placeAbove: boolean;
+        horizontalAlign: 'start' | 'center' | 'end';
     } | null>(null);
 
     const handlePinClick = useCallback((actionId: string, screenPos: { x: number; y: number }) => {
-        setPopoverPin({ id: actionId, screenX: screenPos.x, screenY: screenPos.y });
+        const placement = decidePopoverPlacement(screenPos.x, screenPos.y);
+        setPopoverPin({
+            id: actionId,
+            screenX: screenPos.x,
+            screenY: screenPos.y,
+            ...placement,
+        });
     }, []);
 
     const handlePinDoubleClick = useCallback((actionId: string) => {
@@ -668,12 +689,12 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     ref={popoverRef}
                     data-testid="action-overview-popover"
                     data-action-id={popoverPin.id}
+                    data-place-above={popoverPin.placeAbove ? 'true' : 'false'}
+                    data-horizontal-align={popoverPin.horizontalAlign}
                     style={{
-                        position: 'fixed',
-                        left: popoverPin.screenX - 170,
-                        top: popoverPin.screenY + 24,
-                        width: 340,
-                        maxHeight: '70vh',
+                        ...computePopoverStyle(popoverPin),
+                        width: POPOVER_WIDTH,
+                        maxHeight: POPOVER_MAX_HEIGHT,
                         overflowY: 'auto',
                         background: 'white',
                         border: '1px solid #cbd5e1',

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -126,6 +126,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // here as well (moving children into a `<g>` with reduced
     // opacity) so the DOM mutation happens on the detached element
     // before it enters the live document — no forced layout.
+    /* eslint-disable react-hooks/purity -- performance.now() is side-effect-free in practice (timing only) */
     const preparedSvg = useMemo<SVGSVGElement | null>(() => {
         if (!svgString) return null;
         const start = performance.now();
@@ -191,6 +192,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         console.log(`[SVG] Action overview pre-parse took ${(performance.now() - start).toFixed(2)}ms`);
         return svg;
     }, [svgString]);
+    /* eslint-enable react-hooks/purity */
 
     const pins = useMemo(() => {
         if (!n1MetaIndex || !actions) return [];

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ActionDetail, DiagramData, MetadataIndex, ViewBox } from '../types';
 import {
+    applyActionOverviewHighlights,
     applyActionOverviewPins,
     buildActionOverviewPins,
     computeActionOverviewFitRect,
@@ -229,6 +230,20 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         onActionSelect(actionId);
     }, [onActionSelect]);
 
+    // (Re)apply contingency + overload highlights whenever the
+    // contingency or the N-1 overload set changes.  Mirrors what
+    // the N-1 tab shows so the operator keeps the same situational
+    // awareness on the overview.  The helper inserts a dedicated
+    // `.nad-overview-highlight-layer` as a sibling of the dim layer
+    // so the halos render at full opacity above the faded
+    // background but below the pin layer.
+    useEffect(() => {
+        if (!svgReady) return;
+        const container = containerRef.current;
+        if (!container) return;
+        applyActionOverviewHighlights(container, n1MetaIndex ?? null, contingency, overloadedLines);
+    }, [svgReady, svgString, n1MetaIndex, contingency, overloadedLines]);
+
     // (Re)apply pins whenever the source SVG or pin list changes.
     // Pins are appended to the SVG itself (not to the container
     // div) so the existing viewBox-based pan/zoom naturally
@@ -255,6 +270,14 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // every update: the wheel-zoom path in usePanZoom writes the
     // DOM directly (bypassing React state for perf), so a plain
     // `pz.viewBox` useEffect dep would lag behind the live drag.
+    //
+    // The rescale call is rAF-throttled because the wheel-zoom and
+    // drag-pan paths in usePanZoom mutate the viewBox on every
+    // animation frame (and sometimes more than once per frame on
+    // wheel bursts). Without throttling, large grids would call
+    // `getScreenCTM()` — a forced layout — many times per frame
+    // and freeze the page (the "Page ne répondant pas" we saw in
+    // the field). One scheduled rescale per frame is enough.
     useEffect(() => {
         if (!svgReady || !visible) return;
         const container = containerRef.current;
@@ -267,11 +290,20 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         // come up at the right size on the first paint.
         rescaleActionOverviewPins(container);
 
-        const observer = new MutationObserver(() => {
-            rescaleActionOverviewPins(container);
-        });
+        let rafId: number | null = null;
+        const scheduleRescale = () => {
+            if (rafId !== null) return;
+            rafId = requestAnimationFrame(() => {
+                rafId = null;
+                rescaleActionOverviewPins(container);
+            });
+        };
+        const observer = new MutationObserver(scheduleRescale);
         observer.observe(svg, { attributes: true, attributeFilter: ['viewBox'] });
-        return () => observer.disconnect();
+        return () => {
+            observer.disconnect();
+            if (rafId !== null) cancelAnimationFrame(rafId);
+        };
     }, [svgReady, visible, svgString, pins]);
 
     // When the view becomes visible for the first time (or again

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -25,6 +25,12 @@ import {
     computePopoverStyle,
 } from '../utils/popoverPlacement';
 
+/** Measure a named code section and log it to the console + Performance timeline. */
+const perfMeasure = (name: string, startMark: string, endMark: string) => {
+    const entry = performance.measure(name, startMark, endMark);
+    console.log(`[PERF] ${name}: ${entry.duration.toFixed(2)}ms`);
+};
+
 /**
  * Action-overview diagram.
  *
@@ -165,7 +171,11 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
 
     const pins = useMemo(() => {
         if (!n1MetaIndex || !actions) return [];
-        return buildActionOverviewPins(actions, n1MetaIndex, monitoringFactor);
+        performance.mark('aod:buildPins:start');
+        const result = buildActionOverviewPins(actions, n1MetaIndex, monitoringFactor);
+        performance.mark('aod:buildPins:end');
+        perfMeasure('aod:buildPins', 'aod:buildPins:start', 'aod:buildPins:end');
+        return result;
     }, [n1MetaIndex, actions, monitoringFactor]);
 
     // Deterministic auto-fit rectangle derived from the bounding
@@ -254,12 +264,18 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     } | null>(null);
 
     const handlePinClick = useCallback((actionId: string, screenPos: { x: number; y: number }) => {
+        performance.mark('aod:pinClick:start');
         const placement = decidePopoverPlacement(screenPos.x, screenPos.y);
         setPopoverPin({
             id: actionId,
             screenX: screenPos.x,
             screenY: screenPos.y,
             ...placement,
+        });
+        // Measure will complete after React commits the state update.
+        requestAnimationFrame(() => {
+            performance.mark('aod:pinClick:end');
+            perfMeasure('aod:pinClick', 'aod:pinClick:start', 'aod:pinClick:end');
         });
     }, []);
 
@@ -281,7 +297,10 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         if (!svgReady) return;
         const container = containerRef.current;
         if (!container) return;
+        performance.mark('aod:highlights:start');
         applyActionOverviewHighlights(container, n1MetaIndex ?? null, contingency, overloadedLines);
+        performance.mark('aod:highlights:end');
+        perfMeasure('aod:highlights', 'aod:highlights:start', 'aod:highlights:end');
     }, [svgReady, preparedSvg, n1MetaIndex, contingency, overloadedLines]);
 
     // (Re)apply pins whenever the source SVG or pin list changes.
@@ -292,7 +311,10 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         if (!svgReady) return;
         const container = containerRef.current;
         if (!container) return;
+        performance.mark('aod:applyPins:start');
         applyActionOverviewPins(container, pins, handlePinClick, handlePinDoubleClick);
+        performance.mark('aod:applyPins:end');
+        perfMeasure('aod:applyPins', 'aod:applyPins:start', 'aod:applyPins:end');
     }, [pins, handlePinClick, handlePinDoubleClick, svgReady, preparedSvg]);
 
     // Screen-constant pin compensation.
@@ -482,13 +504,20 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             style={{
                 position: 'absolute',
                 inset: 0,
-                display: visible ? 'flex' : 'none',
+                display: 'flex',
                 flexDirection: 'column',
                 background: 'white',
+                // Use visibility instead of display:none so the SVG stays
+                // painted in a cached composite layer.  Switching from
+                // visibility:hidden→visible is a composite-only operation
+                // (~1ms) whereas display:none→flex forces a full re-layout
+                // and re-paint of all ~11k SVG elements (~11s on large grids).
+                visibility: visible ? 'visible' : 'hidden',
+                pointerEvents: visible ? 'auto' : 'none',
                 // Sit above the hidden MemoizedSvgContainer for
                 // actionDiagram (which stays mounted to preserve
                 // zoom state) so clicks land on the overview.
-                zIndex: 15,
+                zIndex: visible ? 15 : -1,
             }}
         >
             {/* Header strip — title + severity legend, mirrors the

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -12,6 +12,7 @@ import {
     buildActionOverviewPins,
     computeActionOverviewFitRect,
     computeEquipmentFitRect,
+    rescaleActionOverviewPins,
 } from '../utils/svgUtils';
 import { usePanZoom } from '../hooks/usePanZoom';
 
@@ -172,6 +173,40 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         if (!container) return;
         applyActionOverviewPins(container, pins, onActionSelect);
     }, [pins, onActionSelect, svgReady, svgString]);
+
+    // Screen-constant pin compensation.
+    //
+    // The pin glyph is drawn in SVG-space at a base radius equal to
+    // the voltage-level circle radius (so at normal zoom they match
+    // the VL glyphs). As the operator zooms OUT, the SVG units map
+    // to fewer screen pixels and the pins would become tiny dots on
+    // large grids. To fight that we upscale the pin body in
+    // SVG-space whenever the viewBox changes — same spirit as the
+    // non-scaling-stroke trick used on overload / contingency
+    // circle halos in App.css.
+    //
+    // A MutationObserver on the svg's `viewBox` attribute catches
+    // every update: the wheel-zoom path in usePanZoom writes the
+    // DOM directly (bypassing React state for perf), so a plain
+    // `pz.viewBox` useEffect dep would lag behind the live drag.
+    useEffect(() => {
+        if (!svgReady || !visible) return;
+        const container = containerRef.current;
+        if (!container) return;
+        const svg = container.querySelector('svg');
+        if (!svg) return;
+
+        // Initial compensation — pins are already mounted by the
+        // applyActionOverviewPins effect above; make sure they
+        // come up at the right size on the first paint.
+        rescaleActionOverviewPins(container);
+
+        const observer = new MutationObserver(() => {
+            rescaleActionOverviewPins(container);
+        });
+        observer.observe(svg, { attributes: true, attributeFilter: ['viewBox'] });
+        return () => observer.disconnect();
+    }, [svgReady, visible, svgString, pins]);
 
     // When the view becomes visible for the first time (or again
     // after a round-trip through an action drill-down), re-assert

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -149,6 +149,19 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // doesn't steal wheel events from other tabs.
     const pz = usePanZoom(containerRef, initialViewBox, visible && svgReady);
 
+    // Asset-focus "consume once" tracking — declared up here so
+    // `handleReset` (defined just below) can clear it.
+    //
+    // Mirrors the pattern used by `useDiagrams` for the main
+    // inspect field (see `lastZoomState` and the auto-zoom
+    // effect around useDiagrams.ts:787): only apply the zoom
+    // when the resolved query TRANSITIONS to a new value. If we
+    // re-ran the zoom on every dependency change (e.g. every
+    // time `pz.viewBox` updates on wheel-zoom), the user would
+    // get yanked back onto the asset the moment they try to
+    // zoom out — the "sticking" bug.
+    const lastFocusedRef = useRef<string | null>(null);
+
     // (Re)apply pins whenever the source SVG or pin list changes.
     // Pins are appended to the SVG itself (not to the container
     // div) so the existing viewBox-based pan/zoom naturally
@@ -186,6 +199,11 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
 
     const handleReset = useCallback(() => {
         if (initialViewBox) pz.setViewBox(initialViewBox);
+        // Clearing here ensures that re-typing the same asset id
+        // after a reset will focus it again — without this the
+        // consume-once guard would treat the effect re-run as
+        // "nothing changed" and silently skip the zoom.
+        lastFocusedRef.current = null;
     }, [initialViewBox, pz]);
 
     // ----- Inspect / asset-focus search -----
@@ -208,17 +226,37 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         return inspectableItems.find(item => item.toUpperCase() === q) ?? null;
     }, [inspectQuery, inspectableItems]);
 
+    useEffect(() => {
+        if (!svgReady || !visible || !n1MetaIndex) return;
+        // Nothing changed — bail out. This is the guard that
+        // suppresses re-zooming when the effect re-runs because
+        // `pz.viewBox` (and therefore the `pz` object) changed
+        // during a user-initiated pan/zoom.
+        if (exactInspectMatch === lastFocusedRef.current) return;
+
+        if (exactInspectMatch) {
+            // Consume the new query — zoom onto the asset.
+            const target = computeEquipmentFitRect(n1MetaIndex, exactInspectMatch);
+            if (target) pz.setViewBox(target);
+        } else if (lastFocusedRef.current && initialViewBox) {
+            // Query cleared (or no longer an exact match): go
+            // back to the auto-fit rectangle so the user sees
+            // the whole network-plus-pins again.
+            pz.setViewBox(initialViewBox);
+        }
+        lastFocusedRef.current = exactInspectMatch;
+    }, [exactInspectMatch, svgReady, visible, n1MetaIndex, pz, initialViewBox]);
+
+    // Imperative zoom helper used by the suggestions dropdown —
+    // committing the query through state triggers the effect
+    // above, but the dropdown also commits the text value so
+    // the click feels instantaneous without waiting for the
+    // next effect tick.
     const focusEquipment = useCallback((equipmentId: string) => {
         const target = computeEquipmentFitRect(n1MetaIndex, equipmentId);
-        if (target) {
-            pz.setViewBox(target);
-        }
+        if (target) pz.setViewBox(target);
+        lastFocusedRef.current = equipmentId;
     }, [n1MetaIndex, pz]);
-
-    useEffect(() => {
-        if (!exactInspectMatch) return;
-        focusEquipment(exactInspectMatch);
-    }, [exactInspectMatch, focusEquipment]);
 
     const hasAnyAction = !!actions && Object.keys(actions).length > 0;
     const noBackground = !n1Diagram?.svg;
@@ -465,7 +503,6 @@ const Legend: React.FC<{ color: string; label: string }> = ({ color, label }) =>
                 height: 10,
                 borderRadius: '50%',
                 background: color,
-                border: '1px solid #1f2937',
             }}
         />
         <span style={{ color: '#475569' }}>{label}</span>

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -15,6 +15,7 @@ import {
     rescaleActionOverviewPins,
 } from '../utils/svgUtils';
 import { usePanZoom } from '../hooks/usePanZoom';
+import ActionCard from './ActionCard';
 
 /**
  * Action-overview diagram.
@@ -42,8 +43,21 @@ interface ActionOverviewDiagramProps {
     n1MetaIndex: MetadataIndex | null;
     actions: Record<string, ActionDetail> | undefined;
     monitoringFactor: number;
-    /** Invoked when a pin is clicked — wired to the existing action-select flow. */
+    /**
+     * Called with a pin id on a DOUBLE click — this is the
+     * "activate the action drill-down view" path. The parent
+     * wires it to the existing action-select flow so the action
+     * network diagram replaces the overview in the tab.
+     */
     onActionSelect: (actionId: string) => void;
+    /** Toggle the favourite status of an action (popover action). */
+    onActionFavorite?: (actionId: string) => void;
+    /** Reject an action (popover action). */
+    onActionReject?: (actionId: string) => void;
+    /** Selected-action set, for the popover's `isSelected` styling. */
+    selectedActionIds?: Set<string>;
+    /** Rejected-action set, for the popover's `isRejected` styling. */
+    rejectedActionIds?: Set<string>;
     /** Current contingency (selected branch) — included in the auto-fit rectangle. */
     contingency: string | null;
     /** Overloaded lines in the N-1 state — included in the auto-fit rectangle. */
@@ -52,6 +66,13 @@ interface ActionOverviewDiagramProps {
     inspectableItems: readonly string[];
     visible: boolean;
 }
+
+/**
+ * Opacity applied to the wrapped NAD background so the pin layer
+ * on top reads with high visual contrast. Chosen low enough to
+ * make pins pop without completely hiding the network topology.
+ */
+const DIM_BACKGROUND_OPACITY = '0.35';
 
 const ZOOM_STEP_IN = 0.8;
 const ZOOM_STEP_OUT = 1.25;
@@ -69,6 +90,10 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     actions,
     monitoringFactor,
     onActionSelect,
+    onActionFavorite,
+    onActionReject,
+    selectedActionIds,
+    rejectedActionIds,
     contingency,
     overloadedLines,
     inspectableItems,
@@ -123,6 +148,14 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // DECLARED BEFORE `usePanZoom` so React runs this layout
     // effect first and the hook can cache its svgElRef against the
     // freshly-injected element.
+    //
+    // As part of the injection we WRAP every existing top-level
+    // child of the SVG in a dedicated `.nad-overview-dim-layer`
+    // `<g>` with opacity set to DIM_BACKGROUND_OPACITY. The pin
+    // layer, added later by `applyActionOverviewPins`, is
+    // appended as a SIBLING of that group so it renders at full
+    // opacity on top of the faded network — maximising pin
+    // visibility without hiding the grid topology entirely.
     useLayoutEffect(() => {
         const container = containerRef.current;
         if (!container) return;
@@ -142,6 +175,17 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
             (svg as SVGSVGElement).style.width = '100%';
             (svg as SVGSVGElement).style.height = '100%';
+
+            // Wrap existing children in a dim layer.
+            const existingChildren = Array.from(svg.childNodes);
+            if (existingChildren.length > 0) {
+                const SVG_NS = 'http://www.w3.org/2000/svg';
+                const dimGroup = document.createElementNS(SVG_NS, 'g');
+                dimGroup.setAttribute('class', 'nad-overview-dim-layer');
+                dimGroup.setAttribute('opacity', DIM_BACKGROUND_OPACITY);
+                existingChildren.forEach(c => dimGroup.appendChild(c));
+                svg.appendChild(dimGroup);
+            }
         }
     }, [svgString]);
 
@@ -163,6 +207,28 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // zoom out — the "sticking" bug.
     const lastFocusedRef = useRef<string | null>(null);
 
+    // ----- Click popover -----
+    // Single-click on a pin opens a floating ActionCard popover
+    // anchored next to the pin in screen coordinates; double-click
+    // activates the full action drill-down view (see
+    // `handlePinDoubleClick`) and closes the popover.
+    const [popoverPin, setPopoverPin] = useState<{
+        id: string;
+        screenX: number;
+        screenY: number;
+    } | null>(null);
+
+    const handlePinClick = useCallback((actionId: string, screenPos: { x: number; y: number }) => {
+        setPopoverPin({ id: actionId, screenX: screenPos.x, screenY: screenPos.y });
+    }, []);
+
+    const handlePinDoubleClick = useCallback((actionId: string) => {
+        // Make sure no stale popover is left behind on the way
+        // into the drill-down view.
+        setPopoverPin(null);
+        onActionSelect(actionId);
+    }, [onActionSelect]);
+
     // (Re)apply pins whenever the source SVG or pin list changes.
     // Pins are appended to the SVG itself (not to the container
     // div) so the existing viewBox-based pan/zoom naturally
@@ -171,8 +237,8 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         if (!svgReady) return;
         const container = containerRef.current;
         if (!container) return;
-        applyActionOverviewPins(container, pins, onActionSelect);
-    }, [pins, onActionSelect, svgReady, svgString]);
+        applyActionOverviewPins(container, pins, handlePinClick, handlePinDoubleClick);
+    }, [pins, handlePinClick, handlePinDoubleClick, svgReady, svgString]);
 
     // Screen-constant pin compensation.
     //
@@ -295,6 +361,45 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
 
     const hasAnyAction = !!actions && Object.keys(actions).length > 0;
     const noBackground = !n1Diagram?.svg;
+
+    // ----- Popover dismissal -----
+    // Close on Escape, on outside-click, or when visibility is
+    // toggled away (e.g. the user switched tabs).
+    const popoverRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+        if (!popoverPin) return;
+        const onDocMouseDown = (e: MouseEvent) => {
+            const target = e.target as Node | null;
+            if (popoverRef.current && target && popoverRef.current.contains(target)) return;
+            // Also ignore clicks on any pin — the pin's own click
+            // handler owns the popover-state update and would
+            // otherwise race with this listener.
+            if (target instanceof Element && target.closest('.nad-action-overview-pin')) return;
+            setPopoverPin(null);
+        };
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setPopoverPin(null);
+        };
+        document.addEventListener('mousedown', onDocMouseDown);
+        document.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('mousedown', onDocMouseDown);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [popoverPin]);
+
+    // Pre-compute the props ActionCard needs for the popover render.
+    const popoverDetails = popoverPin && actions ? actions[popoverPin.id] : null;
+    const popoverIndex = useMemo(() => {
+        if (!popoverPin || !actions) return 0;
+        const keys = Object.keys(actions);
+        const idx = keys.indexOf(popoverPin.id);
+        return idx < 0 ? 0 : idx;
+    }, [popoverPin, actions]);
+    // Stubs for ActionCard callbacks we don't need in the popover
+    // (re-simulate inputs, asset-click-to-zoom, etc.). Kept stable
+    // via useCallback so ActionCard's React.memo can skip re-renders.
+    const noopActionCardCb = useCallback(() => { /* intentional no-op */ }, []);
     const showInspectDropdown = inspectFocused
         && inspectQuery.length > 0
         && filteredInspectables.length > 0
@@ -510,6 +615,101 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     pointerEvents: 'none',
                 }}>
                     Run &ldquo;Analyze &amp; Suggest&rdquo; to see prioritised remedial actions as pins on the network.
+                </div>
+            )}
+
+            {/*
+              Click popover.
+              - Position is fixed (not absolute) because the
+                click handler captured screen-space coordinates
+                at click time, and we want the popover to land
+                exactly next to the pin the operator clicked.
+              - `portaled` via React means the popover sits in
+                the same React tree as the overview, so React
+                owns its lifecycle and we don't need a separate
+                reconciliation root.
+              - Outside clicks, Escape, and popover close button
+                all dismiss it via setPopoverPin(null).
+            */}
+            {visible && popoverPin && popoverDetails && (
+                <div
+                    ref={popoverRef}
+                    data-testid="action-overview-popover"
+                    data-action-id={popoverPin.id}
+                    style={{
+                        position: 'fixed',
+                        left: popoverPin.screenX - 170,
+                        top: popoverPin.screenY + 24,
+                        width: 340,
+                        maxHeight: '70vh',
+                        overflowY: 'auto',
+                        background: 'white',
+                        border: '1px solid #cbd5e1',
+                        borderRadius: 8,
+                        boxShadow: '0 10px 24px rgba(0, 0, 0, 0.25)',
+                        zIndex: 300,
+                    }}
+                    onMouseDown={e => e.stopPropagation()}
+                >
+                    {/* Close control — mirrors the ✕ shape used by
+                        other floating panels (SLD overlay, confirm
+                        dialogs). */}
+                    <button
+                        data-testid="action-overview-popover-close"
+                        onClick={() => setPopoverPin(null)}
+                        title="Close"
+                        style={{
+                            position: 'absolute',
+                            top: 6,
+                            right: 8,
+                            zIndex: 2,
+                            background: 'white',
+                            border: '1px solid #cbd5e1',
+                            borderRadius: '50%',
+                            width: 22,
+                            height: 22,
+                            cursor: 'pointer',
+                            fontSize: 12,
+                            color: '#475569',
+                            boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+                            lineHeight: 1,
+                        }}
+                    >
+                        {'\u2715'}
+                    </button>
+                    <ActionCard
+                        id={popoverPin.id}
+                        details={popoverDetails}
+                        index={popoverIndex}
+                        isViewing={false}
+                        isSelected={selectedActionIds?.has(popoverPin.id) ?? false}
+                        isRejected={rejectedActionIds?.has(popoverPin.id) ?? false}
+                        linesOverloaded={Array.from(overloadedLines)}
+                        monitoringFactor={monitoringFactor}
+                        nodesByEquipmentId={n1MetaIndex?.nodesByEquipmentId ?? null}
+                        edgesByEquipmentId={n1MetaIndex?.edgesByEquipmentId ?? null}
+                        cardEditMw={{}}
+                        cardEditTap={{}}
+                        resimulating={null}
+                        // Clicking the card body activates the
+                        // full action drill-down view — same
+                        // effect as a double-click on the pin.
+                        onActionSelect={(id) => {
+                            setPopoverPin(null);
+                            if (id) onActionSelect(id);
+                        }}
+                        onActionFavorite={onActionFavorite ?? noopActionCardCb}
+                        onActionReject={onActionReject ?? noopActionCardCb}
+                        // Asset-click from the popover badges does
+                        // not zoom the overview diagram — kept as
+                        // a no-op to avoid surprising the operator
+                        // while the popover is open.
+                        onAssetClick={noopActionCardCb}
+                        onCardEditMwChange={noopActionCardCb}
+                        onCardEditTapChange={noopActionCardCb}
+                        onResimulate={noopActionCardCb}
+                        onResimulateTap={noopActionCardCb}
+                    />
                 </div>
             )}
         </div>

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -13,6 +13,7 @@ import {
     buildActionOverviewPins,
     computeActionOverviewFitRect,
     computeEquipmentFitRect,
+    invalidateIdMapCache,
     rescaleActionOverviewPins,
 } from '../utils/svgUtils';
 import { usePanZoom } from '../hooks/usePanZoom';
@@ -119,6 +120,49 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // svgElRef). Once the string is in hand the svg IS in the DOM.
     const svgReady = svgString != null;
 
+    // Pre-parse the SVG string into an SVGSVGElement so the layout
+    // effect below can inject it with `replaceChildren()` — zero
+    // extra parse, matching the MemoizedSvgContainer optimisation
+    // used by the N and N-1 tabs.  The dim-layer wrapping is done
+    // here as well (moving children into a `<g>` with reduced
+    // opacity) so the DOM mutation happens on the detached element
+    // before it enters the live document — no forced layout.
+    const preparedSvg = useMemo<SVGSVGElement | null>(() => {
+        if (!svgString) return null;
+        const start = performance.now();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(svgString, 'image/svg+xml');
+        const svg = doc.documentElement as unknown as SVGSVGElement;
+        if (!svg || svg.nodeName !== 'svg') return null;
+
+        // Style the root so it fills the container; viewBox is the
+        // only thing usePanZoom manipulates.
+        svg.setAttribute('width', '100%');
+        svg.setAttribute('height', '100%');
+        svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+        // Guard: jsdom's DOMParser returns XML documents whose
+        // elements lack a `.style` property; real browsers always
+        // have it.
+        if (svg.style) {
+            svg.style.width = '100%';
+            svg.style.height = '100%';
+        }
+
+        // Wrap existing children in a dim layer (done off-DOM — no
+        // forced layout).
+        const existingChildren = Array.from(svg.childNodes);
+        if (existingChildren.length > 0) {
+            const SVG_NS = 'http://www.w3.org/2000/svg';
+            const dimGroup = document.createElementNS(SVG_NS, 'g');
+            dimGroup.setAttribute('class', 'nad-overview-dim-layer');
+            dimGroup.setAttribute('opacity', DIM_BACKGROUND_OPACITY);
+            existingChildren.forEach(c => dimGroup.appendChild(c));
+            svg.appendChild(dimGroup);
+        }
+        console.log(`[SVG] Action overview pre-parse took ${(performance.now() - start).toFixed(2)}ms`);
+        return svg;
+    }, [svgString]);
+
     const pins = useMemo(() => {
         if (!n1MetaIndex || !actions) return [];
         return buildActionOverviewPins(actions, n1MetaIndex, monitoringFactor);
@@ -147,54 +191,29 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         return { x: parts[0], y: parts[1], w: parts[2], h: parts[3] };
     }, [fitRect, svgString]);
 
-    // Inject (or re-inject) the N-1 SVG into our own container.
-    // Using innerHTML is intentional: we want a standalone DOM
-    // subtree so nothing clashes with the main-window pan/zoom
-    // infra that drives the N-1 and action-variant tabs.
+    // Inject the pre-parsed SVGSVGElement into the container using
+    // `replaceChildren()` — zero extra parse, matching the
+    // MemoizedSvgContainer optimisation used by the N/N-1 tabs.
     //
     // DECLARED BEFORE `usePanZoom` so React runs this layout
     // effect first and the hook can cache its svgElRef against the
     // freshly-injected element.
     //
-    // As part of the injection we WRAP every existing top-level
-    // child of the SVG in a dedicated `.nad-overview-dim-layer`
-    // `<g>` with opacity set to DIM_BACKGROUND_OPACITY. The pin
-    // layer, added later by `applyActionOverviewPins`, is
-    // appended as a SIBLING of that group so it renders at full
-    // opacity on top of the faded network — maximising pin
-    // visibility without hiding the grid topology entirely.
+    // The dim-layer wrapping has already been done in `preparedSvg`
+    // (off-DOM), so this effect only moves the ready element in.
     useLayoutEffect(() => {
         const container = containerRef.current;
         if (!container) return;
-        if (!svgString) {
-            container.innerHTML = '';
+        if (!preparedSvg) {
+            container.replaceChildren();
             return;
         }
-        container.innerHTML = svgString;
-        const svg = container.querySelector('svg');
-        if (svg) {
-            // Let the SVG fill the container. The viewBox is the
-            // only thing usePanZoom manipulates, so width/height
-            // 100% gives a stable mapping from SVG coords to
-            // screen coords.
-            svg.setAttribute('width', '100%');
-            svg.setAttribute('height', '100%');
-            svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-            (svg as SVGSVGElement).style.width = '100%';
-            (svg as SVGSVGElement).style.height = '100%';
-
-            // Wrap existing children in a dim layer.
-            const existingChildren = Array.from(svg.childNodes);
-            if (existingChildren.length > 0) {
-                const SVG_NS = 'http://www.w3.org/2000/svg';
-                const dimGroup = document.createElementNS(SVG_NS, 'g');
-                dimGroup.setAttribute('class', 'nad-overview-dim-layer');
-                dimGroup.setAttribute('opacity', DIM_BACKGROUND_OPACITY);
-                existingChildren.forEach(c => dimGroup.appendChild(c));
-                svg.appendChild(dimGroup);
-            }
-        }
-    }, [svgString]);
+        const start = performance.now();
+        container.replaceChildren(preparedSvg);
+        // The id-map cache from a previous SVG is now stale.
+        invalidateIdMapCache(container);
+        console.log(`[SVG] Action overview replaceChildren took ${(performance.now() - start).toFixed(2)}ms`);
+    }, [preparedSvg]);
 
     // The hook handles wheel-zoom and drag-pan on the container.
     // `active` gates the event listeners so an invisible overview
@@ -263,7 +282,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         const container = containerRef.current;
         if (!container) return;
         applyActionOverviewHighlights(container, n1MetaIndex ?? null, contingency, overloadedLines);
-    }, [svgReady, svgString, n1MetaIndex, contingency, overloadedLines]);
+    }, [svgReady, preparedSvg, n1MetaIndex, contingency, overloadedLines]);
 
     // (Re)apply pins whenever the source SVG or pin list changes.
     // Pins are appended to the SVG itself (not to the container
@@ -274,7 +293,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         const container = containerRef.current;
         if (!container) return;
         applyActionOverviewPins(container, pins, handlePinClick, handlePinDoubleClick);
-    }, [pins, handlePinClick, handlePinDoubleClick, svgReady, svgString]);
+    }, [pins, handlePinClick, handlePinDoubleClick, svgReady, preparedSvg]);
 
     // Screen-constant pin compensation.
     //
@@ -325,7 +344,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             observer.disconnect();
             if (rafId !== null) cancelAnimationFrame(rafId);
         };
-    }, [svgReady, visible, svgString, pins]);
+    }, [svgReady, visible, preparedSvg, pins]);
 
     // When the view becomes visible for the first time (or again
     // after a round-trip through an action drill-down), re-assert

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -16,7 +16,7 @@ import {
     rescaleActionOverviewPins,
 } from '../utils/svgUtils';
 import { usePanZoom } from '../hooks/usePanZoom';
-import ActionCard from './ActionCard';
+import ActionCardPopover from './ActionCardPopover';
 import {
     POPOVER_WIDTH,
     POPOVER_MAX_HEIGHT,
@@ -449,10 +449,9 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         const idx = keys.indexOf(popoverPin.id);
         return idx < 0 ? 0 : idx;
     }, [popoverPin, actions]);
-    // Stubs for ActionCard callbacks we don't need in the popover
-    // (re-simulate inputs, asset-click-to-zoom, etc.). Kept stable
-    // via useCallback so ActionCard's React.memo can skip re-renders.
-    const noopActionCardCb = useCallback(() => { /* intentional no-op */ }, []);
+    // ActionCardPopover wraps the no-op stubs for the
+    // re-simulate / asset-click callbacks internally — we only
+    // need to pass the minimal set of handlers below.
     const showInspectDropdown = inspectFocused
         && inspectQuery.length > 0
         && filteredInspectables.length > 0
@@ -684,86 +683,46 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
               - Outside clicks, Escape, and popover close button
                 all dismiss it via setPopoverPin(null).
             */}
+            {/*
+              Popover.
+              The ActionCard rendered inside the popover is the
+              EXACT SAME `ActionCard` component the sidebar feed
+              uses — both callsites import from the same module.
+              The `ActionCardPopover` wrapper handles the floating
+              chrome (position, close button, shadow) and forwards
+              the minimal set of callbacks this preview view
+              needs, so when we add or rename a field on
+              `ActionCard` we only need to update the feed's
+              render call and the popover wrapper — never
+              two parallel implementations.
+            */}
             {visible && popoverPin && popoverDetails && (
-                <div
-                    ref={popoverRef}
-                    data-testid="action-overview-popover"
-                    data-action-id={popoverPin.id}
-                    data-place-above={popoverPin.placeAbove ? 'true' : 'false'}
-                    data-horizontal-align={popoverPin.horizontalAlign}
+                <ActionCardPopover
+                    popoverRef={popoverRef}
+                    testId="action-overview-popover"
+                    extraDataAttributes={{
+                        'data-place-above': popoverPin.placeAbove ? 'true' : 'false',
+                        'data-horizontal-align': popoverPin.horizontalAlign,
+                    }}
+                    actionId={popoverPin.id}
+                    details={popoverDetails}
+                    index={popoverIndex}
                     style={{
                         ...computePopoverStyle(popoverPin),
                         width: POPOVER_WIDTH,
                         maxHeight: POPOVER_MAX_HEIGHT,
                         overflowY: 'auto',
-                        background: 'white',
-                        border: '1px solid #cbd5e1',
-                        borderRadius: 8,
-                        boxShadow: '0 10px 24px rgba(0, 0, 0, 0.25)',
-                        zIndex: 300,
                     }}
-                    onMouseDown={e => e.stopPropagation()}
-                >
-                    {/* Close control — mirrors the ✕ shape used by
-                        other floating panels (SLD overlay, confirm
-                        dialogs). */}
-                    <button
-                        data-testid="action-overview-popover-close"
-                        onClick={() => setPopoverPin(null)}
-                        title="Close"
-                        style={{
-                            position: 'absolute',
-                            top: 6,
-                            right: 8,
-                            zIndex: 2,
-                            background: 'white',
-                            border: '1px solid #cbd5e1',
-                            borderRadius: '50%',
-                            width: 22,
-                            height: 22,
-                            cursor: 'pointer',
-                            fontSize: 12,
-                            color: '#475569',
-                            boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
-                            lineHeight: 1,
-                        }}
-                    >
-                        {'\u2715'}
-                    </button>
-                    <ActionCard
-                        id={popoverPin.id}
-                        details={popoverDetails}
-                        index={popoverIndex}
-                        isViewing={false}
-                        isSelected={selectedActionIds?.has(popoverPin.id) ?? false}
-                        isRejected={rejectedActionIds?.has(popoverPin.id) ?? false}
-                        linesOverloaded={Array.from(overloadedLines)}
-                        monitoringFactor={monitoringFactor}
-                        nodesByEquipmentId={n1MetaIndex?.nodesByEquipmentId ?? null}
-                        edgesByEquipmentId={n1MetaIndex?.edgesByEquipmentId ?? null}
-                        cardEditMw={{}}
-                        cardEditTap={{}}
-                        resimulating={null}
-                        // Clicking the card body activates the
-                        // full action drill-down view — same
-                        // effect as a double-click on the pin.
-                        onActionSelect={(id) => {
-                            setPopoverPin(null);
-                            if (id) onActionSelect(id);
-                        }}
-                        onActionFavorite={onActionFavorite ?? noopActionCardCb}
-                        onActionReject={onActionReject ?? noopActionCardCb}
-                        // Asset-click from the popover badges does
-                        // not zoom the overview diagram — kept as
-                        // a no-op to avoid surprising the operator
-                        // while the popover is open.
-                        onAssetClick={noopActionCardCb}
-                        onCardEditMwChange={noopActionCardCb}
-                        onCardEditTapChange={noopActionCardCb}
-                        onResimulate={noopActionCardCb}
-                        onResimulateTap={noopActionCardCb}
-                    />
-                </div>
+                    linesOverloaded={overloadedLines}
+                    monitoringFactor={monitoringFactor}
+                    metaIndex={n1MetaIndex ?? null}
+                    selectedActionIds={selectedActionIds}
+                    rejectedActionIds={rejectedActionIds}
+                    onActivateAction={onActionSelect}
+                    onActionFavorite={onActionFavorite}
+                    onActionReject={onActionReject}
+                    onClose={() => setPopoverPin(null)}
+                />
             )}
         </div>
     );

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -157,9 +157,10 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
         // each child individually (~25-31s on large grids).
         //
         // Visual stack (back to front):
-        //   1. original NAD content (full opacity)
-        //   2. white rect overlay (opacity 0.65 → dims to ~35% visible)
-        //   3. highlight layer (inserted later by applyActionOverviewHighlights)
+        //   1. highlight layer (inserted later by applyActionOverviewHighlights
+        //      at SVG start — behind NAD, matching N-1 tab behaviour)
+        //   2. original NAD content (full opacity)
+        //   3. white rect overlay (opacity 0.65 → dims NAD + highlights)
         //   4. pin layer (inserted later by applyActionOverviewPins)
         const SVG_NS = 'http://www.w3.org/2000/svg';
         const vb = svg.getAttribute('viewBox');
@@ -185,7 +186,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             }
         }
         // Mark the SVG so highlight/pin insertion code knows the
-        // dimming rect is present and can insert AFTER it.
+        // dimming rect is present.
         svg.classList.add('nad-overview-dimmed');
         console.log(`[SVG] Action overview pre-parse took ${(performance.now() - start).toFixed(2)}ms`);
         return svg;
@@ -312,9 +313,9 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // contingency or the N-1 overload set changes.  Mirrors what
     // the N-1 tab shows so the operator keeps the same situational
     // awareness on the overview.  The helper inserts a dedicated
-    // `.nad-overview-highlight-layer` as a sibling of the dim layer
-    // so the halos render at full opacity above the faded
-    // background but below the pin layer.
+    // `.nad-overview-highlight-layer` at the START of the SVG so
+    // the halos render behind the NAD content, matching the N-1
+    // tab's getBackgroundLayer() pattern.
     useEffect(() => {
         if (!svgReady) return;
         const container = containerRef.current;

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -81,13 +81,6 @@ interface ActionOverviewDiagramProps {
     visible: boolean;
 }
 
-/**
- * Opacity applied to the wrapped NAD background so the pin layer
- * on top reads with high visual contrast. Chosen low enough to
- * make pins pop without completely hiding the network topology.
- */
-const DIM_BACKGROUND_OPACITY = '0.35';
-
 const ZOOM_STEP_IN = 0.8;
 const ZOOM_STEP_OUT = 1.25;
 
@@ -154,14 +147,45 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             svg.style.height = '100%';
         }
 
-        // Dim the network background by applying a CSS class instead
-        // of wrapping in a <g opacity="0.35">.  The SVG `opacity`
-        // attribute creates a transparency group that forces Chrome
-        // to rasterize all ~43k children into an intermediate buffer
-        // before compositing — the "Layerize" step takes ~31s on
-        // large grids.  Using a CSS class avoids that by letting the
-        // browser apply the dimming as a simple style on each child
-        // without creating a stacking context.
+        // Dim the network background by inserting a semi-transparent
+        // white <rect> that covers the entire viewBox, placed AFTER
+        // all the original NAD content.  This dims everything behind
+        // it without applying `opacity` to any child element — which
+        // avoids creating stacking contexts (CSS per-child opacity)
+        // or SVG transparency groups (SVG opacity attribute on <g>),
+        // both of which force Chrome's Layerize step to composite
+        // each child individually (~25-31s on large grids).
+        //
+        // Visual stack (back to front):
+        //   1. original NAD content (full opacity)
+        //   2. white rect overlay (opacity 0.65 → dims to ~35% visible)
+        //   3. highlight layer (inserted later by applyActionOverviewHighlights)
+        //   4. pin layer (inserted later by applyActionOverviewPins)
+        const SVG_NS = 'http://www.w3.org/2000/svg';
+        const vb = svg.getAttribute('viewBox');
+        if (vb) {
+            const parts = vb.split(/[\s,]+/).map(Number);
+            if (parts.length === 4) {
+                const dimRect = document.createElementNS(SVG_NS, 'rect');
+                dimRect.setAttribute('class', 'nad-overview-dim-rect');
+                // Extend 10% beyond viewBox on each side to cover any
+                // pan-zoom overshoot — the rect is cheap, and gaps at
+                // the edges look ugly.
+                const margin = Math.max(parts[2], parts[3]) * 0.1;
+                dimRect.setAttribute('x', String(parts[0] - margin));
+                dimRect.setAttribute('y', String(parts[1] - margin));
+                dimRect.setAttribute('width', String(parts[2] + 2 * margin));
+                dimRect.setAttribute('height', String(parts[3] + 2 * margin));
+                dimRect.setAttribute('fill', 'white');
+                dimRect.setAttribute('opacity', '0.65');
+                // pointer-events: none so clicks pass through to
+                // highlights/pins above OR the NAD content below.
+                dimRect.setAttribute('pointer-events', 'none');
+                svg.appendChild(dimRect);
+            }
+        }
+        // Mark the SVG so highlight/pin insertion code knows the
+        // dimming rect is present and can insert AFTER it.
         svg.classList.add('nad-overview-dimmed');
         console.log(`[SVG] Action overview pre-parse took ${(performance.now() - start).toFixed(2)}ms`);
         return svg;

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -114,15 +114,6 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     visible,
 }) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
-
-    // Track whether the component has been shown at least once.
-    // Before the first show we use `display: none` (zero rendering
-    // cost).  After that we switch to `visibility: hidden` so the
-    // SVG stays in its composite layer and subsequent tab-switches
-    // are instant (~1ms compositor-only vs ~11s full repaint).
-    const hasBeenVisibleRef = useRef(false);
-    if (visible) hasBeenVisibleRef.current = true;
-
     // Pull the svg string into a local so the React Compiler can
     // see that both the injection effect and the initialViewBox memo
     // depend on the same primitive, not on the full `n1Diagram`
@@ -513,20 +504,13 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             style={{
                 position: 'absolute',
                 inset: 0,
+                display: visible ? 'flex' : 'none',
                 flexDirection: 'column',
                 background: 'white',
-                // Before the first show: display:none → zero cost.
-                // After the first show: visibility:hidden keeps the SVG
-                // painted in its composite layer so re-showing is a
-                // compositor-only operation (~1ms vs ~11s full repaint).
-                ...(hasBeenVisibleRef.current
-                    ? { display: 'flex', visibility: visible ? 'visible' as const : 'hidden' as const }
-                    : { display: visible ? 'flex' : 'none' }),
-                pointerEvents: visible ? 'auto' : 'none',
                 // Sit above the hidden MemoizedSvgContainer for
                 // actionDiagram (which stays mounted to preserve
                 // zoom state) so clicks land on the overview.
-                zIndex: visible ? 15 : -1,
+                zIndex: 15,
             }}
         >
             {/* Header strip — title + severity legend, mirrors the

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -5,9 +5,15 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
-import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
-import type { ActionDetail, DiagramData, MetadataIndex } from '../types';
-import { applyActionOverviewPins, buildActionOverviewPins } from '../utils/svgUtils';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { ActionDetail, DiagramData, MetadataIndex, ViewBox } from '../types';
+import {
+    applyActionOverviewPins,
+    buildActionOverviewPins,
+    computeActionOverviewFitRect,
+    computeEquipmentFitRect,
+} from '../utils/svgUtils';
+import { usePanZoom } from '../hooks/usePanZoom';
 
 /**
  * Action-overview diagram.
@@ -18,19 +24,17 @@ import { applyActionOverviewPins, buildActionOverviewPins } from '../utils/svgUt
  * style pin per prioritised action, anchored on the asset the
  * corresponding action card highlights in its badges.
  *
- * Design notes:
- *  - We deliberately do NOT reuse `actionSvgContainerRef` /
- *    `actionPZ` from useDiagrams because those are tied to the
- *    post-action diagram. Mixing the two would blur the
- *    "overview vs drill-down" distinction and force us to
- *    invalidate the action diagram state on every pin refresh.
- *  - We DO re-use the N-1 metadata index (same positions that
- *    drive `applyActionTargetHighlights`), so a pin and the
- *    yellow halo for the same asset share one source of truth.
- *  - The view is pan/zoom-less by default — the pins already
- *    act as the overview; a user who wants to drill in clicks
- *    a pin (or the corresponding card) and gets the detailed
- *    action diagram that already supports zoom.
+ * Interactions supported here:
+ *  - auto-zoom on open to the bounding rectangle of
+ *    (contingency + overloads + all pins), with a small margin
+ *  - wheel-zoom + drag-pan via the shared `usePanZoom` hook
+ *  - local zoom-in / zoom-out / reset buttons
+ *  - asset-focus inspect search that pans/zooms to a named
+ *    equipment (line or voltage-level) using the same metadata
+ *    index as the rest of the NAD highlights
+ *  - pin click → delegate to the existing action-select flow,
+ *    which folds this view away and reveals the detailed
+ *    action-variant diagram with all its existing interactions
  */
 interface ActionOverviewDiagramProps {
     n1Diagram: DiagramData | null;
@@ -39,8 +43,24 @@ interface ActionOverviewDiagramProps {
     monitoringFactor: number;
     /** Invoked when a pin is clicked — wired to the existing action-select flow. */
     onActionSelect: (actionId: string) => void;
+    /** Current contingency (selected branch) — included in the auto-fit rectangle. */
+    contingency: string | null;
+    /** Overloaded lines in the N-1 state — included in the auto-fit rectangle. */
+    overloadedLines: readonly string[];
+    /** Searchable equipment ids for the inspect field. */
+    inspectableItems: readonly string[];
     visible: boolean;
 }
+
+const ZOOM_STEP_IN = 0.8;
+const ZOOM_STEP_OUT = 1.25;
+
+const scaleViewBox = (vb: ViewBox, factor: number): ViewBox => ({
+    x: vb.x + (vb.w * (1 - factor)) / 2,
+    y: vb.y + (vb.h * (1 - factor)) / 2,
+    w: vb.w * factor,
+    h: vb.h * factor,
+});
 
 const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     n1Diagram,
@@ -48,51 +68,164 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     actions,
     monitoringFactor,
     onActionSelect,
+    contingency,
+    overloadedLines,
+    inspectableItems,
     visible,
 }) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
+    // Pull the svg string into a local so the React Compiler can
+    // see that both the injection effect and the initialViewBox memo
+    // depend on the same primitive, not on the full `n1Diagram`
+    // object identity.
+    const svgString = n1Diagram?.svg ?? null;
+    // `svgReady` is derived, not stateful: svg injection happens
+    // synchronously in the layout effect below (which is declared
+    // BEFORE usePanZoom so its layout effect runs first, i.e. the
+    // DOM is already populated by the time usePanZoom caches its
+    // svgElRef). Once the string is in hand the svg IS in the DOM.
+    const svgReady = svgString != null;
 
-    // Build the pin list — pure, memo-able, independent from DOM.
     const pins = useMemo(() => {
         if (!n1MetaIndex || !actions) return [];
         return buildActionOverviewPins(actions, n1MetaIndex, monitoringFactor);
     }, [n1MetaIndex, actions, monitoringFactor]);
 
-    // Inject / re-inject the N-1 SVG into our own container whenever
-    // the source SVG string changes. Using innerHTML (instead of
-    // mutating the shared parsed SVG from useDiagrams) guarantees we
-    // get a standalone DOM subtree — the N-1 tab's own container is
-    // untouched and keeps its viewBox / zoom state.
+    // Deterministic auto-fit rectangle derived from the bounding
+    // box of contingency + overloads + pins. Recomputed whenever any
+    // of those inputs changes — the new object identity propagates
+    // into `usePanZoom` via its `initialViewBox` effect, which
+    // re-applies the fit automatically.
+    const fitRect = useMemo<ViewBox | null>(() => {
+        if (!n1MetaIndex) return null;
+        return computeActionOverviewFitRect(n1MetaIndex, contingency, overloadedLines, pins);
+    }, [n1MetaIndex, contingency, overloadedLines, pins]);
+
+    // Fall back to the original NAD viewBox if we couldn't build a
+    // fit rectangle (e.g. no analysis has run yet) — that way the
+    // user still sees the full network the moment the tab opens.
+    const initialViewBox = useMemo<ViewBox | null>(() => {
+        if (fitRect) return fitRect;
+        if (!svgString) return null;
+        const match = svgString.match(/viewBox=["']([^"']+)["']/);
+        if (!match) return null;
+        const parts = match[1].split(/\s+|,/).map(parseFloat);
+        if (parts.length !== 4 || parts.some(p => !Number.isFinite(p))) return null;
+        return { x: parts[0], y: parts[1], w: parts[2], h: parts[3] };
+    }, [fitRect, svgString]);
+
+    // Inject (or re-inject) the N-1 SVG into our own container.
+    // Using innerHTML is intentional: we want a standalone DOM
+    // subtree so nothing clashes with the main-window pan/zoom
+    // infra that drives the N-1 and action-variant tabs.
+    //
+    // DECLARED BEFORE `usePanZoom` so React runs this layout
+    // effect first and the hook can cache its svgElRef against the
+    // freshly-injected element.
     useLayoutEffect(() => {
         const container = containerRef.current;
         if (!container) return;
-        if (!n1Diagram?.svg) {
+        if (!svgString) {
             container.innerHTML = '';
             return;
         }
-        container.innerHTML = n1Diagram.svg;
+        container.innerHTML = svgString;
         const svg = container.querySelector('svg');
         if (svg) {
-            // Make the SVG fill the container — the existing
-            // diagram SVGs embed their viewBox, so width/height
-            // 100% lets the browser handle the fit.
+            // Let the SVG fill the container. The viewBox is the
+            // only thing usePanZoom manipulates, so width/height
+            // 100% gives a stable mapping from SVG coords to
+            // screen coords.
             svg.setAttribute('width', '100%');
             svg.setAttribute('height', '100%');
             svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
             (svg as SVGSVGElement).style.width = '100%';
             (svg as SVGSVGElement).style.height = '100%';
         }
-    }, [n1Diagram?.svg]);
+    }, [svgString]);
 
-    // (Re)apply pins whenever the underlying SVG or pin list changes.
+    // The hook handles wheel-zoom and drag-pan on the container.
+    // `active` gates the event listeners so an invisible overview
+    // doesn't steal wheel events from other tabs.
+    const pz = usePanZoom(containerRef, initialViewBox, visible && svgReady);
+
+    // (Re)apply pins whenever the source SVG or pin list changes.
+    // Pins are appended to the SVG itself (not to the container
+    // div) so the existing viewBox-based pan/zoom naturally
+    // transforms them with the rest of the diagram.
     useEffect(() => {
+        if (!svgReady) return;
         const container = containerRef.current;
         if (!container) return;
         applyActionOverviewPins(container, pins, onActionSelect);
-    }, [pins, onActionSelect, n1Diagram?.svg]);
+    }, [pins, onActionSelect, svgReady, svgString]);
+
+    // When the view becomes visible for the first time (or again
+    // after a round-trip through an action drill-down), re-assert
+    // the fit rectangle. Without this, a card selection + deselect
+    // would leave the overview on whatever viewBox the user had
+    // last panned to — surprising, because the tab is nominally
+    // "opening fresh".
+    const wasVisibleRef = useRef(false);
+    useEffect(() => {
+        if (visible && !wasVisibleRef.current && initialViewBox) {
+            pz.setViewBox(initialViewBox);
+        }
+        wasVisibleRef.current = visible;
+    }, [visible, initialViewBox, pz]);
+
+    const handleZoomIn = useCallback(() => {
+        if (!pz.viewBox) return;
+        pz.setViewBox(scaleViewBox(pz.viewBox, ZOOM_STEP_IN));
+    }, [pz]);
+
+    const handleZoomOut = useCallback(() => {
+        if (!pz.viewBox) return;
+        pz.setViewBox(scaleViewBox(pz.viewBox, ZOOM_STEP_OUT));
+    }, [pz]);
+
+    const handleReset = useCallback(() => {
+        if (initialViewBox) pz.setViewBox(initialViewBox);
+    }, [initialViewBox, pz]);
+
+    // ----- Inspect / asset-focus search -----
+    // Kept deliberately local so the overview manages its own
+    // focus without plumbing through the detached-tab /
+    // tied-tab infrastructure of the main-window inspect field.
+    const [inspectQuery, setInspectQuery] = useState('');
+    const [inspectFocused, setInspectFocused] = useState(false);
+    const closeTimerRef = useRef<number | null>(null);
+
+    const filteredInspectables = useMemo(() => {
+        const q = inspectQuery.toUpperCase();
+        if (!q) return [] as string[];
+        return inspectableItems.filter(item => item.toUpperCase().includes(q)).slice(0, 20);
+    }, [inspectQuery, inspectableItems]);
+
+    const exactInspectMatch = useMemo(() => {
+        if (!inspectQuery) return null;
+        const q = inspectQuery.toUpperCase();
+        return inspectableItems.find(item => item.toUpperCase() === q) ?? null;
+    }, [inspectQuery, inspectableItems]);
+
+    const focusEquipment = useCallback((equipmentId: string) => {
+        const target = computeEquipmentFitRect(n1MetaIndex, equipmentId);
+        if (target) {
+            pz.setViewBox(target);
+        }
+    }, [n1MetaIndex, pz]);
+
+    useEffect(() => {
+        if (!exactInspectMatch) return;
+        focusEquipment(exactInspectMatch);
+    }, [exactInspectMatch, focusEquipment]);
 
     const hasAnyAction = !!actions && Object.keys(actions).length > 0;
     const noBackground = !n1Diagram?.svg;
+    const showInspectDropdown = inspectFocused
+        && inspectQuery.length > 0
+        && filteredInspectables.length > 0
+        && !exactInspectMatch;
 
     return (
         <div
@@ -109,8 +242,8 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                 zIndex: 15,
             }}
         >
-            {/* Header strip — mirrors the severity legend used by
-                the cards so the operator understands the colour
+            {/* Header strip — title + severity legend, mirrors the
+                card palette so the operator understands the colour
                 encoding at a glance. */}
             <div
                 style={{
@@ -141,6 +274,9 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     <Legend color="#9ca3af" label="Divergent / islanded" />
                 </div>
             </div>
+
+            {/* SVG body: the pan/zoom container. Wheel + drag work
+                via usePanZoom listeners bound in useEffect. */}
             <div
                 ref={containerRef}
                 className="svg-container nad-action-overview-container"
@@ -150,6 +286,139 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     position: 'relative',
                 }}
             />
+
+            {/* Bottom-left control cluster: zoom buttons + inspect
+                search. Rendered inside the overview's own flex
+                layout (not via renderTabOverlay) so they are
+                trivially shown/hidden with the overview itself. */}
+            {svgReady && (
+                <div
+                    data-testid="overview-controls"
+                    style={{
+                        position: 'absolute',
+                        bottom: 12,
+                        left: 12,
+                        zIndex: 100,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 6,
+                        alignItems: 'flex-start',
+                        pointerEvents: 'none',
+                    }}
+                >
+                    <div style={{ display: 'flex', gap: 4, alignItems: 'center', pointerEvents: 'auto' }}>
+                        <button
+                            onClick={handleZoomIn}
+                            title="Zoom In"
+                            style={controlButtonStyle}
+                        >
+                            +
+                        </button>
+                        <button
+                            onClick={handleReset}
+                            title="Reset view to auto-fit (contingency + overloads + pins)"
+                            style={{ ...controlButtonStyle, padding: '5px 14px', fontSize: 12 }}
+                        >
+                            {'\uD83D\uDD0D Fit'}
+                        </button>
+                        <button
+                            onClick={handleZoomOut}
+                            title="Zoom Out"
+                            style={controlButtonStyle}
+                        >
+                            -
+                        </button>
+                    </div>
+                    <div style={{ display: 'flex', gap: 4, alignItems: 'center', position: 'relative', pointerEvents: 'auto' }}>
+                        <div style={{ position: 'relative' }}>
+                            <input
+                                data-testid="overview-inspect-input"
+                                value={inspectQuery}
+                                onChange={e => setInspectQuery(e.target.value)}
+                                onFocus={() => {
+                                    if (closeTimerRef.current !== null) {
+                                        window.clearTimeout(closeTimerRef.current);
+                                        closeTimerRef.current = null;
+                                    }
+                                    setInspectFocused(true);
+                                }}
+                                onBlur={() => {
+                                    closeTimerRef.current = window.setTimeout(() => {
+                                        setInspectFocused(false);
+                                        closeTimerRef.current = null;
+                                    }, 150);
+                                }}
+                                placeholder="🔍 Focus asset..."
+                                style={{
+                                    padding: '5px 10px',
+                                    border: inspectQuery ? '2px solid #3498db' : '1px solid #ccc',
+                                    borderRadius: 4,
+                                    fontSize: 12,
+                                    width: 180,
+                                    boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
+                                    background: 'white',
+                                }}
+                            />
+                            {showInspectDropdown && (
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        bottom: '100%',
+                                        left: 0,
+                                        marginBottom: 4,
+                                        width: 220,
+                                        maxHeight: 220,
+                                        overflowY: 'auto',
+                                        background: 'white',
+                                        border: '1px solid #3498db',
+                                        borderRadius: 4,
+                                        boxShadow: '0 4px 12px rgba(0,0,0,0.18)',
+                                        zIndex: 200,
+                                        fontSize: 12,
+                                    }}
+                                >
+                                    {filteredInspectables.map(item => (
+                                        <div
+                                            key={item}
+                                            onMouseDown={e => {
+                                                e.preventDefault();
+                                                setInspectQuery(item);
+                                                focusEquipment(item);
+                                            }}
+                                            style={{
+                                                padding: '5px 10px',
+                                                cursor: 'pointer',
+                                                borderBottom: '1px solid #eee',
+                                                whiteSpace: 'nowrap',
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                            }}
+                                            onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = '#f0f8ff'; }}
+                                            onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'white'; }}
+                                        >
+                                            {item}
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                        {inspectQuery && (
+                            <button
+                                onClick={() => setInspectQuery('')}
+                                style={{
+                                    background: '#e74c3c', color: 'white', border: 'none',
+                                    borderRadius: 4, padding: '4px 8px', cursor: 'pointer',
+                                    fontSize: 12, boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
+                                }}
+                                title="Clear"
+                            >
+                                X
+                            </button>
+                        )}
+                    </div>
+                </div>
+            )}
+
             {noBackground && (
                 <div style={{
                     position: 'absolute', inset: 0, top: 40,
@@ -172,6 +441,18 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             )}
         </div>
     );
+};
+
+const controlButtonStyle: React.CSSProperties = {
+    background: 'white',
+    color: '#333',
+    border: '1px solid #ccc',
+    borderRadius: 4,
+    padding: '5px 12px',
+    cursor: 'pointer',
+    fontSize: 14,
+    fontWeight: 600,
+    boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
 };
 
 const Legend: React.FC<{ color: string; label: string }> = ({ color, label }) => (

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -154,17 +154,15 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             svg.style.height = '100%';
         }
 
-        // Wrap existing children in a dim layer (done off-DOM — no
-        // forced layout).
-        const existingChildren = Array.from(svg.childNodes);
-        if (existingChildren.length > 0) {
-            const SVG_NS = 'http://www.w3.org/2000/svg';
-            const dimGroup = document.createElementNS(SVG_NS, 'g');
-            dimGroup.setAttribute('class', 'nad-overview-dim-layer');
-            dimGroup.setAttribute('opacity', DIM_BACKGROUND_OPACITY);
-            existingChildren.forEach(c => dimGroup.appendChild(c));
-            svg.appendChild(dimGroup);
-        }
+        // Dim the network background by applying a CSS class instead
+        // of wrapping in a <g opacity="0.35">.  The SVG `opacity`
+        // attribute creates a transparency group that forces Chrome
+        // to rasterize all ~43k children into an intermediate buffer
+        // before compositing — the "Layerize" step takes ~31s on
+        // large grids.  Using a CSS class avoids that by letting the
+        // browser apply the dimming as a simple style on each child
+        // without creating a stacking context.
+        svg.classList.add('nad-overview-dimmed');
         console.log(`[SVG] Action overview pre-parse took ${(performance.now() - start).toFixed(2)}ms`);
         return svg;
     }, [svgString]);

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -114,6 +114,15 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     visible,
 }) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
+
+    // Track whether the component has been shown at least once.
+    // Before the first show we use `display: none` (zero rendering
+    // cost).  After that we switch to `visibility: hidden` so the
+    // SVG stays in its composite layer and subsequent tab-switches
+    // are instant (~1ms compositor-only vs ~11s full repaint).
+    const hasBeenVisibleRef = useRef(false);
+    if (visible) hasBeenVisibleRef.current = true;
+
     // Pull the svg string into a local so the React Compiler can
     // see that both the injection effect and the initialViewBox memo
     // depend on the same primitive, not on the full `n1Diagram`
@@ -504,15 +513,15 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             style={{
                 position: 'absolute',
                 inset: 0,
-                display: 'flex',
                 flexDirection: 'column',
                 background: 'white',
-                // Use visibility instead of display:none so the SVG stays
-                // painted in a cached composite layer.  Switching from
-                // visibility:hidden→visible is a composite-only operation
-                // (~1ms) whereas display:none→flex forces a full re-layout
-                // and re-paint of all ~11k SVG elements (~11s on large grids).
-                visibility: visible ? 'visible' : 'hidden',
+                // Before the first show: display:none → zero cost.
+                // After the first show: visibility:hidden keeps the SVG
+                // painted in its composite layer so re-showing is a
+                // compositor-only operation (~1ms vs ~11s full repaint).
+                ...(hasBeenVisibleRef.current
+                    ? { display: 'flex', visibility: visible ? 'visible' as const : 'hidden' as const }
+                    : { display: visible ? 'flex' : 'none' }),
                 pointerEvents: visible ? 'auto' : 'none',
                 // Sit above the hidden MemoizedSvgContainer for
                 // actionDiagram (which stays mounted to preserve

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -18,6 +18,7 @@ import {
 } from '../utils/svgUtils';
 import { usePanZoom } from '../hooks/usePanZoom';
 import ActionCardPopover from './ActionCardPopover';
+import { interactionLogger } from '../utils/interactionLogger';
 import {
     POPOVER_WIDTH,
     POPOVER_MAX_HEIGHT,
@@ -289,6 +290,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     } | null>(null);
 
     const handlePinClick = useCallback((actionId: string, screenPos: { x: number; y: number }) => {
+        interactionLogger.record('overview_pin_clicked', { action_id: actionId });
         performance.mark('aod:pinClick:start');
         const placement = decidePopoverPlacement(screenPos.x, screenPos.y);
         setPopoverPin({
@@ -305,6 +307,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     }, []);
 
     const handlePinDoubleClick = useCallback((actionId: string) => {
+        interactionLogger.record('overview_pin_double_clicked', { action_id: actionId });
         // Make sure no stale popover is left behind on the way
         // into the drill-down view.
         setPopoverPin(null);
@@ -401,23 +404,29 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     // "opening fresh".
     const wasVisibleRef = useRef(false);
     useEffect(() => {
-        if (visible && !wasVisibleRef.current && initialViewBox) {
-            pz.setViewBox(initialViewBox);
+        if (visible && !wasVisibleRef.current) {
+            interactionLogger.record('overview_shown', { has_pins: pins.length > 0, pin_count: pins.length });
+            if (initialViewBox) pz.setViewBox(initialViewBox);
+        } else if (!visible && wasVisibleRef.current) {
+            interactionLogger.record('overview_hidden');
         }
         wasVisibleRef.current = visible;
-    }, [visible, initialViewBox, pz]);
+    }, [visible, initialViewBox, pz, pins.length]);
 
     const handleZoomIn = useCallback(() => {
         if (!pz.viewBox) return;
+        interactionLogger.record('overview_zoom_in');
         pz.setViewBox(scaleViewBox(pz.viewBox, ZOOM_STEP_IN));
     }, [pz]);
 
     const handleZoomOut = useCallback(() => {
         if (!pz.viewBox) return;
+        interactionLogger.record('overview_zoom_out');
         pz.setViewBox(scaleViewBox(pz.viewBox, ZOOM_STEP_OUT));
     }, [pz]);
 
     const handleReset = useCallback(() => {
+        interactionLogger.record('overview_zoom_fit');
         if (initialViewBox) pz.setViewBox(initialViewBox);
         // Clearing here ensures that re-typing the same asset id
         // after a reset will focus it again — without this the
@@ -456,9 +465,11 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
 
         if (exactInspectMatch) {
             // Consume the new query — zoom onto the asset.
+            interactionLogger.record('overview_inspect_changed', { query: exactInspectMatch, action: 'focus' });
             const target = computeEquipmentFitRect(n1MetaIndex, exactInspectMatch);
             if (target) pz.setViewBox(target);
         } else if (lastFocusedRef.current && initialViewBox) {
+            interactionLogger.record('overview_inspect_changed', { query: '', action: 'cleared' });
             // Query cleared (or no longer an exact match): go
             // back to the auto-fit rectangle so the user sees
             // the whole network-plus-pins again.
@@ -482,22 +493,25 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
     const noBackground = !n1Diagram?.svg;
 
     // ----- Popover dismissal -----
-    // Close on Escape, on outside-click, or when visibility is
-    // toggled away (e.g. the user switched tabs).
+    // All close paths (Escape, outside-click, ✕ button, drill-down
+    // activation) route through this helper so the log entry is
+    // emitted exactly once per dismiss.
+    const closePopover = useCallback((reason: string) => {
+        interactionLogger.record('overview_popover_closed', { reason });
+        setPopoverPin(null);
+    }, []);
+
     const popoverRef = useRef<HTMLDivElement | null>(null);
     useEffect(() => {
         if (!popoverPin) return;
         const onDocMouseDown = (e: MouseEvent) => {
             const target = e.target as Node | null;
             if (popoverRef.current && target && popoverRef.current.contains(target)) return;
-            // Also ignore clicks on any pin — the pin's own click
-            // handler owns the popover-state update and would
-            // otherwise race with this listener.
             if (target instanceof Element && target.closest('.nad-action-overview-pin')) return;
-            setPopoverPin(null);
+            closePopover('outside_click');
         };
         const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') setPopoverPin(null);
+            if (e.key === 'Escape') closePopover('escape');
         };
         document.addEventListener('mousedown', onDocMouseDown);
         document.addEventListener('keydown', onKey);
@@ -505,7 +519,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
             document.removeEventListener('mousedown', onDocMouseDown);
             document.removeEventListener('keydown', onKey);
         };
-    }, [popoverPin]);
+    }, [popoverPin, closePopover]);
 
     // Pre-compute the props ActionCard needs for the popover render.
     const popoverDetails = popoverPin && actions ? actions[popoverPin.id] : null;
@@ -787,7 +801,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     onActivateAction={onActionSelect}
                     onActionFavorite={onActionFavorite}
                     onActionReject={onActionReject}
-                    onClose={() => setPopoverPin(null)}
+                    onClose={() => closePopover('close_button')}
                 />
             )}
         </div>

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -705,4 +705,50 @@ describe('VisualizationPanel', () => {
             expect(screen.queryByText('Loading configuration...')).not.toBeInTheDocument();
         });
     });
+
+    describe('Action tab "back to overview" close button', () => {
+        const actionDiagram: DiagramData = {
+            svg: '<svg viewBox="0 0 100 100"><g/></svg>',
+            metadata: null,
+        };
+
+        it('renders the close ✕ when a card is selected and the action diagram is loaded', () => {
+            render(<VisualizationPanel {...createDefaultProps({
+                activeTab: 'action' as TabId,
+                selectedActionId: 'action_1',
+                actionDiagram,
+            })} />);
+            expect(screen.getByTestId('action-tab-back-to-overview')).toBeInTheDocument();
+        });
+
+        it('does NOT render the close ✕ when no action is selected', () => {
+            render(<VisualizationPanel {...createDefaultProps({
+                activeTab: 'action' as TabId,
+                selectedActionId: null,
+                actionDiagram,
+            })} />);
+            expect(screen.queryByTestId('action-tab-back-to-overview')).not.toBeInTheDocument();
+        });
+
+        it('does NOT render the close ✕ when the action diagram has not loaded yet', () => {
+            render(<VisualizationPanel {...createDefaultProps({
+                activeTab: 'action' as TabId,
+                selectedActionId: 'action_1',
+                actionDiagram: null,
+            })} />);
+            expect(screen.queryByTestId('action-tab-back-to-overview')).not.toBeInTheDocument();
+        });
+
+        it('calls onActionSelect(null) on click (returns to overview)', async () => {
+            const onActionSelect = vi.fn();
+            render(<VisualizationPanel {...createDefaultProps({
+                activeTab: 'action' as TabId,
+                selectedActionId: 'action_1',
+                actionDiagram,
+                onActionSelect,
+            })} />);
+            await userEvent.click(screen.getByTestId('action-tab-back-to-overview'));
+            expect(onActionSelect).toHaveBeenCalledWith(null);
+        });
+    });
 });

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -6,7 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
@@ -70,7 +70,12 @@ describe('VisualizationPanel', () => {
 
     it('renders action tab with action ID when action is selected', () => {
         render(<VisualizationPanel {...createDefaultProps({ selectedActionId: 'action_1' })} />);
-        expect(screen.getByText('Remedial Action: action_1')).toBeInTheDocument();
+        // The label is now JSX: "Remedial Action: " + a clickable
+        // chip containing the action id. Assert on the chip
+        // presence + content rather than the plain-text match.
+        const chip = screen.getByTestId('action-tab-deselect-chip');
+        expect(chip).toBeInTheDocument();
+        expect(chip.textContent).toContain('action_1');
     });
 
     it('renders action tab with default label when no action selected', () => {
@@ -706,48 +711,73 @@ describe('VisualizationPanel', () => {
         });
     });
 
-    describe('Action tab "back to overview" close button', () => {
+    describe('Action tab "back to overview" interaction', () => {
+        // The "back to overview" affordance lives INSIDE the
+        // action tab label as a clickable chip around the action
+        // id (data-testid="action-tab-deselect-chip"). The
+        // previous top-right ✕ button was removed because it
+        // overlapped with the Flow/Impacts toggle.
         const actionDiagram: DiagramData = {
             svg: '<svg viewBox="0 0 100 100"><g/></svg>',
             metadata: null,
         };
 
-        it('renders the close ✕ when a card is selected and the action diagram is loaded', () => {
+        it('renders the deselect chip when a card is selected', () => {
             render(<VisualizationPanel {...createDefaultProps({
                 activeTab: 'action' as TabId,
                 selectedActionId: 'action_1',
                 actionDiagram,
+                n1Diagram: { svg: '<svg/>', metadata: null },
             })} />);
-            expect(screen.getByTestId('action-tab-back-to-overview')).toBeInTheDocument();
+            const chip = screen.getByTestId('action-tab-deselect-chip');
+            expect(chip).toBeInTheDocument();
+            expect(chip.textContent).toContain('action_1');
         });
 
-        it('does NOT render the close ✕ when no action is selected', () => {
+        it('does NOT render the deselect chip when no action is selected', () => {
             render(<VisualizationPanel {...createDefaultProps({
                 activeTab: 'action' as TabId,
                 selectedActionId: null,
                 actionDiagram,
+                n1Diagram: { svg: '<svg/>', metadata: null },
             })} />);
-            expect(screen.queryByTestId('action-tab-back-to-overview')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('action-tab-deselect-chip')).not.toBeInTheDocument();
+            // The default overview label is shown instead.
+            expect(screen.getByText('Remedial action: overview')).toBeInTheDocument();
         });
 
-        it('does NOT render the close ✕ when the action diagram has not loaded yet', () => {
+        it('clicking the chip calls onActionSelect(null) and does NOT trigger onTabChange', async () => {
+            const onActionSelect = vi.fn();
+            const onTabChange = vi.fn();
             render(<VisualizationPanel {...createDefaultProps({
                 activeTab: 'action' as TabId,
                 selectedActionId: 'action_1',
-                actionDiagram: null,
+                actionDiagram,
+                n1Diagram: { svg: '<svg/>', metadata: null },
+                onActionSelect,
+                onTabChange,
             })} />);
-            expect(screen.queryByTestId('action-tab-back-to-overview')).not.toBeInTheDocument();
+            await userEvent.click(screen.getByTestId('action-tab-deselect-chip'));
+            expect(onActionSelect).toHaveBeenCalledWith(null);
+            // stopPropagation must keep the parent <button>'s
+            // onTabChange from firing.
+            expect(onTabChange).not.toHaveBeenCalled();
         });
 
-        it('calls onActionSelect(null) on click (returns to overview)', async () => {
+        it('Enter / Space on the chip also deselects the action (keyboard accessibility)', () => {
             const onActionSelect = vi.fn();
             render(<VisualizationPanel {...createDefaultProps({
                 activeTab: 'action' as TabId,
                 selectedActionId: 'action_1',
                 actionDiagram,
+                n1Diagram: { svg: '<svg/>', metadata: null },
                 onActionSelect,
             })} />);
-            await userEvent.click(screen.getByTestId('action-tab-back-to-overview'));
+            const chip = screen.getByTestId('action-tab-deselect-chip');
+            chip.focus();
+            // Use fireEvent.keyDown directly to exercise the
+            // span's role="button" + onKeyDown handler.
+            fireEvent.keyDown(chip, { key: 'Enter' });
             expect(onActionSelect).toHaveBeenCalledWith(null);
         });
     });

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -75,7 +75,7 @@ describe('VisualizationPanel', () => {
 
     it('renders action tab with default label when no action selected', () => {
         render(<VisualizationPanel {...createDefaultProps()} />);
-        expect(screen.getByText('Remedial Action')).toBeInTheDocument();
+        expect(screen.getByText('Remedial action: overview')).toBeInTheDocument();
     });
 
     it('always renders overflow tab (even without pdf_url)', () => {

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -578,14 +578,68 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
             <div style={{ display: 'flex', borderBottom: '1px solid #ccc', flexShrink: 0 }}>
                 {(
                     [
-                        { id: 'n' as TabId, label: 'Network (N)', available: !!nDiagram?.svg, accentColor: '#3498db', dimColor: '#7f8c8d', placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
-                        { id: 'n-1' as TabId, label: 'Contingency (N-1)', available: !!n1Diagram?.svg, accentColor: '#e74c3c', dimColor: '#aab', placeholder: 'Select a contingency element from the dropdown to view the N-1 state.' },
+                        { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: '#3498db', dimColor: '#7f8c8d', placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
+                        { id: 'n-1' as TabId, label: 'Contingency (N-1)' as React.ReactNode, available: !!n1Diagram?.svg, accentColor: '#e74c3c', dimColor: '#aab', placeholder: 'Select a contingency element from the dropdown to view the N-1 state.' },
                         // When no card is selected, the Remedial Action tab hosts the
                         // action-overview view (pins over the N-1 network). It is considered
                         // "available" as soon as the N-1 diagram has loaded, so the tab is no
                         // longer italicised while the user is still browsing the overview.
-                        { id: 'action' as TabId, label: selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview', available: !!actionDiagram?.svg || !!n1Diagram?.svg, accentColor: '#ff4081', dimColor: '#aab', placeholder: 'Select a contingency and run the analysis to see remedial actions.' },
-                        { id: 'overflow' as TabId, label: 'Overflow Analysis', available: !!result?.pdf_url, accentColor: '#27ae60', dimColor: '#aab', placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
+                        //
+                        // When a card IS selected, the action id is rendered as a
+                        // clickable chip that deselects the action on click — taking
+                        // the user back to the overview view in the same tab. The chip
+                        // lives INSIDE the tab text instead of as a separate close
+                        // button so it does not collide with the Flow/Impacts toggle
+                        // and other top-right controls.
+                        {
+                            id: 'action' as TabId,
+                            label: selectedActionId ? (
+                                <>
+                                    Remedial Action:{' '}
+                                    <span
+                                        data-testid="action-tab-deselect-chip"
+                                        role="button"
+                                        tabIndex={0}
+                                        title="Click the action id to return to the overview"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onActionSelect?.(null);
+                                        }}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter' || e.key === ' ') {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                onActionSelect?.(null);
+                                            }
+                                        }}
+                                        style={{
+                                            display: 'inline-flex',
+                                            alignItems: 'center',
+                                            gap: 4,
+                                            padding: '1px 8px',
+                                            borderRadius: 10,
+                                            background: '#fce4ec',
+                                            color: '#ad1457',
+                                            border: '1px solid #f48fb1',
+                                            cursor: 'pointer',
+                                            textDecoration: 'underline dotted',
+                                            fontWeight: 600,
+                                            maxWidth: '100%',
+                                            overflow: 'hidden',
+                                            textOverflow: 'ellipsis',
+                                        }}
+                                    >
+                                        {selectedActionId}
+                                        <span aria-hidden style={{ fontSize: 10, opacity: 0.8 }}>{'\u2715'}</span>
+                                    </span>
+                                </>
+                            ) : 'Remedial action: overview',
+                            available: !!actionDiagram?.svg || !!n1Diagram?.svg,
+                            accentColor: '#ff4081',
+                            dimColor: '#aab',
+                            placeholder: 'Select a contingency and run the analysis to see remedial actions.',
+                        },
+                        { id: 'overflow' as TabId, label: 'Overflow Analysis' as React.ReactNode, available: !!result?.pdf_url, accentColor: '#27ae60', dimColor: '#aab', placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
                     ] as const
                 ).map(tab => {
                     const isActive = activeTab === tab.id;
@@ -878,40 +932,13 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             visible={!selectedActionId && !actionDiagramLoading}
                         />
                         {/*
-                          Close ✕ — appears at the top-right of the
-                          action tab when a card is selected (i.e.
-                          the drill-down action-variant diagram is
-                          being shown). Clicking it deselects the
-                          action, which folds the overview back in.
+                          The "back to overview" affordance now lives
+                          inside the tab label as a clickable chip
+                          around the action id (see the action tab
+                          definition above). The previous top-right ✕
+                          button was removed because it overlapped
+                          with the Flow/Impacts toggle.
                         */}
-                        {selectedActionId && actionDiagram?.svg && (
-                            <button
-                                data-testid="action-tab-back-to-overview"
-                                onClick={() => onActionSelect?.(null)}
-                                title="Back to actions overview"
-                                style={{
-                                    position: 'absolute',
-                                    top: 10,
-                                    right: 10,
-                                    zIndex: 110,
-                                    background: 'white',
-                                    border: '1px solid #cbd5e1',
-                                    borderRadius: 16,
-                                    padding: '4px 12px',
-                                    cursor: 'pointer',
-                                    fontSize: 12,
-                                    fontWeight: 600,
-                                    color: '#334155',
-                                    boxShadow: '0 2px 6px rgba(0,0,0,0.18)',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: 6,
-                                }}
-                            >
-                                <span style={{ fontSize: 14 }}>{'\u2715'}</span>
-                                Overview
-                            </button>
-                        )}
                         {actionDiagramLoading && (
                             <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Generating Action Variant Diagram...

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -129,6 +129,11 @@ const InspectSearchField: React.FC<{
     );
 };
 
+// Module-level stable references so React.memo children don't
+// break referential equality on every parent render.
+const NOOP_ACTION_SELECT = (_id: string | null) => { /* intentional no-op */ };
+const EMPTY_STRING_ARRAY: readonly string[] = [];
+
 interface VisualizationPanelProps {
     activeTab: TabId;
     configLoading: boolean;
@@ -297,6 +302,14 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     const viewModeChangeForTabCb = onViewModeChangeForTab ?? ((_tab: TabId, mode: 'network' | 'delta') => onViewModeChange(mode));
     const isTabTiedFn = isTabTied ?? (() => false);
     const toggleTabTieCb = onToggleTabTie ?? (() => {});
+
+    // Stable fallbacks for the ActionOverviewDiagram props so that
+    // React.memo on the child doesn't break on every parent render.
+    const actionSelectCb = onActionSelect ?? NOOP_ACTION_SELECT;
+    const overloadedLinesMemo = React.useMemo(
+        () => n1Diagram?.lines_overloaded ?? result?.lines_overloaded ?? EMPTY_STRING_ARRAY,
+        [n1Diagram?.lines_overloaded, result?.lines_overloaded],
+    );
     const [warningDismissed, setWarningDismissed] = useState(false);
     const [voltageFilterExpanded, setVoltageFilterExpanded] = useState(false);
 
@@ -974,13 +987,13 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             n1MetaIndex={n1MetaIndex ?? null}
                             actions={result?.actions}
                             monitoringFactor={monitoringFactor ?? 1}
-                            onActionSelect={onActionSelect ?? (() => {})}
+                            onActionSelect={actionSelectCb}
                             onActionFavorite={onActionFavorite}
                             onActionReject={onActionReject}
                             selectedActionIds={selectedActionIds}
                             rejectedActionIds={rejectedActionIds}
                             contingency={selectedBranch || null}
-                            overloadedLines={n1Diagram?.lines_overloaded ?? result?.lines_overloaded ?? []}
+                            overloadedLines={overloadedLinesMemo}
                             inspectableItems={inspectableItems}
                             visible={!selectedActionId && !actionDiagramLoading}
                         />

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -591,16 +591,30 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         // lives INSIDE the tab text instead of as a separate close
                         // button so it does not collide with the Flow/Impacts toggle
                         // and other top-right controls.
+                        //
+                        // The label uses a flex layout so the chip stays visible and
+                        // clickable even on narrow tabs (the outer button otherwise
+                        // applies `overflow: hidden; text-overflow: ellipsis` which
+                        // was truncating the chip to a bare "..." ellipsis).
                         {
                             id: 'action' as TabId,
                             label: selectedActionId ? (
-                                <>
-                                    Remedial Action:{' '}
+                                <span
+                                    style={{
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        gap: 6,
+                                        width: '100%',
+                                        minWidth: 0,
+                                    }}
+                                >
+                                    <span style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>Remedial Action:</span>
                                     <span
                                         data-testid="action-tab-deselect-chip"
                                         role="button"
                                         tabIndex={0}
-                                        title="Click the action id to return to the overview"
+                                        title={`${selectedActionId} — click to return to the overview`}
                                         onClick={(e) => {
                                             e.stopPropagation();
                                             onActionSelect?.(null);
@@ -615,25 +629,52 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                         style={{
                                             display: 'inline-flex',
                                             alignItems: 'center',
-                                            gap: 4,
-                                            padding: '1px 8px',
-                                            borderRadius: 10,
+                                            gap: 6,
+                                            padding: '2px 10px',
+                                            borderRadius: 12,
                                             background: '#fce4ec',
                                             color: '#ad1457',
-                                            border: '1px solid #f48fb1',
+                                            border: '1.5px solid #ec407a',
                                             cursor: 'pointer',
-                                            textDecoration: 'underline dotted',
-                                            fontWeight: 600,
+                                            fontWeight: 700,
+                                            // Let the chip shrink before the "Remedial Action:" label does
+                                            flex: '1 1 auto',
+                                            minWidth: 0,
                                             maxWidth: '100%',
                                             overflow: 'hidden',
-                                            textOverflow: 'ellipsis',
                                         }}
                                     >
-                                        {selectedActionId}
-                                        <span aria-hidden style={{ fontSize: 10, opacity: 0.8 }}>{'\u2715'}</span>
+                                        <span
+                                            style={{
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                                minWidth: 0,
+                                            }}
+                                        >
+                                            {selectedActionId}
+                                        </span>
+                                        <span
+                                            aria-hidden
+                                            style={{
+                                                display: 'inline-flex',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                                flexShrink: 0,
+                                                width: 14,
+                                                height: 14,
+                                                borderRadius: '50%',
+                                                background: '#ec407a',
+                                                color: 'white',
+                                                fontSize: 10,
+                                                lineHeight: 1,
+                                            }}
+                                        >
+                                            {'\u2715'}
+                                        </span>
                                     </span>
-                                </>
-                            ) : 'Remedial action: overview',
+                                </span>
+                            ) as React.ReactNode : 'Remedial action: overview' as React.ReactNode,
                             available: !!actionDiagram?.svg || !!n1Diagram?.svg,
                             accentColor: '#ff4081',
                             dimColor: '#aab',
@@ -671,7 +712,19 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     background: 'transparent',
                                     color: isDetached ? '#7c8894' : (tab.available ? (isActive ? '#2c3e50' : tab.dimColor) : '#bbb'),
                                     fontSize: tab.id === 'action' && selectedActionId ? '0.75rem' : '0.85rem',
-                                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                                    // The action tab with a selected card carries its
+                                    // own flex label with internal ellipsis on the chip.
+                                    // We must NOT apply white-space: nowrap /
+                                    // text-overflow: ellipsis on the outer button for
+                                    // that tab — it was truncating the whole label
+                                    // down to a bare "Remedial Action: ..." string and
+                                    // hiding the clickable deselect chip.
+                                    overflow: 'hidden',
+                                    textOverflow: tab.id === 'action' && selectedActionId ? 'clip' : 'ellipsis',
+                                    whiteSpace: tab.id === 'action' && selectedActionId ? 'normal' : 'nowrap',
+                                    display: tab.id === 'action' && selectedActionId ? 'flex' : undefined,
+                                    alignItems: tab.id === 'action' && selectedActionId ? 'center' : undefined,
+                                    justifyContent: tab.id === 'action' && selectedActionId ? 'center' : undefined,
                                     minWidth: 0,
                                 }}
                             >

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -131,6 +131,7 @@ const InspectSearchField: React.FC<{
 
 // Module-level stable references so React.memo children don't
 // break referential equality on every parent render.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const NOOP_ACTION_SELECT = (_id: string | null) => { /* intentional no-op */ };
 const EMPTY_STRING_ARRAY: readonly string[] = [];
 

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -855,6 +855,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             actions={result?.actions}
                             monitoringFactor={monitoringFactor ?? 1}
                             onActionSelect={onActionSelect ?? (() => {})}
+                            contingency={selectedBranch || null}
+                            overloadedLines={n1Diagram?.lines_overloaded ?? result?.lines_overloaded ?? []}
+                            inspectableItems={inspectableItems}
                             visible={!selectedActionId && !actionDiagramLoading}
                         />
                         {actionDiagramLoading && (

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -6,10 +6,11 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
 import React, { useState, useMemo, useRef, type RefObject } from 'react';
-import type { DiagramData, AnalysisResult, TabId, VlOverlay, SldTab } from '../types';
+import type { DiagramData, AnalysisResult, TabId, VlOverlay, SldTab, MetadataIndex } from '../types';
 import MemoizedSvgContainer from './MemoizedSvgContainer';
 import SldOverlay from './SldOverlay';
 import DetachableTabHost from './DetachableTabHost';
+import ActionOverviewDiagram from './ActionOverviewDiagram';
 import type { DetachedTabsMap } from '../hooks/useDetachedTabs';
 
 /**
@@ -200,6 +201,24 @@ interface VisualizationPanelProps {
     isTabTied?: (tab: TabId) => boolean;
     /** Toggle the "tied" flag for the given tab. */
     onToggleTabTie?: (tab: TabId) => void;
+    /**
+     * Metadata index for the N-1 diagram. Used by the
+     * action-overview view (shown in the Remedial Action tab
+     * when no card is selected) to resolve each action to an
+     * (x, y) anchor on the network.
+     */
+    n1MetaIndex?: MetadataIndex | null;
+    /**
+     * Invoked when the user clicks a pin on the action-overview
+     * view — should trigger the same action-select flow as
+     * clicking a card in the sidebar.
+     */
+    onActionSelect?: (actionId: string) => void;
+    /**
+     * Monitoring factor used to derive each action's severity
+     * colour, kept in sync with the card palette.
+     */
+    monitoringFactor?: number;
 }
 
 
@@ -248,6 +267,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     onViewModeChangeForTab,
     isTabTied,
     onToggleTabTie,
+    n1MetaIndex,
+    onActionSelect,
+    monitoringFactor,
 }) => {
     // No-op fallbacks so conditional branches don't need to guard.
     const detachTabCb = onDetachTab ?? (() => {});
@@ -545,7 +567,11 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                     [
                         { id: 'n' as TabId, label: 'Network (N)', available: !!nDiagram?.svg, accentColor: '#3498db', dimColor: '#7f8c8d', placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
                         { id: 'n-1' as TabId, label: 'Contingency (N-1)', available: !!n1Diagram?.svg, accentColor: '#e74c3c', dimColor: '#aab', placeholder: 'Select a contingency element from the dropdown to view the N-1 state.' },
-                        { id: 'action' as TabId, label: selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial Action', available: !!actionDiagram?.svg, accentColor: '#ff4081', dimColor: '#aab', placeholder: 'Select an action card from the suggestions panel to view its effect on the network.' },
+                        // When no card is selected, the Remedial Action tab hosts the
+                        // action-overview view (pins over the N-1 network). It is considered
+                        // "available" as soon as the N-1 diagram has loaded, so the tab is no
+                        // longer italicised while the user is still browsing the overview.
+                        { id: 'action' as TabId, label: selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview', available: !!actionDiagram?.svg || !!n1Diagram?.svg, accentColor: '#ff4081', dimColor: '#aab', placeholder: 'Select a contingency and run the analysis to see remedial actions.' },
                         { id: 'overflow' as TabId, label: 'Overflow Analysis', available: !!result?.pdf_url, accentColor: '#27ae60', dimColor: '#aab', placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
                     ] as const
                 ).map(tab => {
@@ -801,7 +827,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         width: '100%', height: '100%',
                         position: 'absolute', top: 0, left: 0,
                     }}>
-                        {detachedTabs['action'] && renderDetachedHeader('action', selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial Action', '#ff4081')}
+                        {detachedTabs['action'] && renderDetachedHeader('action', selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview', '#ff4081')}
                         {/* Convergence warning banner */}
                         {actionDiagram && actionDiagram.lf_converged === false && (
                             <div style={{
@@ -815,6 +841,22 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         )}
                         {/* Always mounted — see comment on N-1 container. */}
                         <MemoizedSvgContainer svg={actionDiagram?.svg || ''} containerRef={actionSvgContainerRef} display="block" tabId="action" />
+                        {/*
+                          Action-overview layer: rendered on top of the
+                          (hidden) action-diagram container when no card
+                          is selected. When a card IS selected it folds
+                          away (visible=false) and the existing action
+                          variant diagram + highlights take over, so the
+                          selection-driven interactions persist intact.
+                        */}
+                        <ActionOverviewDiagram
+                            n1Diagram={n1Diagram}
+                            n1MetaIndex={n1MetaIndex ?? null}
+                            actions={result?.actions}
+                            monitoringFactor={monitoringFactor ?? 1}
+                            onActionSelect={onActionSelect ?? (() => {})}
+                            visible={!selectedActionId && !actionDiagramLoading}
+                        />
                         {actionDiagramLoading && (
                             <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Generating Action Variant Diagram...
@@ -825,15 +867,16 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                 Failed to load diagram for action {selectedActionId}
                             </div>
                         )}
-                        {!actionDiagramLoading && !actionDiagram?.svg && !selectedActionId && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', fontStyle: 'italic', textAlign: 'center', padding: '40px', background: 'white' }}>
-                                Select an action card from the suggestions panel to view its effect on the network.
-                            </div>
-                        )}
+                        {/*
+                          The "select a card..." placeholder is now
+                          replaced by the ActionOverviewDiagram above
+                          (which itself shows its own empty-state copy
+                          when the N-1 background is missing).
+                        */}
                         {renderTabOverlay('action', true)}
                     </div>
                 </DetachableTabHost>
-                {activeTab === 'action' && detachedTabs['action'] && renderDetachedPlaceholder('action', selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial Action', '#ff4081')}
+                {activeTab === 'action' && detachedTabs['action'] && renderDetachedPlaceholder('action', selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview', '#ff4081')}
 
                 {/* Voltage Range Sidebar — collapsed by default, toggle to expand */}
                 {uniqueVoltages.length > 1 && (() => {

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -211,9 +211,18 @@ interface VisualizationPanelProps {
     /**
      * Invoked when the user clicks a pin on the action-overview
      * view — should trigger the same action-select flow as
-     * clicking a card in the sidebar.
+     * clicking a card in the sidebar. Accepts `null` so the
+     * top-right ✕ button on the action tab can deselect.
      */
-    onActionSelect?: (actionId: string) => void;
+    onActionSelect?: (actionId: string | null) => void;
+    /** Toggle an action's favourite (starred) status. */
+    onActionFavorite?: (actionId: string) => void;
+    /** Reject an action from the suggestions feed. */
+    onActionReject?: (actionId: string) => void;
+    /** Selected-action id set (for the overview popover styling). */
+    selectedActionIds?: Set<string>;
+    /** Rejected-action id set (for the overview popover styling). */
+    rejectedActionIds?: Set<string>;
     /**
      * Monitoring factor used to derive each action's severity
      * colour, kept in sync with the card palette.
@@ -269,6 +278,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     onToggleTabTie,
     n1MetaIndex,
     onActionSelect,
+    onActionFavorite,
+    onActionReject,
+    selectedActionIds,
+    rejectedActionIds,
     monitoringFactor,
 }) => {
     // No-op fallbacks so conditional branches don't need to guard.
@@ -855,11 +868,50 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             actions={result?.actions}
                             monitoringFactor={monitoringFactor ?? 1}
                             onActionSelect={onActionSelect ?? (() => {})}
+                            onActionFavorite={onActionFavorite}
+                            onActionReject={onActionReject}
+                            selectedActionIds={selectedActionIds}
+                            rejectedActionIds={rejectedActionIds}
                             contingency={selectedBranch || null}
                             overloadedLines={n1Diagram?.lines_overloaded ?? result?.lines_overloaded ?? []}
                             inspectableItems={inspectableItems}
                             visible={!selectedActionId && !actionDiagramLoading}
                         />
+                        {/*
+                          Close ✕ — appears at the top-right of the
+                          action tab when a card is selected (i.e.
+                          the drill-down action-variant diagram is
+                          being shown). Clicking it deselects the
+                          action, which folds the overview back in.
+                        */}
+                        {selectedActionId && actionDiagram?.svg && (
+                            <button
+                                data-testid="action-tab-back-to-overview"
+                                onClick={() => onActionSelect?.(null)}
+                                title="Back to actions overview"
+                                style={{
+                                    position: 'absolute',
+                                    top: 10,
+                                    right: 10,
+                                    zIndex: 110,
+                                    background: 'white',
+                                    border: '1px solid #cbd5e1',
+                                    borderRadius: 16,
+                                    padding: '4px 12px',
+                                    cursor: 'pointer',
+                                    fontSize: 12,
+                                    fontWeight: 600,
+                                    color: '#334155',
+                                    boxShadow: '0 2px 6px rgba(0,0,0,0.18)',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 6,
+                                }}
+                            >
+                                <span style={{ fontSize: 14 }}>{'\u2715'}</span>
+                                Overview
+                            </button>
+                        )}
                         {actionDiagramLoading && (
                             <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Generating Action Variant Diagram...

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -416,6 +416,16 @@ export type InteractionType =
     | 'sld_overlay_opened'
     | 'sld_overlay_tab_changed'
     | 'sld_overlay_closed'
+    // Action Overview Diagram
+    | 'overview_shown'
+    | 'overview_hidden'
+    | 'overview_pin_clicked'
+    | 'overview_pin_double_clicked'
+    | 'overview_popover_closed'
+    | 'overview_zoom_in'
+    | 'overview_zoom_out'
+    | 'overview_zoom_fit'
+    | 'overview_inspect_changed'
     // Session Management
     | 'session_saved'
     | 'session_reload_modal_opened'

--- a/frontend/src/utils/popoverPlacement.test.ts
+++ b/frontend/src/utils/popoverPlacement.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { describe, it, expect } from 'vitest';
+import {
+    decidePopoverPlacement,
+    computePopoverStyle,
+    POPOVER_WIDTH,
+    POPOVER_MAX_HEIGHT,
+    POPOVER_PIN_OFFSET,
+    POPOVER_VIEWPORT_MARGIN,
+} from './popoverPlacement';
+
+const VIEWPORT = { width: 1600, height: 900 };
+
+describe('decidePopoverPlacement', () => {
+    describe('vertical', () => {
+        it('places BELOW when there is plenty of room below the pin', () => {
+            // Pin near the top → spaceBelow >> POPOVER_MAX_HEIGHT
+            const p = decidePopoverPlacement(800, 50, VIEWPORT);
+            expect(p.placeAbove).toBe(false);
+        });
+
+        it('places ABOVE when the pin is at the bottom (no room below for the popover)', () => {
+            const p = decidePopoverPlacement(800, VIEWPORT.height - 30, VIEWPORT);
+            expect(p.placeAbove).toBe(true);
+        });
+
+        it('falls back to whichever side has more room when neither fits the full max-height', () => {
+            // Tiny viewport so neither side can fit POPOVER_MAX_HEIGHT
+            const tinyViewport = { width: 1600, height: 300 };
+            // Pin closer to the bottom → spaceAbove > spaceBelow → above wins
+            const lower = decidePopoverPlacement(800, 220, tinyViewport);
+            expect(lower.placeAbove).toBe(true);
+            // Pin closer to the top → spaceBelow > spaceAbove → below wins
+            const upper = decidePopoverPlacement(800, 80, tinyViewport);
+            expect(upper.placeAbove).toBe(false);
+        });
+    });
+
+    describe('horizontal', () => {
+        it('aligns START when the pin is in the LEFT third of the viewport', () => {
+            const p = decidePopoverPlacement(300, 400, VIEWPORT);
+            expect(p.horizontalAlign).toBe('start');
+        });
+
+        it('aligns CENTER when the pin is in the MIDDLE third of the viewport', () => {
+            const p = decidePopoverPlacement(800, 400, VIEWPORT);
+            expect(p.horizontalAlign).toBe('center');
+        });
+
+        it('aligns END when the pin is in the RIGHT third of the viewport', () => {
+            const p = decidePopoverPlacement(1300, 400, VIEWPORT);
+            expect(p.horizontalAlign).toBe('end');
+        });
+    });
+});
+
+describe('computePopoverStyle', () => {
+    it('uses `top` when placing BELOW the pin', () => {
+        const style = computePopoverStyle({
+            screenX: 800,
+            screenY: 100,
+            placeAbove: false,
+            horizontalAlign: 'center',
+        }, VIEWPORT);
+        expect(style.position).toBe('fixed');
+        expect(style.top).toBe(100 + POPOVER_PIN_OFFSET);
+        expect(style.bottom).toBeUndefined();
+    });
+
+    it('uses `bottom` (not `top`) when placing ABOVE the pin so the bottom edge anchors at the pin', () => {
+        const style = computePopoverStyle({
+            screenX: 800,
+            screenY: 800,
+            placeAbove: true,
+            horizontalAlign: 'center',
+        }, VIEWPORT);
+        expect(style.bottom).toBe(VIEWPORT.height - 800 + POPOVER_PIN_OFFSET);
+        expect(style.top).toBeUndefined();
+    });
+
+    it('horizontal alignment START offsets the popover to the right of the pin', () => {
+        const style = computePopoverStyle({
+            screenX: 200,
+            screenY: 400,
+            placeAbove: false,
+            horizontalAlign: 'start',
+        }, VIEWPORT);
+        // start: left edge ≈ pin.x - POPOVER_PIN_OFFSET
+        expect(style.left).toBe(200 - POPOVER_PIN_OFFSET);
+    });
+
+    it('horizontal alignment END puts the popover to the left of the pin', () => {
+        const style = computePopoverStyle({
+            screenX: 1400,
+            screenY: 400,
+            placeAbove: false,
+            horizontalAlign: 'end',
+        }, VIEWPORT);
+        // end: left edge = pin.x - POPOVER_WIDTH + POPOVER_PIN_OFFSET
+        expect(style.left).toBe(1400 - POPOVER_WIDTH + POPOVER_PIN_OFFSET);
+    });
+
+    it('horizontal alignment CENTER centres the popover on the pin', () => {
+        const style = computePopoverStyle({
+            screenX: 800,
+            screenY: 400,
+            placeAbove: false,
+            horizontalAlign: 'center',
+        }, VIEWPORT);
+        expect(style.left).toBe(800 - POPOVER_WIDTH / 2);
+    });
+
+    it('clamps the popover to the LEFT viewport edge when the requested left would go negative', () => {
+        const style = computePopoverStyle({
+            screenX: 5,
+            screenY: 400,
+            placeAbove: false,
+            horizontalAlign: 'center',
+        }, VIEWPORT);
+        expect(style.left).toBe(POPOVER_VIEWPORT_MARGIN);
+    });
+
+    it('clamps the popover to the RIGHT viewport edge when the requested left would overflow', () => {
+        const style = computePopoverStyle({
+            screenX: VIEWPORT.width - 5,
+            screenY: 400,
+            placeAbove: false,
+            horizontalAlign: 'center',
+        }, VIEWPORT);
+        expect(style.left).toBe(VIEWPORT.width - POPOVER_WIDTH - POPOVER_VIEWPORT_MARGIN);
+    });
+
+    it('end-to-end: a pin in the BOTTOM-RIGHT corner produces an above + end placement that stays in viewport', () => {
+        const placement = decidePopoverPlacement(VIEWPORT.width - 50, VIEWPORT.height - 50, VIEWPORT);
+        expect(placement.placeAbove).toBe(true);
+        expect(placement.horizontalAlign).toBe('end');
+        const style = computePopoverStyle({
+            screenX: VIEWPORT.width - 50,
+            screenY: VIEWPORT.height - 50,
+            ...placement,
+        }, VIEWPORT);
+        // Above placement → uses bottom (not top)
+        expect(style.bottom).toBeDefined();
+        // End placement clamps inside the right edge
+        const left = style.left as number;
+        expect(left).toBeGreaterThanOrEqual(POPOVER_VIEWPORT_MARGIN);
+        expect(left + POPOVER_WIDTH).toBeLessThanOrEqual(VIEWPORT.width - POPOVER_VIEWPORT_MARGIN);
+    });
+
+    it('end-to-end: a pin in the TOP-LEFT corner produces a below + start placement that stays in viewport', () => {
+        const placement = decidePopoverPlacement(40, 40, VIEWPORT);
+        expect(placement.placeAbove).toBe(false);
+        expect(placement.horizontalAlign).toBe('start');
+        const style = computePopoverStyle({
+            screenX: 40,
+            screenY: 40,
+            ...placement,
+        }, VIEWPORT);
+        expect(style.top).toBe(40 + POPOVER_PIN_OFFSET);
+        const left = style.left as number;
+        expect(left).toBeGreaterThanOrEqual(POPOVER_VIEWPORT_MARGIN);
+        expect(left + POPOVER_WIDTH).toBeLessThanOrEqual(VIEWPORT.width - POPOVER_VIEWPORT_MARGIN);
+    });
+
+    it('exports placement constants for downstream consumers', () => {
+        expect(POPOVER_WIDTH).toBe(340);
+        expect(POPOVER_MAX_HEIGHT).toBe(480);
+    });
+});

--- a/frontend/src/utils/popoverPlacement.ts
+++ b/frontend/src/utils/popoverPlacement.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import type { CSSProperties } from 'react';
+
+/**
+ * Pin-anchored popover placement helpers used by
+ * `ActionOverviewDiagram`.
+ *
+ * Extracted into its own module so the component file only
+ * exports React components — `react-refresh/only-export-components`
+ * would otherwise refuse to fast-refresh the diagram when these
+ * pure helpers were colocated with the JSX.
+ */
+
+/** Approximate popover dimensions used by the placement heuristic. */
+export const POPOVER_WIDTH = 340;
+export const POPOVER_MAX_HEIGHT = 480;
+/** Pixel offset between the pin and the popover so the pin tip stays visible. */
+export const POPOVER_PIN_OFFSET = 28;
+/** Safety margin from the viewport edge. */
+export const POPOVER_VIEWPORT_MARGIN = 8;
+
+export interface PopoverPlacement {
+    placeAbove: boolean;
+    horizontalAlign: 'start' | 'center' | 'end';
+}
+
+const defaultViewport = (): { width: number; height: number } => ({
+    width: typeof window !== 'undefined' ? window.innerWidth : 1024,
+    height: typeof window !== 'undefined' ? window.innerHeight : 768,
+});
+
+/**
+ * Decide where to anchor the popover relative to the pin so it
+ * stays inside the viewport.
+ *
+ * Rules:
+ *  - Vertical: place ABOVE if there's not enough room below for
+ *    the full popover; otherwise BELOW. Falls back to whichever
+ *    side has more room when neither side fits the full max
+ *    height.
+ *  - Horizontal: align the popover's LEFT edge to the pin if the
+ *    pin is in the left third of the viewport, RIGHT edge if the
+ *    pin is in the right third, otherwise CENTRE the popover on
+ *    the pin.
+ */
+export const decidePopoverPlacement = (
+    pinScreenX: number,
+    pinScreenY: number,
+    viewport: { width: number; height: number } = defaultViewport(),
+): PopoverPlacement => {
+    const spaceBelow = viewport.height - pinScreenY - POPOVER_PIN_OFFSET - POPOVER_VIEWPORT_MARGIN;
+    const spaceAbove = pinScreenY - POPOVER_PIN_OFFSET - POPOVER_VIEWPORT_MARGIN;
+    let placeAbove: boolean;
+    if (spaceBelow >= POPOVER_MAX_HEIGHT) {
+        placeAbove = false;
+    } else if (spaceAbove >= POPOVER_MAX_HEIGHT) {
+        placeAbove = true;
+    } else {
+        placeAbove = spaceAbove > spaceBelow;
+    }
+
+    let horizontalAlign: 'start' | 'center' | 'end';
+    if (pinScreenX < viewport.width / 3) {
+        horizontalAlign = 'start';
+    } else if (pinScreenX > (viewport.width * 2) / 3) {
+        horizontalAlign = 'end';
+    } else {
+        horizontalAlign = 'center';
+    }
+    return { placeAbove, horizontalAlign };
+};
+
+/**
+ * Translate a placement decision into concrete CSS positioning.
+ * Uses `bottom` rather than `top` for above-placement so the
+ * popover anchors its bottom edge at the pin regardless of its
+ * actual rendered height (avoids the white-gap when the popover
+ * is shorter than POPOVER_MAX_HEIGHT).
+ */
+export const computePopoverStyle = (
+    pin: { screenX: number; screenY: number } & PopoverPlacement,
+    viewport: { width: number; height: number } = defaultViewport(),
+): CSSProperties => {
+    let left: number;
+    if (pin.horizontalAlign === 'start') {
+        left = pin.screenX - POPOVER_PIN_OFFSET;
+    } else if (pin.horizontalAlign === 'end') {
+        left = pin.screenX - POPOVER_WIDTH + POPOVER_PIN_OFFSET;
+    } else {
+        left = pin.screenX - POPOVER_WIDTH / 2;
+    }
+    // Clamp to viewport with a small margin.
+    left = Math.max(
+        POPOVER_VIEWPORT_MARGIN,
+        Math.min(left, viewport.width - POPOVER_WIDTH - POPOVER_VIEWPORT_MARGIN),
+    );
+
+    if (pin.placeAbove) {
+        return {
+            position: 'fixed',
+            left,
+            bottom: viewport.height - pin.screenY + POPOVER_PIN_OFFSET,
+        };
+    }
+    return {
+        position: 'fixed',
+        left,
+        top: pin.screenY + POPOVER_PIN_OFFSET,
+    };
+};

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1555,33 +1555,7 @@ describe('applyActionOverviewHighlights', () => {
         expect(clone!.classList.contains('nad-highlight-clone')).toBe(true);
     });
 
-    it('inserts the highlight layer BEFORE the dim layer (background-style placement)', () => {
-        // Regression guard: highlights must render BEHIND the
-        // dimmed network so halos peek out around line strokes,
-        // matching the `#nad-background-layer` placement on the
-        // N-1 tab.
-        const { container, meta } = buildContainer();
-        // Wrap existing children in a dim-layer stub the way
-        // ActionOverviewDiagram does at injection time.
-        const svg = container.querySelector('svg')!;
-        const dimGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        dimGroup.setAttribute('class', 'nad-overview-dim-layer');
-        Array.from(svg.childNodes).forEach(c => dimGroup.appendChild(c));
-        svg.appendChild(dimGroup);
-
-        applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
-
-        const directChildren = Array.from(svg.children) as Element[];
-        const highlightIdx = directChildren.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
-        const dimIdx = directChildren.findIndex(c => c.classList.contains('nad-overview-dim-layer'));
-        expect(highlightIdx).toBeGreaterThan(-1);
-        expect(dimIdx).toBeGreaterThan(-1);
-        // Highlight layer must come BEFORE dim layer in document
-        // order so it renders behind the dimmed network.
-        expect(highlightIdx).toBeLessThan(dimIdx);
-    });
-
-    it('falls back to inserting at the start of the SVG when no dim layer is present', () => {
+    it('inserts the highlight layer at the START of the SVG (background-style placement)', () => {
         const { container, meta } = buildContainer();
         applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
         const svg = container.querySelector('svg')!;

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1555,14 +1555,13 @@ describe('applyActionOverviewHighlights', () => {
         expect(clone!.classList.contains('nad-highlight-clone')).toBe(true);
     });
 
-    it('inserts the highlight layer BEFORE the pin layer (or at the end of the SVG)', () => {
+    it('inserts the highlight layer AFTER the dim rect (above dimmed NAD, below pins)', () => {
         const { container, meta } = buildContainer();
         applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
         const svg = container.querySelector('svg')!;
-        // The highlight layer should be a direct child of the SVG.
         const layer = svg.querySelector(':scope > g.nad-overview-highlight-layer');
         expect(layer).not.toBeNull();
-        // When there is no pin layer yet, the highlight layer goes at the end.
+        // When there is no pin layer, the highlight layer goes at the end.
         expect(svg.lastElementChild).toBe(layer);
     });
 

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1533,20 +1533,39 @@ describe('applyActionOverviewHighlights', () => {
         expect(clone!.classList.contains('nad-highlight-clone')).toBe(true);
     });
 
-    it('inserts the highlight layer BEFORE the action-overview pin layer', () => {
+    it('inserts the highlight layer BEFORE the dim layer (background-style placement)', () => {
+        // Regression guard: highlights must render BEHIND the
+        // dimmed network so halos peek out around line strokes,
+        // matching the `#nad-background-layer` placement on the
+        // N-1 tab.
         const { container, meta } = buildContainer();
-        // First create a pin layer to lock the desired ordering
-        applyActionOverviewPins(container, [
-            { id: 'a', x: 50, y: 50, severity: 'green', label: '50%', title: '' },
-        ], () => {});
+        // Wrap existing children in a dim-layer stub the way
+        // ActionOverviewDiagram does at injection time.
+        const svg = container.querySelector('svg')!;
+        const dimGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        dimGroup.setAttribute('class', 'nad-overview-dim-layer');
+        Array.from(svg.childNodes).forEach(c => dimGroup.appendChild(c));
+        svg.appendChild(dimGroup);
+
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
+
+        const directChildren = Array.from(svg.children) as Element[];
+        const highlightIdx = directChildren.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+        const dimIdx = directChildren.findIndex(c => c.classList.contains('nad-overview-dim-layer'));
+        expect(highlightIdx).toBeGreaterThan(-1);
+        expect(dimIdx).toBeGreaterThan(-1);
+        // Highlight layer must come BEFORE dim layer in document
+        // order so it renders behind the dimmed network.
+        expect(highlightIdx).toBeLessThan(dimIdx);
+    });
+
+    it('falls back to inserting at the start of the SVG when no dim layer is present', () => {
+        const { container, meta } = buildContainer();
         applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
         const svg = container.querySelector('svg')!;
-        const directChildren = Array.from(svg.children).filter(c => c.tagName === 'g' || c.tagName === 'G');
-        const highlightIdx = directChildren.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
-        const pinIdx = directChildren.findIndex(c => c.classList.contains('nad-action-overview-pins'));
-        expect(highlightIdx).toBeGreaterThan(-1);
-        expect(pinIdx).toBeGreaterThan(-1);
-        expect(highlightIdx).toBeLessThan(pinIdx);
+        // The first <g> child of the SVG should be our highlight layer.
+        const firstG = svg.querySelector(':scope > g');
+        expect(firstG?.classList.contains('nad-overview-highlight-layer')).toBe(true);
     });
 
     it('is idempotent — repeated calls wipe the previous highlight layer', () => {

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1706,17 +1706,17 @@ describe('rescaleActionOverviewPins', () => {
     });
 
     it('upscales the pin body when the zoom level puts VL circles below the screen-pixel floor', () => {
-        // Simulate a very zoomed-out NAD by mocking getScreenCTM to
-        // return a tiny pxPerSvgUnit (0.1 → 1 SVG unit = 0.1 px).
+        // Simulate a very zoomed-out NAD: viewBox is 1000 wide but the
+        // container is only 100 px wide → pxPerSvgUnit = 100 / 1000 = 0.1.
         // At that ratio, baseR=30 → 3 screen px, well below the
         // 22-px floor, so the rescaler must upscale the body.
         const container = renderContainer();
         applyActionOverviewPins(container, [
             { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
         ], () => {});
-        const svg = container.querySelector('svg') as unknown as SVGGraphicsElement;
-        const fakeMatrix = { a: 0.1, b: 0, c: 0, d: 0.1, e: 0, f: 0 };
-        svg.getScreenCTM = (() => fakeMatrix) as unknown as SVGGraphicsElement['getScreenCTM'];
+        // Mock clientWidth on the container (jsdom reports 0 by default).
+        // viewBox="0 0 1000 1000", clientWidth=100 → pxPerSvgUnit = 0.1
+        Object.defineProperty(container, 'clientWidth', { value: 100, configurable: true });
 
         rescaleActionOverviewPins(container);
         const body = container.querySelector('g.nad-action-overview-pin-body')!;
@@ -1733,11 +1733,9 @@ describe('rescaleActionOverviewPins', () => {
         applyActionOverviewPins(container, [
             { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
         ], () => {});
-        const svg = container.querySelector('svg') as unknown as SVGGraphicsElement;
-        // pxPerSvgUnit=2 → 30 units = 60 screen px, way above the
-        // 22 px floor, so no upscaling.
-        const fakeMatrix = { a: 2, b: 0, c: 0, d: 2, e: 0, f: 0 };
-        svg.getScreenCTM = (() => fakeMatrix) as unknown as SVGGraphicsElement['getScreenCTM'];
+        // viewBox="0 0 1000 1000", clientWidth=2000 → pxPerSvgUnit = 2
+        // → 30 units = 60 screen px, way above the 22 px floor.
+        Object.defineProperty(container, 'clientWidth', { value: 2000, configurable: true });
 
         rescaleActionOverviewPins(container);
         const body = container.querySelector('g.nad-action-overview-pin-body')!;
@@ -1751,8 +1749,8 @@ describe('rescaleActionOverviewPins', () => {
             { id: 'b', x: 100, y: 0, severity: 'red', label: '110%', title: '' },
             { id: 'c', x: 200, y: 0, severity: 'orange', label: '92%', title: '' },
         ], () => {});
-        const svg = container.querySelector('svg') as unknown as SVGGraphicsElement;
-        svg.getScreenCTM = (() => ({ a: 0.1, b: 0, c: 0, d: 0.1, e: 0, f: 0 })) as unknown as SVGGraphicsElement['getScreenCTM'];
+        // viewBox="0 0 1000 1000", clientWidth=100 → pxPerSvgUnit = 0.1
+        Object.defineProperty(container, 'clientWidth', { value: 100, configurable: true });
 
         rescaleActionOverviewPins(container);
         const bodies = container.querySelectorAll('g.nad-action-overview-pin-body');

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1372,6 +1372,28 @@ describe('applyActionOverviewPins', () => {
         expect(path!.hasAttribute('stroke-width')).toBe(false);
     });
 
+    it('uses a high-contrast dark slate fill on the pin label text (not the severity colour)', () => {
+        // Regression: earlier the label text was filled with the
+        // severity colour, which matched the teardrop and faded
+        // into the pin outline when the text slightly overflowed
+        // the inner white disc.
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'g', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+            { id: 'o', x: 0, y: 0, severity: 'orange', label: '90%', title: '' },
+            { id: 'r', x: 0, y: 0, severity: 'red', label: '110%', title: '' },
+            { id: 'x', x: 0, y: 0, severity: 'grey', label: 'DIV', title: '' },
+        ], () => {});
+        const texts = Array.from(container.querySelectorAll('g.nad-action-overview-pin text'));
+        // Every pin label — regardless of severity — uses the
+        // same dark fill so it stays readable on the white disc
+        // AND on the coloured teardrop if it overflows.
+        texts.forEach(t => {
+            expect(t.getAttribute('fill')).toBe('#1f2937');
+        });
+    });
+
     it('is idempotent — re-applying wipes the previous layer', () => {
         const container = document.createElement('div');
         container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -20,6 +20,7 @@ import {
     applyContingencyHighlight,
     buildActionOverviewPins,
     applyActionOverviewPins,
+    rescaleActionOverviewPins,
     computeActionOverviewFitRect,
     computeEquipmentFitRect,
 } from './svgUtils';
@@ -1346,7 +1347,10 @@ describe('applyActionOverviewPins', () => {
             { id: 'r', x: 0, y: 0, severity: 'red', label: '110%', title: '' },
             { id: 'x', x: 0, y: 0, severity: 'grey', label: 'DIV', title: '' },
         ], () => {});
-        const fills = Array.from(container.querySelectorAll('g.nad-action-overview-pin > path'))
+        // path now lives inside the inner `pin-body` wrapper so the
+        // screen-constant rescaler can upscale it on unzoom. Use a
+        // descendant selector so the assertion keeps working.
+        const fills = Array.from(container.querySelectorAll('g.nad-action-overview-pin path'))
             .map(el => el.getAttribute('fill'));
         expect(fills).toEqual(['#28a745', '#f0ad4e', '#dc3545', '#9ca3af']);
     });
@@ -1360,7 +1364,7 @@ describe('applyActionOverviewPins', () => {
         applyActionOverviewPins(container, [
             { id: 'a', x: 10, y: 10, severity: 'green', label: '50%', title: '' },
         ], () => {});
-        const path = container.querySelector('g.nad-action-overview-pin > path');
+        const path = container.querySelector('g.nad-action-overview-pin path');
         expect(path).not.toBeNull();
         expect(path!.getAttribute('stroke')).toBe('none');
         expect(path!.hasAttribute('stroke-width')).toBe(false);
@@ -1411,6 +1415,161 @@ describe('applyActionOverviewPins', () => {
         expect(() => applyActionOverviewPins(container, [
             { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
         ], () => {})).not.toThrow();
+    });
+
+    it('wraps pin glyph inside a .nad-action-overview-pin-body subgroup for rescaling', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 10, y: 20, severity: 'green', label: '50%', title: 'A' },
+        ], () => {});
+        const pin = container.querySelector('g.nad-action-overview-pin')!;
+        // Outer group: translate only (no scale at this level)
+        expect(pin.getAttribute('transform')).toBe('translate(10 20)');
+        // Inner body group: carries the rescaling scale() transform
+        const body = pin.querySelector(':scope > g.nad-action-overview-pin-body');
+        expect(body).not.toBeNull();
+        expect(body!.getAttribute('transform')).toMatch(/^scale\(/);
+        // The glyph (path, inner disc, text) all live inside the body
+        expect(body!.querySelector('path')).not.toBeNull();
+        expect(body!.querySelector('circle')).not.toBeNull();
+        expect(body!.querySelector('text')).not.toBeNull();
+    });
+
+    it('uses the VL circle radius from the SVG as the pin base radius', () => {
+        // Large-grid NAD: VL circles have r=80 (after boost).
+        // The pin teardrop path must reference R=80 in its `d`
+        // attribute so it matches VL circles at 1:1 zoom.
+        const container = document.createElement('div');
+        container.innerHTML =
+            '<svg viewBox="0 0 200000 200000">' +
+            '  <g class="nad-vl-nodes"><circle r="80"/></g>' +
+            '</svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        const path = container.querySelector('g.nad-action-overview-pin path')!;
+        // Teardrop arc endpoints: A ${R} ${R} … ${R} ${-R-tail}
+        // With R=80, the d attribute must reference "80" in the arc.
+        expect(path.getAttribute('d')).toContain('A 80 80');
+    });
+
+    it('falls back to r=30 when the SVG has no usable VL circles', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        const path = container.querySelector('g.nad-action-overview-pin path')!;
+        expect(path.getAttribute('d')).toContain('A 30 30');
+    });
+});
+
+describe('rescaleActionOverviewPins', () => {
+    const renderContainer = (svgInner: string = ''): HTMLElement => {
+        const container = document.createElement('div');
+        container.innerHTML =
+            '<svg viewBox="0 0 1000 1000">' +
+            '  <g class="nad-vl-nodes"><circle r="30"/></g>' +
+            svgInner +
+            '</svg>';
+        return container;
+    };
+
+    it('is a no-op when the container has no pin layer', () => {
+        const container = renderContainer();
+        // Should NOT throw even though there's no pin layer yet.
+        expect(() => rescaleActionOverviewPins(container)).not.toThrow();
+    });
+
+    it('is a no-op when the container has no <svg>', () => {
+        const container = document.createElement('div');
+        expect(() => rescaleActionOverviewPins(container)).not.toThrow();
+    });
+
+    it('applies a scale(1) body transform at 1:1 mapping (jsdom fallback)', () => {
+        // jsdom does not implement getScreenCTM, so the rescaler
+        // falls back to pxPerSvgUnit=1. With baseR=30 (VL circle)
+        // and MIN_SCREEN_RADIUS_PX=22, baseR wins as the floor and
+        // the body scale stays at 1.
+        const container = renderContainer();
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 50, y: 50, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        rescaleActionOverviewPins(container);
+        const body = container.querySelector('g.nad-action-overview-pin-body')!;
+        expect(body.getAttribute('transform')).toBe('scale(1)');
+    });
+
+    it('upscales the pin body when the zoom level puts VL circles below the screen-pixel floor', () => {
+        // Simulate a very zoomed-out NAD by mocking getScreenCTM to
+        // return a tiny pxPerSvgUnit (0.1 → 1 SVG unit = 0.1 px).
+        // At that ratio, baseR=30 → 3 screen px, well below the
+        // 22-px floor, so the rescaler must upscale the body.
+        const container = renderContainer();
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        const svg = container.querySelector('svg') as unknown as SVGGraphicsElement;
+        const fakeMatrix = { a: 0.1, b: 0, c: 0, d: 0.1, e: 0, f: 0 };
+        svg.getScreenCTM = (() => fakeMatrix) as unknown as SVGGraphicsElement['getScreenCTM'];
+
+        rescaleActionOverviewPins(container);
+        const body = container.querySelector('g.nad-action-overview-pin-body')!;
+        const match = body.getAttribute('transform')!.match(/^scale\(([0-9.]+)\)$/);
+        expect(match).not.toBeNull();
+        const scale = parseFloat(match![1]);
+        // Effective SVG radius = 22 px / 0.1 px/unit = 220 units.
+        // Scale = 220 / 30 ≈ 7.33.
+        expect(scale).toBeCloseTo(220 / 30, 2);
+    });
+
+    it('keeps scale=1 when zoom level is detailed enough (VL circles already above floor)', () => {
+        const container = renderContainer();
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        const svg = container.querySelector('svg') as unknown as SVGGraphicsElement;
+        // pxPerSvgUnit=2 → 30 units = 60 screen px, way above the
+        // 22 px floor, so no upscaling.
+        const fakeMatrix = { a: 2, b: 0, c: 0, d: 2, e: 0, f: 0 };
+        svg.getScreenCTM = (() => fakeMatrix) as unknown as SVGGraphicsElement['getScreenCTM'];
+
+        rescaleActionOverviewPins(container);
+        const body = container.querySelector('g.nad-action-overview-pin-body')!;
+        expect(body.getAttribute('transform')).toBe('scale(1)');
+    });
+
+    it('rescales EVERY pin on the layer, not just the first', () => {
+        const container = renderContainer();
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+            { id: 'b', x: 100, y: 0, severity: 'red', label: '110%', title: '' },
+            { id: 'c', x: 200, y: 0, severity: 'orange', label: '92%', title: '' },
+        ], () => {});
+        const svg = container.querySelector('svg') as unknown as SVGGraphicsElement;
+        svg.getScreenCTM = (() => ({ a: 0.1, b: 0, c: 0, d: 0.1, e: 0, f: 0 })) as unknown as SVGGraphicsElement['getScreenCTM'];
+
+        rescaleActionOverviewPins(container);
+        const bodies = container.querySelectorAll('g.nad-action-overview-pin-body');
+        expect(bodies.length).toBe(3);
+        const scales = Array.from(bodies).map(b => b.getAttribute('transform'));
+        // All three pins share the same screen-constant scale.
+        expect(new Set(scales).size).toBe(1);
+        expect(scales[0]).not.toBe('scale(1)');
+    });
+
+    it('is automatically invoked by applyActionOverviewPins for initial sizing', () => {
+        // If we never called rescaleActionOverviewPins directly,
+        // the pin body should still have a transform attribute —
+        // applyActionOverviewPins calls the rescaler at the end so
+        // the first paint is already compensated.
+        const container = renderContainer();
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        const body = container.querySelector('g.nad-action-overview-pin-body')!;
+        expect(body.hasAttribute('transform')).toBe(true);
     });
 });
 

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -20,6 +20,7 @@ import {
     applyContingencyHighlight,
     buildActionOverviewPins,
     applyActionOverviewPins,
+    applyActionOverviewHighlights,
     rescaleActionOverviewPins,
     computeActionOverviewFitRect,
     computeEquipmentFitRect,
@@ -1459,6 +1460,124 @@ describe('applyActionOverviewPins', () => {
         expect(() => applyActionOverviewPins(container, [
             { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
         ], () => {})).not.toThrow();
+    });
+
+    it('stops mousedown propagation so usePanZoom drag does not eat the click', () => {
+        // Regression: if mousedown bubbles up to the svg-container,
+        // usePanZoom calls setInteracting(true) which sets
+        // pointer-events: none on every svg child via App.css. The
+        // pin's click never lands. We assert here that mousedown
+        // is stopped at the pin (propagation chain truncated).
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 10, y: 10, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        const pin = container.querySelector('g.nad-action-overview-pin') as SVGGElement;
+        let bubbled = false;
+        // Listen on the svg ancestor — if propagation is properly
+        // stopped at the pin, this listener will NOT fire.
+        const svg = container.querySelector('svg')!;
+        svg.addEventListener('mousedown', () => { bubbled = true; });
+        pin.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        expect(bubbled).toBe(false);
+    });
+});
+
+describe('applyActionOverviewHighlights', () => {
+    const buildContainer = (): { container: HTMLElement; meta: MetadataIndex } => {
+        const container = document.createElement('div');
+        container.innerHTML =
+            '<svg viewBox="0 0 1000 1000">' +
+            '  <g class="nad-edges">' +
+            '    <g id="svg-cont"><line x1="0" y1="0" x2="100" y2="0"/></g>' +
+            '    <g id="svg-ovl-1"><line x1="0" y1="100" x2="100" y2="100"/></g>' +
+            '    <g id="svg-ovl-2"><line x1="0" y1="200" x2="100" y2="200"/></g>' +
+            '  </g>' +
+            '</svg>';
+        const meta: MetadataIndex = {
+            nodesByEquipmentId: new Map(),
+            nodesBySvgId: new Map(),
+            edgesByEquipmentId: new Map<string, EdgeMeta>([
+                ['CONT_LINE', { equipmentId: 'CONT_LINE', svgId: 'svg-cont', node1: '', node2: '' }],
+                ['OVL_1', { equipmentId: 'OVL_1', svgId: 'svg-ovl-1', node1: '', node2: '' }],
+                ['OVL_2', { equipmentId: 'OVL_2', svgId: 'svg-ovl-2', node1: '', node2: '' }],
+            ]),
+            edgesByNode: new Map(),
+        };
+        return { container, meta };
+    };
+
+    it('creates a .nad-overview-highlight-layer with one clone per highlighted edge', () => {
+        const { container, meta } = buildContainer();
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1', 'OVL_2']);
+        const layer = container.querySelector('g.nad-overview-highlight-layer');
+        expect(layer).not.toBeNull();
+        // 1 contingency + 2 overloads = 3 clones
+        expect(layer!.children.length).toBe(3);
+    });
+
+    it('uses the existing nad-contingency-highlight class on the contingency clone', () => {
+        const { container, meta } = buildContainer();
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
+        const clone = container.querySelector('g.nad-overview-highlight-layer .nad-contingency-highlight');
+        expect(clone).not.toBeNull();
+        expect(clone!.classList.contains('nad-highlight-clone')).toBe(true);
+    });
+
+    it('uses the existing nad-overloaded class on overload clones', () => {
+        const { container, meta } = buildContainer();
+        applyActionOverviewHighlights(container, meta, null, ['OVL_1']);
+        const clone = container.querySelector('g.nad-overview-highlight-layer .nad-overloaded');
+        expect(clone).not.toBeNull();
+        expect(clone!.classList.contains('nad-highlight-clone')).toBe(true);
+    });
+
+    it('inserts the highlight layer BEFORE the action-overview pin layer', () => {
+        const { container, meta } = buildContainer();
+        // First create a pin layer to lock the desired ordering
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 50, y: 50, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
+        const svg = container.querySelector('svg')!;
+        const directChildren = Array.from(svg.children).filter(c => c.tagName === 'g' || c.tagName === 'G');
+        const highlightIdx = directChildren.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+        const pinIdx = directChildren.findIndex(c => c.classList.contains('nad-action-overview-pins'));
+        expect(highlightIdx).toBeGreaterThan(-1);
+        expect(pinIdx).toBeGreaterThan(-1);
+        expect(highlightIdx).toBeLessThan(pinIdx);
+    });
+
+    it('is idempotent — repeated calls wipe the previous highlight layer', () => {
+        const { container, meta } = buildContainer();
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1', 'OVL_2']);
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1']);
+        const layers = container.querySelectorAll('g.nad-overview-highlight-layer');
+        expect(layers.length).toBe(1);
+        expect(layers[0].children.length).toBe(2); // 1 contingency + 1 overload
+    });
+
+    it('clears the highlight layer when called with neither contingency nor overloads', () => {
+        const { container, meta } = buildContainer();
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1']);
+        applyActionOverviewHighlights(container, meta, null, []);
+        expect(container.querySelector('g.nad-overview-highlight-layer')).toBeNull();
+    });
+
+    it('skips equipment ids that are not in the metadata', () => {
+        const { container, meta } = buildContainer();
+        applyActionOverviewHighlights(container, meta, 'GHOST', ['OVL_1', 'GHOST2']);
+        const layer = container.querySelector('g.nad-overview-highlight-layer')!;
+        // Only OVL_1 resolved → 1 clone
+        expect(layer.children.length).toBe(1);
+    });
+
+    it('no-ops gracefully on null container / metaIndex / svg', () => {
+        expect(() => applyActionOverviewHighlights(null, null, null, [])).not.toThrow();
+        expect(() => applyActionOverviewHighlights(document.createElement('div'), null, 'X', ['Y'])).not.toThrow();
+        const empty = document.createElement('div');
+        expect(() => applyActionOverviewHighlights(empty, { nodesByEquipmentId: new Map(), nodesBySvgId: new Map(), edgesByEquipmentId: new Map(), edgesByNode: new Map() }, 'X', [])).not.toThrow();
     });
 
     it('wraps pin glyph inside a .nad-action-overview-pin-body subgroup for rescaling', () => {

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1876,3 +1876,140 @@ describe('computeEquipmentFitRect', () => {
         expect(computeEquipmentFitRect(null, 'LINE_A', 0)).toBeNull();
     });
 });
+
+// ============================================================
+// Performance-critical batching & caching tests
+// ============================================================
+
+describe('applyActionOverviewHighlights — batched DOM writes', () => {
+    const buildContainer = (): { container: HTMLElement; meta: MetadataIndex } => {
+        const container = document.createElement('div');
+        container.innerHTML =
+            '<svg viewBox="0 0 1000 1000">' +
+            '  <g class="nad-edges">' +
+            '    <g id="svg-cont"><line x1="0" y1="0" x2="100" y2="0"/></g>' +
+            '    <g id="svg-ovl-1"><line x1="0" y1="100" x2="100" y2="100"/></g>' +
+            '    <g id="svg-ovl-2"><line x1="0" y1="200" x2="100" y2="200"/></g>' +
+            '  </g>' +
+            '</svg>';
+        const meta: MetadataIndex = {
+            nodesByEquipmentId: new Map(),
+            nodesBySvgId: new Map(),
+            edgesByEquipmentId: new Map<string, EdgeMeta>([
+                ['CONT_LINE', { equipmentId: 'CONT_LINE', svgId: 'svg-cont', node1: '', node2: '' }],
+                ['OVL_1', { equipmentId: 'OVL_1', svgId: 'svg-ovl-1', node1: '', node2: '' }],
+                ['OVL_2', { equipmentId: 'OVL_2', svgId: 'svg-ovl-2', node1: '', node2: '' }],
+            ]),
+            edgesByNode: new Map(),
+        };
+        return { container, meta };
+    };
+
+    it('inserts all clones in a single DOM mutation (no interleaved appendChild)', () => {
+        const { container, meta } = buildContainer();
+        const svg = container.querySelector('svg')!;
+
+        // Count how many times the highlight layer's children change.
+        // With the batched DocumentFragment approach, the layer gets
+        // a single appendChild(frag) at the end.
+        let insertCount = 0;
+        const realInsertBefore = svg.insertBefore.bind(svg);
+        svg.insertBefore = function <T extends Node>(node: T, ref: Node | null): T {
+            const result = realInsertBefore(node, ref);
+            // The highlight layer is the <g> being inserted
+            if (node instanceof Element && node.classList?.contains('nad-overview-highlight-layer')) {
+                // After the layer is in the DOM, spy on its appendChild
+                const origAppend = node.appendChild.bind(node);
+                node.appendChild = function <U extends Node>(child: U): U {
+                    insertCount++;
+                    return origAppend(child);
+                };
+            }
+            return result;
+        };
+
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1', 'OVL_2']);
+
+        // With DocumentFragment batching, there should be exactly 1
+        // appendChild call on the layer (the fragment), not 3 (one
+        // per clone).
+        expect(insertCount).toBe(1);
+        // But all 3 clones still appear in the DOM:
+        const layer = container.querySelector('g.nad-overview-highlight-layer')!;
+        expect(layer.children.length).toBe(3);
+    });
+
+    it('strips nad-delta-* classes from cloned highlights', () => {
+        const { container, meta } = buildContainer();
+        // Tag an original edge with delta classes that should be
+        // stripped on the clone.
+        const orig = container.querySelector('#svg-ovl-1')!;
+        orig.classList.add('nad-delta-positive');
+
+        applyActionOverviewHighlights(container, meta, null, ['OVL_1']);
+        const clone = container.querySelector('g.nad-overview-highlight-layer .nad-overloaded')!;
+        expect(clone.classList.contains('nad-delta-positive')).toBe(false);
+        expect(clone.classList.contains('nad-delta-negative')).toBe(false);
+        expect(clone.classList.contains('nad-delta-grey')).toBe(false);
+    });
+});
+
+describe('applyActionOverviewPins — batched DOM writes', () => {
+    it('builds all pins off-DOM before inserting the layer into the SVG', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        const svg = container.querySelector('svg')!;
+
+        // Track appendChild calls on the SVG itself.
+        let svgAppendCount = 0;
+        const origAppend = svg.appendChild.bind(svg);
+        svg.appendChild = function <T extends Node>(child: T): T {
+            svgAppendCount++;
+            return origAppend(child);
+        };
+
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 10, y: 20, severity: 'green', label: '50%', title: 'A' },
+            { id: 'b', x: 30, y: 40, severity: 'red', label: '120%', title: 'B' },
+            { id: 'c', x: 50, y: 60, severity: 'orange', label: '90%', title: 'C' },
+        ], () => {});
+
+        // Only ONE appendChild on the SVG (the fully-populated layer),
+        // not one per pin.
+        expect(svgAppendCount).toBe(1);
+        // All 3 pins are present in the DOM:
+        expect(container.querySelectorAll('g.nad-action-overview-pin').length).toBe(3);
+    });
+});
+
+describe('rescaleActionOverviewPins — baseRadius caching', () => {
+    it('does not re-query circle[r] on subsequent rescale calls', () => {
+        const container = document.createElement('div');
+        container.innerHTML =
+            '<svg viewBox="0 0 1000 1000">' +
+            '  <g class="nad-vl-nodes"><circle r="30"/></g>' +
+            '</svg>';
+
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 50, y: 50, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+
+        const svg = container.querySelector('svg')!;
+        // After applyActionOverviewPins, the cache is populated.
+        // Spy on querySelector to verify it's not called for circle[r]
+        // during rescale.
+        const origQS = svg.querySelector.bind(svg);
+        let circleQueryCount = 0;
+        svg.querySelector = function (selector: string) {
+            if (selector.includes('circle[r]')) circleQueryCount++;
+            return origQS(selector);
+        } as typeof svg.querySelector;
+
+        rescaleActionOverviewPins(container);
+        rescaleActionOverviewPins(container);
+        rescaleActionOverviewPins(container);
+
+        // The cached path should skip the circle[r] lookup entirely.
+        expect(circleQueryCount).toBe(0);
+    });
+});

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1555,14 +1555,49 @@ describe('applyActionOverviewHighlights', () => {
         expect(clone!.classList.contains('nad-highlight-clone')).toBe(true);
     });
 
-    it('inserts the highlight layer AFTER the dim rect (above dimmed NAD, below pins)', () => {
+    it('inserts the highlight layer at the START of the SVG (behind NAD content)', () => {
         const { container, meta } = buildContainer();
         applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
         const svg = container.querySelector('svg')!;
         const layer = svg.querySelector(':scope > g.nad-overview-highlight-layer');
         expect(layer).not.toBeNull();
-        // When there is no pin layer, the highlight layer goes at the end.
-        expect(svg.lastElementChild).toBe(layer);
+        // Highlight layer should be the first child (behind everything).
+        expect(svg.firstElementChild).toBe(layer);
+    });
+
+    it('inserts highlight layer BEFORE existing dim rect and pin layer', () => {
+        const { container, meta } = buildContainer();
+        const svg = container.querySelector('svg')!;
+        const SVG_NS = 'http://www.w3.org/2000/svg';
+
+        // Simulate dim rect and pin layer already present (as in the real component).
+        const dimRect = document.createElementNS(SVG_NS, 'rect');
+        dimRect.setAttribute('class', 'nad-overview-dim-rect');
+        svg.appendChild(dimRect);
+
+        const pinLayer = document.createElementNS(SVG_NS, 'g');
+        pinLayer.setAttribute('class', 'nad-action-overview-pins');
+        svg.appendChild(pinLayer);
+
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1']);
+        const children = Array.from(svg.children);
+        const highlightIdx = children.findIndex(c => c.classList.contains('nad-overview-highlight-layer'));
+        const dimIdx = children.findIndex(c => c.classList.contains('nad-overview-dim-rect'));
+        const pinIdx = children.findIndex(c => c.classList.contains('nad-action-overview-pins'));
+        // Highlights behind NAD content (at start), dim rect and pins after
+        expect(highlightIdx).toBe(0);
+        expect(highlightIdx).toBeLessThan(dimIdx);
+        expect(dimIdx).toBeLessThan(pinIdx);
+    });
+
+    it('re-inserts highlight layer at SVG start on idempotent re-call', () => {
+        const { container, meta } = buildContainer();
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1']);
+        applyActionOverviewHighlights(container, meta, 'CONT_LINE', ['OVL_1', 'OVL_2']);
+        const svg = container.querySelector('svg')!;
+        const layer = svg.querySelector(':scope > g.nad-overview-highlight-layer');
+        // Should still be at the start after the second call.
+        expect(svg.firstElementChild).toBe(layer);
     });
 
     it('is idempotent — repeated calls wipe the previous highlight layer', () => {

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -18,6 +18,10 @@ import {
     applyDeltaVisuals,
     applyActionTargetHighlights,
     applyContingencyHighlight,
+    buildActionOverviewPins,
+    applyActionOverviewPins,
+    computeActionOverviewFitRect,
+    computeEquipmentFitRect,
 } from './svgUtils';
 import type { ActionDetail, NodeMeta, EdgeMeta, MetadataIndex } from '../types';
 
@@ -1160,5 +1164,352 @@ describe('Highlight Layering', () => {
             expect(actionTargetIdx).toBeGreaterThan(-1);
             expect(deltaIdx).toBeGreaterThan(Math.max(overloadIdx, contingencyIdx, actionTargetIdx));
         });
+    });
+});
+
+// ============================================================
+// Action-overview pins + fit-rect helpers
+// ============================================================
+
+const makeOverviewMetaIndex = (): MetadataIndex => {
+    // Simple 4-node grid laid out as:
+    //   N1 (0,0) ──LINE_A── N2 (100,0)
+    //   │                    │
+    //  LINE_C               LINE_B
+    //   │                    │
+    //   N3 (0,100) ─LINE_D─ N4 (100,100)
+    //
+    // Plus an isolated voltage-level "VL_FAR" at (500, 500).
+    const nodes: NodeMeta[] = [
+        { equipmentId: 'VL_N1', svgId: 'svg-n1', x: 0, y: 0 },
+        { equipmentId: 'VL_N2', svgId: 'svg-n2', x: 100, y: 0 },
+        { equipmentId: 'VL_N3', svgId: 'svg-n3', x: 0, y: 100 },
+        { equipmentId: 'VL_N4', svgId: 'svg-n4', x: 100, y: 100 },
+        { equipmentId: 'VL_FAR', svgId: 'svg-far', x: 500, y: 500 },
+    ];
+    const edges: EdgeMeta[] = [
+        { equipmentId: 'LINE_A', svgId: 'svg-line-a', node1: 'svg-n1', node2: 'svg-n2' },
+        { equipmentId: 'LINE_B', svgId: 'svg-line-b', node1: 'svg-n2', node2: 'svg-n4' },
+        { equipmentId: 'LINE_C', svgId: 'svg-line-c', node1: 'svg-n1', node2: 'svg-n3' },
+        { equipmentId: 'LINE_D', svgId: 'svg-line-d', node1: 'svg-n3', node2: 'svg-n4' },
+    ];
+    const nodesByEquipmentId = new Map(nodes.map(n => [n.equipmentId, n] as const));
+    const nodesBySvgId = new Map(nodes.map(n => [n.svgId, n] as const));
+    const edgesByEquipmentId = new Map(edges.map(e => [e.equipmentId, e] as const));
+    const edgesByNode = new Map<string, EdgeMeta[]>();
+    edges.forEach(e => {
+        if (!edgesByNode.has(e.node1 as string)) edgesByNode.set(e.node1 as string, []);
+        edgesByNode.get(e.node1 as string)!.push(e);
+        if (!edgesByNode.has(e.node2 as string)) edgesByNode.set(e.node2 as string, []);
+        edgesByNode.get(e.node2 as string)!.push(e);
+    });
+    return { nodesByEquipmentId, nodesBySvgId, edgesByEquipmentId, edgesByNode };
+};
+
+const makeAction = (overrides: Partial<ActionDetail> = {}): ActionDetail => ({
+    description_unitaire: 'test action',
+    rho_before: null,
+    rho_after: null,
+    max_rho: null,
+    max_rho_line: '',
+    is_rho_reduction: false,
+    ...overrides,
+});
+
+describe('buildActionOverviewPins', () => {
+    const metaIndex = makeOverviewMetaIndex();
+
+    it('resolves a line action to the edge midpoint', () => {
+        const actions: Record<string, ActionDetail> = {
+            'disco_LINE_A': makeAction({
+                action_topology: { lines_ex_bus: { LINE_A: -1 }, lines_or_bus: { LINE_A: -1 }, gens_bus: {}, loads_bus: {} },
+                max_rho: 0.88,
+                max_rho_line: 'LINE_B',
+            }),
+        };
+        const pins = buildActionOverviewPins(actions, metaIndex, 0.95);
+        expect(pins).toHaveLength(1);
+        // LINE_A midpoint = midpoint of (0,0) and (100,0) = (50, 0)
+        expect(pins[0]).toMatchObject({ id: 'disco_LINE_A', x: 50, y: 0 });
+    });
+
+    it('falls back to the voltage-level node for nodal actions', () => {
+        const actions: Record<string, ActionDetail> = {
+            'coupling_VL_FAR': makeAction({
+                description_unitaire: "Ouverture du poste 'VL_FAR'",
+                max_rho: 1.1,
+                max_rho_line: 'LINE_D',
+            }),
+        };
+        const pins = buildActionOverviewPins(actions, metaIndex, 0.95);
+        expect(pins).toHaveLength(1);
+        expect(pins[0]).toMatchObject({ id: 'coupling_VL_FAR', x: 500, y: 500 });
+    });
+
+    it('falls back to max_rho_line when no topology target resolves', () => {
+        const actions: Record<string, ActionDetail> = {
+            'mystery_action': makeAction({
+                description_unitaire: 'mystery',
+                max_rho: 0.9,
+                max_rho_line: 'LINE_D',
+            }),
+        };
+        const pins = buildActionOverviewPins(actions, metaIndex, 0.95);
+        expect(pins).toHaveLength(1);
+        // LINE_D midpoint = ((0+100)/2, (100+100)/2) = (50, 100)
+        expect(pins[0]).toMatchObject({ x: 50, y: 100 });
+    });
+
+    it('skips actions whose asset cannot be located', () => {
+        const actions: Record<string, ActionDetail> = {
+            'unknown': makeAction({ description_unitaire: 'floating', max_rho: 0.5, max_rho_line: 'GHOST_LINE' }),
+        };
+        const pins = buildActionOverviewPins(actions, metaIndex, 0.95);
+        expect(pins).toHaveLength(0);
+    });
+
+    it('assigns severity based on monitoringFactor', () => {
+        const actions: Record<string, ActionDetail> = {
+            'solved': makeAction({
+                action_topology: { lines_ex_bus: { LINE_A: -1 }, lines_or_bus: { LINE_A: -1 }, gens_bus: {}, loads_bus: {} },
+                max_rho: 0.5,
+            }),
+            'low_margin': makeAction({
+                action_topology: { lines_ex_bus: { LINE_B: -1 }, lines_or_bus: { LINE_B: -1 }, gens_bus: {}, loads_bus: {} },
+                max_rho: 0.92,
+            }),
+            'still_overloaded': makeAction({
+                action_topology: { lines_ex_bus: { LINE_C: -1 }, lines_or_bus: { LINE_C: -1 }, gens_bus: {}, loads_bus: {} },
+                max_rho: 1.1,
+            }),
+            'divergent': makeAction({
+                action_topology: { lines_ex_bus: { LINE_D: -1 }, lines_or_bus: { LINE_D: -1 }, gens_bus: {}, loads_bus: {} },
+                non_convergence: 'did not converge',
+            }),
+        };
+        const pins = buildActionOverviewPins(actions, metaIndex, 0.95);
+        const byId = Object.fromEntries(pins.map(p => [p.id, p] as const));
+        expect(byId['solved'].severity).toBe('green');
+        expect(byId['low_margin'].severity).toBe('orange');
+        expect(byId['still_overloaded'].severity).toBe('red');
+        expect(byId['divergent'].severity).toBe('grey');
+    });
+
+    it('labels pins with the rounded max loading percentage', () => {
+        const actions: Record<string, ActionDetail> = {
+            'a': makeAction({
+                action_topology: { lines_ex_bus: { LINE_A: -1 }, lines_or_bus: { LINE_A: -1 }, gens_bus: {}, loads_bus: {} },
+                max_rho: 0.873,
+                max_rho_line: 'LINE_A',
+            }),
+        };
+        const pins = buildActionOverviewPins(actions, metaIndex, 0.95);
+        expect(pins[0].label).toBe('87%');
+    });
+
+    it('honours the filterIds allowlist', () => {
+        const actions: Record<string, ActionDetail> = {
+            'a': makeAction({
+                action_topology: { lines_ex_bus: { LINE_A: -1 }, lines_or_bus: { LINE_A: -1 }, gens_bus: {}, loads_bus: {} },
+                max_rho: 0.5,
+            }),
+            'b': makeAction({
+                action_topology: { lines_ex_bus: { LINE_B: -1 }, lines_or_bus: { LINE_B: -1 }, gens_bus: {}, loads_bus: {} },
+                max_rho: 0.5,
+            }),
+        };
+        const pins = buildActionOverviewPins(actions, metaIndex, 0.95, ['a']);
+        expect(pins.map(p => p.id)).toEqual(['a']);
+    });
+});
+
+describe('applyActionOverviewPins', () => {
+    it('appends one <g.nad-action-overview-pin> per pin inside the svg', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 10, y: 20, severity: 'green', label: '50%', title: 'A' },
+            { id: 'b', x: 30, y: 40, severity: 'red', label: '120%', title: 'B' },
+        ], () => {});
+        const pinGroups = container.querySelectorAll('g.nad-action-overview-pin');
+        expect(pinGroups.length).toBe(2);
+        const layer = container.querySelector('g.nad-action-overview-pins');
+        expect(layer).not.toBeNull();
+    });
+
+    it('uses the severity palette (green/orange/red/grey)', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'g', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+            { id: 'o', x: 0, y: 0, severity: 'orange', label: '90%', title: '' },
+            { id: 'r', x: 0, y: 0, severity: 'red', label: '110%', title: '' },
+            { id: 'x', x: 0, y: 0, severity: 'grey', label: 'DIV', title: '' },
+        ], () => {});
+        const fills = Array.from(container.querySelectorAll('g.nad-action-overview-pin > path'))
+            .map(el => el.getAttribute('fill'));
+        expect(fills).toEqual(['#28a745', '#f0ad4e', '#dc3545', '#9ca3af']);
+    });
+
+    it('draws pins WITHOUT an outline (stroke=none, no stroke-width)', () => {
+        // Regression guard for the "no black outline around pins"
+        // requirement — earlier versions drew a dark stroke and it
+        // competed visually with the NAD line strokes.
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 10, y: 10, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        const path = container.querySelector('g.nad-action-overview-pin > path');
+        expect(path).not.toBeNull();
+        expect(path!.getAttribute('stroke')).toBe('none');
+        expect(path!.hasAttribute('stroke-width')).toBe(false);
+    });
+
+    it('is idempotent — re-applying wipes the previous layer', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+            { id: 'b', x: 10, y: 10, severity: 'red', label: '110%', title: '' },
+        ], () => {});
+        applyActionOverviewPins(container, [
+            { id: 'c', x: 20, y: 20, severity: 'orange', label: '92%', title: '' },
+        ], () => {});
+        const layers = container.querySelectorAll('g.nad-action-overview-pins');
+        expect(layers.length).toBe(1);
+        const pinGroups = container.querySelectorAll('g.nad-action-overview-pin');
+        expect(pinGroups.length).toBe(1);
+        expect(pinGroups[0].getAttribute('data-action-id')).toBe('c');
+    });
+
+    it('empty pin list clears the layer entirely', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+        ], () => {});
+        applyActionOverviewPins(container, [], () => {});
+        expect(container.querySelectorAll('g.nad-action-overview-pin').length).toBe(0);
+    });
+
+    it('clicking a pin invokes the onPinClick callback with the action id', () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+        const clicks: string[] = [];
+        applyActionOverviewPins(container, [
+            { id: 'action_42', x: 10, y: 10, severity: 'green', label: '50%', title: '' },
+        ], id => clicks.push(id));
+        const pinGroup = container.querySelector('g.nad-action-overview-pin') as SVGGElement;
+        pinGroup.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(clicks).toEqual(['action_42']);
+    });
+
+    it('does nothing when the container has no <svg>', () => {
+        const container = document.createElement('div');
+        // Should NOT throw
+        expect(() => applyActionOverviewPins(container, [
+            { id: 'a', x: 0, y: 0, severity: 'green', label: '50%', title: '' },
+        ], () => {})).not.toThrow();
+    });
+});
+
+describe('computeActionOverviewFitRect', () => {
+    const metaIndex = makeOverviewMetaIndex();
+
+    it('returns null when nothing can be located', () => {
+        expect(computeActionOverviewFitRect(metaIndex, null, [], [])).toBeNull();
+    });
+
+    it('includes the contingency edge endpoints in the rectangle', () => {
+        // LINE_A spans (0,0)→(100,0). Both spans are below
+        // MIN_SPAN=200 so they're expanded around their centers:
+        //   x: span 100 → 200 centered on 50 → [-50, 150]
+        //   y: span 0   → 200 centered on 0  → [-100, 100]
+        const rect = computeActionOverviewFitRect(metaIndex, 'LINE_A', [], [], 0);
+        expect(rect!.x).toBeCloseTo(-50);
+        expect(rect!.w).toBeCloseTo(200);
+        expect(rect!.y).toBeCloseTo(-100);
+        expect(rect!.h).toBeCloseTo(200);
+    });
+
+    it('unions contingency + overloads + pins', () => {
+        const rect = computeActionOverviewFitRect(
+            metaIndex,
+            'LINE_A', // (0,0)..(100,0)
+            ['LINE_D'], // (0,100)..(100,100)
+            [{ x: 500, y: 500 }],
+            0,
+        );
+        expect(rect!.x).toBeCloseTo(0);
+        expect(rect!.y).toBeCloseTo(0);
+        expect(rect!.w).toBeCloseTo(500);
+        expect(rect!.h).toBeCloseTo(500);
+    });
+
+    it('applies a 5% margin by default', () => {
+        // Regression guard for the "5% margin" requirement.
+        const rect = computeActionOverviewFitRect(
+            metaIndex,
+            null,
+            [],
+            [{ x: 0, y: 0 }, { x: 1000, y: 1000 }],
+        );
+        // Raw bbox is 1000x1000. With 5% padding on each side we
+        // expect: x = -50, y = -50, w = 1100, h = 1100.
+        expect(rect!.x).toBeCloseTo(-50);
+        expect(rect!.y).toBeCloseTo(-50);
+        expect(rect!.w).toBeCloseTo(1100);
+        expect(rect!.h).toBeCloseTo(1100);
+    });
+
+    it('expands degenerate spans (single point) to a minimum size', () => {
+        const rect = computeActionOverviewFitRect(
+            metaIndex,
+            null,
+            [],
+            [{ x: 10, y: 20 }],
+            0,
+        );
+        // Single point: w=h<MIN_SPAN=200 → expanded to 200 around center
+        expect(rect!.w).toBeCloseTo(200);
+        expect(rect!.h).toBeCloseTo(200);
+        expect(rect!.x).toBeCloseTo(10 - 100);
+        expect(rect!.y).toBeCloseTo(20 - 100);
+    });
+
+    it('returns null when metaIndex is null', () => {
+        expect(computeActionOverviewFitRect(null, 'LINE_A', [], [])).toBeNull();
+    });
+});
+
+describe('computeEquipmentFitRect', () => {
+    const metaIndex = makeOverviewMetaIndex();
+
+    it('focuses on an edge using both endpoints', () => {
+        const rect = computeEquipmentFitRect(metaIndex, 'LINE_A', 0);
+        // LINE_A spans (0,0)→(100,0); both spans below MIN_SPAN=150
+        // → expanded around center (50, 0): x ∈ [-25, 125], y ∈ [-75, 75].
+        expect(rect!.x).toBeCloseTo(-25);
+        expect(rect!.w).toBeCloseTo(150);
+        expect(rect!.y).toBeCloseTo(-75);
+        expect(rect!.h).toBeCloseTo(150);
+    });
+
+    it('focuses on a voltage-level node', () => {
+        const rect = computeEquipmentFitRect(metaIndex, 'VL_FAR', 0);
+        // Single point at (500,500) → expanded to 150x150 around center
+        expect(rect!.x).toBeCloseTo(500 - 75);
+        expect(rect!.y).toBeCloseTo(500 - 75);
+        expect(rect!.w).toBeCloseTo(150);
+        expect(rect!.h).toBeCloseTo(150);
+    });
+
+    it('returns null for an unknown equipment id', () => {
+        expect(computeEquipmentFitRect(metaIndex, 'UNKNOWN', 0)).toBeNull();
+    });
+
+    it('returns null when metaIndex is null', () => {
+        expect(computeEquipmentFitRect(null, 'LINE_A', 0)).toBeNull();
     });
 });

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1555,13 +1555,15 @@ describe('applyActionOverviewHighlights', () => {
         expect(clone!.classList.contains('nad-highlight-clone')).toBe(true);
     });
 
-    it('inserts the highlight layer at the START of the SVG (background-style placement)', () => {
+    it('inserts the highlight layer BEFORE the pin layer (or at the end of the SVG)', () => {
         const { container, meta } = buildContainer();
         applyActionOverviewHighlights(container, meta, 'CONT_LINE', []);
         const svg = container.querySelector('svg')!;
-        // The first <g> child of the SVG should be our highlight layer.
-        const firstG = svg.querySelector(':scope > g');
-        expect(firstG?.classList.contains('nad-overview-highlight-layer')).toBe(true);
+        // The highlight layer should be a direct child of the SVG.
+        const layer = svg.querySelector(':scope > g.nad-overview-highlight-layer');
+        expect(layer).not.toBeNull();
+        // When there is no pin layer yet, the highlight layer goes at the end.
+        expect(svg.lastElementChild).toBe(layer);
     });
 
     it('is idempotent — repeated calls wipe the previous highlight layer', () => {
@@ -1885,18 +1887,29 @@ describe('applyActionOverviewHighlights — batched DOM writes', () => {
         // With the batched DocumentFragment approach, the layer gets
         // a single appendChild(frag) at the end.
         let insertCount = 0;
-        const realInsertBefore = svg.insertBefore.bind(svg);
-        svg.insertBefore = function <T extends Node>(node: T, ref: Node | null): T {
-            const result = realInsertBefore(node, ref);
-            // The highlight layer is the <g> being inserted
+        // The highlight layer is inserted via appendChild (when no
+        // pin layer exists) or insertBefore (when pin layer exists).
+        // Spy on both paths to catch the layer insertion, then spy
+        // on the layer's appendChild to count clone insertions.
+        const spyOnLayer = (node: Node) => {
             if (node instanceof Element && node.classList?.contains('nad-overview-highlight-layer')) {
-                // After the layer is in the DOM, spy on its appendChild
                 const origAppend = node.appendChild.bind(node);
                 node.appendChild = function <U extends Node>(child: U): U {
                     insertCount++;
                     return origAppend(child);
                 };
             }
+        };
+        const realAppendChild = svg.appendChild.bind(svg);
+        svg.appendChild = function <T extends Node>(node: T): T {
+            const result = realAppendChild(node);
+            spyOnLayer(node);
+            return result;
+        };
+        const realInsertBefore = svg.insertBefore.bind(svg);
+        svg.insertBefore = function <T extends Node>(node: T, ref: Node | null): T {
+            const result = realInsertBefore(node, ref);
+            spyOnLayer(node);
             return result;
         };
 

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
     processSvg,
     boostSvgForLargeGrid,
@@ -23,6 +23,7 @@ import {
     rescaleActionOverviewPins,
     computeActionOverviewFitRect,
     computeEquipmentFitRect,
+    PIN_SINGLE_CLICK_DELAY_MS,
 } from './svgUtils';
 import type { ActionDetail, NodeMeta, EdgeMeta, MetadataIndex } from '../types';
 
@@ -1397,16 +1398,59 @@ describe('applyActionOverviewPins', () => {
         expect(container.querySelectorAll('g.nad-action-overview-pin').length).toBe(0);
     });
 
-    it('clicking a pin invokes the onPinClick callback with the action id', () => {
-        const container = document.createElement('div');
-        container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
-        const clicks: string[] = [];
-        applyActionOverviewPins(container, [
-            { id: 'action_42', x: 10, y: 10, severity: 'green', label: '50%', title: '' },
-        ], id => clicks.push(id));
-        const pinGroup = container.querySelector('g.nad-action-overview-pin') as SVGGElement;
-        pinGroup.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        expect(clicks).toEqual(['action_42']);
+    it('clicking a pin invokes onPinClick (deferred) with the action id and screen position', () => {
+        vi.useFakeTimers();
+        try {
+            const container = document.createElement('div');
+            container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+            const clicks: Array<{ id: string; pos: { x: number; y: number } }> = [];
+            applyActionOverviewPins(container, [
+                { id: 'action_42', x: 10, y: 10, severity: 'green', label: '50%', title: '' },
+            ], (id, pos) => clicks.push({ id, pos }));
+            const pinGroup = container.querySelector('g.nad-action-overview-pin') as SVGGElement;
+            pinGroup.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            // Deferred: the callback has NOT fired yet because the
+            // 250 ms single-click delay is still pending.
+            expect(clicks).toEqual([]);
+            vi.advanceTimersByTime(PIN_SINGLE_CLICK_DELAY_MS + 10);
+            expect(clicks.length).toBe(1);
+            expect(clicks[0].id).toBe('action_42');
+            // Screen position is derived from getBoundingClientRect;
+            // jsdom returns zeros but the object shape is preserved.
+            expect(clicks[0].pos).toHaveProperty('x');
+            expect(clicks[0].pos).toHaveProperty('y');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('double-clicking a pin cancels the pending single-click and fires onPinDoubleClick', () => {
+        vi.useFakeTimers();
+        try {
+            const container = document.createElement('div');
+            container.innerHTML = '<svg viewBox="0 0 200 200"></svg>';
+            const singleClicks: string[] = [];
+            const doubleClicks: string[] = [];
+            applyActionOverviewPins(
+                container,
+                [{ id: 'action_42', x: 10, y: 10, severity: 'green', label: '50%', title: '' }],
+                id => singleClicks.push(id),
+                id => doubleClicks.push(id),
+            );
+            const pinGroup = container.querySelector('g.nad-action-overview-pin') as SVGGElement;
+            // A real browser double-click sends two click events followed
+            // by dblclick. The first click schedules the timer, the
+            // second is ignored (timer already pending), then dblclick
+            // clears the timer and fires the double-click callback.
+            pinGroup.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            pinGroup.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            pinGroup.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+            vi.advanceTimersByTime(PIN_SINGLE_CLICK_DELAY_MS + 10);
+            expect(singleClicks).toEqual([]);
+            expect(doubleClicks).toEqual(['action_42']);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('does nothing when the container has no <svg>', () => {

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -862,6 +862,113 @@ export const buildActionOverviewPins = (
 };
 
 /**
+ * Apply contingency + overload halo highlights to the
+ * action-overview diagram, mirroring what the N-1 tab shows.
+ *
+ * The overview wraps every imported NAD child in a
+ * `.nad-overview-dim-layer <g opacity="0.35">` so the pin overlay
+ * reads at high contrast. That dimming, however, would also fade
+ * the contingency / overload halos to invisibility if we styled
+ * the originals in place — SVG group opacity multiplies through
+ * to descendants and is not overridable per-element.
+ *
+ * The fix is to clone each highlighted edge into a dedicated
+ * `.nad-overview-highlight-layer` that lives as a SIBLING of the
+ * dim layer (and ABOVE it in document order), so the halos
+ * inherit no opacity and render at full saturation. Pins are
+ * appended as the SVG's last child later, so the visual stack is:
+ *
+ *   1. dim layer (faded NAD background)
+ *   2. overview highlight layer (contingency + overload halos)
+ *   3. action overview pin layer (Google-Maps pins)
+ *
+ * The clones reuse the existing `.nad-contingency-highlight` and
+ * `.nad-overloaded` CSS rules from App.css so the visual encoding
+ * stays identical to the N-1 tab.
+ *
+ * Idempotent: the existing highlight layer is removed before
+ * being re-created, so calling this on every `selectedBranch`
+ * change is safe.
+ */
+export const applyActionOverviewHighlights = (
+    container: HTMLElement | null,
+    metaIndex: MetadataIndex | null,
+    contingency: string | null,
+    overloadedLines: readonly string[],
+) => {
+    if (!container) return;
+    const svg = container.querySelector('svg') as SVGSVGElement | null;
+    if (!svg) return;
+
+    // Wipe any existing overview highlight layer — keeps repeated
+    // calls idempotent.
+    svg.querySelectorAll('.nad-overview-highlight-layer').forEach(el => el.remove());
+
+    if (!metaIndex) return;
+    const haveContingency = !!contingency;
+    const haveOverloads = overloadedLines.length > 0;
+    if (!haveContingency && !haveOverloads) return;
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const layer = document.createElementNS(SVG_NS, 'g') as SVGGElement;
+    layer.setAttribute('class', 'nad-overview-highlight-layer');
+    // Insert BEFORE the pin layer if it exists, otherwise append
+    // at the end. Either way the highlights render above the
+    // dim layer (which is appended first by the component) and
+    // below the pins.
+    const pinLayer = svg.querySelector('.nad-action-overview-pins');
+    if (pinLayer) {
+        svg.insertBefore(layer, pinLayer);
+    } else {
+        svg.appendChild(layer);
+    }
+
+    const idMap = getIdMap(container);
+    let cachedLayerCTM: DOMMatrix | null = null;
+
+    const cloneEdge = (svgId: string, klass: string) => {
+        const original = idMap.get(svgId);
+        if (!original) return;
+        const clone = original.cloneNode(true) as SVGGraphicsElement;
+        clone.removeAttribute('id');
+        clone.classList.add(klass);
+        clone.classList.add('nad-highlight-clone');
+        // Strip any delta-* class the original carries so the
+        // delta CSS does not override the halo on the clone (same
+        // hardening as applyOverloadedHighlights).
+        clone.classList.remove('nad-delta-positive', 'nad-delta-negative', 'nad-delta-grey');
+
+        try {
+            const origCTM = (original as SVGGraphicsElement).getScreenCTM?.();
+            if (!cachedLayerCTM) {
+                cachedLayerCTM = (layer as unknown as SVGGraphicsElement).getScreenCTM?.() ?? null;
+            }
+            if (origCTM && cachedLayerCTM) {
+                const m = cachedLayerCTM.inverse().multiply(origCTM);
+                clone.setAttribute(
+                    'transform',
+                    `matrix(${m.a}, ${m.b}, ${m.c}, ${m.d}, ${m.e}, ${m.f})`,
+                );
+            }
+        } catch {
+            // jsdom / disconnected element — skip the matrix
+            // transform; the clone still renders, just at the
+            // original's local coordinates.
+        }
+        layer.appendChild(clone);
+    };
+
+    if (contingency) {
+        const edge = metaIndex.edgesByEquipmentId.get(contingency);
+        if (edge?.svgId) cloneEdge(edge.svgId, 'nad-contingency-highlight');
+    }
+    overloadedLines.forEach(name => {
+        const edge = metaIndex.edgesByEquipmentId.get(name);
+        if (edge?.svgId) cloneEdge(edge.svgId, 'nad-overloaded');
+    });
+};
+
+/**
  * Read a sensible base radius for the pin glyph from the SVG.
  *
  * We want pins to be "similar in size to voltage-level circles when
@@ -1063,6 +1170,21 @@ export const applyActionOverviewPins = (
         // the `dblclick` event; that still works because the
         // dblclick handler no-ops when the timer is null.
         let clickTimer: ReturnType<typeof setTimeout> | null = null;
+
+        // CRITICAL: stop mousedown propagation so the container's
+        // pan/zoom drag handler (registered by `usePanZoom`) does
+        // not start a drag and call `setInteracting(true)` — that
+        // adds `.svg-interacting` to the container which, via the
+        // App.css rule `.svg-container.svg-interacting svg *
+        // { pointer-events: none !important }`, would disable
+        // pointer events on ALL svg children before the click
+        // event can land on the pin. The hover tooltip would
+        // still work (pointer-events is briefly disabled and
+        // re-enabled), but click would silently never fire.
+        g.addEventListener('mousedown', (evt) => {
+            evt.stopPropagation();
+        });
+
         g.addEventListener('click', (evt) => {
             evt.stopPropagation();
             if (clickTimer !== null) return;

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -926,48 +926,56 @@ export const applyActionOverviewHighlights = (
     }
 
     const idMap = getIdMap(container);
-    let cachedLayerCTM: DOMMatrix | null = null;
 
-    const cloneEdge = (svgId: string, klass: string) => {
-        const original = idMap.get(svgId);
-        if (!original) return;
-        const clone = original.cloneNode(true) as SVGGraphicsElement;
-        clone.removeAttribute('id');
-        clone.classList.add(klass);
-        clone.classList.add('nad-highlight-clone');
-        // Strip any delta-* class the original carries so the
-        // delta CSS does not override the halo on the clone (same
-        // hardening as applyOverloadedHighlights).
-        clone.classList.remove('nad-delta-positive', 'nad-delta-negative', 'nad-delta-grey');
-
-        try {
-            const origCTM = (original as SVGGraphicsElement).getScreenCTM?.();
-            if (!cachedLayerCTM) {
-                cachedLayerCTM = (layer as unknown as SVGGraphicsElement).getScreenCTM?.() ?? null;
-            }
-            if (origCTM && cachedLayerCTM) {
-                const m = cachedLayerCTM.inverse().multiply(origCTM);
-                clone.setAttribute(
-                    'transform',
-                    `matrix(${m.a}, ${m.b}, ${m.c}, ${m.d}, ${m.e}, ${m.f})`,
-                );
-            }
-        } catch {
-            // jsdom / disconnected element — skip the matrix
-            // transform; the clone still renders, just at the
-            // original's local coordinates.
-        }
-        layer.appendChild(clone);
-    };
-
+    // --- BATCHED READ/WRITE PATTERN ---
+    // Phase 1: collect all edge ids to highlight (pure data — no DOM reads).
+    const edgesToClone: { svgId: string; klass: string }[] = [];
     if (contingency) {
         const edge = metaIndex.edgesByEquipmentId.get(contingency);
-        if (edge?.svgId) cloneEdge(edge.svgId, 'nad-contingency-highlight');
+        if (edge?.svgId) edgesToClone.push({ svgId: edge.svgId, klass: 'nad-contingency-highlight' });
     }
     overloadedLines.forEach(name => {
         const edge = metaIndex.edgesByEquipmentId.get(name);
-        if (edge?.svgId) cloneEdge(edge.svgId, 'nad-overloaded');
+        if (edge?.svgId) edgesToClone.push({ svgId: edge.svgId, klass: 'nad-overloaded' });
     });
+    if (edgesToClone.length === 0) return;
+
+    // Phase 2: READ — clone nodes and read all CTMs in a single
+    // contiguous pass (no DOM writes in between, avoiding layout
+    // thrashing).
+    let layerCTM: DOMMatrix | null = null;
+    try {
+        layerCTM = (layer as unknown as SVGGraphicsElement).getScreenCTM?.() ?? null;
+    } catch { /* jsdom */ }
+
+    const prepared: { clone: SVGGraphicsElement; transform: string | null }[] = [];
+    for (const { svgId, klass } of edgesToClone) {
+        const original = idMap.get(svgId);
+        if (!original) continue;
+        const clone = original.cloneNode(true) as SVGGraphicsElement;
+        clone.removeAttribute('id');
+        clone.classList.add(klass, 'nad-highlight-clone');
+        clone.classList.remove('nad-delta-positive', 'nad-delta-negative', 'nad-delta-grey');
+
+        let transform: string | null = null;
+        try {
+            const origCTM = (original as SVGGraphicsElement).getScreenCTM?.();
+            if (origCTM && layerCTM) {
+                const m = layerCTM.inverse().multiply(origCTM);
+                transform = `matrix(${m.a}, ${m.b}, ${m.c}, ${m.d}, ${m.e}, ${m.f})`;
+            }
+        } catch { /* jsdom */ }
+        prepared.push({ clone, transform });
+    }
+
+    // Phase 3: WRITE — batch all DOM mutations via a DocumentFragment
+    // to trigger a single reflow instead of one per clone.
+    const frag = document.createDocumentFragment();
+    for (const { clone, transform } of prepared) {
+        if (transform) clone.setAttribute('transform', transform);
+        frag.appendChild(clone);
+    }
+    layer.appendChild(frag);
 };
 
 /**
@@ -1015,6 +1023,10 @@ const PIN_MIN_SCREEN_RADIUS_PX = 22;
  * (e.g. in jsdom or when the element is detached), falling back to
  * a 1:1 mapping which keeps the pins at their base radius.
  */
+// Cache the base radius per SVG element so `rescaleActionOverviewPins`
+// (called on every rAF during zoom) skips the querySelectorAll lookup.
+const pinBaseRadiusCache = new WeakMap<SVGSVGElement, number>();
+
 export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
     if (!container) return;
     const svg = container.querySelector('svg') as SVGSVGElement | null;
@@ -1033,7 +1045,13 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
         // fine, we'll fall through with pxPerSvgUnit=1.
     }
 
-    const baseR = readPinBaseRadius(svg);
+    // Use cached base radius — avoids querySelectorAll('circle[r]')
+    // on every zoom frame.
+    let baseR = pinBaseRadiusCache.get(svg);
+    if (baseR === undefined) {
+        baseR = readPinBaseRadius(svg);
+        pinBaseRadiusCache.set(svg, baseR);
+    }
     const minSvgR = PIN_MIN_SCREEN_RADIUS_PX / pxPerSvgUnit;
     // Keep `baseR` as the floor — this is what makes pins match VL
     // circles at normal zoom. When the user zooms far out, minSvgR
@@ -1090,13 +1108,19 @@ export const applyActionOverviewPins = (
     // {@link rescaleActionOverviewPins} then enforces a screen-pixel
     // floor so pins stay visible when the operator unzooms.
     const r = readPinBaseRadius(svg);
+    // Populate the cache eagerly so rescaleActionOverviewPins (called
+    // on every zoom frame) skips the querySelectorAll lookup.
+    pinBaseRadiusCache.set(svg, r);
     const labelFont = Math.max(9, r * 0.8);
 
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const layer = document.createElementNS(SVG_NS, 'g');
     layer.setAttribute('class', 'nad-action-overview-pins');
-    // Render on top of everything else in the SVG.
-    svg.appendChild(layer);
+
+    // Build all pin elements into a DocumentFragment off-DOM first,
+    // then insert them in a single DOM mutation to avoid per-pin
+    // reflow.
+    const frag = document.createDocumentFragment();
 
     pins.forEach(pin => {
         // OUTER group: anchor translate + click handler. The click
@@ -1216,8 +1240,13 @@ export const applyActionOverviewPins = (
             if (onPinDoubleClick) onPinDoubleClick(pin.id);
         });
 
-        layer.appendChild(g);
+        frag.appendChild(g);
     });
+
+    // Batch-insert all pins, then mount the layer in the live SVG
+    // — a single DOM mutation for the entire pin set.
+    layer.appendChild(frag);
+    svg.appendChild(layer);
 
     // Apply the initial scale compensation so the pins come up at
     // the right size on the very first paint, before the user has

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -862,6 +862,82 @@ export const buildActionOverviewPins = (
 };
 
 /**
+ * Read a sensible base radius for the pin glyph from the SVG.
+ *
+ * We want pins to be "similar in size to voltage-level circles when
+ * zoomed" (as the operator sees other highlights in the NAD), so we
+ * pick up the radius of the first VL circle in the diagram and use
+ * it as the pin body radius. Falls back to 30 user units when the
+ * SVG has no circles (e.g. a handcrafted test fixture).
+ */
+const readPinBaseRadius = (svg: SVGSVGElement): number => {
+    // Prefer circles under the voltage-level nodes group; fall back
+    // to any circle that has an explicit `r` attribute.
+    const vlCircle =
+        svg.querySelector('.nad-vl-nodes circle[r]') ??
+        svg.querySelector('circle[r]');
+    if (vlCircle) {
+        const attr = vlCircle.getAttribute('r');
+        const n = attr ? parseFloat(attr) : NaN;
+        if (Number.isFinite(n) && n > 0) return n;
+    }
+    return 30;
+};
+
+/**
+ * Minimum pin body radius in SCREEN pixels. Enforced by
+ * {@link rescaleActionOverviewPins} so that pins remain readable
+ * when the operator zooms far out to inspect a large grid — the
+ * rescaler upscales the pin body in SVG-space as the viewBox grows.
+ */
+const PIN_MIN_SCREEN_RADIUS_PX = 22;
+
+/**
+ * Rescale the action-overview pin glyphs so that, as the viewBox
+ * grows (user zooms out), they grow proportionally in SVG-space to
+ * stay at least `PIN_MIN_SCREEN_RADIUS_PX` pixels wide on screen —
+ * mirroring the non-scaling-stroke trick used on contingency and
+ * overload circle halos in App.css.
+ *
+ * The per-pin transform is applied to the inner `<g>` wrapping the
+ * glyph, leaving the outer `translate(x y)` and the click listener
+ * intact. Reads `getScreenCTM()` on the SVG to map SVG units back
+ * to screen pixels. No-ops gracefully when the CTM is unavailable
+ * (e.g. in jsdom or when the element is detached), falling back to
+ * a 1:1 mapping which keeps the pins at their base radius.
+ */
+export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
+    if (!container) return;
+    const svg = container.querySelector('svg') as SVGSVGElement | null;
+    if (!svg) return;
+    const layer = svg.querySelector('.nad-action-overview-pins');
+    if (!layer) return;
+
+    let pxPerSvgUnit = 1;
+    try {
+        const ctm = (svg as unknown as SVGGraphicsElement).getScreenCTM?.();
+        if (ctm && Number.isFinite(ctm.a) && ctm.a !== 0) {
+            pxPerSvgUnit = Math.abs(ctm.a);
+        }
+    } catch {
+        // jsdom may throw / not implement getScreenCTM — that's
+        // fine, we'll fall through with pxPerSvgUnit=1.
+    }
+
+    const baseR = readPinBaseRadius(svg);
+    const minSvgR = PIN_MIN_SCREEN_RADIUS_PX / pxPerSvgUnit;
+    // Keep `baseR` as the floor — this is what makes pins match VL
+    // circles at normal zoom. When the user zooms far out, minSvgR
+    // exceeds baseR and the pins grow to stay visible.
+    const effectiveR = Math.max(baseR, minSvgR);
+    const scale = effectiveR / baseR;
+
+    layer.querySelectorAll('.nad-action-overview-pin-body').forEach(body => {
+        body.setAttribute('transform', `scale(${scale})`);
+    });
+};
+
+/**
  * Inject (or refresh) the action-overview pin layer inside the
  * given container's SVG. Clicking a pin invokes `onPinClick` with
  * the action id, which should trigger the existing action-select
@@ -873,7 +949,7 @@ export const applyActionOverviewPins = (
     onPinClick: (actionId: string) => void,
 ) => {
     if (!container) return;
-    const svg = container.querySelector('svg');
+    const svg = container.querySelector('svg') as SVGSVGElement | null;
     if (!svg) return;
 
     // Purge any existing layer so repeated calls stay idempotent.
@@ -881,19 +957,12 @@ export const applyActionOverviewPins = (
 
     if (pins.length === 0) return;
 
-    // Pins are sized relative to the viewBox so they remain
-    // visually stable across large and small grids.
-    const vbAttr = svg.getAttribute('viewBox');
-    let diagramSize = 1000;
-    if (vbAttr) {
-        const parts = vbAttr.split(/\s+|,/).map(parseFloat);
-        if (parts.length === 4) {
-            diagramSize = Math.max(parts[2], parts[3]);
-        }
-    }
-    // Pin body radius ~ 2% of the diagram span, clamped so the
-    // pin is always legible without swamping small grids.
-    const r = Math.max(12, Math.min(60, diagramSize * 0.018));
+    // Base pin body radius = radius of a voltage-level circle. This
+    // is the "when zoomed in" size — at typical detail zoom, pins
+    // appear roughly the same size as the VL glyphs they sit on.
+    // {@link rescaleActionOverviewPins} then enforces a screen-pixel
+    // floor so pins stay visible when the operator unzooms.
+    const r = readPinBaseRadius(svg);
     const labelFont = Math.max(9, r * 0.8);
 
     const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -903,15 +972,28 @@ export const applyActionOverviewPins = (
     svg.appendChild(layer);
 
     pins.forEach(pin => {
+        // OUTER group: anchor translate + click handler. The click
+        // listener is scoped here so the inner body can be
+        // rescaled on every zoom change without reattaching.
         const g = document.createElementNS(SVG_NS, 'g');
         g.setAttribute('class', 'nad-action-overview-pin');
         g.setAttribute('transform', `translate(${pin.x} ${pin.y})`);
         g.setAttribute('data-action-id', pin.id);
         (g as unknown as SVGGElement).style.cursor = 'pointer';
 
+        // INNER group: the glyph itself. Its `transform` attribute
+        // is re-written by `rescaleActionOverviewPins` whenever the
+        // viewBox changes, so the pin grows in SVG-space as the
+        // user zooms out (keeping its on-screen size roughly
+        // constant) and shrinks back to `r` at normal zoom.
+        const body = document.createElementNS(SVG_NS, 'g');
+        body.setAttribute('class', 'nad-action-overview-pin-body');
+        body.setAttribute('transform', 'scale(1)');
+        g.appendChild(body);
+
         const title = document.createElementNS(SVG_NS, 'title');
         title.textContent = pin.title;
-        g.appendChild(title);
+        body.appendChild(title);
 
         // Google-Maps style teardrop: a circle bubble with a
         // triangular tail ending at the anchor point (0,0). The
@@ -927,7 +1009,7 @@ export const applyActionOverviewPins = (
         // network SVG and matches the action card's left-border
         // accent instead of competing with the NAD line strokes.
         path.setAttribute('stroke', 'none');
-        g.appendChild(path);
+        body.appendChild(path);
 
         // Inner white disc to host the label.
         const inner = document.createElementNS(SVG_NS, 'circle');
@@ -937,7 +1019,7 @@ export const applyActionOverviewPins = (
         inner.setAttribute('fill', '#ffffff');
         inner.setAttribute('fill-opacity', '0.92');
         inner.setAttribute('pointer-events', 'none');
-        g.appendChild(inner);
+        body.appendChild(inner);
 
         const text = document.createElementNS(SVG_NS, 'text');
         text.setAttribute('x', '0');
@@ -950,7 +1032,7 @@ export const applyActionOverviewPins = (
         text.setAttribute('fill', severityFill[pin.severity]);
         text.setAttribute('pointer-events', 'none');
         text.textContent = pin.label;
-        g.appendChild(text);
+        body.appendChild(text);
 
         g.addEventListener('click', (evt) => {
             evt.stopPropagation();
@@ -959,6 +1041,12 @@ export const applyActionOverviewPins = (
 
         layer.appendChild(g);
     });
+
+    // Apply the initial scale compensation so the pins come up at
+    // the right size on the very first paint, before the user has
+    // panned or zoomed. Safe to call here — the layer is already in
+    // the DOM (we just appended it).
+    rescaleActionOverviewPins(container);
 };
 
 /**

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -867,20 +867,19 @@ export const buildActionOverviewPins = (
  *
  * The overview wraps every imported NAD child in a
  * `.nad-overview-dim-layer <g opacity="0.35">` so the pin overlay
- * reads at high contrast. That dimming, however, would also fade
- * the contingency / overload halos to invisibility if we styled
- * the originals in place — SVG group opacity multiplies through
- * to descendants and is not overridable per-element.
+ * reads at high contrast.
  *
- * The fix is to clone each highlighted edge into a dedicated
- * `.nad-overview-highlight-layer` that lives as a SIBLING of the
- * dim layer (and ABOVE it in document order), so the halos
- * inherit no opacity and render at full saturation. Pins are
- * appended as the SVG's last child later, so the visual stack is:
+ * To match the N-1 tab visually, the highlight clones live in a
+ * dedicated `.nad-overview-highlight-layer` that is inserted
+ * BEFORE the dim layer in document order. That puts the halos
+ * BEHIND the dimmed network — the same compositing relationship
+ * as the N-1 tab, where halos peek out from behind the original
+ * line strokes (see App.css `#nad-background-layer`). Visual
+ * stack:
  *
- *   1. dim layer (faded NAD background)
- *   2. overview highlight layer (contingency + overload halos)
- *   3. action overview pin layer (Google-Maps pins)
+ *   1. overview highlight layer (contingency + overload halos)
+ *   2. dim layer (faded NAD background, painted on top)
+ *   3. action overview pin layer (Google-Maps pins on top)
  *
  * The clones reuse the existing `.nad-contingency-highlight` and
  * `.nad-overloaded` CSS rules from App.css so the visual encoding
@@ -912,13 +911,16 @@ export const applyActionOverviewHighlights = (
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const layer = document.createElementNS(SVG_NS, 'g') as SVGGElement;
     layer.setAttribute('class', 'nad-overview-highlight-layer');
-    // Insert BEFORE the pin layer if it exists, otherwise append
-    // at the end. Either way the highlights render above the
-    // dim layer (which is appended first by the component) and
-    // below the pins.
-    const pinLayer = svg.querySelector('.nad-action-overview-pins');
-    if (pinLayer) {
-        svg.insertBefore(layer, pinLayer);
+    // Insert BEFORE the dim layer (which itself is inserted by the
+    // ActionOverviewDiagram wrap-on-injection step). That puts the
+    // highlight clones BEHIND the dimmed NAD just like the N-1 tab
+    // background-layer pattern. Fall back to inserting at the
+    // start of the SVG if the dim layer is not yet present.
+    const dimLayer = svg.querySelector('.nad-overview-dim-layer');
+    if (dimLayer) {
+        svg.insertBefore(layer, dimLayer);
+    } else if (svg.firstChild) {
+        svg.insertBefore(layer, svg.firstChild);
     } else {
         svg.appendChild(layer);
     }

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -923,9 +923,10 @@ export const applyActionOverviewPins = (
         const d = `M ${-R} ${-R - tail} A ${R} ${R} 0 1 1 ${R} ${-R - tail} L 0 0 Z`;
         path.setAttribute('d', d);
         path.setAttribute('fill', severityFill[pin.severity]);
-        path.setAttribute('stroke', '#1f2937');
-        path.setAttribute('stroke-width', String(Math.max(1.5, r * 0.08)));
-        path.setAttribute('stroke-linejoin', 'round');
+        // No outline — the fill-only pin blends cleanly with the
+        // network SVG and matches the action card's left-border
+        // accent instead of competing with the NAD line strokes.
+        path.setAttribute('stroke', 'none');
         g.appendChild(path);
 
         // Inner white disc to host the label.
@@ -1004,7 +1005,7 @@ export const computeActionOverviewFitRect = (
     contingency: string | null,
     overloads: readonly string[],
     pins: readonly { x: number; y: number }[],
-    padRatio: number = 0.15,
+    padRatio: number = 0.05,
 ): ViewBox | null => {
     if (!metaIndex) return null;
     const xs: number[] = [];

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -1034,15 +1034,28 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
     const layer = svg.querySelector('.nad-action-overview-pins');
     if (!layer) return;
 
+    // Derive pxPerSvgUnit from the viewBox width and the container's
+    // client width — pure math, no forced layout.  The previous
+    // implementation called `getScreenCTM()` which triggers a
+    // synchronous layout recalculation on every zoom frame and was
+    // the root cause of "Page ne répondant pas" on large grids.
+    //
+    // `clientWidth` is cheap to read (it's already known to the
+    // layout engine from the last completed layout) and does NOT
+    // force a layout flush on its own — only a forced layout happens
+    // when you read geometry AFTER pending DOM writes, but here the
+    // only pending write is the `viewBox` attribute which changes the
+    // SVG viewport, not the CSS box model of the container div.
     let pxPerSvgUnit = 1;
-    try {
-        const ctm = (svg as unknown as SVGGraphicsElement).getScreenCTM?.();
-        if (ctm && Number.isFinite(ctm.a) && ctm.a !== 0) {
-            pxPerSvgUnit = Math.abs(ctm.a);
+    const vbAttr = svg.getAttribute('viewBox');
+    if (vbAttr) {
+        const parts = vbAttr.split(/[\s,]+/).map(Number);
+        if (parts.length === 4 && Number.isFinite(parts[2]) && parts[2] > 0) {
+            const containerW = container.clientWidth;
+            if (containerW > 0) {
+                pxPerSvgUnit = containerW / parts[2];
+            }
         }
-    } catch {
-        // jsdom may throw / not implement getScreenCTM — that's
-        // fine, we'll fall through with pxPerSvgUnit=1.
     }
 
     // Use cached base radius — avoids querySelectorAll('circle[r]')

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -959,3 +959,133 @@ export const applyActionOverviewPins = (
         layer.appendChild(g);
     });
 };
+
+/**
+ * Collect SVG (x, y) coordinates for a single equipment id, looking
+ * it up first as an edge (accumulating both endpoints) and then as
+ * a voltage-level node. Silently no-ops if nothing matches —
+ * callers accumulate into a shared xs/ys array.
+ */
+const pushEquipmentPoints = (
+    metaIndex: MetadataIndex,
+    equipmentId: string,
+    xs: number[],
+    ys: number[],
+) => {
+    const edge = metaIndex.edgesByEquipmentId.get(equipmentId);
+    if (edge) {
+        const lookupNode = (ref: unknown): NodeMeta | undefined => {
+            if (typeof ref !== 'string') return undefined;
+            return metaIndex.nodesBySvgId.get(ref) ?? metaIndex.nodesByEquipmentId.get(ref);
+        };
+        const n1 = lookupNode(edge.node1);
+        const n2 = lookupNode(edge.node2);
+        if (n1 && Number.isFinite(n1.x)) { xs.push(n1.x); ys.push(n1.y); }
+        if (n2 && Number.isFinite(n2.x)) { xs.push(n2.x); ys.push(n2.y); }
+        if (n1 || n2) return;
+    }
+    const node = metaIndex.nodesByEquipmentId.get(equipmentId);
+    if (node && Number.isFinite(node.x)) {
+        xs.push(node.x);
+        ys.push(node.y);
+    }
+};
+
+/**
+ * Compute a padded bounding rectangle that contains the contingency
+ * edge, all overloaded lines, and every action-overview pin. Used by
+ * the action-overview auto-zoom when the Remedial Action tab opens
+ * without any card selected. Returns `null` when nothing can be
+ * located (in which case the caller typically falls back to the
+ * full NAD viewBox).
+ */
+export const computeActionOverviewFitRect = (
+    metaIndex: MetadataIndex | null,
+    contingency: string | null,
+    overloads: readonly string[],
+    pins: readonly { x: number; y: number }[],
+    padRatio: number = 0.15,
+): ViewBox | null => {
+    if (!metaIndex) return null;
+    const xs: number[] = [];
+    const ys: number[] = [];
+
+    if (contingency) pushEquipmentPoints(metaIndex, contingency, xs, ys);
+    overloads.forEach(o => pushEquipmentPoints(metaIndex, o, xs, ys));
+    pins.forEach(p => {
+        if (Number.isFinite(p.x) && Number.isFinite(p.y)) {
+            xs.push(p.x);
+            ys.push(p.y);
+        }
+    });
+
+    if (xs.length === 0) return null;
+
+    let minX = Math.min(...xs);
+    let maxX = Math.max(...xs);
+    let minY = Math.min(...ys);
+    let maxY = Math.max(...ys);
+
+    // A single point (or a degenerate line) would give a zero-size
+    // viewBox that the browser refuses to render — clamp it to a
+    // minimum span scaled loosely on the overall diagram.
+    let w = maxX - minX;
+    let h = maxY - minY;
+    const MIN_SPAN = 200;
+    if (w < MIN_SPAN) {
+        const cx = (minX + maxX) / 2;
+        minX = cx - MIN_SPAN / 2;
+        maxX = cx + MIN_SPAN / 2;
+        w = MIN_SPAN;
+    }
+    if (h < MIN_SPAN) {
+        const cy = (minY + maxY) / 2;
+        minY = cy - MIN_SPAN / 2;
+        maxY = cy + MIN_SPAN / 2;
+        h = MIN_SPAN;
+    }
+
+    const padX = w * padRatio;
+    const padY = h * padRatio;
+    return { x: minX - padX, y: minY - padY, w: w + 2 * padX, h: h + 2 * padY };
+};
+
+/**
+ * Compute a padded viewBox centred on a single equipment id — used
+ * by the action-overview's inspect-search asset focus. Reuses the
+ * same point-collection helper as the fit-rect.
+ */
+export const computeEquipmentFitRect = (
+    metaIndex: MetadataIndex | null,
+    equipmentId: string,
+    padRatio: number = 0.35,
+): ViewBox | null => {
+    if (!metaIndex || !equipmentId) return null;
+    const xs: number[] = [];
+    const ys: number[] = [];
+    pushEquipmentPoints(metaIndex, equipmentId, xs, ys);
+    if (xs.length === 0) return null;
+
+    let minX = Math.min(...xs);
+    let maxX = Math.max(...xs);
+    let minY = Math.min(...ys);
+    let maxY = Math.max(...ys);
+    let w = maxX - minX;
+    let h = maxY - minY;
+    const MIN_SPAN = 150;
+    if (w < MIN_SPAN) {
+        const cx = (minX + maxX) / 2;
+        minX = cx - MIN_SPAN / 2;
+        maxX = cx + MIN_SPAN / 2;
+        w = MIN_SPAN;
+    }
+    if (h < MIN_SPAN) {
+        const cy = (minY + maxY) / 2;
+        minY = cy - MIN_SPAN / 2;
+        maxY = cy + MIN_SPAN / 2;
+        h = MIN_SPAN;
+    }
+    const padX = w * padRatio;
+    const padY = h * padRatio;
+    return { x: minX - padX, y: minY - padY, w: w + 2 * padX, h: h + 2 * padY };
+};

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -874,9 +874,10 @@ export const buildActionOverviewPins = (
  * contexts (both cause ~25-31s Layerize on large grids).
  *
  * Visual stack (back to front):
- *   1. original NAD content (full opacity)
- *   2. dim rect (white, opacity 0.65)
- *   3. overview highlight layer (contingency + overload halos)
+ *   1. overview highlight layer (contingency + overload halos —
+ *      behind NAD content, matching N-1 tab's background-layer)
+ *   2. original NAD content (full opacity)
+ *   3. dim rect (white, opacity 0.65 — dims NAD + highlights)
  *   4. action overview pin layer (Google-Maps pins on top)
  *
  * The clones reuse the existing `.nad-contingency-highlight` and
@@ -909,17 +910,17 @@ export const applyActionOverviewHighlights = (
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const layer = document.createElementNS(SVG_NS, 'g') as SVGGElement;
     layer.setAttribute('class', 'nad-overview-highlight-layer');
-    // Insert AFTER the dim rect but BEFORE the pin layer, so
-    // highlights render ABOVE the dimmed background (fully visible
-    // and undimmed) but BELOW the pins.  The thick halo strokes
-    // (120-150px) visually extend well beyond the network lines,
-    // giving the "background glow" effect even though the layer
-    // sits above the dimmed NAD in paint order.
+    // Insert at the START of the SVG so highlights render BEHIND
+    // the NAD content, matching the N-1 tab's getBackgroundLayer()
+    // pattern.  The dim rect (which sits above NAD content) will
+    // partially dim the highlights, but the thick halo strokes
+    // (120-150px) with bright colours still show through, creating
+    // a visible "background glow" behind the network lines — the
+    // same visual effect as the N-1 diagram.
     //
-    // Visual stack: NAD content → dim rect → highlights → pins.
-    const pinLayer = svg.querySelector('.nad-action-overview-pins');
-    if (pinLayer) {
-        svg.insertBefore(layer, pinLayer);
+    // Visual stack: highlights → NAD content → dim rect → pins.
+    if (svg.firstChild) {
+        svg.insertBefore(layer, svg.firstChild);
     } else {
         svg.appendChild(layer);
     }

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -938,15 +938,33 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
 };
 
 /**
+ * Delay (ms) used by {@link applyActionOverviewPins} to distinguish
+ * a pin single-click from the first click of a double-click. The
+ * single-click action is deferred for this window and cancelled if
+ * a `dblclick` event lands on the same pin. Exposed as a constant
+ * so tests can fast-forward it deterministically.
+ */
+export const PIN_SINGLE_CLICK_DELAY_MS = 250;
+
+/**
  * Inject (or refresh) the action-overview pin layer inside the
- * given container's SVG. Clicking a pin invokes `onPinClick` with
- * the action id, which should trigger the existing action-select
- * flow. Calling this with an empty `pins` array wipes the layer.
+ * given container's SVG.
+ *
+ * Click semantics:
+ *  - a single click on a pin invokes `onPinClick` after
+ *    {@link PIN_SINGLE_CLICK_DELAY_MS} ms, with the pin's screen
+ *    coordinates so the caller can anchor a popover next to it;
+ *  - a double click on a pin cancels the pending single-click and
+ *    invokes `onPinDoubleClick` instead — the caller typically
+ *    uses that to activate the action drill-down view.
+ *
+ * Calling this with an empty `pins` array wipes the layer.
  */
 export const applyActionOverviewPins = (
     container: HTMLElement | null,
     pins: ActionPinInfo[],
-    onPinClick: (actionId: string) => void,
+    onPinClick: (actionId: string, screenPos: { x: number; y: number }) => void,
+    onPinDoubleClick?: (actionId: string) => void,
 ) => {
     if (!container) return;
     const svg = container.querySelector('svg') as SVGSVGElement | null;
@@ -1034,9 +1052,39 @@ export const applyActionOverviewPins = (
         text.textContent = pin.label;
         body.appendChild(text);
 
+        // Click vs. double-click arbitration.
+        //
+        // A real browser double-click fires two `click` events in a
+        // row followed by `dblclick`. We defer the single-click
+        // action (the popover) so the dblclick has a chance to
+        // cancel it — matching Google Maps and similar UIs.
+        //
+        // Tests may use `fireEvent.doubleClick` which only fires
+        // the `dblclick` event; that still works because the
+        // dblclick handler no-ops when the timer is null.
+        let clickTimer: ReturnType<typeof setTimeout> | null = null;
         g.addEventListener('click', (evt) => {
             evt.stopPropagation();
-            onPinClick(pin.id);
+            if (clickTimer !== null) return;
+            // Compute screen-space anchor NOW (before React rerenders)
+            // so the popover lands exactly next to the pin.
+            const rect = (evt.currentTarget as SVGGElement).getBoundingClientRect();
+            const screenPos = {
+                x: rect.left + rect.width / 2,
+                y: rect.top + rect.height / 2,
+            };
+            clickTimer = setTimeout(() => {
+                clickTimer = null;
+                onPinClick(pin.id, screenPos);
+            }, PIN_SINGLE_CLICK_DELAY_MS);
+        });
+        g.addEventListener('dblclick', (evt) => {
+            evt.stopPropagation();
+            if (clickTimer !== null) {
+                clearTimeout(clickTimer);
+                clickTimer = null;
+            }
+            if (onPinDoubleClick) onPinDoubleClick(pin.id);
         });
 
         layer.appendChild(g);

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -1034,6 +1034,8 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
     const layer = svg.querySelector('.nad-action-overview-pins');
     if (!layer) return;
 
+    performance.mark('aod:rescalePins:start');
+
     // Derive pxPerSvgUnit from the viewBox width and the container's
     // client width — pure math, no forced layout.  The previous
     // implementation called `getScreenCTM()` which triggers a
@@ -1084,6 +1086,10 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
     layer.querySelectorAll('.nad-action-overview-pin-body').forEach(body => {
         body.setAttribute('transform', `scale(${scale})`);
     });
+
+    performance.mark('aod:rescalePins:end');
+    const entry = performance.measure('aod:rescalePins', 'aod:rescalePins:start', 'aod:rescalePins:end');
+    if (entry.duration > 5) console.log(`[PERF] aod:rescalePins: ${entry.duration.toFixed(2)}ms`);
 };
 
 /**

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -865,20 +865,15 @@ export const buildActionOverviewPins = (
  * Apply contingency + overload halo highlights to the
  * action-overview diagram, mirroring what the N-1 tab shows.
  *
- * The overview wraps every imported NAD child in a
- * `.nad-overview-dim-layer <g opacity="0.35">` so the pin overlay
- * reads at high contrast.
+ * The overview dims the NAD background via a CSS class
+ * (`nad-overview-dimmed`) on the SVG root — each direct child
+ * gets `opacity: 0.35` via CSS, avoiding an SVG transparency
+ * group that would force Chrome to rasterize all ~43k elements
+ * into an intermediate buffer (Layerize: 31s on large grids).
  *
- * To match the N-1 tab visually, the highlight clones live in a
- * dedicated `.nad-overview-highlight-layer` that is inserted
- * BEFORE the dim layer in document order. That puts the halos
- * BEHIND the dimmed network — the same compositing relationship
- * as the N-1 tab, where halos peek out from behind the original
- * line strokes (see App.css `#nad-background-layer`). Visual
- * stack:
- *
+ * Visual stack (back to front):
  *   1. overview highlight layer (contingency + overload halos)
- *   2. dim layer (faded NAD background, painted on top)
+ *   2. dimmed NAD content (original SVG children at 0.35 opacity)
  *   3. action overview pin layer (Google-Maps pins on top)
  *
  * The clones reuse the existing `.nad-contingency-highlight` and
@@ -911,15 +906,10 @@ export const applyActionOverviewHighlights = (
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const layer = document.createElementNS(SVG_NS, 'g') as SVGGElement;
     layer.setAttribute('class', 'nad-overview-highlight-layer');
-    // Insert BEFORE the dim layer (which itself is inserted by the
-    // ActionOverviewDiagram wrap-on-injection step). That puts the
-    // highlight clones BEHIND the dimmed NAD just like the N-1 tab
-    // background-layer pattern. Fall back to inserting at the
-    // start of the SVG if the dim layer is not yet present.
-    const dimLayer = svg.querySelector('.nad-overview-dim-layer');
-    if (dimLayer) {
-        svg.insertBefore(layer, dimLayer);
-    } else if (svg.firstChild) {
+    // Insert at the START of the SVG so the highlight clones render
+    // BEHIND the dimmed NAD content — same compositing relationship
+    // as the N-1 tab background-layer pattern.
+    if (svg.firstChild) {
         svg.insertBefore(layer, svg.firstChild);
     } else {
         svg.appendChild(layer);

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -867,14 +867,17 @@ export const buildActionOverviewPins = (
  *
  * The overview dims the NAD background via a CSS class
  * (`nad-overview-dimmed`) on the SVG root — each direct child
- * gets `opacity: 0.35` via CSS, avoiding an SVG transparency
- * group that would force Chrome to rasterize all ~43k elements
- * into an intermediate buffer (Layerize: 31s on large grids).
+ * stays at full opacity — the dimming is achieved by a single
+ * white `<rect>` overlay with `opacity: 0.65` placed between
+ * the NAD content and the highlight/pin layers, avoiding both
+ * SVG transparency groups and CSS per-child opacity stacking
+ * contexts (both cause ~25-31s Layerize on large grids).
  *
  * Visual stack (back to front):
- *   1. overview highlight layer (contingency + overload halos)
- *   2. dimmed NAD content (original SVG children at 0.35 opacity)
- *   3. action overview pin layer (Google-Maps pins on top)
+ *   1. original NAD content (full opacity)
+ *   2. dim rect (white, opacity 0.65)
+ *   3. overview highlight layer (contingency + overload halos)
+ *   4. action overview pin layer (Google-Maps pins on top)
  *
  * The clones reuse the existing `.nad-contingency-highlight` and
  * `.nad-overloaded` CSS rules from App.css so the visual encoding
@@ -906,11 +909,14 @@ export const applyActionOverviewHighlights = (
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const layer = document.createElementNS(SVG_NS, 'g') as SVGGElement;
     layer.setAttribute('class', 'nad-overview-highlight-layer');
-    // Insert at the START of the SVG so the highlight clones render
-    // BEHIND the dimmed NAD content — same compositing relationship
-    // as the N-1 tab background-layer pattern.
-    if (svg.firstChild) {
-        svg.insertBefore(layer, svg.firstChild);
+    // Insert AFTER the dim rect (if present) so highlights render
+    // ABOVE the dimming overlay but BELOW the pin layer.  The dim
+    // rect has class `.nad-overview-dim-rect`; the pin layer has
+    // class `.nad-action-overview-pins`.  We insert before the pin
+    // layer if it exists, otherwise at the end of the SVG.
+    const pinLayer = svg.querySelector('.nad-action-overview-pins');
+    if (pinLayer) {
+        svg.insertBefore(layer, pinLayer);
     } else {
         svg.appendChild(layer);
     }

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -1046,6 +1046,9 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
     // when you read geometry AFTER pending DOM writes, but here the
     // only pending write is the `viewBox` attribute which changes the
     // SVG viewport, not the CSS box model of the container div.
+    //
+    // Falls back to getScreenCTM() when clientWidth is unavailable
+    // (e.g. element not yet laid out) to keep pin scaling working.
     let pxPerSvgUnit = 1;
     const vbAttr = svg.getAttribute('viewBox');
     if (vbAttr) {
@@ -1054,6 +1057,12 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
             const containerW = container.clientWidth;
             if (containerW > 0) {
                 pxPerSvgUnit = containerW / parts[2];
+            } else {
+                // Fallback: use getScreenCTM when container has no layout yet.
+                // This path is hit only once (initial render) — subsequent
+                // calls during zoom will have a valid clientWidth.
+                const ctm = (svg as unknown as SVGGraphicsElement).getScreenCTM?.();
+                if (ctm) pxPerSvgUnit = ctm.a;
             }
         }
     }

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -909,11 +909,14 @@ export const applyActionOverviewHighlights = (
     const SVG_NS = 'http://www.w3.org/2000/svg';
     const layer = document.createElementNS(SVG_NS, 'g') as SVGGElement;
     layer.setAttribute('class', 'nad-overview-highlight-layer');
-    // Insert AFTER the dim rect (if present) so highlights render
-    // ABOVE the dimming overlay but BELOW the pin layer.  The dim
-    // rect has class `.nad-overview-dim-rect`; the pin layer has
-    // class `.nad-action-overview-pins`.  We insert before the pin
-    // layer if it exists, otherwise at the end of the SVG.
+    // Insert AFTER the dim rect but BEFORE the pin layer, so
+    // highlights render ABOVE the dimmed background (fully visible
+    // and undimmed) but BELOW the pins.  The thick halo strokes
+    // (120-150px) visually extend well beyond the network lines,
+    // giving the "background glow" effect even though the layer
+    // sits above the dimmed NAD in paint order.
+    //
+    // Visual stack: NAD content → dim rect → highlights → pins.
     const pinLayer = svg.querySelector('.nad-action-overview-pins');
     if (pinLayer) {
         svg.insertBefore(layer, pinLayer);
@@ -1006,6 +1009,17 @@ const readPinBaseRadius = (svg: SVGSVGElement): number => {
 const PIN_MIN_SCREEN_RADIUS_PX = 22;
 
 /**
+ * Minimum pin body radius as a fraction of the current viewBox
+ * extent. On large grids the VL circle radius (used as `baseR`)
+ * is tiny relative to the diagram — e.g. r=40 on a 30000-unit
+ * wide diagram. The screen-pixel floor (`PIN_MIN_SCREEN_RADIUS_PX`)
+ * only kicks in during zoom, but at the initial auto-fit zoom the
+ * pins may still be too small to notice. This fraction ensures
+ * pin diameter is always at least 1/50th of the viewBox window.
+ */
+const PIN_VIEWBOX_FRACTION = 50;
+
+/**
  * Rescale the action-overview pin glyphs so that, as the viewBox
  * grows (user zooms out), they grow proportionally in SVG-space to
  * stay at least `PIN_MIN_SCREEN_RADIUS_PX` pixels wide on screen —
@@ -1073,10 +1087,23 @@ export const rescaleActionOverviewPins = (container: HTMLElement | null) => {
         pinBaseRadiusCache.set(svg, baseR);
     }
     const minSvgR = PIN_MIN_SCREEN_RADIUS_PX / pxPerSvgUnit;
+    // Second floor: pin radius must be at least 1/50th of the
+    // current viewBox extent so pins stay prominent on large grids
+    // where the VL circles are tiny relative to the diagram.
+    let viewBoxMinR = 0;
+    if (vbAttr) {
+        const parts = vbAttr.split(/[\s,]+/).map(Number);
+        if (parts.length === 4) {
+            const extent = Math.max(parts[2], parts[3]);
+            viewBoxMinR = extent / PIN_VIEWBOX_FRACTION;
+        }
+    }
     // Keep `baseR` as the floor — this is what makes pins match VL
     // circles at normal zoom. When the user zooms far out, minSvgR
-    // exceeds baseR and the pins grow to stay visible.
-    const effectiveR = Math.max(baseR, minSvgR);
+    // exceeds baseR and the pins grow to stay visible. The viewBox
+    // fraction floor ensures pins are prominent even on first render
+    // of very large grids.
+    const effectiveR = Math.max(baseR, minSvgR, viewBoxMinR);
     const scale = effectiveR / baseR;
 
     layer.querySelectorAll('.nad-action-overview-pin-body').forEach(body => {

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -714,3 +714,248 @@ export const applyDeltaVisuals = (
         }
     }
 };
+
+// ============================================================
+// Action-overview pins
+//
+// Renders Google-Maps style pins on top of the N-1 network SVG,
+// one per prioritised action. Each pin anchors on the asset
+// (line mid-point or voltage-level node) that the corresponding
+// action card highlights in its badges — the same resolution
+// logic (getActionTargetLines / getActionTargetVoltageLevels) is
+// reused so card↔diagram stay in sync.
+//
+// The pin colour follows the severity palette used by the cards
+// (green/orange/red) and the label shows the max loading (%).
+// Pins are clickable: the click callback maps through to the
+// action-select handler, giving the operator direct manipulation
+// from the overview to the drill-down view.
+//
+// Like the other NAD highlights, this helper is idempotent: it
+// purges any previously-injected pin layer before re-rendering.
+// ============================================================
+
+export interface ActionPinInfo {
+    id: string;
+    x: number;
+    y: number;
+    severity: 'green' | 'orange' | 'red' | 'grey';
+    label: string;
+    title: string;
+}
+
+const severityFill: Record<ActionPinInfo['severity'], string> = {
+    green: '#28a745',
+    orange: '#f0ad4e',
+    red: '#dc3545',
+    grey: '#9ca3af',
+};
+
+const computeActionSeverity = (
+    details: ActionDetail,
+    monitoringFactor: number,
+): ActionPinInfo['severity'] => {
+    if (details.non_convergence || details.is_islanded) return 'grey';
+    if (details.max_rho == null) {
+        return details.is_rho_reduction ? 'green' : 'red';
+    }
+    if (details.max_rho > monitoringFactor) return 'red';
+    if (details.max_rho > monitoringFactor - 0.05) return 'orange';
+    return 'green';
+};
+
+/**
+ * Resolve an action to a point on the NAD background.
+ *
+ * For line / PST actions we take the midpoint of the edge; for
+ * nodal actions we take the voltage-level node position. Returns
+ * null when no impacted asset can be located — the pin is then
+ * silently skipped.
+ */
+const resolveActionAnchor = (
+    actionId: string,
+    details: ActionDetail,
+    metaIndex: MetadataIndex,
+): { x: number; y: number } | null => {
+    const { nodesByEquipmentId, nodesBySvgId, edgesByEquipmentId } = metaIndex;
+
+    const lookupNode = (nodeRef: unknown): NodeMeta | undefined => {
+        if (typeof nodeRef !== 'string') return undefined;
+        return nodesBySvgId.get(nodeRef) ?? nodesByEquipmentId.get(nodeRef);
+    };
+
+    // Try line targets first
+    const lineTargets = getActionTargetLines(details, actionId, edgesByEquipmentId);
+    for (const lineName of lineTargets) {
+        const edge = edgesByEquipmentId.get(lineName);
+        if (!edge) continue;
+        const n1 = lookupNode(edge.node1);
+        const n2 = lookupNode(edge.node2);
+        if (n1 && n2 && Number.isFinite(n1.x) && Number.isFinite(n2.x)) {
+            return { x: (n1.x + n2.x) / 2, y: (n1.y + n2.y) / 2 };
+        }
+        if (n1 && Number.isFinite(n1.x)) return { x: n1.x, y: n1.y };
+        if (n2 && Number.isFinite(n2.x)) return { x: n2.x, y: n2.y };
+    }
+
+    // Fallback on voltage-level targets
+    const vlTargets = getActionTargetVoltageLevels(details, actionId, nodesByEquipmentId);
+    for (const vlName of vlTargets) {
+        const node = nodesByEquipmentId.get(vlName);
+        if (node && Number.isFinite(node.x)) {
+            return { x: node.x, y: node.y };
+        }
+    }
+
+    // Last resort: max_rho_line (a line the action redistributes onto)
+    if (details.max_rho_line) {
+        const edge = edgesByEquipmentId.get(details.max_rho_line);
+        if (edge) {
+            const n1 = lookupNode(edge.node1);
+            const n2 = lookupNode(edge.node2);
+            if (n1 && n2 && Number.isFinite(n1.x) && Number.isFinite(n2.x)) {
+                return { x: (n1.x + n2.x) / 2, y: (n1.y + n2.y) / 2 };
+            }
+        }
+    }
+    return null;
+};
+
+/**
+ * Build the list of pin descriptors for the action-overview view.
+ * Pure function — no DOM access — so it can be unit-tested.
+ */
+export const buildActionOverviewPins = (
+    actions: Record<string, ActionDetail>,
+    metaIndex: MetadataIndex,
+    monitoringFactor: number,
+    filterIds?: Iterable<string>,
+): ActionPinInfo[] => {
+    const allowed = filterIds ? new Set(filterIds) : null;
+    const pins: ActionPinInfo[] = [];
+    for (const [actionId, details] of Object.entries(actions)) {
+        if (allowed && !allowed.has(actionId)) continue;
+        const anchor = resolveActionAnchor(actionId, details, metaIndex);
+        if (!anchor) continue;
+        const severity = computeActionSeverity(details, monitoringFactor);
+        const label = details.max_rho != null
+            ? `${(details.max_rho * 100).toFixed(0)}%`
+            : details.non_convergence
+                ? 'DIV'
+                : details.is_islanded
+                    ? 'ISL'
+                    : '\u2014';
+        const title = [
+            actionId,
+            details.description_unitaire,
+            details.max_rho != null
+                ? `max loading ${(details.max_rho * 100).toFixed(1)}%${details.max_rho_line ? ` on ${details.max_rho_line}` : ''}`
+                : details.non_convergence
+                    ? 'load-flow divergent'
+                    : details.is_islanded
+                        ? 'islanding'
+                        : '',
+        ].filter(Boolean).join(' \u2014 ');
+        pins.push({ id: actionId, x: anchor.x, y: anchor.y, severity, label, title });
+    }
+    return pins;
+};
+
+/**
+ * Inject (or refresh) the action-overview pin layer inside the
+ * given container's SVG. Clicking a pin invokes `onPinClick` with
+ * the action id, which should trigger the existing action-select
+ * flow. Calling this with an empty `pins` array wipes the layer.
+ */
+export const applyActionOverviewPins = (
+    container: HTMLElement | null,
+    pins: ActionPinInfo[],
+    onPinClick: (actionId: string) => void,
+) => {
+    if (!container) return;
+    const svg = container.querySelector('svg');
+    if (!svg) return;
+
+    // Purge any existing layer so repeated calls stay idempotent.
+    svg.querySelectorAll('.nad-action-overview-pins').forEach(el => el.remove());
+
+    if (pins.length === 0) return;
+
+    // Pins are sized relative to the viewBox so they remain
+    // visually stable across large and small grids.
+    const vbAttr = svg.getAttribute('viewBox');
+    let diagramSize = 1000;
+    if (vbAttr) {
+        const parts = vbAttr.split(/\s+|,/).map(parseFloat);
+        if (parts.length === 4) {
+            diagramSize = Math.max(parts[2], parts[3]);
+        }
+    }
+    // Pin body radius ~ 2% of the diagram span, clamped so the
+    // pin is always legible without swamping small grids.
+    const r = Math.max(12, Math.min(60, diagramSize * 0.018));
+    const labelFont = Math.max(9, r * 0.8);
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const layer = document.createElementNS(SVG_NS, 'g');
+    layer.setAttribute('class', 'nad-action-overview-pins');
+    // Render on top of everything else in the SVG.
+    svg.appendChild(layer);
+
+    pins.forEach(pin => {
+        const g = document.createElementNS(SVG_NS, 'g');
+        g.setAttribute('class', 'nad-action-overview-pin');
+        g.setAttribute('transform', `translate(${pin.x} ${pin.y})`);
+        g.setAttribute('data-action-id', pin.id);
+        (g as unknown as SVGGElement).style.cursor = 'pointer';
+
+        const title = document.createElementNS(SVG_NS, 'title');
+        title.textContent = pin.title;
+        g.appendChild(title);
+
+        // Google-Maps style teardrop: a circle bubble with a
+        // triangular tail ending at the anchor point (0,0). The
+        // glyph is drawn in a local coord system where (0,0) is
+        // the pointer tip and the bubble sits above it.
+        const R = r;
+        const tail = R * 0.9;
+        const path = document.createElementNS(SVG_NS, 'path');
+        const d = `M ${-R} ${-R - tail} A ${R} ${R} 0 1 1 ${R} ${-R - tail} L 0 0 Z`;
+        path.setAttribute('d', d);
+        path.setAttribute('fill', severityFill[pin.severity]);
+        path.setAttribute('stroke', '#1f2937');
+        path.setAttribute('stroke-width', String(Math.max(1.5, r * 0.08)));
+        path.setAttribute('stroke-linejoin', 'round');
+        g.appendChild(path);
+
+        // Inner white disc to host the label.
+        const inner = document.createElementNS(SVG_NS, 'circle');
+        inner.setAttribute('cx', '0');
+        inner.setAttribute('cy', String(-R - tail));
+        inner.setAttribute('r', String(R * 0.72));
+        inner.setAttribute('fill', '#ffffff');
+        inner.setAttribute('fill-opacity', '0.92');
+        inner.setAttribute('pointer-events', 'none');
+        g.appendChild(inner);
+
+        const text = document.createElementNS(SVG_NS, 'text');
+        text.setAttribute('x', '0');
+        text.setAttribute('y', String(-R - tail));
+        text.setAttribute('text-anchor', 'middle');
+        text.setAttribute('dominant-baseline', 'central');
+        text.setAttribute('font-size', String(labelFont));
+        text.setAttribute('font-weight', '700');
+        text.setAttribute('font-family', 'system-ui, -apple-system, Arial, sans-serif');
+        text.setAttribute('fill', severityFill[pin.severity]);
+        text.setAttribute('pointer-events', 'none');
+        text.textContent = pin.label;
+        g.appendChild(text);
+
+        g.addEventListener('click', (evt) => {
+            evt.stopPropagation();
+            onPinClick(pin.id);
+        });
+
+        layer.appendChild(g);
+    });
+};

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -1154,9 +1154,14 @@ export const applyActionOverviewPins = (
         text.setAttribute('text-anchor', 'middle');
         text.setAttribute('dominant-baseline', 'central');
         text.setAttribute('font-size', String(labelFont));
-        text.setAttribute('font-weight', '700');
+        text.setAttribute('font-weight', '800');
         text.setAttribute('font-family', 'system-ui, -apple-system, Arial, sans-serif');
-        text.setAttribute('fill', severityFill[pin.severity]);
+        // Use a high-contrast slate colour instead of the severity
+        // hue — when the label text slightly overflows the inner
+        // white disc it would otherwise blend into the coloured
+        // teardrop. Dark slate reads clearly against both the
+        // white disc AND every severity fill.
+        text.setAttribute('fill', '#1f2937');
         text.setAttribute('pointer-events', 'none');
         text.textContent = pin.label;
         body.appendChild(text);


### PR DESCRIPTION
## Summary

This PR introduces an interactive action-overview diagram that displays when the Remedial Action tab is open without a specific action card selected. The view overlays Google Maps-style pins on the N-1 network diagram, with each pin representing a prioritised remedial action anchored to the asset it targets (line midpoint or voltage-level node).

## Key Changes

- **New `ActionOverviewDiagram` component** (`ActionOverviewDiagram.tsx`): 
  - Renders the N-1 SVG background with a semi-transparent white overlay to dim the network
  - Builds and displays action pins with severity-based colour coding (green/orange/red/grey)
  - Supports wheel-zoom, drag-pan, and local zoom controls via the existing `usePanZoom` hook
  - Auto-fits the viewport to show contingency + overloads + all pins on mount
  - Single-click on a pin shows a floating action card popover; double-click activates the drill-down view
  - Includes an inspect search field to pan/zoom to named equipment

- **New `ActionCardPopover` component** (`ActionCardPopover.tsx`):
  - Floating preview of an action card anchored to a pin location
  - Reuses the existing `ActionCard` component for visual consistency with the sidebar feed
  - Includes close button and favourite/reject action buttons

- **New popover placement utilities** (`popoverPlacement.ts`):
  - `decidePopoverPlacement`: Chooses whether to place popover above/below/left/right of a pin
  - `computePopoverStyle`: Generates CSS positioning to keep the popover within viewport bounds
  - Handles edge cases when popover dimensions exceed available space

- **Extended `svgUtils.ts`** with action-overview helpers:
  - `buildActionOverviewPins`: Pure function that resolves each action to an (x, y) anchor and assigns severity
  - `applyActionOverviewPins`: Injects pin DOM elements into the SVG with click handlers
  - `applyActionOverviewHighlights`: Clones contingency and overload edge highlights behind the NAD content
  - `rescaleActionOverviewPins`: Adjusts pin size on zoom to maintain screen-constant appearance
  - `computeActionOverviewFitRect`: Calculates bounding box for auto-fit (contingency + overloads + pins)
  - `computeEquipmentFitRect`: Resolves equipment names to fit rectangles for the inspect search

- **Comprehensive test coverage**:
  - `svgUtils.test.ts`: 866 new lines testing pin building, severity assignment, anchor resolution, and DOM injection
  - `ActionOverviewDiagram.test.tsx`: 773 lines testing component rendering, interactions, zoom/pan, and popover placement
  - `ActionCardPopover.test.tsx`: 139 lines testing popover rendering and interactions
  - `popoverPlacement.test.ts`: 175 lines testing placement heuristics and edge cases

- **UI styling** (`App.css`):
  - Pin visual styles (circle + label, no stroke outline)
  - Highlight layer styling for contingency/overload halos
  - Dim rect overlay for background dimming

- **Integration with existing components**:
  - `VisualizationPanel.tsx`: Wired to show `ActionOverviewDiagram` in the Remedial Action tab when no card is selected
  - `ActionFeed.tsx`: Added auto-scroll effect to center the selected action card when activated from the overview
  - `App.tsx`: Passes metadata index and action callbacks to the visualization panel

## Notable Implementation Details

- **Idempotent DOM updates**: All highlight and pin injection functions safely remove and re-create layers on repeated calls
- **Performance optimizations**: 
  - SVG pre-parsing in a useMemo to avoid re-parsing on every render
  - Dim rect overlay uses a single white rectangle with opacity instead of per-child opacity (avoids expensive Layerize on large grids)
  - Pin rescaling on zoom is screen-constant (pins stay same visual size regardless of zoom level)
- **Visual consistency**: Reuses existing severity palette, highlight CSS classes

https://claude.ai/code/session_01PvjCv9TShcVwdQnDyht5dv