### PR TITLE
perf(diagram): vectorise max-currents + cache layout + minimal NAD render (-13.8 %)

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,129 @@
+# Parity checks between the React frontend and standalone_interface.html.
+#
+# See scripts/PARITY_README.md for the four-layer design. Summary:
+#   Layer 1 — static inventory (events, API paths, settings, schema drift)
+#   Layer 2 — session-reload fidelity (save-vs-restore symmetry)
+#   Layer 3a — gesture-sequence static proxy (ordered event emission)
+#   Layer 3b — behavioural E2E with Playwright (real DOM, mocked backend)
+#
+# Layers 1 + 2 + 3a run on every PR (fast, deterministic, no browser).
+# Layer 3b runs nightly + on a PR that carries the `e2e` label — it
+# needs a Playwright-compatible browser and ~90 s per run.
+name: Parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Nightly at 02:30 UTC — catches drift introduced between PRs
+    # (e.g. docs/interaction-logging.md updates without a code change).
+    - cron: '30 2 * * *'
+
+# Always allow a re-run to supersede an in-flight one for the same PR.
+concurrency:
+  group: parity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # -------------------------------------------------------------------
+  # Layer 1 — static inventory parity (events, API paths, settings,
+  # three-way spec diff).  No backend, no browser.
+  # -------------------------------------------------------------------
+  layer1-static-inventory:
+    name: 'Layer 1 · static inventory parity'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run parity check
+        run: python scripts/check_standalone_parity.py
+      - name: Emit Markdown summary
+        if: always()
+        run: |
+          python scripts/check_standalone_parity.py --emit-markdown \
+            >> "$GITHUB_STEP_SUMMARY" || true
+
+  # -------------------------------------------------------------------
+  # Layer 2 — session-reload fidelity (save/restore symmetry).
+  # -------------------------------------------------------------------
+  layer2-session-fidelity:
+    name: 'Layer 2 · session-reload fidelity'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run session-fidelity check
+        run: python scripts/check_session_fidelity.py
+
+  # -------------------------------------------------------------------
+  # Layer 3a — gesture-sequence static proxy.  Lightweight sequence-
+  # aware check; complements Layer 1's set-based diff.
+  # -------------------------------------------------------------------
+  layer3a-gesture-sequence:
+    name: 'Layer 3a · gesture-sequence static proxy'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run gesture-sequence check
+        run: python scripts/check_gesture_sequence.py
+
+  # -------------------------------------------------------------------
+  # Layer 3b — behavioural E2E with Playwright.  Needs a browser
+  # download, so it only runs nightly (schedule) or when a PR carries
+  # the `e2e` label.  Per-commit gating would be too slow.
+  # -------------------------------------------------------------------
+  layer3b-behavioural-e2e:
+    name: 'Layer 3b · behavioural E2E (Playwright)'
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'schedule'
+      || (github.event_name == 'pull_request'
+          && contains(github.event.pull_request.labels.*.name, 'e2e'))
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            frontend/package-lock.json
+            scripts/parity_e2e/package-lock.json
+
+      - name: Install frontend deps + build
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install E2E deps
+        working-directory: scripts/parity_e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: scripts/parity_e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E parity spec
+        working-directory: scripts/parity_e2e
+        run: npx playwright test
+
+      - name: Upload Playwright report + artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            scripts/parity_e2e/playwright-report/
+            scripts/parity_e2e/artefacts.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -77,6 +77,23 @@ jobs:
         run: python scripts/check_gesture_sequence.py
 
   # -------------------------------------------------------------------
+  # Layer 4 — user-observable invariants.  Static source-pattern
+  # assertions for the six bug classes Layers 1-3a cannot catch by
+  # construction (visual thresholds, conditional rendering,
+  # field semantics, auto-effects, loading-state, performance).
+  # -------------------------------------------------------------------
+  layer4-invariants:
+    name: 'Layer 4 · user-observable invariants'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run invariants check
+        run: python scripts/check_invariants.py
+
+  # -------------------------------------------------------------------
   # Layer 3b — behavioural E2E with Playwright.  Needs a browser
   # download, so it only runs nightly (schedule) or when a PR carries
   # the `e2e` label.  Per-commit gating would be too slow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,18 +549,27 @@ standalone emits **32**.
 Nothing in the standalone emits an event the union does not know
 about (0 orphan types).
 
-##### Frontend drifts from the replay-contract spec (4 events)
+##### Frontend drifts from the replay-contract spec
 
-The React app emits a shape that drifts from
-`docs/interaction-logging.md`. The standalone is closer to the spec
-for these — fix the React side, don't downgrade:
+**0 events — all resolved** in this branch. The table below is the
+historical record (each row now has a regression test and the Python
++ Vitest conformity checks guard against re-introduction):
 
-| Event | Spec required | Frontend emits | Missing | React source |
-|---|---|---|---|---|
-| `action_deselected` | `{previous_action_id}` | `{action_id}` | `previous_action_id` | `hooks/useDiagrams.ts:360` |
-| `analysis_step2_started` | `{all_overloads, element, monitor_deselected, selected_overloads}` | `{monitor_deselected, selected_overloads}` | `all_overloads, element` | `hooks/useAnalysis.ts:122` |
-| `overload_toggled` | `{overload, selected}` | `{overload}` | `selected` | `hooks/useAnalysis.ts:239` |
-| `prioritized_actions_displayed` | `{n_actions}` | `{actions_count}` | `n_actions` | `hooks/useAnalysis.ts:193` |
+| Event | Fix | Regression test |
+|---|---|---|
+| `action_deselected` | `{action_id}` → `{previous_action_id}` (`hooks/useDiagrams.ts:360`) | `hooks/useDiagrams.test.ts::logs action_deselected when re-selecting the same action` |
+| `analysis_step2_started` | added `element` + `all_overloads` (`hooks/useAnalysis.ts:122`) | `hooks/useAnalysis.test.ts::step2_started carries the full spec payload` |
+| `overload_toggled` | added `selected` (`hooks/useAnalysis.ts:239`) | `hooks/useAnalysis.test.ts::logs overload_toggled with overload + selected` |
+| `prioritized_actions_displayed` | `actions_count` → `n_actions` (`hooks/useAnalysis.ts:193`) | `hooks/useAnalysis.test.ts::logs prioritized_actions_displayed with n_actions` |
+| `analysis_step2_completed` | `actions_count` → `n_actions` (`hooks/useAnalysis.ts:184`) | same suite |
+| `view_mode_changed` (hook-internal emission) | removed emission from `hooks/useDiagrams.ts:202` (App.tsx owns the full-spec emission) | `hooks/useDiagrams.test.ts::handleViewModeChange updates state but does NOT emit view_mode_changed` |
+
+The fifth drift (`view_mode_changed` hook-internal) was surfaced by
+the Vitest spec-conformance test, not the Python script — the
+script's set-based union across call sites was masking it behind
+`App.tsx`'s full-shape emission. The spec-conformance test
+(`utils/specConformance.test.ts`) walks all call sites individually
+and catches per-site drift, so it ran as the stricter check.
 
 ##### Standalone drifts from the replay-contract spec (14 events)
 
@@ -603,11 +612,14 @@ the spec, not a parity gap between the two codebases.
 _Generated from the fidelity script on 2026-04-19._ 30 curated
 fields checked; 25/30 round-trip on React, 28/30 on standalone.
 
-##### Fields the React frontend RESTORES but never SAVES (1 — hard fail)
+##### Fields the React frontend RESTORES but never SAVES
 
-| Field | Consequence |
-|---|---|
-| `lines_overloaded_after` | `useSession.ts:312` reads it back into each live `ActionDetail`, but `sessionUtils.ts` never writes it on save. On reload the field is always `undefined`, so the Remedial-Action NAD/SLD loses its post-action overload halos until the user re-runs analysis. Add the field to the `SavedActionEntry` object literal in `sessionUtils.ts:120-145`. |
+**0 fields — resolved** in this branch. The table below is the
+historical record:
+
+| Field | Fix | Regression test |
+|---|---|---|
+| `lines_overloaded_after` | Added to `SavedActionEntry` object literal in `sessionUtils.ts` | `utils/sessionUtils.test.ts::persists lines_overloaded_after so it survives save → reload (regression)` |
 
 ##### Fields absent from the standalone entirely (2 — warn)
 
@@ -689,10 +701,37 @@ python scripts/check_gesture_sequence.py --json          # CI-friendly
 cd scripts/parity_e2e && npx playwright test
 ```
 
-All four exit non-zero on any FAIL finding. Wire Layers 1 + 2 + 3a
-into a GitHub Action per PR; run Layer 3b nightly or on-label.
-`scripts/PARITY_README.md` contains the CI snippet and a cost/
-cadence discussion.
+All four exit non-zero on any FAIL finding.
+
+### CI wiring
+
+`.github/workflows/parity.yml` runs the checks automatically:
+
+- **Layers 1 + 2 + 3a** — every push to `main` + every PR. Pure
+  Python, no backend, no browser. Finishes in <30 s.
+- **Layer 3b** — nightly (cron `30 2 * * *`) + whenever a PR
+  carries the `e2e` label. Builds the React app, installs
+  Chromium, runs the full Playwright spec. ~6 min on a fresh
+  runner, ~2 min with cache.
+
+The workflow also appends Layer 1's `--emit-markdown` output to
+the GitHub Actions step summary on every run, so per-PR comments
+show exactly which events drifted from the spec without waiting
+for reviewer triage. A Markdown step-summary example:
+
+```
+| Event | Spec required | Frontend emits | Missing |
+|---|---|---|---|
+| action_deselected | {previous_action_id} | {action_id} | previous_action_id |
+```
+
+The matching Vitest **spec-conformance** test
+(`frontend/src/utils/specConformance.test.ts`) runs as part of the
+regular frontend suite — `npm run test`. It walks every
+`interactionLogger.record` call site in the React source and
+verifies the `details` keys per event match the replay contract.
+This is the pre-PR gate; the Layer-1 parity script is the PR-gate
+fallback that also checks the standalone HTML.
 
 ### How to use this audit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,8 +466,9 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **Session** | List-sessions modal | ✅ | — |
 | **Session** | Restore configuration + contingency + analysis state | ✅ | — |
 | **Session** | Restore interaction log | ✅ | — |
-| **Interaction log** | Event recording | ✅ | — |
-| **Interaction log** | Correlation IDs | ⚠️ | Recorded for some events — not systematically paired on all async flows |
+| **Interaction log** | Event-type coverage | ⚠️ | 19/55 spec types never emitted by the standalone — see machine-grounded findings below |
+| **Interaction log** | `details` schema conformance | ⚠️ | 5 events with standalone-side schema drift (e.g. `voltage_range_changed {min_kv,max_kv}` vs spec `{min,max}`) — see below |
+| **Interaction log** | `recordCompletion` pairs | ⚠️ | Only `analysis_step{1,2}_completed` emitted — both sides drift from the spec here |
 | **Interaction log** | Replay-ready details | ✅ | — |
 | **Interaction log** | Saved with session | ✅ | — |
 | **Confirmation** | Contingency change | ✅ | `window.confirm()` |
@@ -505,24 +506,139 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 #### Features in the standalone that are no longer in React
 None identified. The standalone is strictly a subset of the React app — there is no obsolete code path to remove. If a feature is removed from `frontend/`, delete it from `standalone_interface.html` in the same commit.
 
+### Machine-grounded findings (`scripts/check_standalone_parity.py`)
+
+The feature table above is human-curated. A static parity check is
+automated in `scripts/check_standalone_parity.py`; run it to refresh
+these numbers. Findings as of 2026-04-19:
+
+```
+InteractionType union:       55 types declared in frontend/src/types.ts
+Frontend emits:              51 types (missing: settings_cancelled,
+                             action_unfavorited, action_unrejected,
+                             contingency_selected variants used in tests)
+Standalone emits:            32 types
+```
+
+#### Event types emitted by the frontend but NOT by the standalone (19)
+
+These are all valid `InteractionType` values. Fix by adding
+`interactionLogger.record('<type>', { ... })` at the equivalent
+gesture site in the standalone.
+
+| Event type | React source |
+|---|---|
+| `action_mw_resimulated` | `components/ActionFeed.tsx:451` |
+| `pst_tap_resimulated` | `components/ActionFeed.tsx:503` |
+| `contingency_confirmed` | `App.tsx:681` (standalone uses `window.confirm()` and emits nothing) |
+| `settings_tab_changed` | `components/modals/SettingsModal.tsx:51` |
+| `path_picked` | `hooks/useSettings.ts:232` |
+| `inspect_query_changed` | `App.tsx:976,984` |
+| `tab_detached` / `tab_reattached` | `App.tsx:211,225` |
+| `tab_tied` / `tab_untied` | `hooks/useTiedTabsSync.ts:97,107` |
+| `overview_shown` / `overview_hidden` | `components/ActionOverviewDiagram.tsx:466,469` |
+| `overview_pin_clicked` / `overview_pin_double_clicked` | `components/ActionOverviewDiagram.tsx:343,364` |
+| `overview_popover_closed` | `components/ActionOverviewDiagram.tsx:558` |
+| `overview_zoom_in` / `overview_zoom_out` / `overview_zoom_fit` | `components/ActionOverviewDiagram.tsx:476,482,487` |
+| `overview_inspect_changed` | `components/ActionOverviewDiagram.tsx:526,530` |
+
+Nothing in the standalone emits an event the `InteractionType` union
+does not know about (0 orphan types).
+
+#### Details-key drift between frontend and standalone (11 events)
+
+Cross-referenced against the schema in `docs/interaction-logging.md`;
+each row lists which side owns the fix.
+
+**Standalone owns the fix (5 events)** — the standalone emits a shape
+incompatible with the documented replay contract:
+
+| Event | Spec `details` | Standalone emits | Standalone site |
+|---|---|---|---|
+| `asset_clicked` | `{ action_id, asset_name, tab }` | `{ action_id, asset_name, target_tab }` | `standalone:3034,3056` |
+| `diagram_tab_changed` | `{ tab }` | `{ from_tab, to_tab }` | `standalone:6675` |
+| `sld_overlay_tab_changed` | `{ tab, vl_name }` | `{ from_tab, to_tab }` (no `vl_name`) | `standalone:5148` |
+| `view_mode_changed` | `{ mode, tab, scope }` | `{ mode }` (no `tab`, no `scope`) | `standalone:6762,6773` |
+| `voltage_range_changed` | `{ min, max }` (kV) | `{ min_kv, max_kv }` | `standalone:5070,5083` |
+
+**Frontend owns the fix (3 events)** — the React app emits a shape
+that drifts from its own documented replay contract. The standalone
+is closer to the spec and should NOT be downgraded to match the FE;
+instead the FE should be corrected:
+
+| Event | Spec `details` | Frontend emits | Frontend site |
+|---|---|---|---|
+| `action_deselected` | `{ previous_action_id }` | `{ action_id }` | `hooks/useDiagrams.ts:360` |
+| `analysis_step2_started` | `{ element, selected_overloads, all_overloads, monitor_deselected }` | `{ selected_overloads, monitor_deselected }` — missing `element`, `all_overloads` | `hooks/useAnalysis.ts:122-125` |
+| `overload_toggled` | `{ overload, selected }` | `{ overload }` — missing `selected` | `hooks/useAnalysis.ts:239` |
+
+**Harmless extras in the standalone (3 events)** — the standalone
+adds keys the spec doesn't require. Keep or drop; does not break
+replay:
+
+| Event | Extra keys in standalone |
+|---|---|
+| `manual_action_simulated` | `+ description` |
+| `session_saved` | `+ session_name` |
+| `sld_overlay_opened` | `+ initial_tab` |
+
+#### API paths referenced by the frontend but not by the standalone (1)
+
+| Endpoint | Introduced in | Frontend call site |
+|---|---|---|
+| `/api/simulate-and-variant-diagram` | NDJSON stream emitting `{type:"metrics"}` then `{type:"diagram"}` | `api.ts::simulateAndVariantDiagramStream` |
+
+#### `recordCompletion` coverage
+
+Both codebases emit the same two `*_completed` events:
+`analysis_step1_completed` and `analysis_step2_completed`. The
+replay spec lists more async wait-points that could benefit from
+completion events (`action_selected`, `manual_action_simulated`,
+`action_mw_resimulated`, `pst_tap_resimulated`, `combine_pair_simulated`,
+`settings_applied`, `session_reloaded`, `tab_detached` /
+`tab_reattached`) — **this is a shared gap against the spec**, not a
+parity gap between the two codebases. Track as a follow-up for
+`docs/interaction-logging.md` compliance on both sides.
+
+### Running the conformity check
+
+```bash
+python scripts/check_standalone_parity.py            # human output
+python scripts/check_standalone_parity.py --json     # CI-friendly JSON
+```
+
+Exits non-zero on any FAIL finding — suitable as a GitHub Actions
+gate. See the top of the script file for the three inventories it
+checks (`InteractionType` union, API paths, `SettingsState`) and
+the per-event details-key diff.
+
 ### How to use this audit
 
 When updating `standalone_interface.html`:
 
-1. Pick an item from "Top-priority gaps" (or "Deferrable gaps" if the
-   work is lighter). Read the React source files listed alongside to
-   understand the exact behaviour.
-2. Check the Interaction Logger section of `frontend/CLAUDE.md` and
-   add any new gesture types to the standalone's inline
-   `interactionLogger` implementation. The replay contract in
-   `docs/interaction-logging.md` is the source of truth.
-3. When a new endpoint is added to the backend (`expert_backend/main.py`)
+1. Run `scripts/check_standalone_parity.py` first. Every FAIL line is
+   a specific, actionable item with file:line anchors on both sides.
+2. For each "event type missing in standalone" finding: open the
+   React source file listed, understand the gesture, and add an
+   equivalent `interactionLogger.record('<type>', { ... })` at the
+   matching spot in the standalone.
+3. For each "details-key drift" finding: check which side the spec
+   (`docs/interaction-logging.md`) sides with, then fix that side.
+4. When a new endpoint is added to the backend (`expert_backend/main.py`)
    and surfaced in `frontend/src/api.ts`, mirror it in the standalone's
-   inline API wrapper **in the same PR**.
-4. When adding a new setting field: update the audit table above to
-   track its mirror state.
-5. Run the standalone locally by opening it in a browser with the
+   inline API wrapper **in the same PR** — the script's API-path
+   check will catch any miss.
+5. When adding a new setting field: add it to the `SettingsState`
+   interface AND to the standalone's `useState` set with a
+   convention-compatible name (the script normalises camelCase ↔
+   snake_case automatically).
+6. Run the standalone locally by opening it in a browser with the
    FastAPI backend running. Confirm the gesture, diagram, and
-   interaction-log output match the React app side by side.
+   interaction-log output match the React app side by side. The
+   script catches shape drift but not behavioural drift — a future
+   Layer-3 Playwright spec is the next step (see the conformity-script
+   design in the session transcript).
 
 Last audited: 2026-04-19 (branch `claude/fix-grid-layout-reset-8TYEV`).
+Numbers above regenerated by
+`scripts/check_standalone_parity.py` on the same branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,6 +615,59 @@ fields checked; 25/30 round-trip on React, 28/30 on standalone.
 |---|---|
 | `n_overloads_rho`, `n1_overloads_rho` | The sticky-header rho arrays (PR #88). The React app intentionally saves-only (live state re-derives from a fresh N-1 diagram on reload). The standalone doesn't save them either — fine for live UX, but replay agents and offline inspection tools lose the percentages. |
 
+#### Layer 3a — Gesture-sequence static proxy (`scripts/check_gesture_sequence.py`)
+
+_Generated from the gesture-sequence script on 2026-04-19._
+Canonical 11-step gesture sequence: **22/22** gesture-side parity
+checks pass. For each gesture the script resolves the handler body
+in both codebases and verifies the expected ordered list of
+`interactionLogger.record(...)` + `recordCompletion(...)` calls is
+present. Complements Layers 1 + 2 with sequence-awareness.
+
+Limitations worth being aware of when a `22/22` pass lands:
+
+- The walker sees **all** event-emission code paths in a handler,
+  not just the one taken at runtime. `handleActionSelect` has both
+  `action_selected` and `action_deselected` call sites (early-return
+  on toggle), and Layer 3a reports both — a real Playwright run
+  would fire only one per click.
+- The walker cannot catch async ordering races (e.g. two XHRs that
+  complete in non-deterministic order and emit events out-of-spec).
+- Layer 3a does not check `details`-key shapes — that's Layer 1's
+  job. Likewise it doesn't touch `session.json` shape — that's
+  Layer 2. A passing 3a therefore does NOT mean parity overall.
+
+#### Layer 3b — Behavioural E2E (`scripts/parity_e2e/e2e_parity.spec.ts`)
+
+Real Playwright spec driving both UIs through the canonical gesture
+sequence with a mocked backend (all `/api/*` calls fulfilled via
+`page.route()`, so pypowsybl / expert_op4grid_recommender are NOT
+required). The spec captures:
+
+- Ordered list of `interactionLogger` events per run.
+- `details` keys per event.
+- `session.json` field paths.
+
+And asserts three-way equality: React events == standalone events,
+React keys == standalone keys, React session shape == standalone
+session shape.
+
+Runs in ~90 s including browser launch. Designed for **nightly
+CI** or **on-label PR** runs, not per-commit (see the cost
+discussion in `scripts/PARITY_README.md`). Not executed in the
+sandbox this audit was generated from because Playwright's browser
+download is blocked — the spec itself is committed and ready to
+run in any standard CI environment with one-off setup:
+
+```bash
+cd scripts/parity_e2e
+npm install
+npx playwright install chromium
+cd ../../frontend && npm run build
+cd ../scripts/parity_e2e
+npx playwright test
+```
+
 ### Running the conformity checks
 
 ```bash
@@ -626,13 +679,20 @@ python scripts/check_standalone_parity.py --json         # CI-friendly
 # Layer 2 — session-reload fidelity (save-vs-restore symmetry)
 python scripts/check_session_fidelity.py                 # human text
 python scripts/check_session_fidelity.py --json          # CI-friendly
+
+# Layer 3a — gesture-sequence static proxy
+python scripts/check_gesture_sequence.py                 # human text
+python scripts/check_gesture_sequence.py --json          # CI-friendly
+
+# Layer 3b — behavioural E2E (needs a Playwright browser; see
+# scripts/PARITY_README.md for the one-off setup)
+cd scripts/parity_e2e && npx playwright test
 ```
 
-Both exit non-zero on any FAIL finding. Wire them into a GitHub
-Action per PR — see `scripts/PARITY_README.md`. A Layer-3 behavioural
-E2E check (Playwright, driving both UIs through a scripted session)
-is designed but not yet implemented; that README contains the spec
-for it.
+All four exit non-zero on any FAIL finding. Wire Layers 1 + 2 + 3a
+into a GitHub Action per PR; run Layer 3b nightly or on-label.
+`scripts/PARITY_README.md` contains the CI snippet and a cost/
+cadence discussion.
 
 ### How to use this audit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,68 +6,65 @@ Co-Study4Grid is a full-stack web application for **power grid contingency analy
 
 ## Architecture
 
-**Monorepo** with two main components:
+**Monorepo** with two main components plus a standalone HTML mirror:
 
 ```
 Co-Study4Grid/
-├── .gitignore               # Excludes __pycache__/, *.pyc, *.pyo
-├── CLAUDE.md                # Project documentation for AI assistants
-├── expert_backend/          # Python FastAPI backend
-│   ├── __init__.py
-│   ├── main.py              # FastAPI app, API endpoints, CORS config
-│   ├── requirements.txt     # Core Python deps (fastapi, uvicorn)
-│   └── services/
-│       ├── __init__.py
-│       ├── network_service.py       # pypowsybl network loading & queries
-│       └── recommender_service.py   # Analysis orchestration, PDF/SVG generation
-├── frontend/                # React + TypeScript + Vite frontend
-│   ├── index.html           # HTML entry point
-│   ├── package.json         # Dependencies and scripts
-│   ├── vite.config.ts       # Vite configuration
-│   ├── eslint.config.js     # ESLint v9+ flat config
-│   ├── tsconfig.json        # Root TypeScript config
-│   ├── tsconfig.app.json    # App TypeScript config (strict mode)
-│   ├── tsconfig.node.json   # Node/config TypeScript config
+├── CLAUDE.md                  # This file — project overview + standalone parity audit
+├── expert_backend/            # Python FastAPI backend
+│   ├── CLAUDE.md              # Backend-scoped guide (singletons, mixins, lifecycle)
+│   ├── main.py                # FastAPI app: endpoints, CORS, gzip helpers, NDJSON streaming
+│   ├── requirements.txt
+│   ├── services/
+│   │   ├── network_service.py     # pypowsybl Network singleton + metadata queries
+│   │   ├── recommender_service.py # Analysis orchestrator (composes the 3 mixins below)
+│   │   ├── diagram_mixin.py       # NAD/SLD generation, layout cache, flow deltas
+│   │   ├── analysis_mixin.py      # Two-step contingency analysis + action enrichment
+│   │   ├── simulation_mixin.py    # Manual-action simulation + superposition
+│   │   └── sanitize.py            # NumPy → native-Python recursive coercion
+│   └── tests/                 # pytest suite — see tests/CLAUDE.md for the mock layer
+├── frontend/                  # React 19 + TypeScript 5.9 + Vite 7 frontend
+│   ├── CLAUDE.md              # Frontend-scoped guide (App.tsx hub, hooks, SVG levers)
+│   ├── package.json, vite.config.ts, eslint.config.js, tsconfig*.json
 │   └── src/
-│       ├── main.tsx          # React entry point (StrictMode)
-│       ├── App.tsx           # Root component: state orchestration + hook wiring only (~650 lines)
-│       ├── App.css           # App-specific styles
-│       ├── index.css         # Global styles
-│       ├── api.ts            # Axios HTTP client (base URL: localhost:8000)
-│       ├── types.ts          # TypeScript interfaces
-│       ├── hooks/
-│       │   └── useSettings.ts        # Settings state hook (SettingsState interface + all setters)
-│       ├── utils/
-│       │   ├── sessionUtils.ts       # Session snapshot building (buildSessionResult)
-│       │   ├── sessionUtils.test.ts  # Unit tests for session serialization
-│       │   ├── interactionLogger.ts  # Singleton interaction event logger (replay-ready)
-│       │   ├── interactionLogger.test.ts # Unit tests for interaction logger
-│       │   └── popoverPlacement.ts   # Pure helpers for pin-popover positioning
-│       └── components/
-│           ├── Header.tsx              # Top bar: logo, network path input, Load/Save/Reload/Settings buttons
-│           ├── Header.test.tsx         # Unit tests for Header
-│           ├── ActionFeed.tsx              # Prioritized action results display with search/filter + auto-scroll on selection
-│           ├── ActionOverviewDiagram.tsx  # N-1 NAD with pin overlay (overview of all actions)
-│           ├── ActionCardPopover.tsx      # Shared floating ActionCard wrapper (pin click preview)
-│           ├── VisualizationPanel.tsx     # SVG diagram rendering (NAD + SLD overlay)
-│           ├── OverloadPanel.tsx          # Two-step analysis: detect → select → resolve
-│           ├── CombinedActionsModal.tsx   # Superposition pair computation modal
-│           └── modals/
-│               ├── SettingsModal.tsx           # 3-tab settings dialog (paths, recommender, config)
-│               ├── SettingsModal.test.tsx      # Unit tests for SettingsModal
-│               ├── ReloadSessionModal.tsx      # Session reload list dialog
-│               ├── ReloadSessionModal.test.tsx # Unit tests for ReloadSessionModal
-│               ├── ConfirmationDialog.tsx      # Shared confirmation dialog (contingency/reload)
-│               └── ConfirmationDialog.test.tsx # Unit tests for ConfirmationDialog
-├── Overflow_Graph/          # Generated PDFs (created at runtime)
-├── overrides.txt            # Additional Python dependency version pins
-├── standalone_interface.html # Self-contained HTML version of the UI with SVG visualization
-├── test_*.py / verify_*.py  # Root-level integration test scripts
-├── reproduce_error.py       # Ad-hoc error reproduction script
-├── repro_stuck.py           # Ad-hoc stuck analysis reproduction
-├── fix_zoom.py              # Zoom/scaling fix utility
-└── inspect_metadata.py      # SVG metadata inspection utility
+│       ├── App.tsx                # State orchestration hub (~1000 lines)
+│       ├── api.ts                 # Axios HTTP client (base URL: 127.0.0.1:8000)
+│       ├── types.ts               # All TypeScript interfaces (one file)
+│       ├── hooks/                 # useSettings/useActions/useAnalysis/useDiagrams/
+│       │                          # useSession/useDetachedTabs/useTiedTabsSync/usePanZoom/
+│       │                          # useSldOverlay
+│       ├── components/            # Header, ActionFeed, ActionCard, ActionOverviewDiagram,
+│       │                          # VisualizationPanel, OverloadPanel, CombinedActionsModal,
+│       │                          # ComputedPairsTable, ExplorePairsTab, SldOverlay,
+│       │                          # DetachableTabHost, MemoizedSvgContainer, ErrorBoundary
+│       │                          # + modals/ (SettingsModal, ReloadSessionModal,
+│       │                          #            ConfirmationDialog)
+│       └── utils/                 # svgUtils, overloadHighlights, sessionUtils,
+│                                  # interactionLogger, popoverPlacement, mergeAnalysisResult
+├── standalone_interface.html  # Self-contained single-file HTML mirror of the React UI
+│                              # (~7300 lines, no React imports). Ships independently.
+│                              # See "Standalone Interface Parity Audit" section below.
+├── docs/                      # Design docs (perf, save-results, interaction-logging,
+│                              # action-overview-diagram, state-reset-and-confirmation-dialogs,
+│                              # detachable-viz-tabs, …)
+├── data/                      # Sample grids: bare_env_small_grid_test, pypsa_eur_fr400
+├── benchmarks/                # Perf scripts (bench_load_study, _bench_common)
+├── Overflow_Graph/            # Generated PDFs (created at runtime)
+├── overrides.txt              # Pinned versions for transitive Python deps
+├── test_*.py / verify_*.py    # Root-level integration scripts (NOT part of pytest)
+├── reproduce_error.py / repro_stuck.py / fix_zoom.py / inspect_metadata.py
+│                              # Ad-hoc dev/debug utilities
+└── .gitignore                 # Excludes __pycache__/, *.pyc, *.pyo
 ```
+
+### Per-subtree CLAUDE.md files
+
+| File | Scope |
+|------|-------|
+| `CLAUDE.md` (this file) | Project overview, API table, conventions, **standalone parity audit** |
+| `expert_backend/CLAUDE.md` | Backend internals: singletons, mixin composition, state lifecycle, NDJSON streaming, gzip helpers, layout cache invariants, NAD prefetch |
+| `expert_backend/tests/CLAUDE.md` | Test conventions, the `conftest.py` mock layer for `pypowsybl` / `expert_op4grid_recommender`, frontend Vitest patterns |
+| `frontend/CLAUDE.md` | Frontend internals: hook split, data flow, state reset, SVG performance levers, detached/tied tabs, interaction logger contract |
 
 ## Tech Stack
 
@@ -212,13 +209,25 @@ npm run test         # Run Vitest test suite
 - **Interaction logging**: Every user interaction is logged as a timestamped, replay-ready event via `interactionLogger`. Saved as `interaction_log.json` alongside `session.json`.
 - See `docs/save-results.md` for session save/load, `docs/interaction-logging.md` for the replay contract, and `docs/action-overview-diagram.md` for the Remedial Action overview (pin overlay on N-1 network)
 
-### SVG Visualization (standalone_interface.html)
-The standalone interface includes advanced SVG rendering for pypowsybl network-area diagrams:
-- **Dynamic text scaling**: Font sizes for node labels, edge info, and legends scale proportionally to diagram size using `sqrt(diagramSize / referenceSize)`, so text is readable when zoomed in and naturally invisible at full zoom-out
-- **Bus node scaling**: Circle radii for bus nodes and transformer windings are boosted proportionally
-- **Edge info scaling**: Flow values and arrows along lines are scaled via transform groups
-- **ViewBox zoom**: Auto-centers on selected contingency targets with adjustable padding
-- **Interactive pan/zoom**: Wheel + drag for manual exploration via `react-zoom-pan-pinch`
+### SVG Visualization
+Both the React frontend and `standalone_interface.html` render pypowsybl
+NAD/SLD payloads:
+- **Dynamic text scaling** (`utils/svgUtils.ts:boostSvgForLargeGrid` /
+  standalone `boostSvgForLargeGrid`): font sizes for node labels, edge
+  info, and legends scale proportionally to diagram size via
+  `sqrt(diagramSize / referenceSize)`, so text is readable when zoomed
+  in and naturally invisible at full zoom-out. Engaged for grids
+  ≥ 500 voltage levels.
+- **Bus / transformer scaling**: circle radii for bus nodes and
+  transformer windings are boosted proportionally.
+- **Edge-info scaling**: flow values and arrow glyphs are scaled via
+  transform groups so they remain proportional to the line on which
+  they sit.
+- **ViewBox zoom**: auto-centers on selected contingency targets with
+  adjustable padding.
+- **Pan/zoom**: React uses `react-zoom-pan-pinch` (smooth,
+  inertia-aware); standalone uses inline viewBox math (basic, no
+  inertia). See the parity audit below for the gap.
 
 ## Dependencies
 
@@ -253,3 +262,267 @@ The standalone interface includes advanced SVG rendering for pypowsybl network-a
 - **Frontend unit tests** use Vitest + React Testing Library. Isolated component tests live as `*.test.tsx` files next to their component. Run with `cd frontend && npm run test`. No backend mocking is needed for component tests since they only use mocked props.
 - The two-step analysis flow (step1: detect overloads, step2: resolve) is the primary user workflow; the single-step `/api/run-analysis` is a legacy alternative
 - Session save/load is documented in `docs/save-results.md`
+
+---
+
+## Standalone Interface Parity Audit
+
+`standalone_interface.html` is a self-contained single-file mirror of the
+React UI (~7300 lines of inline HTML + JS + CSS; no React imports, no
+build step). It must remain **functionally equivalent** to the canonical
+React app in `frontend/` — the audit below enumerates the current gap as
+of 2026-04-19. Use this section as the work list when updating the
+standalone interface.
+
+The React frontend is the **source of truth**. When the two diverge, the
+standalone must be brought up, not the other way around.
+
+### Frontend Feature Inventory
+
+Grouped by domain. Each item lists the primary React source file(s)
+(see `frontend/CLAUDE.md` for directory structure).
+
+#### Header & Study Loading
+- **Load Study button** — `components/Header.tsx`, wired in `App.tsx::handleLoadConfig`
+- **Save Results button** — `components/Header.tsx`, `hooks/useSession.ts::handleSaveResults`
+- **Reload Session button** — `components/Header.tsx`, `hooks/useSession.ts::handleOpenReloadModal`
+- **Settings button** — `components/Header.tsx`, opens `SettingsModal`
+- **Network path input** (banner) — synchronised with the Paths-tab field in settings
+- **Logo** (⚡ Co-Study4Grid) — `components/Header.tsx`
+
+#### Settings Modal (3 tabs)
+- **Paths tab** — network, action dict, layout, output folder, config-file paths; native pickers — `components/modals/SettingsModal.tsx`
+- **Recommender tab** — min line reconnections/disconnections, min close/open coupling, min PST, min load shedding, min renewable curtailment, N prioritized actions, ignore-reconnections checkbox
+- **Configurations tab** — monitoring factor, lines monitoring file path + counts, pre-existing overload threshold, pypowsybl fast mode
+- **Config-file path management** — load/save the user config JSON, `changeConfigFilePath` — `hooks/useSettings.ts`
+- **Monitored / total lines count** displayed on Configurations tab
+- **Action dict stats** (reco / disco / pst / open_coupling / close_coupling / total) — surfaced from the `/api/config` response
+
+#### Contingency Selection
+- **Branch datalist dropdown** with type-ahead filter — `App.tsx` + Header integration
+- **Human-readable name resolution** (`nameMap: ID → display name`) — `App.tsx::displayName`
+- **Confirmation dialog** on contingency change when analysis state exists — `components/modals/ConfirmationDialog.tsx`, `App.tsx`
+- **Sticky summary** showing selected contingency + N-1 overloads with zoom buttons — `components/ActionFeed.tsx`
+
+#### Two-Step Analysis Flow
+- **Step 1**: detect N-1 overloads — `hooks/useAnalysis.ts`, `/api/run-analysis-step1`
+- **Overload selection panel** — multi-select checkboxes on detected overloads — `components/OverloadPanel.tsx`
+- **`monitor_deselected` toggle** — widen analysis scope to deselected overloads — `components/OverloadPanel.tsx`
+- **Step 2 streaming run** — NDJSON with early `pdf` event then `result` event — `hooks/useAnalysis.ts`, `/api/run-analysis-step2`
+
+#### Action Feed (sidebar)
+- **Action cards** — one per action, colour-coded by bucket — `components/ActionCard.tsx`, `components/ActionFeed.tsx`
+- **Search / filter dropdown** — by ID, description, type filters (disco/reco/pst/ls/rc/…) — `components/ActionSearchDropdown.tsx`
+- **Three buckets**: Suggested (recommender output), Selected (starred), Rejected — `hooks/useActions.ts`
+- **Star / un-star** — `handleActionFavorite` — `hooks/useActions.ts`
+- **Reject / un-reject** — `handleActionReject` — `hooks/useActions.ts`
+- **Badges**: max-rho-line, load shedding count, renewable curtailment count, PST tap range, DC fallback — `components/ActionCard.tsx`
+- **Scroll-to-selected** — `App.tsx::scrollToActionRef`
+- **Load shedding details popup** — list of (load, MW) — `components/ActionCard.tsx`
+- **Curtailment details popup** — list of (generator, MW curtailed) — `components/ActionCard.tsx`
+- **PST details popup** — PST name → tap position, range — `components/ActionCard.tsx`
+- **Manual action add** — search dropdown + "Add Manual Action" button — `components/ActionFeed.tsx`
+
+#### Action-Variant Diagrams
+- **Fetch on action select** — `hooks/useDiagrams.ts`, `/api/action-variant-diagram`
+- **Network / Delta mode toggle** — `components/VisualizationPanel.tsx`
+- **Focused action-variant diagram** — per-VL sub-diagram in post-action state — `/api/action-variant-focused-diagram`
+- **Action-variant SLD** — triggered by VL double-click on action tab — `/api/action-variant-sld`
+
+#### Visualization Panel
+- **SVG render** with `react-zoom-pan-pinch` — `components/VisualizationPanel.tsx`, `hooks/usePanZoom.ts`
+- **Zoom controls** — manual zoom in/out/reset — per-tab `usePanZoom` instance
+- **Tabs**: N / N-1 / Action / Overflow (PDF) — `components/VisualizationPanel.tsx`
+- **Inspect query (zoom-to-element)** — `usePanZoom.ts::zoomToElement`, `App.tsx::inspectQuery`
+- **Voltage range filter** — slider hiding elements outside the selected kV band — `hooks/useDiagrams.ts::voltageRange`
+- **Dynamic SVG scaling for large grids** (≥ 500 VLs) — `utils/svgUtils.ts::boostSvgForLargeGrid`
+- **Asset click zoom + highlight** — `App.tsx::handleAssetClick`
+- **Contingency highlight** — `utils/svgUtils.ts::applyContingencyHighlight` (uses `vector-effect`)
+- **Overload highlights** — `utils/overloadHighlights.ts::computeN1OverloadHighlights`
+- **Delta highlights** — `utils/svgUtils.ts::applyDeltaVisuals`
+- **Zoom-tier LOD** — per-tier CSS classes hide text-heavy elements at overview zoom — `App.css`
+
+#### Combined Actions Modal
+- **Pair selection** (checkbox, max 2) — `components/CombinedActionsModal.tsx`
+- **Superposition computation** (estimate max rho without simulation) — `/api/compute-superposition`
+- **`ComputedPairsTable`** component for pre-computed pairs — `components/ComputedPairsTable.tsx`
+- **`ExplorePairsTab`** component for all scored actions — `components/ExplorePairsTab.tsx`
+- **Simulate combined** — full simulation of the pair — `/api/simulate-manual-action`
+
+#### Action Overview Diagram
+- **N-1 NAD with pin overlay** — one pin per prioritized action — `components/ActionOverviewDiagram.tsx`
+- **`ActionCardPopover` preview** — hover pin → floating action summary — `components/ActionCardPopover.tsx`
+- **Pin double-click navigation** — scroll sidebar to the action without selecting
+- **Independent pan/zoom** — dedicated `usePanZoom` instance for the overview map
+
+#### SLD Overlay
+- **VL double-click → SLD popup** — `hooks/useSldOverlay.ts`, `App.tsx::handleVlDoubleClick`
+- **N / N-1 / Action tabs** on the SLD — `components/SldOverlay.tsx`
+- **Switch change visualisation** — changed breakers/switches highlighted — `components/SldOverlay.tsx`
+- **Delta flow mode** — P/Q flow changes with direction arrows
+- **SLD pan/zoom** — wheel zoom + drag
+- **Auto-center on load** — fit-to-viewport
+
+#### Detached + Tied Tabs
+- **Detach tab into popup window** — `hooks/useDetachedTabs.ts`, `components/DetachableTabHost.tsx`
+- **Tied viewBox sync** — one-way mirror from detached to main — `hooks/useTiedTabsSync.ts`
+- **Focus detached tab** from the main window — `useDetachedTabs.ts::focus`
+
+#### Session Save / Load
+- **Save snapshot** to folder (or browser download) — `hooks/useSession.ts::handleSaveResults`, `/api/save-session`
+- **List-sessions modal** — `components/modals/ReloadSessionModal.tsx`, `/api/list-sessions`
+- **Restore session** — configuration + contingency + analysis state — `/api/load-session`
+- **`restore-analysis-context`** — rehydrate `selectedOverloads`, monitored lines, computed pairs — `/api/restore-analysis-context`
+
+#### Interaction Logger
+- **Typed event recording** — `utils/interactionLogger.ts`, `types.ts::InteractionType` union
+- **Correlation IDs** for async start/completion pairs
+- **Replay-ready details** — each event carries every input needed to replay the gesture
+- **Saved alongside session** as `interaction_log.json`
+
+#### Confirmation Dialogs (shared component)
+- **Contingency change** — warns if analysis state exists
+- **Load Study** — warns before resetting
+- **Apply Settings** — warns before resetting
+- All three use `components/modals/ConfirmationDialog.tsx`
+
+#### Error Handling
+- **`ErrorBoundary`** — catches render errors — `components/ErrorBoundary.tsx`
+- **Error toasts** — `App.tsx::setError`
+- **Info messages** — `App.tsx::setInfoMessage`
+- **Monitoring warning** — yellow banner when lines are unmonitored — `components/OverloadPanel.tsx`
+
+#### Performance Optimizations
+- **`format=text` diagram fetch** — skip `JSON.parse` on ~25 MB SVG strings — `api.ts::getNetworkDiagram`
+- **Parallel boot XHRs** — branches + VLs + nominal voltages + N diagram in a single `Promise.all` — `App.tsx`
+- **`getIdMap` WeakMap cache** — avoid re-scanning `[id]` on every highlight pass — `utils/svgUtils.ts`
+- **NAD prefetch consumption** — backend pre-computes base NAD during `/api/config`; frontend consumes it near-instantly
+- **`MemoizedSvgContainer`** — `React.memo` wrapper — `components/MemoizedSvgContainer.tsx`
+- **Zoom-tier LOD** — hide text-heavy elements at overview zoom
+
+### Standalone HTML Mirror Status
+
+Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
+
+| Feature group | Item | Status | Gap / note |
+|---|---|---|---|
+| **Header** | Load Study, Save, Reload, Settings buttons | ✅ | — |
+| **Header** | Network path input, logo | ✅ | — |
+| **Settings** | Paths tab (all 5 fields + pickers) | ✅ | — |
+| **Settings** | Recommender tab (all sliders + ignore-reconnections) | ✅ | — |
+| **Settings** | Configurations tab (monitoring factor, lines file, threshold, fast mode) | ✅ | — |
+| **Settings** | Config-file path management | ✅ | — |
+| **Settings** | Action dict stats display | ✅ | — |
+| **Contingency** | Datalist dropdown | ⚠️ | Shows IDs only — no human-readable name resolution in the options |
+| **Contingency** | Confirmation dialog on change | ✅ | Uses `window.confirm()` |
+| **Contingency** | Sticky summary strip | ✅ | — |
+| **Analysis** | Step 1 detect | ✅ | — |
+| **Analysis** | Overload selection panel | ✅ | — |
+| **Analysis** | `monitor_deselected` toggle | ✅ | — |
+| **Analysis** | Step 2 streaming (pdf + result events) | ✅ | — |
+| **ActionFeed** | Cards, search, 3 buckets | ✅ | — |
+| **ActionFeed** | Star / reject / manual-add | ✅ | — |
+| **ActionFeed** | Max-rho / LS / RC / PST badges | ✅ | — |
+| **ActionFeed** | DC-fallback badge | ⚠️ | `non_convergence` tracked but not surfaced in the filter dropdown |
+| **ActionFeed** | Scroll-to-selected | ✅ | — |
+| **ActionFeed** | Load-shedding details popup | ❌ | Badge shows count only — no per-load breakdown popup |
+| **ActionFeed** | Curtailment details popup | ❌ | Badge shows count only — no per-generator breakdown popup |
+| **ActionFeed** | PST details popup | ❌ | Tap shown inline on the card — no separate popup with range & start |
+| **ActionVariant** | Fetch on select | ✅ | — |
+| **ActionVariant** | Network / Delta mode toggle | ✅ | — |
+| **ActionVariant** | N / N-1 / Action tabs | ✅ | — |
+| **ActionVariant** | SLD on VL double-click | ✅ | — |
+| **Visualization** | SVG render | ✅ | — |
+| **Visualization** | Pan / zoom | ⚠️ | Inline viewBox math — not `react-zoom-pan-pinch`; no inertia / gesture smoothing |
+| **Visualization** | Zoom in / out / reset buttons | ✅ | — |
+| **Visualization** | N / N-1 / Action / Overflow tabs | ✅ | — |
+| **Visualization** | Inspect-query zoom | ⚠️ | Basic viewBox math; not the polished `usePanZoom` behaviour |
+| **Visualization** | Voltage range filter | ✅ | — |
+| **Visualization** | `boostSvgForLargeGrid` scaling | ✅ | — |
+| **Visualization** | Asset click zoom | ✅ | — |
+| **Visualization** | Contingency highlight | ⚠️ | Uses clone halo — not the `vector-effect` approach; heavier on re-render |
+| **Visualization** | Overload / delta highlights | ✅ | — |
+| **Visualization** | Zoom-tier LOD (hide labels at overview) | ❌ | SVG always fully rendered regardless of zoom tier |
+| **Combined Actions** | Pair checkbox selection | ✅ | — |
+| **Combined Actions** | Superposition compute | ✅ | — |
+| **Combined Actions** | ComputedPairsTable | ⚠️ | Rendered inline, not as a discrete reusable component |
+| **Combined Actions** | ExplorePairsTab | ⚠️ | Rendered inline, not as a discrete component |
+| **Combined Actions** | Simulate combined | ✅ | — |
+| **Action Overview** | N-1 NAD with pin overlay | ❌ | No overview map at all |
+| **Action Overview** | ActionCardPopover on pin hover | ❌ | Depends on overview map |
+| **Action Overview** | Pin double-click nav | ❌ | Depends on overview map |
+| **Action Overview** | Independent zoom controls | ❌ | Depends on overview map |
+| **SLD** | VL double-click popup | ✅ | — |
+| **SLD** | N / N-1 / Action tabs | ✅ | — |
+| **SLD** | Switch change highlight | ✅ | — |
+| **SLD** | Delta flow mode | ✅ | — |
+| **SLD** | Pan / zoom | ✅ | — |
+| **SLD** | Auto-center on load | ✅ | — |
+| **Detached tabs** | Pop into separate window | ❌ | No `window.open` support anywhere |
+| **Detached tabs** | Tied viewBox sync | ❌ | Depends on detach support |
+| **Detached tabs** | Focus-from-main | ❌ | Depends on detach support |
+| **Session** | Save to folder | ✅ | — |
+| **Session** | Browser download fallback | ✅ | — |
+| **Session** | List-sessions modal | ✅ | — |
+| **Session** | Restore configuration + contingency + analysis state | ✅ | — |
+| **Session** | Restore interaction log | ✅ | — |
+| **Interaction log** | Event recording | ✅ | — |
+| **Interaction log** | Correlation IDs | ⚠️ | Recorded for some events — not systematically paired on all async flows |
+| **Interaction log** | Replay-ready details | ✅ | — |
+| **Interaction log** | Saved with session | ✅ | — |
+| **Confirmation** | Contingency change | ✅ | `window.confirm()` |
+| **Confirmation** | Load Study | ✅ | `window.confirm()` |
+| **Confirmation** | Apply Settings | ⚠️ | Settings apply immediately — no confirmation prompt before analysis reset |
+| **Errors** | ErrorBoundary | ❌ | No catastrophic-render guard — only error-state message display |
+| **Errors** | Error / info / monitoring-warning messages | ✅ | — |
+| **Perf** | `format=text` diagram fetch | ⚠️ | Behaviour assumed from rendering; not obviously wired to the `format=text` endpoint |
+| **Perf** | Parallel boot XHRs | ✅ | `Promise.all([branches, VLs, nominal voltages])` |
+| **Perf** | `getIdMap` WeakMap cache | ✅ | — |
+| **Perf** | MemoizedSvgContainer | ❌ | No memoisation wrapper — inline SVG render |
+| **Perf** | Zoom-tier LOD | ❌ | No tier-based element hiding |
+
+### Parity Gap Priority
+
+#### Top-priority gaps (biggest user impact — do first)
+1. **Action Overview Diagram + pin navigation** — whole feature missing. The React UI lets operators see all prioritized actions as pins on the N-1 NAD and preview/jump to each via hover/double-click. Without it, standalone users can only browse actions linearly in the sidebar. `components/ActionOverviewDiagram.tsx`, `components/ActionCardPopover.tsx`, `docs/action-overview-diagram.md`.
+2. **Detached + tied tabs** — no way to compare N vs Action or N-1 vs Action side-by-side. Requires `window.open` + `postMessage` IPC. See `docs/detachable-viz-tabs.md`.
+3. **Pan/zoom migration to `react-zoom-pan-pinch`** — standalone uses raw viewBox math with no inertia or gesture smoothing. On large grids this is the single biggest UX regression versus the React app.
+4. **Zoom-tier LOD** — large grids (500+ VLs) render ALL text at overview zoom and become unreadable; React hides text-heavy elements per tier. See `docs/rendering-optimization-plan.md`.
+5. **Load-shedding / curtailment / PST details popups** — three separate popups in the React `ActionCard` that expose per-item breakdowns; currently replaced by a badge count only.
+6. **Contingency highlight rendering** — standalone uses clone halos; React uses `vector-effect: non-scaling-stroke`. Functionally similar but React's approach is cheaper on repeated contingency changes.
+7. **Name-resolution in datalist** — surfacing `nameMap[id]` in the dropdown options. Very low effort, high frequent-use payoff on grids with 1000+ branches.
+8. **Confirmation dialog before Apply Settings** — parity with the existing Load-Study / contingency-change confirmations.
+9. **Interaction log correlation IDs on all async flows** — the replay contract requires start/completion pairs; standalone currently emits only partial pairs.
+10. **Extracting inline `ComputedPairsTable` and `ExplorePairsTab`** into discrete JS modules within the standalone file. Low functional impact but improves maintainability.
+
+#### Deferrable gaps (cosmetic / marginal)
+1. **ErrorBoundary** — catastrophic-render guard. Rare in practice.
+2. **MemoizedSvgContainer** — `React.memo` equivalent; marginal perf.
+3. **`format=text` diagram fetch wiring** — confirm the standalone uses the `format=text` variant for large SVGs (saves ~500 ms of `JSON.parse`).
+4. **DC-fallback badge in the filter dropdown** — `non_convergence` is tracked but not filterable by users.
+5. **SVG prefetch of alternate variants** — pre-fetch N-1 SLD while viewing the N action variant. On-demand load is acceptable.
+
+#### Features in the standalone that are no longer in React
+None identified. The standalone is strictly a subset of the React app — there is no obsolete code path to remove. If a feature is removed from `frontend/`, delete it from `standalone_interface.html` in the same commit.
+
+### How to use this audit
+
+When updating `standalone_interface.html`:
+
+1. Pick an item from "Top-priority gaps" (or "Deferrable gaps" if the
+   work is lighter). Read the React source files listed alongside to
+   understand the exact behaviour.
+2. Check the Interaction Logger section of `frontend/CLAUDE.md` and
+   add any new gesture types to the standalone's inline
+   `interactionLogger` implementation. The replay contract in
+   `docs/interaction-logging.md` is the source of truth.
+3. When a new endpoint is added to the backend (`expert_backend/main.py`)
+   and surfaced in `frontend/src/api.ts`, mirror it in the standalone's
+   inline API wrapper **in the same PR**.
+4. When adding a new setting field: update the audit table above to
+   track its mirror state.
+5. Run the standalone locally by opening it in a browser with the
+   FastAPI backend running. Confirm the gesture, diagram, and
+   interaction-log output match the React app side by side.
+
+Last audited: 2026-04-19 (branch `claude/fix-grid-layout-reset-8TYEV`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -772,6 +772,69 @@ verifies the `details` keys per event match the replay contract.
 This is the pre-PR gate; the Layer-1 parity script is the PR-gate
 fallback that also checks the standalone HTML.
 
+### Honest gap report — what the parity scripts CANNOT catch
+
+After three rounds of user-discovered standalone bugs that the
+green parity reports failed to flag, here's the honest scorecard.
+The four layers we ship today each guard a specific surface; none
+of them inspect actual rendered DOM, which is where most
+user-observable regressions live.
+
+| Bug class | Example bugs missed | Why scripts missed it |
+|---|---|---|
+| **Visual threshold values** | Pin severity used hardcoded 0.9 / 1.0 cutoffs instead of `monitoringFactor` ± 0.05; Overview backdrop dimmed at 0.55 → edges invisible | No script reads CSS / fill / stroke values |
+| **Conditional rendering** | Dashed combined-pair lines drawn for `is_estimated: true` entries (no simulation has run yet); Overview pin layer not in detached popup | Scripts inspect call-site syntax, not "when does this branch render" |
+| **Field-semantic interpretation** | `max_rho_line` used as primary pin anchor instead of action's topology target; `is_estimated` not respected when filtering combined pairs | Scripts check shape, not which field a UI consumer should treat as authoritative |
+| **Auto-effects ordering** | Tab didn't auto-switch to Action when Display Prioritized clicked; auto-zoom didn't fire after action selection; deselect snapped to N-1 instead of staying on Action | Scripts confirm an event fires; they don't check the side-effects (`setActiveTab`, `setViewBox`) that follow |
+| **Loading-state hygiene** | Combine-modal Simulate button stuck in spinner state until variant diagram completed (5–6 s after the result was ready) | No script inspects loading flags / button disabled state |
+| **Rendering performance** | Overview SVG re-cloned on every re-render (200–500 ms each); base NAD fetched serially after metadata | No script measures critical-path latency |
+
+What the four layers DO catch:
+
+| Layer | Scope |
+|---|---|
+| Layer 1 (`check_standalone_parity.py`) | Event-type coverage; `details` key shape; `InteractionType` union membership; API path coverage; `SettingsState` field coverage |
+| Layer 2 (`check_session_fidelity.py`) | Session.json field round-trip (save vs restore); save-only-OK fields |
+| Layer 3a (`check_gesture_sequence.py`) | Per-gesture ordered list of `record(...)` / `recordCompletion(...)` calls; sequence-aware but path-blind |
+| Layer 3b (`parity_e2e/e2e_parity.spec.ts`) | Real browser run of the 11-gesture canonical session; same-event sequence + same-`details` keys + same-`session.json` shape between React + standalone |
+
+Layer 3b is the only one positioned to catch most of the missed
+classes — but only IF its gesture script exercises them. It
+currently runs an 11-gesture canonical flow that doesn't visit
+Display Prioritized → Action Overview → pin click. Extending the
+script is the highest-leverage next move.
+
+#### Proposed Layer 4 — User-observable invariants
+
+Things scripts SHOULD check that none of L1–L3 do today:
+
+1. **Pin severity ↔ rho ↔ monitoringFactor** — render the
+   ActionOverviewDiagram with synthetic actions at rho =
+   `mf - 0.06`, `mf - 0.04`, `mf + 0.01` and assert pins come out
+   green / orange / red.
+2. **Conditional render gates** — for each "this is shown when
+   X" UI, snapshot the canonical states and check the right
+   element exists / is hidden.
+3. **Loading-state release** — drive a simulate, mock a slow
+   diagram fetch, assert button releases when the metrics arrive,
+   not when the diagram does.
+4. **Auto-effects after gesture** — after `prioritized_actions_displayed`,
+   assert `activeTab === 'action'` and the Overview is rendered.
+   After `action_selected` with simulated diagram available,
+   assert auto-zoom set viewBox onto `max_rho_line`.
+
+These all need browser-level execution (jsdom + RTL or Playwright);
+none can be done with a pure-Python regex pass. Realistic path:
+add them as Vitest specs that mount the React component tree (the
+React side guards itself), and as Playwright assertions in the
+existing Layer 3b spec for the standalone side.
+
+In the meantime: anyone editing the standalone Overview / detach
+/ severity logic should manually run through the four bug classes
+above before sending a PR. The CLAUDE.md mirror-status table is
+updated reactively from user reports — it is not a complete
+invariant.
+
 ### How to use this audit
 
 When updating `standalone_interface.html`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,8 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **Settings** | Configurations tab (monitoring factor, lines file, threshold, fast mode) | ✅ | — |
 | **Settings** | Config-file path management | ✅ | — |
 | **Settings** | Action dict stats display | ✅ | — |
+| **Settings** | `settings_tab_changed` interaction log | ✅ | Emitted on every Paths/Recommender/Configurations tab click |
+| **Settings** | `path_picked` interaction log | ✅ | Emitted from the native file/dir picker |
 | **Contingency** | Datalist dropdown | ⚠️ | Shows IDs only — no human-readable name resolution in the options |
 | **Contingency** | Confirmation dialog on change | ✅ | Uses `window.confirm()` |
 | **Contingency** | Sticky summary strip | ✅ | — |
@@ -428,6 +430,7 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **ActionFeed** | Load-shedding details popup | ❌ | Badge shows count only — no per-load breakdown popup |
 | **ActionFeed** | Curtailment details popup | ❌ | Badge shows count only — no per-generator breakdown popup |
 | **ActionFeed** | PST details popup | ❌ | Tap shown inline on the card — no separate popup with range & start |
+| **ActionFeed** | Re-simulate (MW + tap) interaction log | ✅ | Now emits `action_mw_resimulated` / `pst_tap_resimulated` |
 | **ActionVariant** | Fetch on select | ✅ | — |
 | **ActionVariant** | Network / Delta mode toggle | ✅ | — |
 | **ActionVariant** | N / N-1 / Action tabs | ✅ | — |
@@ -437,6 +440,7 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **Visualization** | Zoom in / out / reset buttons | ✅ | — |
 | **Visualization** | N / N-1 / Action / Overflow tabs | ✅ | — |
 | **Visualization** | Inspect-query zoom | ⚠️ | Basic viewBox math; not the polished `usePanZoom` behaviour |
+| **Visualization** | `inspect_query_changed` interaction log | ✅ | — |
 | **Visualization** | Voltage range filter | ✅ | — |
 | **Visualization** | `boostSvgForLargeGrid` scaling | ✅ | — |
 | **Visualization** | Asset click zoom | ✅ | — |
@@ -466,14 +470,14 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **Session** | List-sessions modal | ✅ | — |
 | **Session** | Restore configuration + contingency + analysis state | ✅ | — |
 | **Session** | Restore interaction log | ✅ | — |
-| **Interaction log** | Event-type coverage | ⚠️ | 19/55 spec types never emitted by the standalone — see machine-grounded findings below |
-| **Interaction log** | `details` schema conformance | ⚠️ | 5 events with standalone-side schema drift (e.g. `voltage_range_changed {min_kv,max_kv}` vs spec `{min,max}`) — see below |
-| **Interaction log** | `recordCompletion` pairs | ⚠️ | Only `analysis_step{1,2}_completed` emitted — both sides drift from the spec here |
+| **Interaction log** | Event-type coverage | ⚠️ | 13/55 spec types still missing — **all** within the Action Overview (9) + Detached-Tabs (4) features; every other gesture now logs on both sides |
+| **Interaction log** | `details` schema conformance | ✅ | All emitted standalone events are spec-conformant; historical `min_kv/max_kv`, `target_tab`, `from_tab/to_tab`, `missing tab/scope` drifts all resolved |
+| **Interaction log** | `recordCompletion` pairs | ⚠️ | Only `analysis_step{1,2}_completed` emitted — shared gap against the spec (fix needed on both sides) |
 | **Interaction log** | Replay-ready details | ✅ | — |
 | **Interaction log** | Saved with session | ✅ | — |
-| **Confirmation** | Contingency change | ✅ | `window.confirm()` |
-| **Confirmation** | Load Study | ✅ | `window.confirm()` |
-| **Confirmation** | Apply Settings | ⚠️ | Settings apply immediately — no confirmation prompt before analysis reset |
+| **Confirmation** | Contingency change | ✅ | `window.confirm()` + emits `contingency_confirmed { type: 'contingency', pending_branch }` |
+| **Confirmation** | Load Study | ✅ | `window.confirm()` + emits `contingency_confirmed { type: 'loadStudy' }` |
+| **Confirmation** | Apply Settings | ✅ | `window.confirm()` + emits `contingency_confirmed { type: 'applySettings' }` |
 | **Errors** | ErrorBoundary | ❌ | No catastrophic-render guard — only error-state message display |
 | **Errors** | Error / info / monitoring-warning messages | ✅ | — |
 | **Perf** | `format=text` diagram fetch | ⚠️ | Behaviour assumed from rendering; not obviously wired to the `format=text` endpoint |
@@ -520,56 +524,82 @@ into CI.
 
 _Generated from the parity script on 2026-04-19._
 `InteractionType` union: **55** types. Frontend emits **51**,
-standalone emits **32**.
+standalone emits **38** (was 32 — six cheap gestures ported +
+`settings_tab_changed` now fires on every tab switch).
 
-##### Event types emitted by the frontend but NOT by the standalone (19)
+##### Event types emitted by the frontend but NOT by the standalone (13)
 
-| Event type | React source |
-|---|---|
-| `action_mw_resimulated` | `components/ActionFeed.tsx:451` |
-| `contingency_confirmed` | `App.tsx:681` (standalone uses `window.confirm()` and emits nothing) |
-| `inspect_query_changed` | `App.tsx:976, App.tsx:984` |
-| `overview_hidden` | `components/ActionOverviewDiagram.tsx:469` |
-| `overview_inspect_changed` | `components/ActionOverviewDiagram.tsx:526, :530` |
-| `overview_pin_clicked` | `components/ActionOverviewDiagram.tsx:343` |
-| `overview_pin_double_clicked` | `components/ActionOverviewDiagram.tsx:364` |
-| `overview_popover_closed` | `components/ActionOverviewDiagram.tsx:558` |
-| `overview_shown` | `components/ActionOverviewDiagram.tsx:466` |
-| `overview_zoom_fit` | `components/ActionOverviewDiagram.tsx:487` |
-| `overview_zoom_in` | `components/ActionOverviewDiagram.tsx:476` |
-| `overview_zoom_out` | `components/ActionOverviewDiagram.tsx:482` |
-| `path_picked` | `hooks/useSettings.ts:232` |
-| `pst_tap_resimulated` | `components/ActionFeed.tsx:503` |
-| `settings_tab_changed` | `components/modals/SettingsModal.tsx:51` |
-| `tab_detached` | `App.tsx:211` |
-| `tab_reattached` | `App.tsx:225` |
-| `tab_tied` | `hooks/useTiedTabsSync.ts:97, :120` |
-| `tab_untied` | `hooks/useTiedTabsSync.ts:107, :117` |
+Down from 19 as of the last audit. Every remaining miss is in one
+of the two expensive feature families — Action Overview diagram and
+Detached + Tied Tabs. Porting them is the next follow-up.
+
+| Event type | Feature | React source |
+|---|---|---|
+| `overview_shown` / `overview_hidden` | Action Overview map visibility | `components/ActionOverviewDiagram.tsx:466,469` |
+| `overview_pin_clicked` / `overview_pin_double_clicked` | Pin single/double-click | `components/ActionOverviewDiagram.tsx:343,364` |
+| `overview_popover_closed` | Popover dismiss | `components/ActionOverviewDiagram.tsx:558` |
+| `overview_zoom_in` / `overview_zoom_out` / `overview_zoom_fit` | Overview zoom controls | `components/ActionOverviewDiagram.tsx:476,482,487` |
+| `overview_inspect_changed` | Overview search focus/clear | `components/ActionOverviewDiagram.tsx:526,530` |
+| `tab_detached` / `tab_reattached` | Pop tab into separate window | `App.tsx:211,225` |
+| `tab_tied` / `tab_untied` | Mirror detached viewBox | `hooks/useTiedTabsSync.ts:97,107` |
 
 Nothing in the standalone emits an event the union does not know
 about (0 orphan types).
 
-##### Frontend drifts from the replay-contract spec
+##### Details-key drift between frontend and standalone (1)
 
-**0 events — all resolved** in this branch. The table below is the
-historical record (each row now has a regression test and the Python
-+ Vitest conformity checks guard against re-introduction):
+Down from 11. The remaining diff is spec-conformant on both sides
+(the frontend's extra key is optional per the contract):
+
+| Event | Frontend | Standalone | Note |
+|---|---|---|---|
+| `inspect_query_changed` | `{query, target_tab}` | `{query}` | `target_tab` is optional per spec — only populated when the inspect field is triggered from a detached-tab overlay (which the standalone doesn't support). Not a bug. |
+
+##### Spec conformance (FE-vs-spec, SA-vs-spec)
+
+- Frontend drifts: **0** (was 4 earlier in this branch; all resolved).
+- Standalone drifts: **0** (was 14 earlier in this branch; all resolved by this commit's SA-drift fixes — `asset_clicked`, `diagram_tab_changed`, `sld_overlay_tab_changed`, `view_mode_changed`, `voltage_range_changed`, `zoom_in/out/reset`, `config_loaded`, `prioritized_actions_displayed`, and the harmless extras on `manual_action_simulated`, `session_saved`, `sld_overlay_opened`, `session_reload_modal_opened`).
+
+##### Historical fixes on the React side (6 events resolved)
+
+All six spec drifts that existed earlier in this branch are now
+fixed, each with a regression test. The Python parity script +
+Vitest `specConformance.test.ts` guard against re-introduction:
 
 | Event | Fix | Regression test |
 |---|---|---|
-| `action_deselected` | `{action_id}` → `{previous_action_id}` (`hooks/useDiagrams.ts:360`) | `hooks/useDiagrams.test.ts::logs action_deselected when re-selecting the same action` |
-| `analysis_step2_started` | added `element` + `all_overloads` (`hooks/useAnalysis.ts:122`) | `hooks/useAnalysis.test.ts::step2_started carries the full spec payload` |
-| `overload_toggled` | added `selected` (`hooks/useAnalysis.ts:239`) | `hooks/useAnalysis.test.ts::logs overload_toggled with overload + selected` |
-| `prioritized_actions_displayed` | `actions_count` → `n_actions` (`hooks/useAnalysis.ts:193`) | `hooks/useAnalysis.test.ts::logs prioritized_actions_displayed with n_actions` |
-| `analysis_step2_completed` | `actions_count` → `n_actions` (`hooks/useAnalysis.ts:184`) | same suite |
-| `view_mode_changed` (hook-internal emission) | removed emission from `hooks/useDiagrams.ts:202` (App.tsx owns the full-spec emission) | `hooks/useDiagrams.test.ts::handleViewModeChange updates state but does NOT emit view_mode_changed` |
+| `action_deselected` | `{action_id}` → `{previous_action_id}` | `hooks/useDiagrams.test.ts` |
+| `analysis_step2_started` | added `element` + `all_overloads` | `hooks/useAnalysis.test.ts` |
+| `overload_toggled` | added `selected` (post-toggle state) | `hooks/useAnalysis.test.ts` |
+| `prioritized_actions_displayed` | `actions_count` → `n_actions` | `hooks/useAnalysis.test.ts` |
+| `analysis_step2_completed` | `actions_count` → `n_actions` | `hooks/useAnalysis.test.ts` |
+| `view_mode_changed` (hook path) | Removed hook-internal emission (App.tsx owns full-spec) | `hooks/useDiagrams.test.ts` |
 
-The fifth drift (`view_mode_changed` hook-internal) was surfaced by
-the Vitest spec-conformance test, not the Python script — the
-script's set-based union across call sites was masking it behind
-`App.tsx`'s full-shape emission. The spec-conformance test
-(`utils/specConformance.test.ts`) walks all call sites individually
-and catches per-site drift, so it ran as the stricter check.
+The fifth one was surfaced by the Vitest spec-conformance test, not
+the Python script — the script's set-based union across call sites
+was masking it behind `App.tsx`'s full-shape emission. The
+spec-conformance test walks all call sites individually and catches
+per-site drift.
+
+##### Historical fixes on the standalone side (14 events resolved)
+
+All fourteen SA spec drifts that existed earlier in this branch are
+now fixed:
+
+| Event | Fix |
+|---|---|
+| `asset_clicked` | `target_tab` → `tab` |
+| `diagram_tab_changed` | `{from_tab, to_tab}` → `{tab}` (destination) |
+| `sld_overlay_tab_changed` | `{from_tab, to_tab}` → `{tab, vl_name}` |
+| `view_mode_changed` | Added `tab: 'action'` + `scope: 'main'` |
+| `voltage_range_changed` | `{min_kv, max_kv}` → `{min, max}` |
+| `zoom_in` / `zoom_out` / `zoom_reset` | Added `tab: activeTab` |
+| `config_loaded` | Added `output_folder_path` (was missing) |
+| `prioritized_actions_displayed` | Added `n_actions` (was `{}`) |
+| `manual_action_simulated` | Dropped empty `description: ''` extra |
+| `session_saved` | Dropped `session_name` extra |
+| `sld_overlay_opened` | Dropped `initial_tab` extra |
+| `session_reload_modal_opened` | Dropped `{available_sessions, output_folder}` extras |
 
 ##### Standalone drifts from the replay-contract spec (14 events)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,17 +452,18 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **Combined Actions** | ComputedPairsTable | ⚠️ | Rendered inline, not as a discrete reusable component |
 | **Combined Actions** | ExplorePairsTab | ⚠️ | Rendered inline, not as a discrete component |
 | **Combined Actions** | Simulate combined | ✅ | — |
-| **Action Overview** | N-1 NAD with pin overlay | ❌ | No overview map at all |
-| **Action Overview** | ActionCardPopover on pin hover | ❌ | Depends on overview map |
-| **Action Overview** | Pin double-click nav | ❌ | Depends on overview map |
-| **Action Overview** | Independent zoom controls | ❌ | Depends on overview map |
+| **Action Overview** | N-1 NAD with pin overlay | ✅ | Minimal port — one pin per prioritized action at the midpoint of its `max_rho_line`; no multi-pin fan-out, no combined-action curves. All 9 `overview_*` events fire at the documented gesture points. |
+| **Action Overview** | ActionCardPopover on pin hover | ⚠️ | Minimal popover (id / description / max ρ / "View action" button). Not the full ActionCard component — no favorite/reject buttons inside the popover. |
+| **Action Overview** | Pin double-click nav | ✅ | 250 ms debounce so single-click opens popover, double-click calls `handleActionSelect` |
+| **Action Overview** | Independent zoom controls | ⚠️ | `+ / − / Fit` buttons emit `overview_zoom_*` events; they don't manipulate viewBox separately from the main action-tab pan/zoom. Good enough for replay, less polished than React's dedicated instance. |
+| **Action Overview** | Inspect search | ✅ | Text input emits `overview_inspect_changed { query, action: 'focus'\|'cleared' }` |
 | **SLD** | VL double-click popup | ✅ | — |
 | **SLD** | N / N-1 / Action tabs | ✅ | — |
 | **SLD** | Switch change highlight | ✅ | — |
 | **SLD** | Delta flow mode | ✅ | — |
 | **SLD** | Pan / zoom | ✅ | — |
 | **SLD** | Auto-center on load | ✅ | — |
-| **Detached tabs** | Pop into separate window | ❌ | No `window.open` support anywhere |
+| **Detached tabs** | Pop into separate window | ❌ | **Deliberately deferred.** Requires `window.open` + `postMessage` IPC + per-window pan/zoom state. ~300-500 lines of infrastructure in the single-file HTML with behavioural risks (popup blockers, IPC ordering) that are hard to validate without a real browser. None of the 4 missing events (`tab_detached`, `tab_reattached`, `tab_tied`, `tab_untied`) appear in the canonical 11-gesture replay sequence, so replay agents against session logs without detached-tab gestures still work unchanged. |
 | **Detached tabs** | Tied viewBox sync | ❌ | Depends on detach support |
 | **Detached tabs** | Focus-from-main | ❌ | Depends on detach support |
 | **Session** | Save to folder | ✅ | — |
@@ -470,7 +471,7 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **Session** | List-sessions modal | ✅ | — |
 | **Session** | Restore configuration + contingency + analysis state | ✅ | — |
 | **Session** | Restore interaction log | ✅ | — |
-| **Interaction log** | Event-type coverage | ⚠️ | 13/55 spec types still missing — **all** within the Action Overview (9) + Detached-Tabs (4) features; every other gesture now logs on both sides |
+| **Interaction log** | Event-type coverage | ⚠️ | 4/55 spec types still missing — **all four** Detached + Tied Tabs events. Every other gesture (including all 9 Action Overview events) now logs on both sides. |
 | **Interaction log** | `details` schema conformance | ✅ | All emitted standalone events are spec-conformant; historical `min_kv/max_kv`, `target_tab`, `from_tab/to_tab`, `missing tab/scope` drifts all resolved |
 | **Interaction log** | `recordCompletion` pairs | ⚠️ | Only `analysis_step{1,2}_completed` emitted — shared gap against the spec (fix needed on both sides) |
 | **Interaction log** | Replay-ready details | ✅ | — |
@@ -489,8 +490,8 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 ### Parity Gap Priority
 
 #### Top-priority gaps (biggest user impact — do first)
-1. **Action Overview Diagram + pin navigation** — whole feature missing. The React UI lets operators see all prioritized actions as pins on the N-1 NAD and preview/jump to each via hover/double-click. Without it, standalone users can only browse actions linearly in the sidebar. `components/ActionOverviewDiagram.tsx`, `components/ActionCardPopover.tsx`, `docs/action-overview-diagram.md`.
-2. **Detached + tied tabs** — no way to compare N vs Action or N-1 vs Action side-by-side. Requires `window.open` + `postMessage` IPC. See `docs/detachable-viz-tabs.md`.
+1. ~~**Action Overview Diagram + pin navigation**~~ — **DONE** (minimal port). Pins on the N-1 NAD, single-click popover, double-click navigation, zoom + inspect controls all wired, all 9 `overview_*` events fire. Follow-up polish: multi-pin fan-out on shared anchors, combined-action curves, full ActionCard in the popover.
+2. **Detached + tied tabs** — deliberately deferred. No way to compare N vs Action or N-1 vs Action side-by-side. Requires `window.open` + `postMessage` IPC. See `docs/detachable-viz-tabs.md` and the "Detached tabs" row above for the deferral rationale.
 3. **Pan/zoom migration to `react-zoom-pan-pinch`** — standalone uses raw viewBox math with no inertia or gesture smoothing. On large grids this is the single biggest UX regression versus the React app.
 4. **Zoom-tier LOD** — large grids (500+ VLs) render ALL text at overview zoom and become unreadable; React hides text-heavy elements per tier. See `docs/rendering-optimization-plan.md`.
 5. **Load-shedding / curtailment / PST details popups** — three separate popups in the React `ActionCard` that expose per-item breakdowns; currently replaced by a badge count only.
@@ -524,22 +525,21 @@ into CI.
 
 _Generated from the parity script on 2026-04-19._
 `InteractionType` union: **55** types. Frontend emits **51**,
-standalone emits **38** (was 32 — six cheap gestures ported +
-`settings_tab_changed` now fires on every tab switch).
+standalone emits **47** (was 38 — the 9-event Action Overview
+feature ported in this commit).
 
-##### Event types emitted by the frontend but NOT by the standalone (13)
+##### Event types emitted by the frontend but NOT by the standalone (4)
 
-Down from 19 as of the last audit. Every remaining miss is in one
-of the two expensive feature families — Action Overview diagram and
-Detached + Tied Tabs. Porting them is the next follow-up.
+Down from 13 and 19 across the last two audits. Every remaining
+miss is one of the four **Detached + Tied Tabs** events. Porting
+them requires `window.open` + `postMessage` IPC infrastructure that
+doesn't exist in the single-file HTML and introduces behavioural
+risk (popup blockers, IPC ordering races) that's hard to validate
+without a real browser runtime — see the "Detached tabs" row in
+the mirror-status table above for the deferral rationale.
 
 | Event type | Feature | React source |
 |---|---|---|
-| `overview_shown` / `overview_hidden` | Action Overview map visibility | `components/ActionOverviewDiagram.tsx:466,469` |
-| `overview_pin_clicked` / `overview_pin_double_clicked` | Pin single/double-click | `components/ActionOverviewDiagram.tsx:343,364` |
-| `overview_popover_closed` | Popover dismiss | `components/ActionOverviewDiagram.tsx:558` |
-| `overview_zoom_in` / `overview_zoom_out` / `overview_zoom_fit` | Overview zoom controls | `components/ActionOverviewDiagram.tsx:476,482,487` |
-| `overview_inspect_changed` | Overview search focus/clear | `components/ActionOverviewDiagram.tsx:526,530` |
 | `tab_detached` / `tab_reattached` | Pop tab into separate window | `App.tsx:211,225` |
 | `tab_tied` / `tab_untied` | Mirror detached viewBox | `hooks/useTiedTabsSync.ts:97,107` |
 
@@ -620,11 +620,16 @@ now fixed:
 | `zoom_out` | `{tab}` | `{}` | `tab` | `standalone:2163` |
 | `zoom_reset` | `{tab}` | `{}` | `tab` | `standalone:2178` |
 
-##### API paths referenced by the frontend but not by the standalone (1)
+##### API paths referenced by the frontend but not by the standalone (0)
 
-| Endpoint | Introduced in | Frontend call site |
-|---|---|---|
-| `/api/simulate-and-variant-diagram` | NDJSON stream emitting `{type:"metrics"}` then `{type:"diagram"}` | `api.ts::simulateAndVariantDiagramStream` |
+All API paths the React frontend exercises are now referenced in
+the standalone. `/api/simulate-and-variant-diagram` was wired in
+this commit as the primary path for the "simulate-then-fetch-
+diagram" fallback: the standalone now consumes the NDJSON stream
+(`metrics` event, then `diagram` event) and falls back to the
+sequential `/api/simulate-manual-action` + `/api/action-variant-diagram`
+pair if the stream fails — matching the React app's behaviour and
+the per-event sidebar-first UX on slow NAD regenerations.
 
 ##### `recordCompletion` coverage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,15 +463,15 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 | **SLD** | Delta flow mode | ✅ | — |
 | **SLD** | Pan / zoom | ✅ | — |
 | **SLD** | Auto-center on load | ✅ | — |
-| **Detached tabs** | Pop into separate window | ❌ | **Deliberately deferred.** Requires `window.open` + `postMessage` IPC + per-window pan/zoom state. ~300-500 lines of infrastructure in the single-file HTML with behavioural risks (popup blockers, IPC ordering) that are hard to validate without a real browser. None of the 4 missing events (`tab_detached`, `tab_reattached`, `tab_tied`, `tab_untied`) appear in the canonical 11-gesture replay sequence, so replay agents against session logs without detached-tab gestures still work unchanged. |
-| **Detached tabs** | Tied viewBox sync | ❌ | Depends on detach support |
-| **Detached tabs** | Focus-from-main | ❌ | Depends on detach support |
+| **Detached tabs** | Pop into separate window | ⚠️ | Minimal port via `window.open()`. The popup gets a SNAPSHOT of the current SVG + a wheel/drag pan-zoom + Reattach / Tie buttons in its header. Accepted limitations vs. React: the popup doesn't live-update when main state changes (e.g. selecting a new action) and there's no React portal, so no shared component tree. All 4 events (`tab_detached`/`tab_reattached`/`tab_tied`/`tab_untied`) fire at the documented gesture points. |
+| **Detached tabs** | Tied viewBox sync | ⚠️ | `window.postMessage`-based one-way mirror from popup → main when the popup tab is tied. `isSyncingRef` guard skips the immediate re-fire. |
+| **Detached tabs** | Focus-from-main | ✅ | Clicking a tab header when the tab is already detached calls `focus()` on the popup rather than switching the main active tab. |
 | **Session** | Save to folder | ✅ | — |
 | **Session** | Browser download fallback | ✅ | — |
 | **Session** | List-sessions modal | ✅ | — |
 | **Session** | Restore configuration + contingency + analysis state | ✅ | — |
 | **Session** | Restore interaction log | ✅ | — |
-| **Interaction log** | Event-type coverage | ⚠️ | 4/55 spec types still missing — **all four** Detached + Tied Tabs events. Every other gesture (including all 9 Action Overview events) now logs on both sides. |
+| **Interaction log** | Event-type coverage | ✅ | 51/51 gestures emitted by the frontend are now emitted by the standalone (the full `InteractionType` union minus 4 test-only helpers that neither codebase emits). |
 | **Interaction log** | `details` schema conformance | ✅ | All emitted standalone events are spec-conformant; historical `min_kv/max_kv`, `target_tab`, `from_tab/to_tab`, `missing tab/scope` drifts all resolved |
 | **Interaction log** | `recordCompletion` pairs | ⚠️ | Only `analysis_step{1,2}_completed` emitted — shared gap against the spec (fix needed on both sides) |
 | **Interaction log** | Replay-ready details | ✅ | — |
@@ -491,7 +491,7 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 
 #### Top-priority gaps (biggest user impact — do first)
 1. ~~**Action Overview Diagram + pin navigation**~~ — **DONE** (minimal port). Pins on the N-1 NAD, single-click popover, double-click navigation, zoom + inspect controls all wired, all 9 `overview_*` events fire. Follow-up polish: multi-pin fan-out on shared anchors, combined-action curves, full ActionCard in the popover.
-2. **Detached + tied tabs** — deliberately deferred. No way to compare N vs Action or N-1 vs Action side-by-side. Requires `window.open` + `postMessage` IPC. See `docs/detachable-viz-tabs.md` and the "Detached tabs" row above for the deferral rationale.
+2. ~~**Detached + tied tabs**~~ — **DONE** (minimal port). `window.open`-based popups with SVG snapshot + pan/zoom + postMessage-based tied viewBox mirror. Accepted limitations: popup content is a snapshot (doesn't live-update on main state changes) and there's no React portal. All 4 `tab_*` events fire. Follow-up polish: portal-style live updates, shared inspect-search inside popups.
 3. **Pan/zoom migration to `react-zoom-pan-pinch`** — standalone uses raw viewBox math with no inertia or gesture smoothing. On large grids this is the single biggest UX regression versus the React app.
 4. **Zoom-tier LOD** — large grids (500+ VLs) render ALL text at overview zoom and become unreadable; React hides text-heavy elements per tier. See `docs/rendering-optimization-plan.md`.
 5. **Load-shedding / curtailment / PST details popups** — three separate popups in the React `ActionCard` that expose per-item breakdowns; currently replaced by a badge count only.
@@ -525,26 +525,24 @@ into CI.
 
 _Generated from the parity script on 2026-04-19._
 `InteractionType` union: **55** types. Frontend emits **51**,
-standalone emits **47** (was 38 — the 9-event Action Overview
-feature ported in this commit).
+standalone emits **51**. Full event-type coverage — zero missing
+gestures, zero FE-vs-spec drifts, zero SA-vs-spec drifts, zero
+missing API paths. **Layer 1 exits 0.**
 
-##### Event types emitted by the frontend but NOT by the standalone (4)
+The one symmetric-difference (`inspect_query_changed`: FE has
+`{query, target_tab}`, SA has `{query}`) is spec-conformant on
+both sides — `target_tab` is marked optional in the replay
+contract and is only populated when the inspect field is
+triggered from a detached-tab overlay. The standalone's minimal
+detach port doesn't render an inspect input inside popups, so
+the optional key is never set. Script's `_check_benign_diff`
+helper filters this out.
 
-Down from 13 and 19 across the last two audits. Every remaining
-miss is one of the four **Detached + Tied Tabs** events. Porting
-them requires `window.open` + `postMessage` IPC infrastructure that
-doesn't exist in the single-file HTML and introduces behavioural
-risk (popup blockers, IPC ordering races) that's hard to validate
-without a real browser runtime — see the "Detached tabs" row in
-the mirror-status table above for the deferral rationale.
-
-| Event type | Feature | React source |
-|---|---|---|
-| `tab_detached` / `tab_reattached` | Pop tab into separate window | `App.tsx:211,225` |
-| `tab_tied` / `tab_untied` | Mirror detached viewBox | `hooks/useTiedTabsSync.ts:97,107` |
-
-Nothing in the standalone emits an event the union does not know
-about (0 orphan types).
+The 4 InteractionType values neither codebase emits are
+`settings_cancelled`, `action_unfavorited`, `action_unrejected`,
+and `contingency_selected`-completion — all are declared in
+`types.ts` for future-proofing but no current gesture triggers
+them. Not a parity gap (both sides agree).
 
 ##### Details-key drift between frontend and standalone (1)
 
@@ -656,11 +654,17 @@ historical record:
 |---|---|---|
 | `lines_overloaded_after` | Added to `SavedActionEntry` object literal in `sessionUtils.ts` | `utils/sessionUtils.test.ts::persists lines_overloaded_after so it survives save → reload (regression)` |
 
-##### Fields absent from the standalone entirely (2 — warn)
+##### Fields absent from the standalone entirely
 
-| Field | Note |
-|---|---|
-| `n_overloads_rho`, `n1_overloads_rho` | The sticky-header rho arrays (PR #88). The React app intentionally saves-only (live state re-derives from a fresh N-1 diagram on reload). The standalone doesn't save them either — fine for live UX, but replay agents and offline inspection tools lose the percentages. |
+**0 fields — resolved.** `n_overloads_rho` and `n1_overloads_rho`
+are now persisted by the standalone's session-save path
+(`buildSessionSnapshot`) under the same save-only-OK convention as
+React. Replay agents and offline inspection tools can now read
+the sticky-header rho percentages from both codebases' session
+dumps. The standalone now round-trips **30/30** curated fields
+(React round-trips 26/30; the remaining 4 are intentional
+re-derivation on reload per the React-side design — saved for
+inspection, re-derived from a fresh N-1 diagram on reload).
 
 #### Layer 3a — Gesture-sequence static proxy (`scripts/check_gesture_sequence.py`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,111 +506,133 @@ Legend: ✅ mirrored · ⚠️ partial (gap noted) · ❌ missing
 #### Features in the standalone that are no longer in React
 None identified. The standalone is strictly a subset of the React app — there is no obsolete code path to remove. If a feature is removed from `frontend/`, delete it from `standalone_interface.html` in the same commit.
 
-### Machine-grounded findings (`scripts/check_standalone_parity.py`)
+### Machine-grounded findings
 
-The feature table above is human-curated. A static parity check is
-automated in `scripts/check_standalone_parity.py`; run it to refresh
-these numbers. Findings as of 2026-04-19:
+The feature table above is human-curated. Two static conformity
+scripts produce the machine-authoritative tables below; regenerate
+them via `python scripts/check_standalone_parity.py --emit-markdown`
+and `python scripts/check_session_fidelity.py --json`. See
+`scripts/PARITY_README.md` for the three-layer design
+(static / session-fidelity / E2E) and how to wire the first two
+into CI.
 
-```
-InteractionType union:       55 types declared in frontend/src/types.ts
-Frontend emits:              51 types (missing: settings_cancelled,
-                             action_unfavorited, action_unrejected,
-                             contingency_selected variants used in tests)
-Standalone emits:            32 types
-```
+#### Layer 1 — Static parity (`scripts/check_standalone_parity.py`)
 
-#### Event types emitted by the frontend but NOT by the standalone (19)
+_Generated from the parity script on 2026-04-19._
+`InteractionType` union: **55** types. Frontend emits **51**,
+standalone emits **32**.
 
-These are all valid `InteractionType` values. Fix by adding
-`interactionLogger.record('<type>', { ... })` at the equivalent
-gesture site in the standalone.
+##### Event types emitted by the frontend but NOT by the standalone (19)
 
 | Event type | React source |
 |---|---|
 | `action_mw_resimulated` | `components/ActionFeed.tsx:451` |
-| `pst_tap_resimulated` | `components/ActionFeed.tsx:503` |
 | `contingency_confirmed` | `App.tsx:681` (standalone uses `window.confirm()` and emits nothing) |
-| `settings_tab_changed` | `components/modals/SettingsModal.tsx:51` |
-| `path_picked` | `hooks/useSettings.ts:232` |
-| `inspect_query_changed` | `App.tsx:976,984` |
-| `tab_detached` / `tab_reattached` | `App.tsx:211,225` |
-| `tab_tied` / `tab_untied` | `hooks/useTiedTabsSync.ts:97,107` |
-| `overview_shown` / `overview_hidden` | `components/ActionOverviewDiagram.tsx:466,469` |
-| `overview_pin_clicked` / `overview_pin_double_clicked` | `components/ActionOverviewDiagram.tsx:343,364` |
+| `inspect_query_changed` | `App.tsx:976, App.tsx:984` |
+| `overview_hidden` | `components/ActionOverviewDiagram.tsx:469` |
+| `overview_inspect_changed` | `components/ActionOverviewDiagram.tsx:526, :530` |
+| `overview_pin_clicked` | `components/ActionOverviewDiagram.tsx:343` |
+| `overview_pin_double_clicked` | `components/ActionOverviewDiagram.tsx:364` |
 | `overview_popover_closed` | `components/ActionOverviewDiagram.tsx:558` |
-| `overview_zoom_in` / `overview_zoom_out` / `overview_zoom_fit` | `components/ActionOverviewDiagram.tsx:476,482,487` |
-| `overview_inspect_changed` | `components/ActionOverviewDiagram.tsx:526,530` |
+| `overview_shown` | `components/ActionOverviewDiagram.tsx:466` |
+| `overview_zoom_fit` | `components/ActionOverviewDiagram.tsx:487` |
+| `overview_zoom_in` | `components/ActionOverviewDiagram.tsx:476` |
+| `overview_zoom_out` | `components/ActionOverviewDiagram.tsx:482` |
+| `path_picked` | `hooks/useSettings.ts:232` |
+| `pst_tap_resimulated` | `components/ActionFeed.tsx:503` |
+| `settings_tab_changed` | `components/modals/SettingsModal.tsx:51` |
+| `tab_detached` | `App.tsx:211` |
+| `tab_reattached` | `App.tsx:225` |
+| `tab_tied` | `hooks/useTiedTabsSync.ts:97, :120` |
+| `tab_untied` | `hooks/useTiedTabsSync.ts:107, :117` |
 
-Nothing in the standalone emits an event the `InteractionType` union
-does not know about (0 orphan types).
+Nothing in the standalone emits an event the union does not know
+about (0 orphan types).
 
-#### Details-key drift between frontend and standalone (11 events)
+##### Frontend drifts from the replay-contract spec (4 events)
 
-Cross-referenced against the schema in `docs/interaction-logging.md`;
-each row lists which side owns the fix.
+The React app emits a shape that drifts from
+`docs/interaction-logging.md`. The standalone is closer to the spec
+for these — fix the React side, don't downgrade:
 
-**Standalone owns the fix (5 events)** — the standalone emits a shape
-incompatible with the documented replay contract:
+| Event | Spec required | Frontend emits | Missing | React source |
+|---|---|---|---|---|
+| `action_deselected` | `{previous_action_id}` | `{action_id}` | `previous_action_id` | `hooks/useDiagrams.ts:360` |
+| `analysis_step2_started` | `{all_overloads, element, monitor_deselected, selected_overloads}` | `{monitor_deselected, selected_overloads}` | `all_overloads, element` | `hooks/useAnalysis.ts:122` |
+| `overload_toggled` | `{overload, selected}` | `{overload}` | `selected` | `hooks/useAnalysis.ts:239` |
+| `prioritized_actions_displayed` | `{n_actions}` | `{actions_count}` | `n_actions` | `hooks/useAnalysis.ts:193` |
 
-| Event | Spec `details` | Standalone emits | Standalone site |
-|---|---|---|---|
-| `asset_clicked` | `{ action_id, asset_name, tab }` | `{ action_id, asset_name, target_tab }` | `standalone:3034,3056` |
-| `diagram_tab_changed` | `{ tab }` | `{ from_tab, to_tab }` | `standalone:6675` |
-| `sld_overlay_tab_changed` | `{ tab, vl_name }` | `{ from_tab, to_tab }` (no `vl_name`) | `standalone:5148` |
-| `view_mode_changed` | `{ mode, tab, scope }` | `{ mode }` (no `tab`, no `scope`) | `standalone:6762,6773` |
-| `voltage_range_changed` | `{ min, max }` (kV) | `{ min_kv, max_kv }` | `standalone:5070,5083` |
+##### Standalone drifts from the replay-contract spec (14 events)
 
-**Frontend owns the fix (3 events)** — the React app emits a shape
-that drifts from its own documented replay contract. The standalone
-is closer to the spec and should NOT be downgraded to match the FE;
-instead the FE should be corrected:
+| Event | Spec required | Standalone emits | Missing | Standalone source |
+|---|---|---|---|---|
+| `asset_clicked` | `{action_id, asset_name, tab}` | `{action_id, asset_name, target_tab}` | `tab` | `standalone:3034,3056` |
+| `config_loaded` | `{...17 settings + output_folder_path}` | 16 fields — missing `output_folder_path` | `output_folder_path` | `standalone:2054` |
+| `diagram_tab_changed` | `{tab}` | `{from_tab, to_tab}` | `tab` | `standalone:6675` |
+| `manual_action_simulated` | `{action_id}` | `{action_id, description}` | — (extra `description`, harmless) | `standalone:3823` |
+| `prioritized_actions_displayed` | `{n_actions}` | `{}` | `n_actions` | `standalone:2834` |
+| `session_reload_modal_opened` | `{}` | `{available_sessions, output_folder}` | — (extras, harmless) | `standalone:2477` |
+| `session_saved` | `{output_folder}` | `{output_folder, session_name}` | — (extra `session_name`, harmless) | `standalone:2433` |
+| `sld_overlay_opened` | `{action_id, vl_name}` | `{action_id, initial_tab, vl_name}` | — (extra `initial_tab`, harmless) | `standalone:3076` |
+| `sld_overlay_tab_changed` | `{tab, vl_name}` | `{from_tab, to_tab}` | `tab, vl_name` | `standalone:5148` |
+| `view_mode_changed` | `{mode, tab, scope}` | `{mode}` | `scope, tab` | `standalone:6762,6773` |
+| `voltage_range_changed` | `{max, min}` | `{max_kv, min_kv}` | `max, min` | `standalone:5070,5083` |
+| `zoom_in` | `{tab}` | `{}` | `tab` | `standalone:2148` |
+| `zoom_out` | `{tab}` | `{}` | `tab` | `standalone:2163` |
+| `zoom_reset` | `{tab}` | `{}` | `tab` | `standalone:2178` |
 
-| Event | Spec `details` | Frontend emits | Frontend site |
-|---|---|---|---|
-| `action_deselected` | `{ previous_action_id }` | `{ action_id }` | `hooks/useDiagrams.ts:360` |
-| `analysis_step2_started` | `{ element, selected_overloads, all_overloads, monitor_deselected }` | `{ selected_overloads, monitor_deselected }` — missing `element`, `all_overloads` | `hooks/useAnalysis.ts:122-125` |
-| `overload_toggled` | `{ overload, selected }` | `{ overload }` — missing `selected` | `hooks/useAnalysis.ts:239` |
-
-**Harmless extras in the standalone (3 events)** — the standalone
-adds keys the spec doesn't require. Keep or drop; does not break
-replay:
-
-| Event | Extra keys in standalone |
-|---|---|
-| `manual_action_simulated` | `+ description` |
-| `session_saved` | `+ session_name` |
-| `sld_overlay_opened` | `+ initial_tab` |
-
-#### API paths referenced by the frontend but not by the standalone (1)
+##### API paths referenced by the frontend but not by the standalone (1)
 
 | Endpoint | Introduced in | Frontend call site |
 |---|---|---|
 | `/api/simulate-and-variant-diagram` | NDJSON stream emitting `{type:"metrics"}` then `{type:"diagram"}` | `api.ts::simulateAndVariantDiagramStream` |
 
-#### `recordCompletion` coverage
+##### `recordCompletion` coverage
 
 Both codebases emit the same two `*_completed` events:
 `analysis_step1_completed` and `analysis_step2_completed`. The
-replay spec lists more async wait-points that could benefit from
+replay spec lists more async wait-points that would benefit from
 completion events (`action_selected`, `manual_action_simulated`,
-`action_mw_resimulated`, `pst_tap_resimulated`, `combine_pair_simulated`,
-`settings_applied`, `session_reloaded`, `tab_detached` /
-`tab_reattached`) — **this is a shared gap against the spec**, not a
-parity gap between the two codebases. Track as a follow-up for
-`docs/interaction-logging.md` compliance on both sides.
+`action_mw_resimulated`, `pst_tap_resimulated`,
+`combine_pair_simulated`, `settings_applied`, `session_reloaded`,
+`tab_detached` / `tab_reattached`) — this is a shared gap against
+the spec, not a parity gap between the two codebases.
 
-### Running the conformity check
+#### Layer 2 — Session-reload fidelity (`scripts/check_session_fidelity.py`)
+
+_Generated from the fidelity script on 2026-04-19._ 30 curated
+fields checked; 25/30 round-trip on React, 28/30 on standalone.
+
+##### Fields the React frontend RESTORES but never SAVES (1 — hard fail)
+
+| Field | Consequence |
+|---|---|
+| `lines_overloaded_after` | `useSession.ts:312` reads it back into each live `ActionDetail`, but `sessionUtils.ts` never writes it on save. On reload the field is always `undefined`, so the Remedial-Action NAD/SLD loses its post-action overload halos until the user re-runs analysis. Add the field to the `SavedActionEntry` object literal in `sessionUtils.ts:120-145`. |
+
+##### Fields absent from the standalone entirely (2 — warn)
+
+| Field | Note |
+|---|---|
+| `n_overloads_rho`, `n1_overloads_rho` | The sticky-header rho arrays (PR #88). The React app intentionally saves-only (live state re-derives from a fresh N-1 diagram on reload). The standalone doesn't save them either — fine for live UX, but replay agents and offline inspection tools lose the percentages. |
+
+### Running the conformity checks
 
 ```bash
-python scripts/check_standalone_parity.py            # human output
-python scripts/check_standalone_parity.py --json     # CI-friendly JSON
+# Layer 1 — static parity (events, API paths, settings, spec diff)
+python scripts/check_standalone_parity.py                # human text
+python scripts/check_standalone_parity.py --emit-markdown  # regenerate tables above
+python scripts/check_standalone_parity.py --json         # CI-friendly
+
+# Layer 2 — session-reload fidelity (save-vs-restore symmetry)
+python scripts/check_session_fidelity.py                 # human text
+python scripts/check_session_fidelity.py --json          # CI-friendly
 ```
 
-Exits non-zero on any FAIL finding — suitable as a GitHub Actions
-gate. See the top of the script file for the three inventories it
-checks (`InteractionType` union, API paths, `SettingsState`) and
-the per-event details-key diff.
+Both exit non-zero on any FAIL finding. Wire them into a GitHub
+Action per PR — see `scripts/PARITY_README.md`. A Layer-3 behavioural
+E2E check (Playwright, driving both UIs through a scripted session)
+is designed but not yet implemented; that README contains the spec
+for it.
 
 ### How to use this audit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -731,16 +731,23 @@ python scripts/check_standalone_parity.py --json         # CI-friendly
 python scripts/check_session_fidelity.py                 # human text
 python scripts/check_session_fidelity.py --json          # CI-friendly
 
-# Layer 3a — gesture-sequence static proxy
+# Layer 3a — gesture-sequence static proxy (15-step canonical)
 python scripts/check_gesture_sequence.py                 # human text
 python scripts/check_gesture_sequence.py --json          # CI-friendly
+
+# Layer 4 — user-observable invariants (static Python)
+python scripts/check_invariants.py                       # human text
+python scripts/check_invariants.py --json                # CI-friendly
+
+# Layer 4 — runtime Vitest companion (part of `cd frontend && npm test`)
+#   Lives at frontend/src/utils/userObservableInvariants.test.ts
 
 # Layer 3b — behavioural E2E (needs a Playwright browser; see
 # scripts/PARITY_README.md for the one-off setup)
 cd scripts/parity_e2e && npx playwright test
 ```
 
-All four exit non-zero on any FAIL finding.
+All five exit non-zero on any FAIL finding.
 
 ### CI wiring
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,6 +34,8 @@ export BENCH_CONTINGENCY=DISCO_NAME                  # only for bench_n1_diagram
 | `bench_topology_cache.py` | Per-helper + full `NetworkTopologyCache(net)` init. Validates upstream vectorisation series (0.2.0.post3 → post8). | `docs/perf-vectorize-topology-cache.md`, `docs/perf-topology-cache-iter2.md` |
 | `bench_voltage_level_queries.py` | `/api/voltage-levels`, `/api/nominal-voltages`, `get_monitored_elements`, `_get_switches_with_topology` narrow-attr wins. | `docs/perf-narrow-voltage-level-queries.md` |
 | `bench_n1_diagram.py` | Full `get_n1_diagram(contingency)` cold + warm, per-sub-step breakdown. Validates the 3 N-1 fast-path patches. | `docs/perf-n1-diagram-fast-path.md` |
+| `bench_nad_n_state.py` | `get_network_diagram()` cold + warm on the N-state. Captures NAD / SVG / Meta sub-timings from the `[RECO]` log lines. | `docs/perf-nad-profile-bare-env.md` |
+| `bench_nad_toggles.py` | Matrix of `NadParameters` toggle combinations — quantifies per-flag impact on NAD gen + SVG size, surfaces the cost of `injections_added=True`. | `docs/perf-nad-profile-bare-env.md` |
 | `run_all.py` | Drives every benchmark above sequentially. | — |
 
 ## Reference measurements

--- a/benchmarks/bench_nad_n_state.py
+++ b/benchmarks/bench_nad_n_state.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# SPDX-License-Identifier: MPL-2.0
+
+"""Profile N-state NAD generation times (Load Study base diagram).
+
+Runs 3 iterations in a single Python process against the reference
+grid defined by ``BENCH_NETWORK_PATH``. Iteration 1 is cold (fresh
+JVM / pypowsybl caches), iterations 2-3 are warm.
+
+Wraps ``recommender_service.get_network_diagram()`` with
+``time.perf_counter()`` and captures the three sub-timings already
+emitted by ``diagram_mixin._generate_diagram`` via a logging.Handler
+parsing ``[RECO] Diagram generated: NAD Xs, SVG Ys, Meta Zs …``.
+
+Outputs ``profiling_results.json`` at the project root + a stdout
+summary. See ``docs/perf-nad-profile-bare-env.md``.
+
+Usage:
+
+    BENCH_NETWORK_PATH=/path/to/grid_dir \
+        python benchmarks/bench_nad_n_state.py
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from statistics import median
+
+from _bench_common import NETWORK_PATH, setup_service
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_DIAG_LINE_RE = re.compile(
+    r"\[RECO\] Diagram generated: NAD ([\d.]+)s, SVG ([\d.]+)s, Meta ([\d.]+)s "
+    r"\(SVG length=(\d+)\)"
+)
+
+
+class _DiagramTimingCapture(logging.Handler):
+    """Capture the latest ``[RECO] Diagram generated: …`` log line."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self.last_match: dict | None = None
+
+    def emit(self, record: logging.LogRecord) -> None:
+        m = _DIAG_LINE_RE.search(record.getMessage())
+        if m:
+            self.last_match = {
+                "nad_s": float(m.group(1)),
+                "svg_s": float(m.group(2)),
+                "meta_s": float(m.group(3)),
+                "svg_len": int(m.group(4)),
+            }
+
+
+def _run(iteration: int, cold: bool, capture: _DiagramTimingCapture) -> dict:
+    capture.last_match = None
+    _, recommender_service, _ = setup_service(wait_for_nad_prefetch=False)
+
+    t0 = time.perf_counter()
+    res = recommender_service.get_network_diagram()
+    total = time.perf_counter() - t0
+
+    if capture.last_match is None:
+        raise RuntimeError(
+            "Did not capture `[RECO] Diagram generated` log line. "
+            "Is diagram_mixin.py still emitting it at INFO level?"
+        )
+
+    svg_bytes = len(res["svg"])
+    row = {
+        "run": iteration,
+        "cold": cold,
+        "total_s": round(total, 3),
+        "nad_s": capture.last_match["nad_s"],
+        "svg_s": capture.last_match["svg_s"],
+        "meta_s": capture.last_match["meta_s"],
+        "svg_bytes": svg_bytes,
+        "svg_mb": round(svg_bytes / (1024 * 1024), 2),
+    }
+    print(
+        f"  run {iteration} ({'cold' if cold else 'warm'}): "
+        f"total={row['total_s']}s  NAD={row['nad_s']}s  "
+        f"SVG={row['svg_s']}s  Meta={row['meta_s']}s  "
+        f"size={row['svg_mb']} MB"
+    )
+    return row
+
+
+def main(iterations: int = 3) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    capture = _DiagramTimingCapture()
+    logging.getLogger().addHandler(capture)
+
+    print(f"Network: {NETWORK_PATH}")
+    print(f"Iterations: {iterations}\n")
+
+    rows = [
+        _run(i, cold=(i == 1), capture=capture)
+        for i in range(1, iterations + 1)
+    ]
+
+    warm = [r for r in rows if not r["cold"]]
+    warm_median = (
+        {
+            "nad_s": round(median(r["nad_s"] for r in warm), 3),
+            "svg_s": round(median(r["svg_s"] for r in warm), 3),
+            "meta_s": round(median(r["meta_s"] for r in warm), 3),
+            "total_s": round(median(r["total_s"] for r in warm), 3),
+        }
+        if warm
+        else None
+    )
+
+    out_file = _REPO_ROOT / "profiling_results.json"
+    out_file.write_text(
+        json.dumps(
+            {"network_path": NETWORK_PATH, "runs": rows, "warm_median": warm_median},
+            indent=2,
+        )
+    )
+    print(f"\nSaved: {out_file}")
+    if warm_median:
+        print(
+            f"Warm median: NAD={warm_median['nad_s']}s  "
+            f"SVG={warm_median['svg_s']}s  Meta={warm_median['meta_s']}s  "
+            f"total={warm_median['total_s']}s"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_nad_toggles.py
+++ b/benchmarks/bench_nad_toggles.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# SPDX-License-Identifier: MPL-2.0
+
+"""Benchmark a matrix of ``NadParameters`` toggle combinations.
+
+Drives ``recommender_service.get_network_diagram()`` with several
+``NadParameters`` overrides (applied via monkey-patching
+``DiagramMixin._default_nad_parameters``) to quantify the per-toggle
+impact on NAD generation time and SVG size.
+
+The matrix below validates the "minimal-render" choices documented in
+``docs/perf-nad-profile-bare-env.md`` (section "Results — after #6")
+and surfaces the cost of ``injections_added=True`` so the trade-off
+can be revisited later.
+
+Outputs ``profiling_toggles_results.json`` at the project root +
+a comparison table on stdout.
+
+Usage:
+
+    BENCH_NETWORK_PATH=/path/to/grid_dir \
+        python benchmarks/bench_nad_toggles.py
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from pathlib import Path
+from statistics import median
+
+from _bench_common import NETWORK_PATH, setup_service
+
+from expert_backend.services.diagram_mixin import DiagramMixin
+from pypowsybl.network import NadLayoutType, NadParameters
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_DIAG_LINE_RE = re.compile(
+    r"\[RECO\] Diagram generated: NAD ([\d.]+)s, SVG ([\d.]+)s, Meta ([\d.]+)s "
+    r"\(SVG length=(\d+)\)"
+)
+
+# Mirror the actual production defaults in
+# `DiagramMixin._default_nad_parameters` so any override below is a
+# pure diff. Keep this dict in sync if that method changes.
+_PROD_KWARGS = dict(
+    edge_name_displayed=False,
+    id_displayed=False,
+    edge_info_along_edge=True,
+    power_value_precision=0,
+    angle_value_precision=0,
+    current_value_precision=1,
+    voltage_value_precision=0,
+    bus_legend=False,
+    substation_description_displayed=False,
+    voltage_level_details=False,
+    injections_added=False,
+    layout_type=NadLayoutType.GEOGRAPHICAL,
+)
+
+
+class _DiagramTimingCapture(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self.last_match: dict | None = None
+
+    def emit(self, record: logging.LogRecord) -> None:
+        m = _DIAG_LINE_RE.search(record.getMessage())
+        if m:
+            self.last_match = {
+                "nad_s": float(m.group(1)),
+                "svg_s": float(m.group(2)),
+                "meta_s": float(m.group(3)),
+                "svg_len": int(m.group(4)),
+            }
+
+
+def _make_factory(overrides: dict):
+    """Return a bound-method replacement for `_default_nad_parameters`."""
+    kwargs = dict(_PROD_KWARGS)
+    kwargs.update(overrides)
+
+    def _override(_self):
+        return NadParameters(**kwargs)
+
+    return _override
+
+
+def _run_config(name, overrides, capture, iterations=3):
+    DiagramMixin._default_nad_parameters = _make_factory(overrides)
+
+    print(f"\n>>> Config: {name}")
+    print(f"    overrides: {overrides or '(prod defaults)'}")
+
+    rows = []
+    for i in range(1, iterations + 1):
+        capture.last_match = None
+        _, recommender_service, _ = setup_service(wait_for_nad_prefetch=False)
+
+        t0 = time.perf_counter()
+        res = recommender_service.get_network_diagram()
+        total = time.perf_counter() - t0
+
+        if capture.last_match is None:
+            raise RuntimeError("Did not capture [RECO] Diagram generated line")
+
+        svg_bytes = len(res["svg"])
+        rows.append({
+            "run": i,
+            "total_s": round(total, 3),
+            "nad_s": capture.last_match["nad_s"],
+            "svg_bytes": svg_bytes,
+            "svg_mb": round(svg_bytes / (1024 * 1024), 2),
+        })
+        print(
+            f"  run {i}: total={rows[-1]['total_s']}s  "
+            f"NAD={rows[-1]['nad_s']}s  size={rows[-1]['svg_mb']} MB"
+        )
+
+    # Warm median excludes run 1 (JVM/pypowsybl warm-up absorbed there).
+    warm = rows[1:]
+    return {
+        "config": name,
+        "overrides": overrides,
+        "runs": rows,
+        "warm_median": {
+            "nad_s": round(median(r["nad_s"] for r in warm), 3),
+            "total_s": round(median(r["total_s"] for r in warm), 3),
+            "svg_mb": round(median(r["svg_mb"] for r in warm), 2),
+        },
+    }
+
+
+def main(iterations: int = 3) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    capture = _DiagramTimingCapture()
+    logging.getLogger().addHandler(capture)
+
+    # Revert each toggle individually from the production minimal-render
+    # defaults to quantify its contribution. Plus two "regress" rows for
+    # `injections_added=True` which was measured and *rejected*.
+    configs = [
+        ("prod defaults (minimal-render)", {}),
+        ("+ bus_legend=True (pre-#6 default)", {"bus_legend": True}),
+        (
+            "+ substation_description_displayed=True (pre-#6 default)",
+            {"substation_description_displayed": True},
+        ),
+        ("+ voltage_level_details=True (pypowsybl default)", {"voltage_level_details": True}),
+        ("+ injections_added=True (NOT APPLIED, cost check)", {"injections_added": True}),
+    ]
+
+    print(f"Network: {NETWORK_PATH}")
+    results = [_run_config(n, o, capture, iterations) for n, o in configs]
+
+    out_file = _REPO_ROOT / "profiling_toggles_results.json"
+    out_file.write_text(
+        json.dumps({"network_path": NETWORK_PATH, "configs": results}, indent=2)
+    )
+
+    print("\n" + "=" * 100)
+    print(f"{'Config':<65} | {'NAD(s)':>8} | {'Total(s)':>9} | {'SVG(MB)':>8}")
+    print("-" * 100)
+    baseline = results[0]["warm_median"]
+    for res in results:
+        wm = res["warm_median"]
+        suffix = ""
+        if res["config"] != "prod defaults (minimal-render)":
+            suffix = (
+                f"  Δ nad={wm['nad_s'] - baseline['nad_s']:+.2f}  "
+                f"total={wm['total_s'] - baseline['total_s']:+.2f}  "
+                f"mb={wm['svg_mb'] - baseline['svg_mb']:+.1f}"
+            )
+        print(
+            f"{res['config']:<65} | {wm['nad_s']:>8.3f} | "
+            f"{wm['total_s']:>9.3f} | {wm['svg_mb']:>8.2f}{suffix}"
+        )
+    print("=" * 100)
+    print(f"\nSaved: {out_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/perf-nad-profile-bare-env.md
+++ b/docs/perf-nad-profile-bare-env.md
@@ -1,0 +1,251 @@
+# NAD profile — `bare_env_20240828T0100Z` (N-state)
+
+Reference measurement of the base-case Network Area Diagram (NAD)
+generation time on the `bare_env_20240828T0100Z` grid — the dataset that
+`config_large_grid_20240828T0100Z.json` points to and that most existing
+`docs/perf-*.md` traces use.
+
+Scope: **N-state NAD only** (what is fetched when a user clicks
+**🔄 Load Study** in the frontend, i.e. `GET /api/network-diagram`).
+No N-1, no post-action, no frontend/XHR timing.
+
+## Methodology
+
+- **Script**: `benchmarks/bench_nad_n_state.py` — 3 iterations in a single
+  Python process, fully resetting `recommender_service` and reloading the
+  network between runs. Run 1 is flagged *cold* (fresh JVM / pypowsybl
+  caches), runs 2-3 are *warm*.
+- **Timing source**: a `logging.Handler` parses the existing
+  `[RECO] Diagram generated: NAD Xs, SVG Ys, Meta Zs (SVG length=N)` line
+  emitted by `expert_backend/services/diagram_mixin.py:106`. Total
+  wall-clock is wrapped with `time.perf_counter()` around
+  `recommender_service.get_network_diagram()`.
+- **Venv**: `venv_expert_assist_py310/bin/python`.
+- **Config**: `config_large_grid_20240828T0100Z.json`
+  (`network_path = /home/marotant/dev/Expert_op4grid_recommender/data/bare_env_20240828T0100Z/grid.xiidm`,
+  `pypowsybl_fast_mode: true`, GEOGRAPHICAL NAD layout via the
+  `perf/unmount-inactive-svg` branch baseline — see
+  `docs/perf-loading-parallel.md`).
+- **Command**:
+  ```bash
+  BENCH_NETWORK_PATH=/home/marotant/dev/Expert_op4grid_recommender/data/bare_env_20240828T0100Z \
+      PYTHONUNBUFFERED=1 ./venv_expert_assist_py310/bin/python \
+      benchmarks/bench_nad_n_state.py
+  ```
+- **Raw output**: `profiling_results.json` at project root,
+  `/tmp/nad_profile_run.log` (full backend logs).
+
+## Results — baseline (before optimisations)
+
+| Run | State | NAD (s) | SVG (s) | Meta (s) | Total `get_network_diagram` (s) | SVG size (MB) |
+|---|---|---:|---:|---:|---:|---:|
+| 1 | cold | 10.18 | 0.00 | 0.00 | 14.10 | 13.2 |
+| 2 | warm | 2.46 | 0.00 | 0.00 | 3.61 | 13.2 |
+| 3 | warm | 2.14 | 0.00 | 0.00 | 2.99 | 7.83 |
+| **warm median** | | **2.30** | **0.00** | **0.00** | **3.30** | — |
+
+Notes on the table:
+
+- **`Total` vs `NAD` gap**: The wall-clock `Total` around
+  `get_network_diagram()` includes NAD generation **plus** the
+  `_get_svg_string` / `_get_svg_metadata` calls **and** the downstream
+  `NaN-stripping` step (`diagram_mixin.py:108-128`, removes 74-158
+  elements), plus overloaded-line extraction and the N-state currents
+  cache. The gap is therefore `~1.0 s` of post-processing on top of
+  the pure pypowsybl NAD call.
+- **`SVG 0.00s` / `Meta 0.00s`**: pypowsybl's
+  `Diagram.get_network_area_diagram(...)` returns an object whose SVG
+  is materialised *inside* the pypowsybl call — `_get_svg_string` then
+  returns a cached reference in microseconds. All serialisation time
+  is accounted for inside `NAD`.
+- **Run 3 SVG size drop** (7.83 MB vs 13.2 MB): fewer elements survive
+  the NaN-stripping step on run 3 (74 elements removed vs 149/158). This
+  is a side effect of small variant state differences between resets; it
+  changes SVG payload size slightly but does not invalidate the NAD
+  timing itself.
+
+## Results — after optimisations #1 + #4
+
+Two low-risk changes in `expert_backend/services/diagram_mixin.py` :
+
+1. **`_get_element_max_currents` vectorised** (was `df.iterrows()` over
+   ~10 k lines + ~2 k transfos → numpy mask + `np.maximum(|i1|, |i2|)`).
+   Also narrows the pypowsybl query to `attributes=['i1','i2']`.
+2. **`_load_layout` cached by `(path, mtime)`** on the service instance —
+   repeated NAD generations in the same process skip the JSON parse +
+   DataFrame rebuild.
+
+| Run | State | NAD (s) | Total `get_network_diagram` (s) | SVG size (MB) |
+|---|---|---:|---:|---:|
+| 1 | warm† | 2.50 | 3.03 | 13.2 |
+| 2 | warm | 2.39 | 2.92 | 13.2 |
+| 3 | warm | 2.41 | 2.92 | 13.2 |
+| **warm median** | | **2.41** | **2.92** | — |
+
+† The JVM was already hot from the previous benchmark session, so no
+true cold run was captured in this re-measure. All three runs are
+effectively warm.
+
+### Before / after (warm median)
+
+| Step | Before (s) | After (s) | Δ |
+|---|---:|---:|---:|
+| `NAD` (pypowsybl) | 2.30 | 2.41 | +0.11 (noise) |
+| Post-processing | **~1.00** | **~0.51** | **−0.49 (−49 %)** |
+| **Total** | **3.30** | **2.92** | **−0.38 (−11.5 %)** |
+
+The NAD step itself is unchanged (pypowsybl JVM work, untouched). The
+gain comes entirely from halving the post-processing overhead.
+
+## Observations
+
+- **`_get_element_max_currents` was the dominant post-processing cost**
+  on this grid size. Switching from `iterrows()` to vectorised numpy
+  recovers ~0.3-0.5 s per Load Study on its own.
+- **`_load_layout` cache** contributes a smaller but free win
+  (~50-100 ms on the first warm reuse) and will also benefit
+  subsequent `get_n1_diagram` / `get_action_variant_diagram` calls in
+  the same session.
+- **Remaining warm post-processing (~0.5 s)** is dominated by the
+  `NaN-stripping` lxml roundtrip (parse 13 MB SVG → iterate elements →
+  re-serialise). That is optimisation #3 in the list below, not yet
+  applied.
+- **Consistent with `docs/performance_profiling.md`**: the 2.92 s total
+  beats the 3.5 s "Base Diagram (v2)" reference by ~17 %.
+
+## Attempt #3 — regex NaN-stripping (**REJECTED**, +0.4 s regression)
+
+Tried replacing the lxml `parse → iter → remove → serialise` roundtrip
+with a two-stage Python `re` pipeline (self-closing tags then open/close
+pairs with a tempered-greedy body, lxml fallback if anything remained).
+
+Measured on the same 3-run benchmark:
+
+| Variant | NaN-strip time | Warm total |
+|---|---:|---:|
+| lxml only (baseline post #1 + #4) | ~0.27-0.34 s | 2.92 s |
+| regex #1 + #2 (always runs) | 0.58 s | 3.33 s |
+| regex #1 with short-circuit + #2 | stage1 0.24 s + stage2 0.33 s = 0.58 s | 3.32 s |
+
+The short-circuit on stage 2 never triggered — pypowsybl NAD output mixes
+self-closing tags (`<path/>` with NaN coordinates) **and** paired tags
+(`<text x="NaN">label</text>`), so both stages always fire.
+
+**Why the regex loses against lxml here**:
+- lxml parse + serialise is a single-pass C implementation that releases
+  the GIL. On a 13 MB, ~130 k-element SVG it costs ~270-330 ms end-to-end.
+- Python `re` with a tempered greedy `(?:(?!<\1\b|</\1\b).)*?` body on
+  13 MB runs in CPython with full backtracking on every `<` boundary —
+  ~580 ms, nearly 2× slower.
+- Skipping stage 2 would need either a complete rewrite in a linear
+  `rfind`/`find` tag-walker (high complexity, ~150 lines) or a streaming
+  XML parser — both far beyond the simple improvement this lever promised.
+
+Reverted the regex change; `_strip_nan_elements` is back to the original
+lxml roundtrip. The **`−0.3 to −0.6 s` estimate for #3 was wrong**: it
+was based on an over-attribution of post-processing time to lxml before
+#1 revealed that `_get_element_max_currents.iterrows()` was the dominant
+cost. Post #1, lxml is already a small fraction of `get_network_diagram`
+total and offers little remaining room.
+
+## Results — after #6 (minimal NadParameters)
+
+Changed `_default_nad_parameters()` in
+`expert_backend/services/diagram_mixin.py` to the minimal set matching
+the documented user needs (P at line endpoints, VL nodes + names,
+nominal-voltage colouring, client-side highlight overlays):
+
+```python
+NadParameters(
+    edge_name_displayed=False,
+    id_displayed=False,
+    edge_info_along_edge=True,
+    power_value_precision=0,                  # was 1
+    angle_value_precision=0,
+    current_value_precision=1,
+    voltage_value_precision=0,
+    bus_legend=False,                         # was True
+    substation_description_displayed=False,   # was True
+    voltage_level_details=False,              # explicit (default was True)
+    injections_added=False,                   # explicit (pypowsybl default)
+    layout_type=NadLayoutType.GEOGRAPHICAL,
+)
+```
+
+Measured via `benchmarks/bench_nad_toggles.py` (5 configs × 3 runs,
+same JVM) then confirmed with a standard `benchmarks/bench_nad_n_state.py`
+run on the same dataset:
+
+| Run | State | NAD (s) | Total (s) | SVG (MB) |
+|---|---|---:|---:|---:|
+| 1 | warm† | 2.34 | 2.83 | 12.02 |
+| 2 | warm | 2.40 | 2.86 | 12.02 |
+| 3 | warm | 2.35 | 2.84 | 12.02 |
+| **warm median** | | **2.375** | **2.845** | **12.02** |
+
+### Impact per toggle (isolated, from `profiling_toggles_results.json`)
+
+| Toggle change | Δ NAD | Δ Total | Δ SVG |
+|---|---:|---:|---:|
+| `bus_legend: True → False` | −0.12 s | −0.16 s | −0.93 MB |
+| `voltage_level_details: True → False` | ~0 s | ~0 s | 0 MB ‡ |
+| `substation_description_displayed: True → False` (vs target-with-it) | −0.025 s | −0.025 s | −0.21 MB |
+| `power_value_precision: 1 → 0` | lumped in above | lumped in | ~−40-60 KB |
+| `injections_added: False → True` (tested, **NOT applied**) | +0.80 s | +1.03 s | **+10.9 MB** |
+
+‡ `voltage_level_details` is dead code in our setup — no custom label
+provider is registered, so the flag has no visible output. Kept
+explicit (`False`) for clarity and to document the decision.
+
+### Before / after (warm median, cumulative since the v6 branch baseline)
+
+| Stage | Total (s) | SVG (MB) | Δ vs previous |
+|---|---:|---:|---:|
+| Baseline (start of this doc) | 3.30 | 13.20 | — |
+| After #1 + #4 | 2.92 | 13.20 | −0.38 s |
+| **After #1 + #4 + #6** | **2.845** | **12.02** | **−0.075 s, −1.18 MB** |
+| Cumulative since baseline | — | — | **−0.455 s (−13.8 %), −1.18 MB (−9 %)** |
+
+### On `injections_added`
+
+Originally listed by the user as a need ("show injections on bus
+nodes"). Measured cost on this grid: **+1.03 s per Load Study, +10.9
+MB SVG** (payload nearly doubles from 13.2 → 24.1 MB). The user
+decided to keep it `False` rather than accept the regression, and to
+revisit later via a dedicated toggle (opt-in Settings flag) if the
+feature becomes required. The measurement is preserved here so the
+cost is visible the next time this question surfaces.
+
+## Known remaining levers (not applied)
+
+| # | Lever | Expected warm gain |
+|---|---|---|
+| 2 | Defer `_get_element_max_currents` until the first N-1 call | −0.05 to −0.15 s (small since #1 already halved the cost) |
+| 3 | ~~Regex NaN-strip~~ — **rejected**, see section above | — |
+| 5 | Run lxml NaN-strip and pypowsybl post-queries in parallel (`ThreadPoolExecutor`, GIL released on both sides) | −0.15 to −0.30 s |
+| 6 | ~~NadParameters minimal toggles~~ — **applied**, see section above | realised: −0.15 s, −1.18 MB (less than the original −0.2/−0.5 s estimate) |
+| 7 | Persistent SVG cache keyed by network hash + variant + NadParameters | Load Study 2+ → ~50 ms |
+
+### Architectural note for future #6-like proposals
+
+Before re-opening NAD rendering trade-offs, check the closed design
+questions:
+- **Spatial / focused sub-diagrams on zoom** are ruled out per
+  `docs/spatial_lod_architecture_proposal.md:298-303` — the chosen
+  mechanism is the CSS zoom-tier system
+  (`frontend/src/hooks/usePanZoom.ts` + `frontend/src/App.css`).
+- **Auto-focus on contingency selection** was explicitly retired in
+  commit `75210d1` — the full N-1 diagram is kept, with dynamic text
+  scaling handling readability.
+- Server-side NadParameters toggles (this doc) are complementary to
+  the client-side LOD CSS, not a replacement.
+
+## Out of scope
+
+- N-1 diagram timing (`get_n1_diagram`) — use
+  `scripts/profile_diagram_perf.py` scenario 2 for that.
+- Post-action diagram timing — scenario 3 of the same script.
+- Frontend XHR / paint timing — see `docs/perf-loading-parallel.md`
+  and `docs/perf-svg-tab-unmount.md`.
+- CPU flamegraph (`--cprofile`) — not needed; the three sub-timings
+  already localise the cost.

--- a/docs/state-reset-and-confirmation-dialogs.md
+++ b/docs/state-reset-and-confirmation-dialogs.md
@@ -111,6 +111,10 @@ The `RecommenderService.reset()` method clears:
 - `_base_network`, `_simulation_env`
 - `_last_disconnected_element`
 - `_dict_action`, `_analysis_context`
+- `_layout_cache` — the cached `grid_layout.json` DataFrame used as
+  `fixed_positions` for NAD generation. Must be cleared so a new study
+  loaded from a different grid does not reuse the previous grid's
+  substation coordinates.
 
 ### Why Force Reload?
 

--- a/expert_backend/CLAUDE.md
+++ b/expert_backend/CLAUDE.md
@@ -1,0 +1,286 @@
+# CLAUDE.md — `expert_backend/`
+
+FastAPI backend for Co-Study4Grid. Wraps `pypowsybl` (network +
+diagrams) and `expert_op4grid_recommender` (analysis + remedial-action
+recommendation) behind a stateless HTTP interface consumed by the
+React frontend at `http://localhost:8000`.
+
+For the project-wide overview see the root `CLAUDE.md`. For test
+conventions and the mock layer that lets the suite run without
+`pypowsybl` / `expert_op4grid_recommender` installed see
+`expert_backend/tests/CLAUDE.md`.
+
+## Layout
+
+```
+expert_backend/
+├── __init__.py
+├── main.py                    # FastAPI app: endpoints, CORS, gzip helpers,
+│                              # config-file persistence, NDJSON streaming
+├── requirements.txt           # Pinned core deps (fastapi, uvicorn, multipart)
+├── test_backend.py            # Ad-hoc integration script (not part of pytest)
+├── services/
+│   ├── __init__.py
+│   ├── network_service.py     # NetworkService singleton — pypowsybl Network
+│   │                          # loading, branch / VL / nominal-voltage queries
+│   ├── recommender_service.py # RecommenderService singleton — orchestrates
+│   │                          # analysis. Composes the three mixins below.
+│   ├── diagram_mixin.py       # NAD/SLD generation, layout cache, flow deltas,
+│   │                          # overload detection
+│   ├── analysis_mixin.py      # Two-step contingency analysis (step1 detect,
+│   │                          # step2 resolve), action enrichment, MW/tap-start
+│   ├── simulation_mixin.py    # Manual-action simulation, superposition,
+│   │                          # action-dictionary helpers
+│   └── sanitize.py            # NumPy → native-Python recursive coercion
+│                              # (`sanitize_for_json`)
+└── tests/                     # pytest suite — see tests/CLAUDE.md
+```
+
+## Architecture in one paragraph
+
+`main.py` is a thin HTTP layer. All domain state lives on **two
+module-level singletons**: `network_service` (raw pypowsybl Network +
+metadata queries) and `recommender_service` (everything that needs
+analysis state — base network, action dictionary, observation cache,
+last-result, NAD prefetch, layout cache, …). `RecommenderService`
+inherits from three mixins (`DiagramMixin`, `AnalysisMixin`,
+`SimulationMixin`) each owning a slice of behaviour but operating on
+the same `self`. The composition is intentional: state lifecycle
+(`__init__`, `reset`, `update_config`) stays in `recommender_service.py`
+and the mixins reach into it through `self`. Treat the mixins as one
+class split across files for readability.
+
+## Singletons & shared state
+
+- `network_service` (`services/network_service.py:352`) — owns the
+  `pypowsybl.network.Network` returned by `pn.load()`. Read-only
+  consumers (frontend `/api/branches`, `/api/voltage-levels`, …) go
+  through it.
+- `recommender_service` (`services/recommender_service.py:727`) — owns
+  analysis state. `_get_base_network()` MUTUALISES the same Network
+  object loaded by `network_service` to avoid re-parsing the .xiidm
+  twice (~3-5 s on the PyPSA-EUR France grid). See
+  `docs/perf-grid2op-shared-network.md`.
+
+The shared Network is safe because:
+1. `network_service` only reads (no variant switching).
+2. `recommender_service` switches variants inside
+   `_get_n_variant` / `_get_n1_variant` but always restores the
+   original variant in a `try/finally`.
+
+`pn.load()` is called WITHOUT `allow_variant_multi_thread_access=True`
+on purpose — see the long comment at `network_service.py:30-43` for
+why enabling that is unsafe for the FastAPI thread pool today.
+
+## State lifecycle: load → reset → reload
+
+- **First load** (`/api/config` POST): sets `network_service.network`
+  via `network_service.load_network()`, then calls
+  `recommender_service.update_config(settings)` which:
+  1. Updates `expert_op4grid_recommender.config` globals
+     (`ENV_PATH`, `LAYOUT_FILE_PATH`, `MIN_*`, monitoring config, …).
+  2. Calls `prefetch_base_nad_async()` — kicks a background thread
+     that pre-computes the base NAD so the subsequent
+     `/api/network-diagram` XHR is a near-instant cache hit. See
+     `docs/perf-nad-prefetch.md` and
+     `docs/perf-nad-prefetch-earlier-spawn.md`.
+  3. Loads the action dictionary (`load_actions` +
+     `enrich_actions_lazy`). Auto-generates `disco_*` actions for
+     every line if the file lacks them.
+  4. Pre-builds a `SimulationEnvironment` cached on
+     `_cached_env_context` — saves ~4-8 s per
+     `/api/run-analysis-step1` call.
+
+- **Re-load** (any subsequent `/api/config`): `recommender_service.reset()`
+  is called BEFORE the new network is loaded. `reset()` MUST clear
+  every per-study cache on the service. The full list (also
+  documented at `docs/state-reset-and-confirmation-dialogs.md`):
+  `_last_result`, `_is_running`, `_generator`, `_base_network`,
+  `_simulation_env`, `_last_disconnected_element`, `_dict_action`,
+  `_analysis_context`, `_saved_computed_pairs`, `_cached_obs_n*`,
+  `_cached_env_context`, `_initial_pst_taps`,
+  `_lf_status_by_variant`, `_layout_cache`,
+  `_prefetched_base_nad*`. Adding a new instance-level cache?
+  Add it here too — otherwise it WILL leak across studies (see the
+  `_layout_cache` regression fixed on
+  `claude/fix-grid-layout-reset-8TYEV`).
+
+- **Drain order matters**: `reset()` calls
+  `_drain_pending_base_nad_prefetch()` FIRST so a still-running
+  prefetch thread cannot finish after reset and write into the next
+  study's cache.
+
+## API surface (one-liners; root `CLAUDE.md` has the full table)
+
+Diagram & topology:
+- `GET  /api/branches` / `/api/voltage-levels` / `/api/nominal-voltages`
+  — read-only metadata.
+- `GET  /api/network-diagram` — base-state NAD. Serves the
+  prefetched diagram when available (saves ~5-6 s on large grids).
+  Supports `?format=text` to return a JSON header + raw SVG body
+  (saves ~500 ms of `JSON.parse` on 25 MB SVG strings — see
+  `docs/perf-loading-parallel.md`).
+- `POST /api/n1-diagram` / `/api/action-variant-diagram` /
+  `/api/focused-diagram` / `/api/action-variant-focused-diagram`
+- `POST /api/n-sld` / `/api/n1-sld` / `/api/action-variant-sld`
+
+Analysis:
+- `POST /api/run-analysis-step1` — detect overloads (returns once).
+- `POST /api/run-analysis-step2` — resolve, **streaming** NDJSON.
+- `POST /api/run-analysis` — single-step legacy NDJSON stream.
+- `POST /api/simulate-manual-action` — one-off simulation.
+- `POST /api/simulate-and-variant-diagram` — combined NDJSON stream
+  emitting `{type:"metrics"}` then `{type:"diagram"}` so the
+  sidebar can update ahead of the SVG.
+- `POST /api/compute-superposition` — combined-pair effect.
+
+Session & user config:
+- `POST /api/save-session`, `GET /api/list-sessions`,
+  `POST /api/load-session`, `POST /api/restore-analysis-context`.
+- `GET/POST /api/user-config`, `GET/POST /api/config-file-path`.
+
+OS pickers & static:
+- `GET  /api/pick-path?type=file|dir` — spawns a tkinter subprocess.
+- Static mount at `/results/pdf/` → `Overflow_Graph/`.
+
+## Streaming responses (NDJSON)
+
+`/api/run-analysis`, `/api/run-analysis-step2`, and
+`/api/simulate-and-variant-diagram` use FastAPI `StreamingResponse`
+with `application/x-ndjson`. Events are JSON lines:
+- `{"type":"pdf", "pdf_url":..., "pdf_path":...}` — overflow PDF
+  ready (delivered EARLY so the UI can show it before results).
+- `{"type":"result", ...}` or `{"type":"metrics", ...}` /
+  `{"type":"diagram", ...}` — final payloads.
+- `{"type":"error", "message":...}` — failure event; stream closes.
+
+Do NOT route streaming endpoints through `_maybe_gzip_*`. The
+per-endpoint gzip helper is for non-streaming responses only —
+wrapping NDJSON in gzip buffers events until a flush, breaking the
+early-PDF guarantee. This was the root cause behind the global
+`GZipMiddleware` rollback (`main.py:30-42`,
+`docs/perf-per-endpoint-gzip.md`).
+
+## Per-endpoint gzip
+
+Two helpers in `main.py`:
+- `_maybe_gzip_json(payload, request)` — wraps any JSON-serialisable
+  payload, gzips when ≥ 10 KB and the client signals
+  `Accept-Encoding: gzip`.
+- `_maybe_gzip_svg_text(diagram, request)` — JSON header + raw SVG
+  body (for `/api/network-diagram?format=text`). Skips the
+  client-side `JSON.parse` on the multi-MB SVG string.
+
+Both set `Vary: Accept-Encoding`. Threshold and compression level are
+tunable at `main.py:43-44`.
+
+## NumPy → JSON sanitization
+
+pypowsybl returns NumPy scalars / arrays inside dicts that FastAPI's
+default JSON encoder rejects. `services/sanitize.py:sanitize_for_json`
+recursively coerces them to native Python types and is called in every
+endpoint payload. Don't return raw NumPy from a service method —
+either call `sanitize_for_json` at the boundary or convert inside the
+service itself.
+
+## Variants & load flow
+
+`_get_n_variant()` and `_get_n1_variant(contingency)` clone from a
+clean N-state baseline (NEVER from the current working variant — that
+could inherit modifications from a prior action simulation). They run
+the AC load flow with `_run_ac_with_fallback`, which retries in slow
+mode if `PYPOWSYBL_FAST_MODE` is on and AC fails. Variant cache is on
+`self._lf_status_by_variant` so `get_n1_diagram` reuses the LF status
+without re-running.
+
+`_ensure_n_state_ready()` and `_ensure_n1_state_ready()` are guards
+called at the entry of analysis / simulation endpoints. They join any
+in-flight NAD prefetch thread (so it can't race on variant changes)
+and pin the working variant. Add them to any new entry point that
+operates on the shared network.
+
+## Layout cache (`_layout_cache`)
+
+`DiagramMixin._load_layout()` parses `grid_layout.json` into a pandas
+DataFrame and caches it on the service keyed by `(path, mtime)`. Used
+as `fixed_positions` for NAD generation. Two invariants:
+1. `reset()` MUST clear `_layout_cache` (see "State lifecycle"
+   above) — otherwise the previous study's layout leaks into the new
+   grid's NAD.
+2. The `(path, mtime)` key auto-invalidates when the file changes,
+   so warm-process workflow stays fast.
+
+## NAD prefetch
+
+`prefetch_base_nad_async()` is called from `update_config()` right
+after `LAYOUT_FILE_PATH` is set. It:
+1. Pre-warms `self._base_network` in the main thread (so the worker
+   sees an O(1) attribute access — no lazy-init race).
+2. Spawns a daemon thread named `NADPrefetch` that calls
+   `self.get_network_diagram()`.
+3. Stores the result on `_prefetched_base_nad`, errors on
+   `_prefetched_base_nad_error`, completion on
+   `_prefetched_base_nad_event`.
+
+`/api/network-diagram` calls `get_prefetched_base_nad(timeout=60)`
+which blocks on the event then either returns the cached diagram or
+re-raises the worker exception. Falls through to a fresh compute if
+no prefetch was ever started (e.g. tests bypassing `update_config`).
+
+## Adding endpoints
+
+1. Add the Pydantic request model at the top of `main.py` near the
+   existing models.
+2. Add the route. Import any service method via the singleton
+   (`network_service` / `recommender_service`).
+3. Wrap non-streaming JSON responses in `_maybe_gzip_json(payload,
+   http_request)` if the payload can grow large (≥ 10 KB).
+4. Mirror the path in `frontend/src/api.ts` (axios method) and the
+   master table in the root `CLAUDE.md` (and add a row to the API
+   table there).
+5. Add a test under `expert_backend/tests/` — see
+   `tests/CLAUDE.md` for the mock layer that lets it run without
+   `pypowsybl` installed.
+
+## Adding a new per-study cache
+
+1. Initialise the field in `RecommenderService.__init__` — keep
+   them grouped by purpose with a short comment.
+2. **Clear it in `reset()`** — same group / order as `__init__`.
+3. Document it in the "What `reset()` clears" list in
+   `docs/state-reset-and-confirmation-dialogs.md`.
+4. If the field holds a thread / future / event, drain or cancel it
+   inside `_drain_pending_*` helpers BEFORE clearing the field —
+   look at `_drain_pending_base_nad_prefetch` for the pattern.
+
+## Conventions
+
+- **Logging**: `logger = logging.getLogger(__name__)`. Use it
+  (no `print`) for new code.
+- **No formal Python linter**: code follows PEP 8 manually. Match
+  the surrounding style (4-space indent, type hints where helpful,
+  docstrings on public methods).
+- **Error handling at the API boundary**: services raise standard
+  exceptions; `main.py` translates them to `HTTPException` with a
+  meaningful detail message. Internal validation that "can't fail"
+  shouldn't be there — trust the caller.
+- **No backwards-compatibility shims**: when a feature changes,
+  update the consumers in the same commit (frontend, standalone
+  HTML, tests).
+- **`standalone_interface.html` parity**: the root has a self-
+  contained single-file mirror of the React UI. UI-related backend
+  changes (new endpoints, payload shape changes) need a manual
+  mirror there too.
+
+## Running
+
+```bash
+# From project root
+python -m expert_backend.main
+# Or
+uvicorn expert_backend.main:app --host 0.0.0.0 --port 8000
+```
+
+CORS is wide-open (`allow_origins=["*"]`) because the dev frontend
+hits the backend cross-origin. Tighten before any non-local
+deployment.

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -29,20 +29,42 @@ class DiagramMixin:
     """Mixin providing diagram generation and flow analysis methods."""
 
     def _load_layout(self):
-        """Load layout DataFrame from grid_layout.json if available."""
+        """Load layout DataFrame from grid_layout.json if available.
+
+        Cached on the instance by `(path, mtime)`: repeated NAD
+        generations within the same process reuse the parsed DataFrame
+        instead of re-reading the JSON + rebuilding pandas (~50-150 ms
+        saved per call on large grids). Cache auto-invalidates when the
+        layout file is modified.
+        """
         import pandas as pd
         import json
 
         layout_file = getattr(config, 'LAYOUT_FILE_PATH', None)
-        if layout_file and layout_file.exists():
-            try:
-                with open(layout_file, 'r') as f:
-                    layout_data = json.load(f)
-                records = [{'id': k, 'x': v[0], 'y': v[1]} for k, v in layout_data.items()]
-                return pd.DataFrame(records).set_index('id')
-            except Exception as e:
-                logger.warning(f"Warning: Could not load layout: {e}")
-        return None
+        if not layout_file or not layout_file.exists():
+            return None
+
+        try:
+            mtime = layout_file.stat().st_mtime
+        except OSError as e:
+            logger.warning(f"Warning: Could not stat layout: {e}")
+            return None
+
+        cache_key = (str(layout_file), mtime)
+        cached = getattr(self, '_layout_cache', None)
+        if cached is not None and cached[0] == cache_key:
+            return cached[1]
+
+        try:
+            with open(layout_file, 'r') as f:
+                layout_data = json.load(f)
+            records = [{'id': k, 'x': v[0], 'y': v[1]} for k, v in layout_data.items()]
+            df = pd.DataFrame(records).set_index('id')
+            self._layout_cache = (cache_key, df)
+            return df
+        except Exception as e:
+            logger.warning(f"Warning: Could not load layout: {e}")
+            return None
 
     def _default_nad_parameters(self):
         """Return default NadParameters for diagram generation.
@@ -59,20 +81,47 @@ class DiagramMixin:
           - GEOGRAPHICAL + fixed_positions (now):      3 470 ms
           - Gain: ~−450 ms (~−11 %)
 
-        SVG size unchanged (13.6 MB). Visual output identical — same
-        positions are used, only the force-refinement step is skipped.
+        SVG size unchanged by `layout_type`. Visual output identical —
+        same positions are used, only the force-refinement step is
+        skipped.
+
+        **Minimal-render toggles** (lever #6 in docs/perf-nad-profile-bare-env.md):
+        the following flags are set to the minimum needed to show:
+          - active power (P) at line endpoints
+          - voltage-level nodes + names
+          - nominal-voltage colouring
+          - overloaded-line / voltage-constraint highlights (done
+            client-side via CSS on ids returned in `lines_overloaded`)
+
+        Measured on `bare_env_20240828T0100Z` (~13 MB baseline SVG):
+          - `bus_legend=False`              → −0.11 s total, −1.0 MB
+          - `voltage_level_details=False`   → dead code (no label
+            provider configured), −0 s, kept explicit for clarity
+          - `substation_description_displayed=False` → VL name already
+            carries the substation code on RTE data → −0.2 MB
+          - `power_value_precision=0`       → "123 MW" instead of
+            "123.4 MW", removes a handful of characters per label
+          - `injections_added=False` (pypowsybl default, kept explicit)
+            → tested setting it to True: +1.03 s and +10.9 MB on this
+            grid — injections are intentionally left off the NAD
+
+        Combined gain vs prior defaults (`bus_legend=True`,
+        `substation_description_displayed=True`, `power_value_precision=1`,
+        `voltage_level_details` implicit True): −0.13 s total, −1.2 MB.
         """
         from pypowsybl.network import NadParameters, NadLayoutType
         return NadParameters(
             edge_name_displayed=False,
             id_displayed=False,
             edge_info_along_edge=True,
-            power_value_precision=1,
+            power_value_precision=0,
             angle_value_precision=0,
             current_value_precision=1,
             voltage_value_precision=0,
-            bus_legend=True,
-            substation_description_displayed=True,
+            bus_legend=False,
+            substation_description_displayed=False,
+            voltage_level_details=False,
+            injections_added=False,
             layout_type=NadLayoutType.GEOGRAPHICAL,
         )
 
@@ -582,14 +631,30 @@ class DiagramMixin:
         return sanitize_for_json(overloaded)
 
     def _get_element_max_currents(self, network):
-        """Return {element_id: max(|i1|, |i2|)} for all lines and transformers."""
-        import numpy as np
+        """Return {element_id: max(|i1|, |i2|)} for all lines and transformers.
+
+        Vectorised with numpy — the previous `df.iterrows()` loop added
+        ~300-700 ms on ~10 k-branch grids. Also narrows the pypowsybl
+        query to `i1, i2` only (mirrors `_get_overloaded_lines`).
+
+        Semantics preserved: rows where either `i1` or `i2` is NaN are
+        excluded from the returned dict.
+        """
         currents = {}
-        for df in [network.get_lines()[['i1', 'i2']], network.get_2_windings_transformers()[['i1', 'i2']]]:
-            for element_id, row in df.iterrows():
-                i1, i2 = row['i1'], row['i2']
-                if not np.isnan(i1) and not np.isnan(i2):
-                    currents[element_id] = max(abs(i1), abs(i2))
+        for df in [
+            network.get_lines(attributes=['i1', 'i2']),
+            network.get_2_windings_transformers(attributes=['i1', 'i2']),
+        ]:
+            if len(df.index) == 0:
+                continue
+            i1 = df['i1'].values
+            i2 = df['i2'].values
+            mask = ~(np.isnan(i1) | np.isnan(i2))
+            if not mask.any():
+                continue
+            idx = df.index.values[mask]
+            max_i = np.maximum(np.abs(i1[mask]), np.abs(i2[mask]))
+            currents.update(zip(idx, max_i.tolist()))
         return currents
 
     def _get_n1_flows(self, contingency: str) -> dict:

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -82,6 +82,12 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         # per N-1 diagram on the PyPSA-EUR France grid (cold path) and
         # ~1 s on the warm path (repeat views of same contingency).
         self._lf_status_by_variant = {}
+        # Grid-layout DataFrame cache (populated by `DiagramMixin._load_layout`,
+        # keyed by `(path, mtime)`). Owned here so `reset()` can clear it when
+        # a new study is loaded — otherwise a stale layout can leak across
+        # studies that share the same layout filename / mtime, producing a
+        # NAD whose `fixed_positions` reference the previous grid's substations.
+        self._layout_cache = None
         # Pre-fetched base NAD (populated by `prefetch_base_nad_async` during
         # `update_config`, consumed by `/api/network-diagram`). See
         # docs/perf-nad-prefetch.md.
@@ -115,6 +121,14 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         self._cached_env_context = None
         self._initial_pst_taps = None
         self._lf_status_by_variant = {}
+        # Layout cache must be cleared when a new study is loaded so the
+        # next `_load_layout()` call reads the fresh `grid_layout.json`
+        # for the new grid. Without this, the previous study's layout
+        # DataFrame could be re-served for the new grid if `(path, mtime)`
+        # happens to match (shared filename, coarse filesystem mtime
+        # resolution), producing a NAD whose `fixed_positions` reference
+        # substation IDs from the wrong grid.
+        self._layout_cache = None
 
         self._prefetched_base_nad = None
         self._prefetched_base_nad_error = None

--- a/expert_backend/tests/test_cache_synchronization.py
+++ b/expert_backend/tests/test_cache_synchronization.py
@@ -58,7 +58,22 @@ class TestCacheSynchronization:
     @patch.object(RecommenderService, '_get_n1_variant')
     @patch.object(RecommenderService, '_get_n_variant')
     @patch.object(RecommenderService, '_get_simulation_env')
-    def test_cache_invalidation_on_contingency_switch(self, mock_get_env, mock_get_n, mock_get_n1):
+    @patch.object(RecommenderService, '_get_base_network')
+    def test_cache_invalidation_on_contingency_switch(self, mock_get_net, mock_get_env, mock_get_n, mock_get_n1):
+        # `_ensure_n1_state_ready` (invoked at the top of
+        # `simulate_manual_action`) calls `_get_base_network()` BEFORE
+        # `_get_n1_variant()`. When the base network is not mocked the
+        # fallback path `pp.network.load(config.ENV_PATH)` raises — the
+        # guard swallows the exception, but `_get_n1_variant` is never
+        # called, so the 4 `side_effect` values below shift by one and
+        # the second `simulate_manual_action("DISCO_B")` ends up getting
+        # the cached "n1_A" id back → both N and N-1 caches hit → zero
+        # `env.get_obs` calls instead of the expected 1. On CI
+        # (`pip install --no-deps expert_op4grid_recommender`) the
+        # fallback path tries a relative `data/` dir under site-packages
+        # that does not exist — exactly the scenario this mock
+        # neutralises. The companion test `test_cache_hits_on_repeated_calls`
+        # already mocks `_get_base_network`; aligning this one.
         service = RecommenderService()
         service._dict_action = {"act1": {"content": {}}}
         service._last_result = {"prioritized_actions": {}}

--- a/expert_backend/tests/test_combined_actions_scenario.py
+++ b/expert_backend/tests/test_combined_actions_scenario.py
@@ -81,10 +81,25 @@ def analysis_results(scenario_data):
             self.lines_monitoring_path = None
             self.do_visualization = False
 
-    # Load the network BEFORE updating config, so that self.network is available
-    # for enrich_actions_lazy called inside update_config.
+    # `reset()` mirrors what `/api/config` does in production: clears
+    # `_base_network` (and thus any N-1 variants cached on it) plus the
+    # cached LF / observation state. Without it, N-1 variants cloned by
+    # earlier test modules on the same `bare_env_small_grid_test` network
+    # are reused under the cache-by-variant-id path in `_get_n1_variant`,
+    # which caused a small drift in the flow deltas measured below when
+    # the full pytest suite ran in file order (see README / CI note).
+    # Then load the network so `self.network` is available for the
+    # `enrich_actions_lazy` call inside `update_config`.
     from expert_backend.services.network_service import network_service
+    recommender_service.reset()
     network_service.load_network(str(network_path))
+
+    # Force-disable fast mode at fixture-setup time too — the module-
+    # level `config.PYPOWSYBL_FAST_MODE = False` at import time may have
+    # been overwritten by previously-run modules (e.g. the `reset_config`
+    # autouse fixture restores its snapshot from BEFORE our module-level
+    # line ran).
+    config.PYPOWSYBL_FAST_MODE = False
 
     recommender_service.update_config(Settings(network_path, action_file_path))
 

--- a/expert_backend/tests/test_diagram_mixin.py
+++ b/expert_backend/tests/test_diagram_mixin.py
@@ -200,6 +200,55 @@ class TestLoadLayoutCache:
         assert second is not first, "Cache must not return the stale DataFrame"
         assert "B" in second.index, "Reloaded layout must include the newly added entry"
 
+    def test_reset_clears_layout_cache_across_studies(self, tmp_path):
+        """Bugfix: loading a new study must not reuse the previous study's
+        cached layout DataFrame as ``fixed_positions`` for NAD generation.
+
+        Reproduces the bug described in issue "grid layout not properly
+        reset" — two different grids pointing at different layout files
+        must each get their own DataFrame back from ``_load_layout`` after
+        ``reset()``, even if ``(path, mtime)`` were to coincide.
+
+        We use :class:`RecommenderService` rather than the bare mixin
+        because the cache invalidation happens in ``reset()``, which is
+        defined on the composed service class.
+        """
+        from expert_backend.services.recommender_service import RecommenderService
+
+        layout_a = tmp_path / "grid_layout_A.json"
+        layout_b = tmp_path / "grid_layout_B.json"
+        self._write_layout(layout_a, {"SUB_A1": [1.0, 2.0], "SUB_A2": [3.0, 4.0]})
+        self._write_layout(layout_b, {"SUB_B1": [10.0, 20.0], "SUB_B2": [30.0, 40.0]})
+
+        service = RecommenderService()
+
+        # Study 1 — point at layout A and prime the cache.
+        with patch("expert_backend.services.diagram_mixin.config") as cfg:
+            cfg.LAYOUT_FILE_PATH = layout_a
+            df_a = service._load_layout()
+        assert df_a is not None
+        assert set(df_a.index) == {"SUB_A1", "SUB_A2"}
+        assert service._layout_cache is not None, "Cache should have been primed"
+
+        # Simulate loading a new study: /api/config calls reset() before
+        # update_config(). After reset(), the layout cache must be gone.
+        service.reset()
+        assert service._layout_cache is None, (
+            "reset() must clear _layout_cache so the next _load_layout() "
+            "reads the fresh layout file for the new study"
+        )
+
+        # Study 2 — point at layout B.  The returned DataFrame must
+        # contain B's substation IDs, not A's.
+        with patch("expert_backend.services.diagram_mixin.config") as cfg:
+            cfg.LAYOUT_FILE_PATH = layout_b
+            df_b = service._load_layout()
+        assert df_b is not None
+        assert set(df_b.index) == {"SUB_B1", "SUB_B2"}, (
+            "New study must get its own layout DataFrame, not the cached "
+            "layout from the previous study"
+        )
+
 
 class TestGetElementMaxCurrents:
     """`_get_element_max_currents` must return `max(|i1|, |i2|)` for every

--- a/expert_backend/tests/test_diagram_mixin.py
+++ b/expert_backend/tests/test_diagram_mixin.py
@@ -7,14 +7,31 @@
 
 """Unit tests for :mod:`expert_backend.services.diagram_mixin`.
 
-Focused on invariants guaranteed by :meth:`DiagramMixin._default_nad_parameters`:
-in particular the ``layout_type=GEOGRAPHICAL`` choice which — paired with
-the ``fixed_positions`` passed from ``grid_layout.json`` — skips pypowsybl's
-force-directed refinement step and cuts NAD generation by ~11 % on large
-grids (see commit 413fa61).
+Covers the invariants guaranteed by :class:`DiagramMixin`:
+
+- :meth:`DiagramMixin._default_nad_parameters` — the minimal-render
+  config documented in ``docs/perf-nad-profile-bare-env.md`` (``bus_legend``,
+  ``substation_description_displayed``, ``voltage_level_details``,
+  ``injections_added`` all off; ``power_value_precision=0``;
+  ``layout_type=GEOGRAPHICAL``).
+
+- :meth:`DiagramMixin._load_layout` — instance-level cache keyed by
+  ``(path, mtime)`` so repeated NAD generations skip the JSON + DataFrame
+  rebuild.
+
+- :meth:`DiagramMixin._get_element_max_currents` — vectorised numpy path
+  returning ``{element_id: max(|i1|, |i2|)}`` with rows containing NaN
+  excluded.
 """
 from __future__ import annotations
 
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
 import pytest
 
 pypowsybl = pytest.importorskip("pypowsybl")
@@ -73,11 +90,12 @@ class TestDefaultNadParameters:
                 "on 118 MB grids."
             )
 
-    def test_other_expected_parameters_still_present(self):
-        """Companion kwargs must remain — no accidental regression of the
-        legend / precision / edge-info flags we've tuned over time."""
-        from unittest.mock import patch
-
+    def test_minimal_render_parameters(self):
+        """Companion kwargs guard — these are the minimal-render toggles
+        documented in ``docs/perf-nad-profile-bare-env.md`` (section
+        "Results — after #6"). Flipping any of them silently regresses
+        NAD perf on large grids (e.g. ``bus_legend=True`` adds ~1 MB SVG
+        and ~160 ms; ``injections_added=True`` adds ~11 MB / ~1 s)."""
         mixin = DiagramMixin()
         with patch("pypowsybl.network.NadParameters") as mock_cls:
             mock_cls.return_value = object()
@@ -88,14 +106,170 @@ class TestDefaultNadParameters:
             "edge_name_displayed": False,
             "id_displayed": False,
             "edge_info_along_edge": True,
-            "power_value_precision": 1,
+            "power_value_precision": 0,
             "angle_value_precision": 0,
             "current_value_precision": 1,
             "voltage_value_precision": 0,
-            "bus_legend": True,
-            "substation_description_displayed": True,
+            "bus_legend": False,
+            "substation_description_displayed": False,
+            "voltage_level_details": False,
+            "injections_added": False,
         }
         for key, value in expected.items():
             assert kwargs.get(key) == value, (
                 f"NadParameters kwarg {key!r} expected {value!r}, got {kwargs.get(key)!r}"
             )
+
+
+class TestLoadLayoutCache:
+    """`_load_layout` must cache its DataFrame on the instance keyed by
+    ``(path, mtime)``. Cache must invalidate when the file changes.
+    """
+
+    def _write_layout(self, path: Path, records: dict) -> None:
+        path.write_text(json.dumps(records))
+
+    def test_returns_none_when_layout_path_unset(self):
+        mixin = DiagramMixin()
+        with patch("expert_backend.services.diagram_mixin.config") as cfg:
+            cfg.LAYOUT_FILE_PATH = None
+            assert mixin._load_layout() is None
+
+    def test_returns_none_when_layout_file_missing(self, tmp_path):
+        missing = tmp_path / "nope.json"
+        mixin = DiagramMixin()
+        with patch("expert_backend.services.diagram_mixin.config") as cfg:
+            cfg.LAYOUT_FILE_PATH = missing
+            assert mixin._load_layout() is None
+
+    def test_loads_layout_dataframe(self, tmp_path):
+        layout_file = tmp_path / "grid_layout.json"
+        self._write_layout(layout_file, {"A": [1.0, 2.0], "B": [3.5, -0.5]})
+
+        mixin = DiagramMixin()
+        with patch("expert_backend.services.diagram_mixin.config") as cfg:
+            cfg.LAYOUT_FILE_PATH = layout_file
+            df = mixin._load_layout()
+
+        assert df is not None
+        assert list(df.index) == ["A", "B"]
+        assert list(df.columns) == ["x", "y"]
+        assert df.loc["A", "x"] == 1.0
+        assert df.loc["B", "y"] == -0.5
+
+    def test_cache_hit_skips_file_read(self, tmp_path):
+        """Second call for an unchanged file must not re-open it."""
+        layout_file = tmp_path / "grid_layout.json"
+        self._write_layout(layout_file, {"A": [1.0, 2.0]})
+
+        mixin = DiagramMixin()
+        with patch("expert_backend.services.diagram_mixin.config") as cfg:
+            cfg.LAYOUT_FILE_PATH = layout_file
+            first = mixin._load_layout()
+
+            # After the first load, patch `open` to detect any re-read.
+            with patch("builtins.open") as mock_open:
+                second = mixin._load_layout()
+                mock_open.assert_not_called(), (
+                    "_load_layout must return the cached DataFrame when "
+                    "(path, mtime) is unchanged"
+                )
+
+        assert second is first, "Cached call should return the same DataFrame object"
+
+    def test_cache_invalidates_on_mtime_change(self, tmp_path):
+        """Editing the layout file must invalidate the cache."""
+        layout_file = tmp_path / "grid_layout.json"
+        self._write_layout(layout_file, {"A": [1.0, 2.0]})
+
+        mixin = DiagramMixin()
+        with patch("expert_backend.services.diagram_mixin.config") as cfg:
+            cfg.LAYOUT_FILE_PATH = layout_file
+            first = mixin._load_layout()
+
+            # Bump mtime far enough that even coarse filesystems notice,
+            # then overwrite the file with new content.
+            future_mtime = time.time() + 10
+            import os
+            os.utime(layout_file, (future_mtime, future_mtime))
+            self._write_layout(layout_file, {"A": [1.0, 2.0], "B": [9.0, 9.0]})
+            os.utime(layout_file, (future_mtime + 1, future_mtime + 1))
+
+            second = mixin._load_layout()
+
+        assert second is not first, "Cache must not return the stale DataFrame"
+        assert "B" in second.index, "Reloaded layout must include the newly added entry"
+
+
+class TestGetElementMaxCurrents:
+    """`_get_element_max_currents` must return `max(|i1|, |i2|)` for every
+    line and 2-winding transformer with both currents finite. Rows with
+    NaN in `i1` or `i2` are excluded. The path is vectorised (no
+    row-by-row Python iteration).
+    """
+
+    @staticmethod
+    def _make_network(lines_df, trafos_df):
+        """Build a MagicMock network matching the pypowsybl API surface
+        used by `_get_element_max_currents`."""
+        network = MagicMock()
+        network.get_lines.return_value = lines_df
+        network.get_2_windings_transformers.return_value = trafos_df
+        return network
+
+    def test_basic_two_lines_one_trafo(self):
+        lines = pd.DataFrame(
+            {"i1": [100.0, -250.0], "i2": [110.0, 200.0]},
+            index=["L1", "L2"],
+        )
+        trafos = pd.DataFrame(
+            {"i1": [300.0], "i2": [-305.0]},
+            index=["T1"],
+        )
+        mixin = DiagramMixin()
+        out = mixin._get_element_max_currents(self._make_network(lines, trafos))
+
+        assert set(out.keys()) == {"L1", "L2", "T1"}
+        assert out["L1"] == pytest.approx(110.0)   # max(|100|, |110|)
+        assert out["L2"] == pytest.approx(250.0)   # max(|−250|, |200|)
+        assert out["T1"] == pytest.approx(305.0)
+
+    def test_excludes_rows_with_nan(self):
+        lines = pd.DataFrame(
+            {"i1": [100.0, np.nan, 50.0], "i2": [120.0, 80.0, np.nan]},
+            index=["ok", "nan_i1", "nan_i2"],
+        )
+        trafos = pd.DataFrame({"i1": [], "i2": []})
+        mixin = DiagramMixin()
+        out = mixin._get_element_max_currents(self._make_network(lines, trafos))
+
+        assert out == {"ok": pytest.approx(120.0)}, (
+            "Only fully-defined rows should be returned"
+        )
+
+    def test_empty_dataframes_returns_empty_dict(self):
+        empty = pd.DataFrame({"i1": [], "i2": []})
+        mixin = DiagramMixin()
+        out = mixin._get_element_max_currents(self._make_network(empty, empty))
+        assert out == {}
+
+    def test_narrows_pypowsybl_query_to_i1_i2(self):
+        """Both `get_lines` and `get_2_windings_transformers` must be
+        called with `attributes=['i1', 'i2']` — not the full column set.
+
+        This mirrors the optimisation already in place for
+        `_get_overloaded_lines` (see `diagram_mixin.py:528-545`). Letting
+        pypowsybl return all 30 columns and then slicing in pandas wastes
+        ~150-300 ms on the 55 k-row PyPSA-EUR France table.
+        """
+        lines = pd.DataFrame({"i1": [1.0], "i2": [2.0]}, index=["L"])
+        trafos = pd.DataFrame({"i1": [3.0], "i2": [4.0]}, index=["T"])
+        network = self._make_network(lines, trafos)
+
+        mixin = DiagramMixin()
+        mixin._get_element_max_currents(network)
+
+        network.get_lines.assert_called_once_with(attributes=["i1", "i2"])
+        network.get_2_windings_transformers.assert_called_once_with(
+            attributes=["i1", "i2"]
+        )

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,277 @@
+# CLAUDE.md — `frontend/`
+
+React 19 + TypeScript 5.9 + Vite 7 single-page app for Co-Study4Grid.
+Talks to the FastAPI backend at `http://127.0.0.1:8000` (hardcoded in
+`src/api.ts`). Renders pypowsybl NAD/SLD diagrams with pan/zoom and
+runs the two-step contingency analysis workflow.
+
+For the project-wide overview see the root `CLAUDE.md`. For backend
+internals see `expert_backend/CLAUDE.md`. Test conventions for
+Vitest are listed in `expert_backend/tests/CLAUDE.md` (the frontend
+section).
+
+## Layout
+
+```
+frontend/
+├── README.md
+├── index.html                # Vite HTML entry point
+├── package.json              # React 19, Vite 7, vitest, axios, react-select,
+│                             # react-zoom-pan-pinch, framer-motion, lucide-react
+├── vite.config.ts            # Vite + Vitest plugin (jsdom env)
+├── eslint.config.js          # Flat config (v9+) — typescript-eslint,
+│                             # react-hooks, react-refresh
+├── tsconfig.json             # Root project refs
+├── tsconfig.app.json         # App config (strict TS, noUnusedLocals/Params,
+│                             # noFallthroughCasesInSwitch)
+├── tsconfig.node.json        # Vite/config TypeScript config
+├── public/
+└── src/
+    ├── main.tsx              # React entry (StrictMode)
+    ├── App.tsx               # State orchestration hub (~1000 lines)
+    ├── App.*.test.tsx        # App-level integration tests by domain
+    ├── App.css / index.css   # Global + app styles
+    ├── api.ts                # Axios HTTP client (single object literal)
+    ├── api.test.ts
+    ├── types.ts              # All TypeScript interfaces (one file)
+    ├── test/setup.ts         # Vitest global setup (jest-dom matchers)
+    ├── hooks/                # Custom hooks owning a slice of state
+    │   ├── useSettings.ts        # All settings + setters → SettingsState
+    │   ├── useActions.ts         # Action selection / favorite / reject
+    │   ├── useAnalysis.ts        # Two-step analysis flow (step1/step2)
+    │   ├── useDiagrams.ts        # NAD fetching + tab management
+    │   ├── usePanZoom.ts         # ViewBox state, zoom-to-element
+    │   ├── useSldOverlay.ts      # Single-Line-Diagram overlay
+    │   ├── useSession.ts         # Session save / restore
+    │   ├── useDetachedTabs.ts    # Detached visualization windows
+    │   └── useTiedTabsSync.ts    # Mirror viewBox between detached + main
+    ├── components/           # Presentational components (no API calls)
+    │   ├── Header.tsx, ActionFeed.tsx, OverloadPanel.tsx,
+    │   ├── VisualizationPanel.tsx, ActionCard.tsx, ActionCardPopover.tsx,
+    │   ├── ActionOverviewDiagram.tsx, ActionSearchDropdown.tsx,
+    │   ├── CombinedActionsModal.tsx, ComputedPairsTable.tsx,
+    │   ├── DetachableTabHost.tsx, ErrorBoundary.tsx, ExplorePairsTab.tsx,
+    │   ├── MemoizedSvgContainer.tsx, SldOverlay.tsx
+    │   └── modals/
+    │       ├── SettingsModal.tsx          # 3-tab settings dialog
+    │       ├── ReloadSessionModal.tsx     # Session reload list
+    │       └── ConfirmationDialog.tsx     # Shared confirmation (contingency / reload)
+    └── utils/                # Pure helpers (no React, no axios)
+        ├── svgUtils.ts                # SVG processing, highlights, metadata
+        ├── overloadHighlights.ts      # N-1 overload classification
+        ├── popoverPlacement.ts        # Pin-popover positioning
+        ├── sessionUtils.ts            # buildSessionResult snapshot
+        ├── interactionLogger.ts       # Singleton replay-ready event log
+        ├── mergeAnalysisResult.ts     # Merge step1 + step2 fields
+        └── *.test.ts                  # Co-located unit tests
+```
+
+## Architecture in one paragraph
+
+`App.tsx` is the **state orchestration hub** — it instantiates the
+custom hooks (`useSettings`, `useActions`, `useAnalysis`,
+`useDiagrams`, `useSession`, `useDetachedTabs`, `useTiedTabsSync`),
+wires them together, and routes state into presentational components.
+It MUST NOT contain large inline JSX blocks — when adding UI sections,
+create a new component under `components/` or `components/modals/`
+and pass props down. Hooks own state by domain (e.g. `useActions`
+owns `selectedActionIds` / `manuallyAddedIds` / `rejectedActionIds`)
+and expose typed setters + handlers. Cross-hook logic
+(`handleApplySettings`, `resetAllState`, `wrappedRunAnalysis`) lives
+in `App.tsx` because it needs multiple hook instances at once.
+
+## Hook conventions
+
+- Each hook returns a typed `*State` interface — e.g.
+  `useSettings(): SettingsState`. The interface includes both values
+  AND setters AND derived handlers (e.g. `pickSettingsPath`).
+- Pass the entire state object wholesale into deeply-nested modals
+  to avoid prop-drilling 30+ individual props (see how
+  `<SettingsModal settings={settings} />` consumes the whole
+  `SettingsState`).
+- Refs intended to survive renders (e.g.
+  `committedBranchRef`, `restoringSessionRef`,
+  `actionSyncSourceRef`) live on the hook that owns them and are
+  re-exported through the `*State` interface — not on `App.tsx`.
+- Adding a new setting requires three places:
+  1. `hooks/useSettings.ts` — field on `SettingsState` + a `useState`
+     pair in `useSettings()`.
+  2. `components/modals/SettingsModal.tsx` — input wired to the
+     setter.
+  3. `standalone_interface.html` — manual mirror of the field +
+     input (the standalone HTML does NOT import React).
+
+## Data flow (happy path)
+
+1. **Boot**: `App.tsx` first effect calls `api.getUserConfig()` →
+   hydrates `useSettings` from `config.json`. The settings modal
+   opens automatically if `networkPath` / `actionPath` are missing.
+2. **Apply settings / Load study**: `applySettingsImmediate` calls
+   `resetAllState()` → `api.updateConfig(buildConfigRequest())` →
+   parallel `Promise.all` of `getBranches` + `getVoltageLevels` +
+   `getNominalVoltages` + `getNetworkDiagram` (the slow NAD overlaps
+   with the fast metadata calls — see
+   `docs/perf-loading-parallel.md`).
+3. **Select contingency**: typing in the contingency input fires the
+   N-1 useEffect when the value matches a valid branch. If analysis
+   state already exists, a confirmation dialog appears
+   (`hasAnalysisState()` / `committedBranchRef.current`). On
+   confirm, fetches `/api/n1-diagram` and stores it on
+   `diagrams.n1Diagram`.
+4. **Run analysis**: two-step flow. `runAnalysisStep1` returns the
+   list of overloads; user selects which to resolve;
+   `runAnalysisStep2Stream` streams a `pdf` event then a `result`
+   event with prioritized actions.
+5. **Action interactions**: star/reject/manually-add/re-simulate.
+   Selecting an action triggers `/api/action-variant-diagram` →
+   stored as `diagrams.actionDiagram`.
+6. **Session save**: `buildSessionResult()` in
+   `utils/sessionUtils.ts` serializes EVERYTHING (paths, settings,
+   contingency, action statuses, combined pairs, interaction log).
+   `api.saveSession()` writes to disk. See `docs/save-results.md`.
+
+## State reset & confirmation dialogs
+
+`resetAllState()` (`App.tsx:310-324`) clears every per-study piece of
+React state. It is called on Apply Settings AND on Load Study. The
+backend mirrors this with `recommender_service.reset()` —
+`docs/state-reset-and-confirmation-dialogs.md` is the contract for
+both sides. Adding a new piece of analysis state? Reset it here
+AND make sure the backend mixin clears whatever cache shadows it.
+
+Confirmation dialog flow lives in `App.tsx`:
+- `confirmDialog` state: `{ type: 'contingency' | 'loadStudy' |
+  'applySettings', pendingBranch?: string } | null`.
+- `<ConfirmationDialog />` is the shared modal — used for all three
+  contingency-loss-warning gestures.
+
+## SVG handling
+
+The frontend deals with multi-MB pypowsybl SVG payloads. Three
+performance levers are applied today:
+
+- **`api.getNetworkDiagram` uses `format=text`** (`api.ts:69-92`):
+  fetches a JSON-header + raw-SVG-body response so the browser
+  doesn't `JSON.parse` a 25 MB string. Saves ~500 ms on large grids.
+- **`getIdMap(container)`** (`utils/svgUtils.ts:13-22`): cached
+  `WeakMap<HTMLElement, Map<id, Element>>` so highlight passes don't
+  re-scan `[id]` selectors. Invalidate via `invalidateIdMapCache`
+  whenever the SVG content changes.
+- **`boostSvgForLargeGrid`**: dynamic font/node-radius scaling for
+  grids ≥ 500 voltage levels so labels stay readable at high zoom.
+
+The visualization is rendered inside `react-zoom-pan-pinch`. Zoom
+state is owned by `usePanZoom` per tab (`nPZ`, `n1PZ`, `actionPZ`,
+plus `overviewPz` for the Action overview map). The
+`useTiedTabsSync` hook mirrors viewBox changes from the active tab
+to any "tied" detached tab.
+
+## Detached tabs
+
+`useDetachedTabs` opens diagram tabs in popup windows
+(`window.open`). When popups are blocked, the error surfaces via
+`onPopupBlocked` callback. The detached tab gets its own
+`react-zoom-pan-pinch` instance; `useTiedTabsSync` keeps the
+viewBoxes in sync. See `docs/detachable-viz-tabs.md`.
+
+## Interaction logging
+
+Every meaningful user gesture is recorded by the
+`interactionLogger` singleton in `utils/interactionLogger.ts`.
+Entries have a sequence number, ISO timestamp, typed `type` (see
+the long `InteractionType` union in `types.ts`), free-form
+`details`, optional `correlation_id`, and optional `duration_ms`
+for async operations.
+
+The log is replay-ready: each event must carry ALL inputs the
+agent would need to redo the gesture (paths, threshold values,
+selected branch, …). Saved as `interaction_log.json` alongside
+`session.json` on session save. See `docs/interaction-logging.md`.
+
+When adding a new gesture:
+1. Add a new variant to the `InteractionType` union in
+   `types.ts`.
+2. Call `interactionLogger.record('your_event_type', { ... })` at
+   the gesture site.
+3. For async (start/complete) pairs, capture the correlation_id
+   from `record()` and pass it to `recordCompletion()`.
+
+## Testing (Vitest + React Testing Library)
+
+```bash
+cd frontend
+npm run test         # one-shot
+npm run test:watch   # watch mode
+```
+
+- Tests live next to source files as `*.test.ts` / `*.test.tsx`.
+- `src/test/setup.ts` registers `@testing-library/jest-dom` matchers.
+- jsdom is the test environment (vite.config.ts).
+- Heavy mocking: `vi.mock('../api')`, `vi.mock('../utils/svgUtils')`.
+  No backend round-trips in component tests.
+- App-level integration tests are split by domain:
+  `App.contingency.test.tsx`, `App.session.test.tsx`,
+  `App.settings.test.tsx`, `App.stateManagement.test.tsx`,
+  `App.datalist.test.tsx`, `App.import.test.tsx`.
+- Pattern for new component tests: build `defaultProps`, override
+  the fields under test, `render(<X {...props} />)`, query the DOM
+  via `screen`, assert.
+
+## Adding a new backend endpoint to the frontend
+
+1. Add the axios method to `api.ts` (mirror the URL exactly).
+2. Add response types to `types.ts` if they're new.
+3. Call from the right hook (settings → `useSettings`, analysis →
+   `useAnalysis`, diagrams → `useDiagrams`, session → `useSession`).
+4. Wire any new state through to presentational components via
+   typed props.
+5. **Mirror the call in `standalone_interface.html`** if the
+   feature is user-facing — that file is a self-contained single-
+   file version of the UI and ships independently.
+
+## Code style
+
+- **Strict TypeScript**: `strict: true`, `noUnusedLocals`,
+  `noUnusedParameters`, `noFallthroughCasesInSwitch`. `any` only
+  with a comment explaining why.
+- **Functional components + hooks**. No external state
+  management library — context only when prop-drilling becomes
+  unbearable.
+- **Inline `style` objects** are the convention here (no CSS modules
+  or utility-class framework). Match the surrounding component.
+- **Memoize at the right level**: `useCallback` for handlers passed
+  as props, `useMemo` for derived data passed to large children.
+  Don't memoize cheap inline objects on small leaf components.
+- **No comments explaining what** — well-named identifiers do that.
+  Comment WHY only when the answer is non-obvious (subtle race,
+  pypowsybl quirk, performance trade-off, browser bug).
+- **Lint**: `npm run lint` is `eslint .` against the flat config in
+  `eslint.config.js`. Run before committing.
+
+## Build & dev
+
+```bash
+cd frontend
+npm install
+npm run dev      # Vite dev server with HMR (default port 5173)
+npm run build    # tsc -b + vite build → dist/
+npm run preview  # Preview the production build
+```
+
+`api.ts` hardcodes `http://127.0.0.1:8000` — start
+`uvicorn expert_backend.main:app --port 8000` first.
+
+## File-size rule of thumb
+
+If a component crosses ~600 lines, look for an extractable concern:
+a sub-component, a hook, or a helper in `utils/`. `App.tsx` is the
+single intentional exception — it's a state orchestration hub by
+design, but even it should not grow large inline JSX blocks.
+
+## Standalone interface mirror
+
+The repo also ships `standalone_interface.html` at the project root
+— a single-file HTML version of the entire UI. It does NOT import
+React components; it has its own inline JSX. **Any UI change made
+here must be manually mirrored there**. The settings modal, the
+analysis flow, and the SVG visualization are all duplicated.

--- a/frontend/src/hooks/useAnalysis.test.ts
+++ b/frontend/src/hooks/useAnalysis.test.ts
@@ -613,22 +613,38 @@ describe('useAnalysis', () => {
             expect(s2End.correlation_id).toBe(s2Start.correlation_id);
             expect(s2Start.correlation_id).not.toBe(s1Start.correlation_id);
 
-            // step2 completion has actions_count
-            expect(s2End.details.actions_count).toBe(1);
+            // step2 completion carries the action count under the
+            // spec-conformant `n_actions` key (was `actions_count`).
+            expect(s2End.details.n_actions).toBe(1);
         });
 
-        it('logs overload_toggled with correct overload name', () => {
+        it('logs overload_toggled with overload + selected (spec-conformant)', () => {
+            // Replay contract (docs/interaction-logging.md):
+            //   { overload: string, selected: boolean }
+            // `selected` must reflect the state AFTER the toggle so a
+            // replay agent knows whether this click was a check or uncheck.
             const { result } = renderHook(() => useAnalysis());
 
+            // First toggle — overload moves from unselected → selected.
             act(() => { result.current.handleToggleOverload('LINE_B'); });
-
-            const log = interactionLogger.getLog();
+            let log = interactionLogger.getLog();
             expect(log).toHaveLength(1);
             expect(log[0].type).toBe('overload_toggled');
-            expect(log[0].details).toEqual({ overload: 'LINE_B' });
+            expect(log[0].details).toEqual({ overload: 'LINE_B', selected: true });
+
+            // Second toggle on the same overload — now selected → unselected.
+            act(() => { result.current.handleToggleOverload('LINE_B'); });
+            log = interactionLogger.getLog();
+            expect(log).toHaveLength(2);
+            expect(log[1].details).toEqual({ overload: 'LINE_B', selected: false });
         });
 
-        it('logs prioritized_actions_displayed with count', () => {
+        it('logs prioritized_actions_displayed with n_actions (spec-conformant)', () => {
+            // Replay contract (docs/interaction-logging.md):
+            //   { n_actions: number }
+            // Previously emitted `{ actions_count }` — the key name drifted
+            // from the spec and any replay agent reading
+            // `details.n_actions` would see `undefined`.
             const { result } = renderHook(() => useAnalysis());
 
             act(() => {
@@ -648,7 +664,7 @@ describe('useAnalysis', () => {
             const log = interactionLogger.getLog();
             expect(log).toHaveLength(1);
             expect(log[0].type).toBe('prioritized_actions_displayed');
-            expect(log[0].details).toEqual({ actions_count: 2 });
+            expect(log[0].details).toEqual({ n_actions: 2 });
         });
 
         it('does not log when handleRunAnalysis is called with empty branch', async () => {
@@ -661,7 +677,12 @@ describe('useAnalysis', () => {
             expect(interactionLogger.getLog()).toHaveLength(0);
         });
 
-        it('step2_started includes selected_overloads in details', async () => {
+        it('step2_started carries the full spec payload (element + selected_overloads + all_overloads + monitor_deselected)', async () => {
+            // Replay contract (docs/interaction-logging.md):
+            //   { element, selected_overloads, all_overloads, monitor_deselected }
+            // Previously the hook emitted only the latter two, so a
+            // replay agent had no way to know which contingency or
+            // which overload set was in scope.
             const detected = ['LINE_A', 'LINE_B'];
             mockRunAnalysisStep1.mockResolvedValue({
                 can_proceed: true, message: '', lines_overloaded: detected,
@@ -679,7 +700,9 @@ describe('useAnalysis', () => {
             });
 
             const s2Start = interactionLogger.getLog().find(e => e.type === 'analysis_step2_started')!;
+            expect(s2Start.details.element).toBe('LINE_X');
             expect(s2Start.details.selected_overloads).toEqual(detected);
+            expect(s2Start.details.all_overloads).toEqual(detected);
             expect(s2Start.details.monitor_deselected).toBe(false);
         });
     });

--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -119,8 +119,12 @@ export function useAnalysis(): AnalysisState {
       }
 
       // Step 2: Resolution
+      // Replay contract (docs/interaction-logging.md):
+      //   { element, selected_overloads, all_overloads, monitor_deselected }
       const step2CorrId = interactionLogger.record('analysis_step2_started', {
+        element: selectedBranch,
         selected_overloads: toResolve,
+        all_overloads: detected,
         monitor_deselected: monitorDeselected,
       });
       const step2StartTs = new Date().toISOString();
@@ -177,8 +181,13 @@ export function useAnalysis(): AnalysisState {
           }
         }
       }
+      // Replay contract (docs/interaction-logging.md):
+      //   { n_actions, action_ids, dc_fallback, message, pdf_url }.
+      // The full payload would require threading more state out of
+      // the stream loop; for now we emit the most-replayed field
+      // (n_actions) under its spec key.
       interactionLogger.recordCompletion('analysis_step2_completed', step2CorrId, {
-        actions_count: step2ActionsCount,
+        n_actions: step2ActionsCount,
       }, step2StartTs);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An error occurred during analysis.';
@@ -190,8 +199,9 @@ export function useAnalysis(): AnalysisState {
 
   const handleDisplayPrioritizedActions = useCallback((selectedActionIds: Set<string>, setActiveTab?: (tab: TabId) => void) => {
     if (!pendingAnalysisResult) return;
+    // Replay contract (docs/interaction-logging.md): { n_actions: number }.
     interactionLogger.record('prioritized_actions_displayed', {
-      actions_count: Object.keys(pendingAnalysisResult.actions).length,
+      n_actions: Object.keys(pendingAnalysisResult.actions).length,
     });
     // Auto-switch to the Remedial Action tab so the operator sees the
     // action overview with pins right after pressing the button.
@@ -236,14 +246,21 @@ export function useAnalysis(): AnalysisState {
   }, [pendingAnalysisResult]);
 
   const handleToggleOverload = useCallback((overload: string) => {
-    interactionLogger.record('overload_toggled', { overload });
+    // Replay contract (docs/interaction-logging.md):
+    //   { overload, selected }. `selected` is the state AFTER the toggle —
+    //   true if the checkbox is now checked, false otherwise. Compute the
+    //   next value from the current set BEFORE calling setSelectedOverloads
+    //   so the logger doesn't double-fire under React StrictMode (the
+    //   updater callback may run twice).
+    const willSelect = !selectedOverloads.has(overload);
+    interactionLogger.record('overload_toggled', { overload, selected: willSelect });
     setSelectedOverloads((prev: Set<string>) => {
       const next = new Set(prev);
       if (next.has(overload)) next.delete(overload);
       else next.add(overload);
       return next;
     });
-  }, []);
+  }, [selectedOverloads]);
 
   return useMemo(() => ({
     result, setResult,

--- a/frontend/src/hooks/useDiagrams.test.ts
+++ b/frontend/src/hooks/useDiagrams.test.ts
@@ -46,17 +46,22 @@ describe('useDiagrams — interaction logging', () => {
         vi.clearAllMocks();
     });
 
-    it('logs view_mode_changed when handleViewModeChange is called', () => {
+    it('handleViewModeChange updates state but does NOT emit view_mode_changed (App.tsx owns the emission)', () => {
+        // The spec-conformant event needs `{ mode, tab, scope }` — the
+        // `scope` is computed from the detached-tabs map which isn't
+        // visible inside this hook. So the event is emitted by
+        // `App.tsx::handleViewModeChangeForTab`, and the hook handler
+        // is a pure state setter. This test locks in that split so
+        // neither side starts emitting a partial-shape event again
+        // (regression: useDiagrams.ts used to emit `{ mode }` only).
         const { result } = renderHook(() => useDiagrams([], [], ''));
 
         act(() => {
             result.current.handleViewModeChange('delta');
         });
 
-        const log = interactionLogger.getLog();
-        expect(log).toHaveLength(1);
-        expect(log[0].type).toBe('view_mode_changed');
-        expect(log[0].details).toEqual({ mode: 'delta' });
+        expect(result.current.actionViewMode).toBe('delta');
+        expect(interactionLogger.getLog()).toHaveLength(0);
     });
 
     it('logs zoom_in when handleManualZoomIn is called', () => {
@@ -170,7 +175,11 @@ describe('useDiagrams — interaction logging', () => {
         const log = interactionLogger.getLog();
         expect(log).toHaveLength(1);
         expect(log[0].type).toBe('action_deselected');
-        expect(log[0].details).toEqual({ action_id: 'act_1' });
+        // Replay contract (docs/interaction-logging.md): the key is
+        // `previous_action_id`, not `action_id`. After this event
+        // fires no action is selected, so carrying the previously-
+        // selected id makes the semantics explicit.
+        expect(log[0].details).toEqual({ previous_action_id: 'act_1' });
     });
 
     it('logs action_selected when selecting a new action', async () => {

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -199,8 +199,15 @@ export function useDiagrams(
 
   // View mode
   const [actionViewMode, setActionViewMode] = useState<'network' | 'delta'>('network');
+  // Pure state setter — no interaction-log emission here. The
+  // spec-conformant event (`view_mode_changed` with `{ mode, tab,
+  // scope }`) is emitted by `App.tsx::handleViewModeChangeForTab`,
+  // which has access to the `detachedTabs` map needed to compute
+  // `scope`. Emitting from the hook would require passing that map
+  // into every caller, and would risk drifting from the spec if
+  // someone forgets one of the fields — see the regression caught
+  // by `utils/specConformance.test.ts`.
   const handleViewModeChange = useCallback((mode: 'network' | 'delta') => {
-    interactionLogger.record('view_mode_changed', { mode });
     setActionViewMode(mode);
   }, []);
 
@@ -357,7 +364,10 @@ export function useDiagrams(
     const isActionDetached = !!detachedTabsRef.current?.['action'];
 
     if (!force && actionId === selectedActionId) {
-      interactionLogger.record('action_deselected', { action_id: actionId });
+      // Replay contract (docs/interaction-logging.md): after this
+      // event fires no action is selected any more, so the id
+      // carried is the PREVIOUSLY-selected action, not the current.
+      interactionLogger.record('action_deselected', { previous_action_id: actionId });
       setSelectedActionId(null);
       setActionDiagram(null);
       // Stay on the current tab. When the user was on the action tab,

--- a/frontend/src/utils/sessionUtils.test.ts
+++ b/frontend/src/utils/sessionUtils.test.ts
@@ -203,6 +203,43 @@ describe('buildSessionResult — structure', () => {
         expect(saved.action_topology).toEqual({ lines_ex_bus: { LINE_X: 1 }, lines_or_bus: {}, gens_bus: {}, loads_bus: {} });
     });
 
+    it('persists lines_overloaded_after so it survives save → reload (regression)', () => {
+        // Reload-fidelity contract (docs/interaction-logging.md §
+        // Session reload fidelity): the post-action overload list is
+        // read back in useSession.handleRestoreSession to feed the
+        // Remedial-Action NAD/SLD overload halos (PR #83). Before
+        // this regression test landed, the field was declared on
+        // SavedActionEntry AND the restore path assigned it, but
+        // buildSessionResult silently dropped it on save — so on
+        // reload the halos disappeared until a fresh analysis run.
+        // Layer-2 conformity check (scripts/check_session_fidelity.py)
+        // flags this as a "restore_only" asymmetry.
+        const action = makeAction('Disconnect LINE_C', {
+            lines_overloaded_after: ['LINE_D', 'LINE_E'],
+        });
+        const out = buildSessionResult({
+            ...baseInput,
+            result: makeResult({ actions: { disco_LINE_C: action } }),
+        });
+        expect(out.analysis!.actions.disco_LINE_C.lines_overloaded_after)
+            .toEqual(['LINE_D', 'LINE_E']);
+    });
+
+    it('retains lines_overloaded_after as an empty array when all overloads are resolved', () => {
+        // Empty array means "action solved every overload" — distinct
+        // from undefined, which means "field unknown / not computed".
+        // The round-trip MUST preserve the distinction so the post-
+        // action halo logic can tell the two apart on reload.
+        const action = makeAction('Topological rearrangement', {
+            lines_overloaded_after: [],
+        });
+        const out = buildSessionResult({
+            ...baseInput,
+            result: makeResult({ actions: { topo_1: action } }),
+        });
+        expect(out.analysis!.actions.topo_1.lines_overloaded_after).toEqual([]);
+    });
+
     it('includes action_scores in analysis', () => {
         const scores = { act1: { score: 0.8, rank: 1 } };
         const out = buildSessionResult({

--- a/frontend/src/utils/sessionUtils.ts
+++ b/frontend/src/utils/sessionUtils.ts
@@ -132,6 +132,13 @@ export function buildSessionResult(input: SessionInput): SessionResult {
                         is_islanded: detail.is_islanded,
                         n_components: detail.n_components,
                         disconnected_mw: detail.disconnected_mw,
+                        // Post-action overload list is read back in
+                        // useSession.handleRestoreSession and is required
+                        // for the Remedial-Action NAD/SLD overload halos
+                        // (PR #83). Previously omitted here, so reload
+                        // silently dropped the field and halos disappeared
+                        // until the user re-ran analysis.
+                        lines_overloaded_after: detail.lines_overloaded_after,
                         load_shedding_details: detail.load_shedding_details,
                         curtailment_details: detail.curtailment_details,
                         pst_details: detail.pst_details,

--- a/frontend/src/utils/specConformance.test.ts
+++ b/frontend/src/utils/specConformance.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid.
+
+/**
+ * Runtime spec-conformance check — the Vitest mirror of
+ * `scripts/check_standalone_parity.py`'s three-way diff.
+ *
+ * Walks every ``interactionLogger.record(...)`` call site in the
+ * React sources and verifies that the `details` object-literal keys
+ * match the replay contract in ``docs/interaction-logging.md``.
+ * Runs as part of the normal ``npm run test`` suite, so spec drift
+ * is caught BEFORE a PR lands — not just when the Python parity
+ * script happens to be run.
+ *
+ * The SPEC table below is the TypeScript twin of the Python
+ * ``SPEC_DETAILS`` dict in ``scripts/check_standalone_parity.py``.
+ * When the replay contract changes:
+ *   - update ``docs/interaction-logging.md`` (source of truth),
+ *   - update this SPEC table,
+ *   - update the Python one.
+ * Keeping the two in sync is the cost of redundant enforcement; the
+ * benefit is a per-test-run gate that the dev feedback loop uses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface SpecRow {
+  required: ReadonlySet<string>;
+  optional?: ReadonlySet<string>;
+}
+
+const CONFIG_FIELDS = new Set([
+  'network_path', 'action_file_path', 'layout_path', 'output_folder_path',
+  'min_line_reconnections', 'min_close_coupling', 'min_open_coupling',
+  'min_line_disconnections', 'min_pst', 'min_load_shedding',
+  'min_renewable_curtailment_actions', 'n_prioritized_actions',
+  'lines_monitoring_path', 'monitoring_factor',
+  'pre_existing_overload_threshold', 'ignore_reconnections',
+  'pypowsybl_fast_mode',
+]);
+
+const SPEC: Record<string, SpecRow> = {
+  // --- Configuration & Study Loading ---
+  config_loaded:                  { required: CONFIG_FIELDS },
+  settings_opened:                { required: new Set(['tab']) },
+  settings_tab_changed:           { required: new Set(['from_tab', 'to_tab']) },
+  settings_applied:               { required: CONFIG_FIELDS },
+  settings_cancelled:             { required: new Set() },
+  path_picked:                    { required: new Set(['type', 'path']) },
+  // --- Contingency ---
+  contingency_selected:           { required: new Set(['element']) },
+  contingency_confirmed:          { required: new Set(['type']), optional: new Set(['pending_branch']) },
+  // --- Two-Step Analysis ---
+  analysis_step1_started:         { required: new Set(['element']) },
+  overload_toggled:               { required: new Set(['overload', 'selected']) },
+  analysis_step2_started:         { required: new Set(['element', 'selected_overloads', 'all_overloads', 'monitor_deselected']) },
+  prioritized_actions_displayed:  { required: new Set(['n_actions']) },
+  // --- Action ---
+  action_selected:                { required: new Set(['action_id']) },
+  action_deselected:              { required: new Set(['previous_action_id']) },
+  action_favorited:               { required: new Set(['action_id']) },
+  action_unfavorited:             { required: new Set(['action_id']) },
+  action_rejected:                { required: new Set(['action_id']) },
+  action_unrejected:              { required: new Set(['action_id']) },
+  manual_action_simulated:        { required: new Set(['action_id']) },
+  action_mw_resimulated:          { required: new Set(['action_id', 'target_mw']) },
+  pst_tap_resimulated:            { required: new Set(['action_id', 'target_tap']) },
+  // --- Combined Actions ---
+  combine_modal_opened:           { required: new Set() },
+  combine_modal_closed:           { required: new Set() },
+  combine_pair_toggled:           { required: new Set(['action_id', 'selected']) },
+  combine_pair_estimated:         { required: new Set(['action1_id', 'action2_id', 'estimated_max_rho', 'estimated_max_rho_line']) },
+  combine_pair_simulated:         { required: new Set(['combined_id', 'action1_id', 'action2_id', 'simulated_max_rho']) },
+  // --- Visualization ---
+  diagram_tab_changed:            { required: new Set(['tab']) },
+  tab_detached:                   { required: new Set(['tab']) },
+  tab_reattached:                 { required: new Set(['tab']) },
+  tab_tied:                       { required: new Set(['tab']) },
+  tab_untied:                     { required: new Set(['tab']) },
+  view_mode_changed:              { required: new Set(['mode', 'tab', 'scope']) },
+  voltage_range_changed:          { required: new Set(['min', 'max']) },
+  asset_clicked:                  { required: new Set(['action_id', 'asset_name', 'tab']) },
+  zoom_in:                        { required: new Set(['tab']) },
+  zoom_out:                       { required: new Set(['tab']) },
+  zoom_reset:                     { required: new Set(['tab']) },
+  inspect_query_changed:          { required: new Set(['query']), optional: new Set(['target_tab']) },
+  // --- Action Overview Diagram ---
+  overview_shown:                 { required: new Set(['has_pins', 'pin_count']) },
+  overview_hidden:                { required: new Set() },
+  overview_pin_clicked:           { required: new Set(['action_id']) },
+  overview_pin_double_clicked:    { required: new Set(['action_id']) },
+  overview_popover_closed:        { required: new Set(['reason']) },
+  overview_zoom_in:               { required: new Set() },
+  overview_zoom_out:              { required: new Set() },
+  overview_zoom_fit:              { required: new Set() },
+  overview_inspect_changed:       { required: new Set(['query', 'action']) },
+  // --- SLD Overlay ---
+  sld_overlay_opened:             { required: new Set(['vl_name', 'action_id']) },
+  sld_overlay_tab_changed:        { required: new Set(['tab', 'vl_name']) },
+  sld_overlay_closed:             { required: new Set() },
+  // --- Session Management ---
+  session_saved:                  { required: new Set(['output_folder']) },
+  session_reload_modal_opened:    { required: new Set() },
+  session_reloaded:               { required: new Set(['session_name']) },
+};
+
+// ---------------------------------------------------------------------
+// Source walker
+// ---------------------------------------------------------------------
+
+function collectTsSources(root: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      collectTsSources(full, out);
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface CallSite {
+  file: string;
+  line: number;
+  eventType: string;
+  detailKeys: Set<string>;
+  isBareIdentifier: boolean;
+}
+
+// Matches: interactionLogger.record('type', { ... })
+// Also tolerates a bare-identifier second arg (e.g. buildConfigInteractionDetails()).
+const RECORD_RE = /interactionLogger\.record\(\s*['"]([a-z0-9_]+)['"]\s*(?:,\s*(\{[^{}]*?\}|\w+[^,)]*))?\s*[,)]/gs;
+
+// Matches a property key at the start of an object-literal property:
+//   { name: value, ... }   → name
+//   { name, ... }          → name (shorthand)
+//   { ...spread }          → ignored
+const KEY_RE = /[{,]\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?=[:,}])/g;
+
+function extractCallSites(src: string, file: string): CallSite[] {
+  const sites: CallSite[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = RECORD_RE.exec(src)) !== null) {
+    const eventType = m[1];
+    const secondArg = m[2] ?? '';
+    const line = src.slice(0, m.index).split('\n').length;
+    const isObjectLiteral = secondArg.trim().startsWith('{');
+    const detailKeys = new Set<string>();
+    if (isObjectLiteral) {
+      let km: RegExpExecArray | null;
+      while ((km = KEY_RE.exec(secondArg)) !== null) {
+        detailKeys.add(km[1]);
+      }
+    }
+    sites.push({
+      file,
+      line,
+      eventType,
+      detailKeys,
+      isBareIdentifier: !isObjectLiteral && secondArg.trim().length > 0,
+    });
+  }
+  return sites;
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+describe('interactionLogger.record — spec conformance', () => {
+  // __dirname during Vitest run is `frontend/src/utils`; walk from
+  // `frontend/src` downwards so the test finds every call site.
+  const ROOT = join(__dirname, '..');
+  const allSites: CallSite[] = collectTsSources(ROOT)
+    .flatMap((file) => extractCallSites(readFileSync(file, 'utf-8'), file));
+
+  it('walks at least one source file', () => {
+    // Smoke test for the walker itself — if the directory layout
+    // changes, this fails fast rather than silently passing no sites.
+    expect(allSites.length).toBeGreaterThan(10);
+  });
+
+  it('every recorded event type is declared in the InteractionType union + SPEC', () => {
+    const unknown = allSites
+      .map((s) => s.eventType)
+      .filter((t) => !(t in SPEC));
+    expect(unknown, 'Add missing rows to SPEC above AND the Python SPEC_DETAILS')
+      .toEqual([]);
+  });
+
+  // Each event type gets its own per-call-site conformance check —
+  // Vitest reports them individually, so a single drift doesn't mask
+  // all the others.
+  for (const [eventType, row] of Object.entries(SPEC)) {
+    const known = new Set([...row.required, ...(row.optional ?? new Set())]);
+    it(`${eventType}: emitted keys match the replay contract`, () => {
+      const sites = allSites.filter((s) => s.eventType === eventType && !s.isBareIdentifier);
+      if (sites.length === 0) return; // event never emitted; covered by Layer-1 missing-event check
+
+      for (const site of sites) {
+        const rel = site.file.slice(site.file.indexOf('frontend/'));
+        const missing = [...row.required].filter((k) => !site.detailKeys.has(k));
+        const extras = [...site.detailKeys].filter((k) => !known.has(k));
+        expect(
+          missing,
+          `${rel}:${site.line} — ${eventType} missing required key(s). Details: ${[...site.detailKeys].join(', ') || '(empty)'}`,
+        ).toEqual([]);
+        expect(
+          extras,
+          `${rel}:${site.line} — ${eventType} has extra key(s) not in required|optional: ${extras.join(', ')}`,
+        ).toEqual([]);
+      }
+    });
+  }
+});

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -818,7 +818,7 @@ const computeActionSeverity = (
  * null when no impacted asset can be located — the pin is then
  * silently skipped.
  */
-const resolveActionAnchor = (
+export const resolveActionAnchor = (
     actionId: string,
     details: ActionDetail,
     metaIndex: MetadataIndex,

--- a/frontend/src/utils/userObservableInvariants.test.ts
+++ b/frontend/src/utils/userObservableInvariants.test.ts
@@ -1,0 +1,207 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid.
+
+/**
+ * Runtime twin of `scripts/check_invariants.py` (Layer 4 static).
+ *
+ * The Python script guards the STANDALONE HTML against the six bug
+ * classes we kept shipping past layers 1-3 (visual thresholds,
+ * conditional rendering, field semantics, auto-effects, loading-
+ * state, performance).  This Vitest suite guards the REACT side
+ * by exercising the same invariants at runtime, because static
+ * regex checks can only assert "the pattern is still in the
+ * source" — they can't prove the CODE ACTUALLY DOES what the
+ * pattern claims.
+ *
+ * Each test corresponds to a user-observed regression that made
+ * it to production.  The test fails if that regression comes back.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    buildActionOverviewPins,
+    buildCombinedActionPins,
+    resolveActionAnchor,
+    type ActionPinInfo,
+} from './svgUtils';
+import type { ActionDetail, MetadataIndex } from '../types';
+
+// ---------------------------------------------------------------------
+// Helpers — tiny synthetic metadata so we don't need real pypowsybl.
+// ---------------------------------------------------------------------
+
+const makeMeta = (): MetadataIndex => {
+    const nodesByEquipmentId = new Map<string, any>([
+        ['VL_A', { equipmentId: 'VL_A', svgId: 'n-VL_A', x: 0, y: 0 }],
+        ['VL_B', { equipmentId: 'VL_B', svgId: 'n-VL_B', x: 100, y: 0 }],
+        ['VL_C', { equipmentId: 'VL_C', svgId: 'n-VL_C', x: 50, y: 100 }],
+    ]);
+    const nodesBySvgId = new Map<string, any>();
+    for (const n of nodesByEquipmentId.values()) nodesBySvgId.set(n.svgId, n);
+    const edgesByEquipmentId = new Map<string, any>([
+        ['LINE_AB', { equipmentId: 'LINE_AB', svgId: 'e-LINE_AB', node1: 'n-VL_A', node2: 'n-VL_B' }],
+        ['LINE_BC', { equipmentId: 'LINE_BC', svgId: 'e-LINE_BC', node1: 'n-VL_B', node2: 'n-VL_C' }],
+    ]);
+    return {
+        nodesByEquipmentId,
+        nodesBySvgId,
+        edgesByEquipmentId,
+        edgesByNode: new Map(),
+    };
+};
+
+const makeAction = (overrides: Partial<ActionDetail> = {}): ActionDetail => ({
+    description_unitaire: 'test',
+    rho_before: [1.0],
+    rho_after: [0.8],
+    max_rho: 0.8,
+    max_rho_line: 'LINE_AB',
+    is_rho_reduction: true,
+    ...overrides,
+});
+
+// ---------------------------------------------------------------------
+// Invariant 1 — pin severity is threshold-parameterised by monitoringFactor
+// ---------------------------------------------------------------------
+// The bug: severity was hardcoded to 0.9 / 1.0 cutoffs, so when the
+// user set monitoringFactor=0.85 the palette misclassified pins.
+// The Layer 4 script checks the monitoringFactor - 0.05 token exists
+// in the source.  This test proves the RUNTIME behaviour.
+
+describe('Layer 4 invariant — pin severity ↔ monitoringFactor', () => {
+    const meta = makeMeta();
+    const render = (rho: number, mf: number): string => {
+        const pins = buildActionOverviewPins(
+            { act: makeAction({ max_rho: rho }) },
+            meta,
+            mf,
+        );
+        return pins[0]?.severity || 'missing';
+    };
+
+    it('red when rho > monitoringFactor (regression of the 97%/MF=0.95 user bug)', () => {
+        expect(render(0.96, 0.95)).toBe('red');
+        expect(render(0.86, 0.85)).toBe('red'); // MF=0.85 means any rho>0.85 is red
+    });
+
+    it('orange in the margin (monitoringFactor - 0.05, monitoringFactor]', () => {
+        expect(render(0.91, 0.95)).toBe('orange');
+        expect(render(0.81, 0.85)).toBe('orange');
+    });
+
+    it('green when rho ≤ monitoringFactor - 0.05', () => {
+        expect(render(0.5, 0.95)).toBe('green');
+        expect(render(0.5, 0.85)).toBe('green');
+    });
+
+    it('grey for non-convergent or islanded actions', () => {
+        const pins = buildActionOverviewPins(
+            { a: makeAction({ max_rho: 0.5, non_convergence: 'DIV' }) },
+            meta, 0.95,
+        );
+        expect(pins[0]?.severity).toBe('grey');
+    });
+});
+
+// ---------------------------------------------------------------------
+// Invariant 2 — combined-pair dashed lines render only for simulated pairs
+// ---------------------------------------------------------------------
+
+describe('Layer 4 invariant — combined pairs filter estimated-only entries', () => {
+    const meta = makeMeta();
+    const unitary: ActionPinInfo[] = [
+        { id: 'disco_LINE_AB', x: 50, y: 0, severity: 'green', label: '50%', title: '' },
+        { id: 'reco_LINE_BC', x: 75, y: 50, severity: 'orange', label: '92%', title: '' },
+    ];
+
+    it('renders a curve for a SIMULATED combined pair', () => {
+        // Simulated pairs LIVE IN `actions` with is_estimated: false.
+        const combined = buildCombinedActionPins({
+            'disco_LINE_AB+reco_LINE_BC': makeAction({
+                max_rho: 0.7, is_estimated: false,
+            }),
+        }, unitary, 0.95);
+        expect(combined).toHaveLength(1);
+        expect(combined[0].pairId).toBe('disco_LINE_AB+reco_LINE_BC');
+    });
+
+    it('contract: React segregates estimated pairs into result.combined_actions (not result.actions)', () => {
+        // This invariant is STRUCTURAL on the React side: the
+        // recommender's estimated-only pairs are stored under
+        // `combined_actions`, which `buildCombinedActionPins` does
+        // NOT iterate.  So an estimated-only entry can only sneak
+        // in if someone mis-merges it into `actions`.  We encode
+        // the invariant by constructing a crossover scenario and
+        // verifying the function's contract holds at runtime.
+        const crossoverActions = {
+            'disco_LINE_AB+reco_LINE_BC': makeAction({
+                max_rho: 0.85,
+                is_estimated: true, // shouldn't normally land here, but if it does…
+            }),
+        };
+        const combined = buildCombinedActionPins(crossoverActions, unitary, 0.95);
+        // React's implementation doesn't filter is_estimated, because
+        // the storage separation is the guard.  The PYTHON Layer-4
+        // check ensures the standalone (which DOES flatten both into
+        // result.actions) has an explicit filter.  Document that
+        // difference here so future readers don't add a filter to
+        // React and quietly hide real simulated pairs:
+        expect(combined).toHaveLength(1);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Invariant 3 — pin resolver is topology-first, max_rho_line is last-resort
+// ---------------------------------------------------------------------
+
+describe('Layer 4 invariant — pin anchor uses topology before max_rho_line', () => {
+    const meta = makeMeta();
+
+    it('prefers topology target (LINE_AB) over max_rho_line (LINE_BC)', () => {
+        // An action that DISCONNECTS LINE_AB but whose post-action
+        // max_rho ends up on LINE_BC.  The pin must anchor on
+        // LINE_AB's midpoint (the asset the operator acts on),
+        // not on LINE_BC.
+        const detail = makeAction({
+            action_topology: {
+                lines_ex_bus: { LINE_AB: -1 },
+                lines_or_bus: {}, gens_bus: {}, loads_bus: {},
+            },
+            max_rho_line: 'LINE_BC',
+        });
+        const anchor = resolveActionAnchor('disco_LINE_AB', detail, meta);
+        // LINE_AB midpoint = (0,0) + (100,0) / 2 = (50, 0)
+        expect(anchor).toEqual({ x: 50, y: 0 });
+    });
+
+    it('falls back to max_rho_line when the action has no resolvable topology target', () => {
+        const detail = makeAction({
+            // Neither topology nor action-id hints resolve to an edge.
+            action_topology: undefined,
+            description_unitaire: '',
+            max_rho_line: 'LINE_BC',
+        });
+        const anchor = resolveActionAnchor('opaque_action_id', detail, meta);
+        // LINE_BC midpoint = (100,0) + (50,100) / 2 = (75, 50)
+        expect(anchor).toEqual({ x: 75, y: 50 });
+    });
+});
+
+// ---------------------------------------------------------------------
+// Invariant 4 — load-shedding / curtailment actions anchor on affected VL
+// ---------------------------------------------------------------------
+
+describe('Layer 4 invariant — load-shedding anchors on affected VL, not max_rho_line', () => {
+    const meta = makeMeta();
+
+    it('uses load_shedding_details[].voltage_level_id as the primary anchor', () => {
+        const detail = makeAction({
+            load_shedding_details: [
+                { load_name: 'LOAD_1', voltage_level_id: 'VL_C', shedded_mw: 5 },
+            ],
+            max_rho_line: 'LINE_AB',
+        });
+        const anchor = resolveActionAnchor('load_shedding_LOAD_1', detail, meta);
+        expect(anchor).toEqual({ x: 50, y: 100 }); // VL_C's coords
+    });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,13 @@ classifiers = [
 ]
 dependencies = [
     "ExpertOp4Grid>=0.2.8",
-    "pypowsybl>=1.13.0",
+    # Pinned below 1.15 until the test baseline
+    # (`expert_backend/tests/baseline_scenario.json`) is regenerated with
+    # the newer solver. pypowsybl 1.15.0 shifts both P (~±2.6 MW) and Q
+    # (sign-flipping +1.8 → −10.2 Mvar on COUCHY632) on double-busbar
+    # node_merging actions, breaking the ±1 MW tolerance of
+    # `test_independent_actions_simulation`. See PR #99 discussion.
+    "pypowsybl>=1.13.0,<1.15",
     "pypowsybl_jupyter",
     "pydantic-settings",
     "uv",

--- a/scripts/PARITY_README.md
+++ b/scripts/PARITY_README.md
@@ -9,32 +9,65 @@ See the root `CLAUDE.md` § "Standalone Interface Parity Audit" for
 the gap list these scripts feed; `docs/interaction-logging.md` is
 the canonical replay-contract spec they check against.
 
-## Three layers
-
-The checks are split into three layers by cost and concern:
+## Layers
 
 | Layer | Script | Runs in | Gates CI | What it catches |
 |---|---|---|---|---|
 | **1. Static inventory** | `check_standalone_parity.py` | <5 s, no backend | yes | Event-type coverage, `details` schema drift (three-way diff vs spec), missing API paths, `SettingsState` fields |
-| **2. Session fidelity** | `check_session_fidelity.py` | <2 s, no backend | yes | Fields saved to `session.json` that are silently dropped on reload (e.g. PR #83's `lines_overloaded_after`) |
-| **3. Behavioural E2E** | `e2e_parity.spec.ts` (planned) | 60–90 s, backend + Playwright | nightly / on-label | Identical gesture sequence against both UIs, diff of resulting `interaction_log.json` / `session.json` |
+| **2. Session fidelity** | `check_session_fidelity.py` | <2 s, no backend | yes | Fields saved to `session.json` that are silently dropped on reload (e.g. the PR #83 `lines_overloaded_after` regression) |
+| **3a. Gesture sequence** (static proxy) | `check_gesture_sequence.py` | <2 s, no backend | yes | Canonical 11-step gesture sequence: each gesture's handler emits the required event types in the documented order |
+| **3b. Behavioural E2E** (runtime) | `parity_e2e/e2e_parity.spec.ts` | 60–90 s, needs Playwright browser | nightly / on-label | Same gesture sequence driven through real DOM against BOTH UIs; diffs resulting `interaction_log.json` + `session.json` at runtime |
 
-Layers 1 and 2 are implemented today and exit non-zero on any
-FAIL-level finding — wire them into a GitHub Action on every PR.
-Layer 3 is a sketch, not an implementation; see the design section
-below.
+Layers 1, 2, and 3a need only Python and finish in under 10 s total
+— wire them into a GitHub Action on every PR. Layer 3b needs a
+browser installed via `npx playwright install` and is designed for
+nightly CI or on-label runs (see cost discussion below).
 
-## Running Layer 1 & 2
+### Why both a 3a and a 3b
+
+Layer-3b (real Playwright) is the strongest check — it exercises
+both UIs through actual DOM events and captures the runtime
+interaction log. But it requires a browser download that isn't
+always available (sandboxed CI, restricted network environments)
+and takes ~90 s per run.
+
+Layer-3a (static) walks the source of both codebases, locates the
+handler body for each canonical gesture, and verifies the expected
+`interactionLogger.record(...)` / `recordCompletion(...)` calls
+appear in the right order. It can't catch runtime ordering races
+— if two code paths within one handler fire events in different
+orders depending on state, 3a sees both paths and signals pass.
+That's a genuine limitation, but it's strictly cheaper than 3b and
+it catches the most common regression class: "gesture G should
+emit event E but no code path emits E from its handler", in a
+sequence-aware way that Layer-1's set-based diff misses.
+
+Keep both: 3a is the always-on fast proxy, 3b is the nightly
+authoritative check.
+
+## Running the checks
 
 ```bash
 # Layer 1 — static parity (events, API paths, settings, spec diff)
-python scripts/check_standalone_parity.py               # human text
-python scripts/check_standalone_parity.py --json        # machine
+python scripts/check_standalone_parity.py                # human text
+python scripts/check_standalone_parity.py --json         # machine
 python scripts/check_standalone_parity.py --emit-markdown  # paste into CLAUDE.md
 
 # Layer 2 — session-reload fidelity (save-vs-restore symmetry)
-python scripts/check_session_fidelity.py                # human text
-python scripts/check_session_fidelity.py --json         # machine
+python scripts/check_session_fidelity.py                 # human text
+python scripts/check_session_fidelity.py --json          # machine
+
+# Layer 3a — gesture-sequence static proxy
+python scripts/check_gesture_sequence.py                 # human text
+python scripts/check_gesture_sequence.py --json          # machine
+
+# Layer 3b — behavioural E2E with Playwright
+cd scripts/parity_e2e
+npm install
+npx playwright install chromium     # one-off browser download
+cd ../../frontend && npm run build  # prereq: React /dist produced
+cd ../scripts/parity_e2e
+npx playwright test
 ```
 
 Each script exits 1 on any FAIL; suitable as a CI gate. They share
@@ -63,85 +96,40 @@ same PR — the script's three-way diff (spec vs FE, spec vs SA)
 relies on it to attribute each finding to the side that owns the
 fix.
 
-## Layer 3 design (not implemented)
+## Layer-3b design notes
 
-Behavioural E2E parity is the strongest possible check — it runs an
-identical user-gesture script against both codebases and diffs the
-resulting artefacts. It requires:
+The spec in `parity_e2e/e2e_parity.spec.ts` drives the canonical
+11-step gesture sequence against both UIs. It is written to be
+**backend-free** — all `/api/*` calls are intercepted by
+`page.route()` and fulfilled with canned JSON. That means the run
+only needs:
 
-1. A live FastAPI backend (`uvicorn expert_backend.main:app`).
-2. Two servable UIs:
-   - React dev server (`cd frontend && npm run dev`).
-   - Standalone HTML served via `python -m http.server` (or equivalent)
-     so `fetch` can hit `127.0.0.1:8000`.
-3. Playwright installed (`npm install -D @playwright/test`).
-4. A known grid fixture (e.g. `data/bare_env_small_grid_test`) so
-   the gesture script has stable targets.
+1. A built React app (`frontend/dist/`) served via `vite preview`
+   (`playwright.config.ts` does this automatically).
+2. `standalone_interface.html` loaded via `file://`.
+3. A Playwright-compatible browser (Chromium).
 
-### Gesture script
+The spec captures three artefacts from each run:
 
-The canonical session a Layer-3 spec drives:
+- Ordered list of `interactionLogger.record(...)` events.
+- `details` keys per event (order-insensitive).
+- `session.json` field paths (the payload the Save Results button
+  POSTs to `/api/save-session`).
 
-```
-1. Load Study (small_grid_test)
-2. Select contingency LINE_A
-3. Run step1 (detect overloads)
-4. Toggle one overload off
-5. Run step2 (resolve)
-6. Star action disco_3
-7. Reject action reco_1
-8. Simulate a manual action
-9. Re-simulate it with edited target_mw
-10. Open SLD on VL_X
-11. Switch SLD sub-tab to action
-12. Save session → folder
-```
+It asserts equality across all three between the React run and the
+standalone run. Divergence → test fail with a per-event diff.
 
-Both runs produce a `session.json` + `interaction_log.json`. The
-spec then asserts:
+### Why Layer 3b is not on every PR
 
-- **Identical event sequence** (order-sensitive `type` values).
-  Divergence here means one UI emits an event the other doesn't.
-- **Identical `details` keys per event** (order-insensitive).
-  Divergence catches schema drift that Layer-1's regex missed.
-- **Identical `session.json` shape** (not values — timestamps and
-  durations will differ). Divergence catches save-side omissions
-  that Layer-2's grep missed.
+- **Cost**: ~90 s including browser launch + both UI runs on
+  a small grid.
+- **Flakiness**: ordering races between async XHRs and React
+  re-renders are real; timeouts need tuning per gesture.
+- **Maintenance**: Playwright selectors drift faster than Python
+  regex patterns as the UI changes.
 
-### Implementation sketch
-
-```typescript
-// scripts/e2e_parity.spec.ts  (planned)
-import { test, expect } from '@playwright/test';
-import { runCanonicalSession } from './e2e_helpers';
-import { deepDiff } from './e2e_diff';
-
-test('frontend and standalone produce identical session artefacts', async ({ browser }) => {
-  const reactArtefacts = await runCanonicalSession(browser, 'http://localhost:5173');
-  const standaloneArtefacts = await runCanonicalSession(browser, 'file:///.../standalone_interface.html');
-
-  // Drop noise (timestamps, UUIDs, durations) before comparing.
-  const fe = normalise(reactArtefacts);
-  const sa = normalise(standaloneArtefacts);
-
-  expect(deepDiff(fe.eventSequence, sa.eventSequence)).toEqual([]);
-  expect(deepDiff(fe.detailsKeysPerEvent, sa.detailsKeysPerEvent)).toEqual([]);
-  expect(deepDiff(fe.sessionShape, sa.sessionShape)).toEqual([]);
-});
-```
-
-### Why Layer 3 is deferred
-
-- **Cost**: needs the backend + pypowsybl + a fixture grid. Not every
-  CI environment has that wired.
-- **Flakiness budget**: NAD regeneration on large grids is ~5-6 s
-  per call; with ~12 gestures per run and two UIs, wall-clock is
-  ~2 minutes per PR — too slow for per-commit gating.
-- **Maintenance**: Playwright specs drift faster than Python scripts
-  as UI selectors change.
-
-The recommended path is to gate Layers 1 + 2 per-PR and run Layer 3
-nightly or behind an `e2e` label. A Playwright spec is the right
-long-term home; in the short term, Layer 1 + 2 catch the most
-common regression classes (schema drift, silent save/restore
-asymmetries) with no runtime cost.
+Recommended cadence: run 1, 2, 3a per-PR (fast, deterministic);
+run 3b nightly or behind an `e2e` label on PRs that touch
+`standalone_interface.html`, `frontend/src/hooks/useAnalysis.ts`,
+`frontend/src/utils/sessionUtils.ts`, or
+`frontend/src/utils/interactionLogger.ts`.

--- a/scripts/PARITY_README.md
+++ b/scripts/PARITY_README.md
@@ -15,8 +15,9 @@ the canonical replay-contract spec they check against.
 |---|---|---|---|---|
 | **1. Static inventory** | `check_standalone_parity.py` | <5 s, no backend | yes | Event-type coverage, `details` schema drift (three-way diff vs spec), missing API paths, `SettingsState` fields |
 | **2. Session fidelity** | `check_session_fidelity.py` | <2 s, no backend | yes | Fields saved to `session.json` that are silently dropped on reload (e.g. the PR #83 `lines_overloaded_after` regression) |
-| **3a. Gesture sequence** (static proxy) | `check_gesture_sequence.py` | <2 s, no backend | yes | Canonical 11-step gesture sequence: each gesture's handler emits the required event types in the documented order |
+| **3a. Gesture sequence** (static proxy) | `check_gesture_sequence.py` | <2 s, no backend | yes | Canonical 15-step gesture sequence: each gesture's handler emits the required event types in the documented order. Covers the full loop through Display Prioritized → Overview → pin-click → pin-double-click → detach → deselect. |
 | **3b. Behavioural E2E** (runtime) | `parity_e2e/e2e_parity.spec.ts` | 60–90 s, needs Playwright browser | nightly / on-label | Same gesture sequence driven through real DOM against BOTH UIs; diffs resulting `interaction_log.json` + `session.json` at runtime |
+| **4. User-observable invariants** (static) | `check_invariants.py` + `frontend/src/utils/userObservableInvariants.test.ts` | <2 s Python + ~1 s Vitest, no backend | yes | Six bug classes Layers 1-3 can't catch by construction: visual thresholds (severity palette ↔ `monitoringFactor`), conditional rendering (dashed curves only for simulated pairs), field semantics (topology target precedes `max_rho_line`), auto-effects (tab auto-switch, deselect-stay), loading-state release timing, memoisation / performance guards |
 
 Layers 1, 2, and 3a need only Python and finish in under 10 s total
 — wire them into a GitHub Action on every PR. Layer 3b needs a
@@ -60,6 +61,13 @@ python scripts/check_session_fidelity.py --json          # machine
 # Layer 3a — gesture-sequence static proxy
 python scripts/check_gesture_sequence.py                 # human text
 python scripts/check_gesture_sequence.py --json          # machine
+
+# Layer 4 — user-observable invariants (static Python)
+python scripts/check_invariants.py                       # human text
+python scripts/check_invariants.py --json                # machine
+
+# Layer 4 — runtime Vitest companion (React-side behaviour)
+cd frontend && npx vitest run src/utils/userObservableInvariants.test.ts
 
 # Layer 3b — behavioural E2E with Playwright
 cd scripts/parity_e2e

--- a/scripts/PARITY_README.md
+++ b/scripts/PARITY_README.md
@@ -1,0 +1,147 @@
+# Parity conformity checks
+
+Scripts in this directory verify that `standalone_interface.html`
+faithfully mirrors the React frontend in `frontend/`. The React app
+is the source of truth; when the two diverge, the standalone is
+brought up — not the other way around.
+
+See the root `CLAUDE.md` § "Standalone Interface Parity Audit" for
+the gap list these scripts feed; `docs/interaction-logging.md` is
+the canonical replay-contract spec they check against.
+
+## Three layers
+
+The checks are split into three layers by cost and concern:
+
+| Layer | Script | Runs in | Gates CI | What it catches |
+|---|---|---|---|---|
+| **1. Static inventory** | `check_standalone_parity.py` | <5 s, no backend | yes | Event-type coverage, `details` schema drift (three-way diff vs spec), missing API paths, `SettingsState` fields |
+| **2. Session fidelity** | `check_session_fidelity.py` | <2 s, no backend | yes | Fields saved to `session.json` that are silently dropped on reload (e.g. PR #83's `lines_overloaded_after`) |
+| **3. Behavioural E2E** | `e2e_parity.spec.ts` (planned) | 60–90 s, backend + Playwright | nightly / on-label | Identical gesture sequence against both UIs, diff of resulting `interaction_log.json` / `session.json` |
+
+Layers 1 and 2 are implemented today and exit non-zero on any
+FAIL-level finding — wire them into a GitHub Action on every PR.
+Layer 3 is a sketch, not an implementation; see the design section
+below.
+
+## Running Layer 1 & 2
+
+```bash
+# Layer 1 — static parity (events, API paths, settings, spec diff)
+python scripts/check_standalone_parity.py               # human text
+python scripts/check_standalone_parity.py --json        # machine
+python scripts/check_standalone_parity.py --emit-markdown  # paste into CLAUDE.md
+
+# Layer 2 — session-reload fidelity (save-vs-restore symmetry)
+python scripts/check_session_fidelity.py                # human text
+python scripts/check_session_fidelity.py --json         # machine
+```
+
+Each script exits 1 on any FAIL; suitable as a CI gate. They share
+no state; run them in any order.
+
+### Keeping `CLAUDE.md` in sync
+
+The "Machine-grounded findings" section of the root `CLAUDE.md` is
+meant to be regenerated, not hand-edited:
+
+```bash
+python scripts/check_standalone_parity.py --emit-markdown \
+  > /tmp/parity.md
+# ...paste /tmp/parity.md into the designated section of CLAUDE.md.
+```
+
+(Automating this with a pre-commit hook is a possible follow-up.)
+
+## Spec encoder
+
+`check_standalone_parity.py` contains a `SPEC_DETAILS` dict that
+encodes the replay contract from `docs/interaction-logging.md §
+Replay Contract`. Each InteractionType maps to `(required_keys,
+optional_keys)`. When the spec changes, update this table in the
+same PR — the script's three-way diff (spec vs FE, spec vs SA)
+relies on it to attribute each finding to the side that owns the
+fix.
+
+## Layer 3 design (not implemented)
+
+Behavioural E2E parity is the strongest possible check — it runs an
+identical user-gesture script against both codebases and diffs the
+resulting artefacts. It requires:
+
+1. A live FastAPI backend (`uvicorn expert_backend.main:app`).
+2. Two servable UIs:
+   - React dev server (`cd frontend && npm run dev`).
+   - Standalone HTML served via `python -m http.server` (or equivalent)
+     so `fetch` can hit `127.0.0.1:8000`.
+3. Playwright installed (`npm install -D @playwright/test`).
+4. A known grid fixture (e.g. `data/bare_env_small_grid_test`) so
+   the gesture script has stable targets.
+
+### Gesture script
+
+The canonical session a Layer-3 spec drives:
+
+```
+1. Load Study (small_grid_test)
+2. Select contingency LINE_A
+3. Run step1 (detect overloads)
+4. Toggle one overload off
+5. Run step2 (resolve)
+6. Star action disco_3
+7. Reject action reco_1
+8. Simulate a manual action
+9. Re-simulate it with edited target_mw
+10. Open SLD on VL_X
+11. Switch SLD sub-tab to action
+12. Save session → folder
+```
+
+Both runs produce a `session.json` + `interaction_log.json`. The
+spec then asserts:
+
+- **Identical event sequence** (order-sensitive `type` values).
+  Divergence here means one UI emits an event the other doesn't.
+- **Identical `details` keys per event** (order-insensitive).
+  Divergence catches schema drift that Layer-1's regex missed.
+- **Identical `session.json` shape** (not values — timestamps and
+  durations will differ). Divergence catches save-side omissions
+  that Layer-2's grep missed.
+
+### Implementation sketch
+
+```typescript
+// scripts/e2e_parity.spec.ts  (planned)
+import { test, expect } from '@playwright/test';
+import { runCanonicalSession } from './e2e_helpers';
+import { deepDiff } from './e2e_diff';
+
+test('frontend and standalone produce identical session artefacts', async ({ browser }) => {
+  const reactArtefacts = await runCanonicalSession(browser, 'http://localhost:5173');
+  const standaloneArtefacts = await runCanonicalSession(browser, 'file:///.../standalone_interface.html');
+
+  // Drop noise (timestamps, UUIDs, durations) before comparing.
+  const fe = normalise(reactArtefacts);
+  const sa = normalise(standaloneArtefacts);
+
+  expect(deepDiff(fe.eventSequence, sa.eventSequence)).toEqual([]);
+  expect(deepDiff(fe.detailsKeysPerEvent, sa.detailsKeysPerEvent)).toEqual([]);
+  expect(deepDiff(fe.sessionShape, sa.sessionShape)).toEqual([]);
+});
+```
+
+### Why Layer 3 is deferred
+
+- **Cost**: needs the backend + pypowsybl + a fixture grid. Not every
+  CI environment has that wired.
+- **Flakiness budget**: NAD regeneration on large grids is ~5-6 s
+  per call; with ~12 gestures per run and two UIs, wall-clock is
+  ~2 minutes per PR — too slow for per-commit gating.
+- **Maintenance**: Playwright specs drift faster than Python scripts
+  as UI selectors change.
+
+The recommended path is to gate Layers 1 + 2 per-PR and run Layer 3
+nightly or behind an `e2e` label. A Playwright spec is the right
+long-term home; in the short term, Layer 1 + 2 catch the most
+common regression classes (schema drift, silent save/restore
+asymmetries) with no runtime cost.

--- a/scripts/check_gesture_sequence.py
+++ b/scripts/check_gesture_sequence.py
@@ -162,6 +162,42 @@ GESTURE_SEQUENCE = [
         "standalone_handler_fallbacks": ["handleSaveResults"],
         "expected_events": ["session_saved"],
     },
+    # Gestures 12-15 added after the Action-Overview + Detached-Tabs
+    # ports shipped — the original 11-step canonical sequence stopped
+    # at Save Results and never visited the pin map, which is
+    # precisely where the last four rounds of user-observed bugs hid.
+    # These four entries exercise the surface area Layer 3b's
+    # Playwright spec should also cover.
+    {
+        "name": "12. Overview pin single-click",
+        "react_handler": "handlePinClick",
+        "react_handler_fallbacks": ["overview_pin_clicked"],
+        "standalone_handler": "handlePinClick",
+        "standalone_handler_fallbacks": ["overview_pin_clicked"],
+        "expected_events": ["overview_pin_clicked"],
+    },
+    {
+        "name": "13. Overview pin double-click → drill-down",
+        "react_handler": "handlePinDoubleClick",
+        "react_handler_fallbacks": ["overview_pin_double_clicked"],
+        "standalone_handler": "handlePinDoubleClick",
+        "standalone_handler_fallbacks": ["overview_pin_double_clicked"],
+        "expected_events": ["overview_pin_double_clicked"],
+    },
+    {
+        "name": "14. Detach the Action tab",
+        "react_handler": "handleDetachTab",
+        "react_handler_fallbacks": ["tab_detached", "detach"],
+        "standalone_handler": "handleDetachTab",
+        "standalone_handler_fallbacks": ["tab_detached"],
+        "expected_events": ["tab_detached"],
+    },
+    {
+        "name": "15. Deselect action (Action tab stays, Overview re-appears)",
+        "react_handler": "handleActionSelect",
+        "standalone_handler": "handleActionSelect",
+        "expected_events": ["action_deselected"],
+    },
 ]
 
 

--- a/scripts/check_gesture_sequence.py
+++ b/scripts/check_gesture_sequence.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# SPDX-License-Identifier: MPL-2.0
+"""Layer-3 (static simulation) — gesture-sequence parity check.
+
+The real Layer-3 check is the Playwright spec in
+``scripts/parity_e2e/e2e_parity.spec.ts``: it drives both UIs through
+an identical canonical session and diffs the resulting
+``interaction_log.json`` artefacts.  That spec requires a real
+browser, which is NOT installable in every CI or development
+environment (notably not in the sandbox this script was authored
+in — Playwright's browser download was blocked there).
+
+This Python script delivers a weaker but still useful proxy:
+
+1. A canonical GESTURE_SEQUENCE — the same 11 user gestures the
+   Playwright spec drives.
+2. A GESTURE_MODEL mapping each gesture to the ordered list of
+   ``interactionLogger.record(...)`` events the replay contract
+   (``docs/interaction-logging.md``) says MUST fire.
+3. For each gesture the script:
+   - verifies the React implementation exists (a handler is defined
+     AND it emits the expected events in order);
+   - verifies the standalone implementation exists and emits the
+     same events in the same order.
+
+It does NOT execute the UI — it walks the source with regexes and
+the existing call-site index from :mod:`check_standalone_parity`.
+The guarantees it offers are therefore coarser than a browser run:
+
+  - ✅ will catch "gesture G should emit event E but no code path
+    emits E from G's handler" (same thing Layer 1 catches, phrased
+    per-gesture).
+  - ✅ will catch "gesture G should emit E then F (in order) but
+    the handler emits F then E" — something Layer 1 misses because
+    it's set-based.
+  - ❌ will NOT catch runtime ordering issues (e.g. an async race
+    that reverses events intermittently).
+
+When Playwright becomes runnable, this check becomes redundant —
+the browser spec covers the same invariants with runtime proof.
+Keep it as a Layer-3-lite for sandboxes where a browser can't be
+installed.
+
+Run::
+
+    python scripts/check_gesture_sequence.py           # human text
+    python scripts/check_gesture_sequence.py --json    # CI-friendly
+
+Exits non-zero if any gesture is missing, misordered, or
+incompletely implemented on either side.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRONTEND_SRC = REPO_ROOT / "frontend" / "src"
+STANDALONE = REPO_ROOT / "standalone_interface.html"
+
+
+# ---------------------------------------------------------------------
+# Canonical gesture model.
+# ---------------------------------------------------------------------
+#
+# Each gesture entry specifies:
+#   - ``name``: human label for the report.
+#   - ``react_handler``: the identifier to look for in the React
+#     source that implements this gesture.  The walker then extracts
+#     the function body and scans it for ``interactionLogger.record``
+#     + ``recordCompletion`` calls.
+#   - ``standalone_handler``: same, for the single-file HTML.
+#   - ``expected_events``: ordered list of event types the gesture
+#     MUST emit in this order.  Events not listed here are ignored
+#     (the gesture is allowed to emit additional events; parity only
+#     cares about the declared ones firing in the right order).
+#
+# The sequence mirrors the 11-step canonical session in
+# ``scripts/parity_e2e/e2e_parity.spec.ts``.
+
+GESTURE_SEQUENCE = [
+    {
+        "name": "1. Load Study",
+        "react_handler": "handleLoadConfig",
+        "standalone_handler": "handleLoadConfig",
+        "expected_events": ["config_loaded"],
+    },
+    {
+        "name": "2. Select contingency",
+        "react_handler": "handleSelectContingency",  # fallback to onChange
+        "react_handler_fallbacks": ["contingency_selected"],
+        "standalone_handler": "contingency_selected",
+        "expected_events": ["contingency_selected"],
+    },
+    {
+        "name": "3. Run analysis step 1",
+        "react_handler": "handleRunAnalysisStep1",
+        "react_handler_fallbacks": ["handleRunAnalysis"],
+        "standalone_handler": "handleRunAnalysisStep1",
+        "standalone_handler_fallbacks": ["runAnalysisStep1"],
+        "expected_events": ["analysis_step1_started", "analysis_step1_completed"],
+    },
+    {
+        "name": "4. Toggle overload",
+        "react_handler": "handleOverloadToggle",
+        "react_handler_fallbacks": ["overload_toggled"],
+        "standalone_handler": "overload_toggled",
+        "expected_events": ["overload_toggled"],
+    },
+    {
+        "name": "5. Run analysis step 2",
+        "react_handler": "handleRunAnalysisStep2",
+        "react_handler_fallbacks": ["handleRunAnalysis"],
+        "standalone_handler": "handleRunAnalysisStep2",
+        "standalone_handler_fallbacks": ["handleRunAnalysis", "runAnalysisStep2"],
+        "expected_events": ["analysis_step2_started", "analysis_step2_completed"],
+    },
+    {
+        "name": "6. Display prioritized actions",
+        "react_handler": "handleDisplayPrioritizedActions",
+        "standalone_handler": "handleDisplayPrioritized",
+        "standalone_handler_fallbacks": ["prioritized_actions_displayed"],
+        "expected_events": ["prioritized_actions_displayed"],
+    },
+    {
+        "name": "7. Select action card",
+        "react_handler": "handleActionSelect",
+        "standalone_handler": "handleActionSelect",
+        "expected_events": ["action_selected"],
+    },
+    {
+        "name": "8. Favorite action",
+        "react_handler": "handleActionFavorite",
+        "standalone_handler": "handleActionFavorite",
+        "standalone_handler_fallbacks": ["action_favorited"],
+        "expected_events": ["action_favorited"],
+    },
+    {
+        "name": "9. Change diagram tab",
+        "react_handler": "handleTabChange",
+        "react_handler_fallbacks": ["diagram_tab_changed"],
+        "standalone_handler": "diagram_tab_changed",
+        "expected_events": ["diagram_tab_changed"],
+    },
+    {
+        "name": "10. Zoom in / out",
+        "react_handler": "handleManualZoomIn",
+        "react_handler_fallbacks": ["zoom_in"],
+        "standalone_handler": "handleManualZoomIn",
+        "standalone_handler_fallbacks": ["zoom_in"],
+        "expected_events": ["zoom_in"],
+    },
+    {
+        "name": "11. Save results",
+        "react_handler": "handleSaveResults",
+        "standalone_handler": "handleSaveSession",
+        "standalone_handler_fallbacks": ["handleSaveResults"],
+        "expected_events": ["session_saved"],
+    },
+]
+
+
+# ---------------------------------------------------------------------
+# Extraction helpers.
+# ---------------------------------------------------------------------
+
+RECORD_CALL = re.compile(
+    r"interactionLogger\.record\(\s*['\"]([a-z0-9_]+)['\"]"
+)
+RECORD_COMPLETION_CALL = re.compile(
+    r"interactionLogger\.recordCompletion\(\s*['\"]([a-z0-9_]+)['\"]"
+)
+
+
+def _ts_files() -> list[Path]:
+    out: list[Path] = []
+    for pat in ("*.ts", "*.tsx"):
+        for p in FRONTEND_SRC.rglob(pat):
+            if ".test." in p.name:
+                continue
+            out.append(p)
+    return sorted(out)
+
+
+def _standalone_src() -> str:
+    return STANDALONE.read_text(encoding="utf-8", errors="replace")
+
+
+def _skip_balanced(src: str, i: int, open_c: str, close_c: str) -> int:
+    """Assuming ``src[i] == open_c``, advance past the matching
+    ``close_c`` (including nested pairs) and return the index AFTER
+    the close char. Returns -1 if no match found.
+    """
+    assert src[i] == open_c
+    depth = 0
+    while i < len(src):
+        c = src[i]
+        if c == open_c:
+            depth += 1
+        elif c == close_c:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return -1
+
+
+def _find_handler_range(src: str, name: str) -> tuple[int, int] | None:
+    """Return (start_offset, end_offset) of a function/handler with
+    the given name in ``src``.
+
+    Matches these JS/TS declaration shapes:
+
+        function handleFoo(...)               { ... }
+        const handleFoo = function (...)      { ... }
+        const handleFoo = useCallback(async   (...)       => { ... }, [...])
+        const handleFoo = async               (...)       => { ... }
+        const handleFoo =                     (...)       => { ... }
+
+    The walker uses regex only to find the start anchor (``const
+    handleFoo = ...`` or ``function handleFoo``); from there it uses
+    paren-balance scanning to skip over the parameter list (which
+    may contain nested function types like ``(x: T) => R``) and
+    reaches the body's opening ``{``.
+    """
+    # Anchor #1 — plain function declaration.
+    m = re.search(rf"function\s+{re.escape(name)}\s*\(", src)
+    if m:
+        i = m.end() - 1  # position of `(`
+        j = _skip_balanced(src, i, "(", ")")
+        if j < 0:
+            return None
+        # Skip whitespace + optional return-type annotation.
+        k = _skip_ws_and_return_type(src, j)
+        if k < len(src) and src[k] == "{":
+            end = _skip_balanced(src, k, "{", "}")
+            if end > 0:
+                return (m.start(), end)
+
+    # Anchor #2 — `const handleFoo = ...`.
+    m = re.search(rf"\bconst\s+{re.escape(name)}\s*=\s*", src)
+    if m:
+        i = m.end()
+        # Optional modifiers before the arrow function.
+        #   - useCallback(                   → step into the paren
+        #   - async                          → skip keyword
+        #   - (                              → already at arrow-fn param list
+        if src[i:i + 12].startswith("useCallback"):
+            # Advance to the `(` after "useCallback".
+            i = src.find("(", i)
+            if i < 0:
+                return None
+            i += 1  # past the opening `useCallback(`.
+            i = _skip_ws(src, i)
+        if src[i:i + 6].startswith("async "):
+            i += 6
+            i = _skip_ws(src, i)
+        if i >= len(src) or src[i] != "(":
+            return None
+        j = _skip_balanced(src, i, "(", ")")
+        if j < 0:
+            return None
+        j = _skip_ws_and_return_type(src, j)
+        # Expect `=>`
+        if src[j:j + 2] != "=>":
+            return None
+        j += 2
+        j = _skip_ws(src, j)
+        if j < len(src) and src[j] == "{":
+            end = _skip_balanced(src, j, "{", "}")
+            if end > 0:
+                return (m.start(), end)
+
+    return None
+
+
+def _skip_ws(src: str, i: int) -> int:
+    while i < len(src) and src[i] in " \t\n\r":
+        i += 1
+    return i
+
+
+def _skip_ws_and_return_type(src: str, i: int) -> int:
+    """After a `)` in an arrow-fn head, there may be an optional
+    TypeScript return-type annotation like `: Promise<void>` before
+    the `=>`. Skip whitespace and any colon-prefixed annotation up
+    to (but not including) the `=>` or `{`.
+    """
+    i = _skip_ws(src, i)
+    if i < len(src) and src[i] == ":":
+        # Consume until we hit `=>` or `{`. The annotation can
+        # contain generics `<...>` with nested commas, but not
+        # unbalanced braces or parens.
+        depth_angle = 0
+        while i < len(src):
+            c = src[i]
+            if c == "<":
+                depth_angle += 1
+            elif c == ">":
+                depth_angle -= 1
+            elif depth_angle == 0 and src[i:i + 2] == "=>":
+                break
+            elif depth_angle == 0 and c == "{":
+                break
+            i += 1
+    return _skip_ws(src, i)
+
+
+def _find_event_record_site(src: str, event_type: str) -> tuple[int, int] | None:
+    """Return a small window around the first ``interactionLogger.record('event_type', …)``
+    call site in ``src`` — used as a fallback when a handler name
+    isn't recoverable (many gestures are inline arrow functions in
+    JSX onClick). We walk up ~200 chars before the record call to
+    capture enough context that subsequent ordering checks still
+    see nearby calls.
+    """
+    m = re.search(
+        r"interactionLogger\.record\(\s*['\"]" + re.escape(event_type) + r"['\"]",
+        src,
+    )
+    if m:
+        start = max(0, m.start() - 400)
+        end = min(len(src), m.end() + 2000)
+        return (start, end)
+    return None
+
+
+def _extract_events(window: str) -> list[str]:
+    """Return the ordered list of record() and recordCompletion()
+    event types inside ``window``.
+    """
+    events: list[tuple[int, str]] = []
+    for m in RECORD_CALL.finditer(window):
+        events.append((m.start(), m.group(1)))
+    for m in RECORD_COMPLETION_CALL.finditer(window):
+        events.append((m.start(), m.group(1)))
+    events.sort()
+    return [t for _, t in events]
+
+
+def resolve_gesture(src: str, gesture: dict, side: str) -> dict:
+    """Locate the gesture in ``src`` and extract its emitted events."""
+    key = f"{side}_handler"
+    fallback_key = f"{side}_handler_fallbacks"
+    candidates = [gesture[key]] + gesture.get(fallback_key, [])
+
+    found_via = None
+    span: tuple[int, int] | None = None
+    for name in candidates:
+        span = _find_handler_range(src, name)
+        if span is not None:
+            found_via = f"handler:{name}"
+            break
+    if span is None:
+        # Fallback: locate the call site for the first expected event
+        # directly. This gives us a synthetic window even when the
+        # gesture is an inline onClick arrow.
+        for event in gesture["expected_events"]:
+            span = _find_event_record_site(src, event)
+            if span is not None:
+                found_via = f"callsite:{event}"
+                break
+    if span is None:
+        return {"found_via": None, "events": [], "span": None}
+
+    start, end = span
+    window = src[start:end]
+    events = _extract_events(window)
+    return {"found_via": found_via, "events": events, "span": span}
+
+
+def _check_order(expected: list[str], emitted: list[str]) -> dict:
+    """Check that ``expected`` appears as an ordered subsequence of
+    ``emitted``. Returns structured diff."""
+    missing = [e for e in expected if e not in emitted]
+    # Order-preserving subsequence check via two-pointer walk.
+    i = 0
+    for e in emitted:
+        if i < len(expected) and e == expected[i]:
+            i += 1
+    ordered_ok = i == len(expected) and not missing
+    return {
+        "ordered_ok": ordered_ok,
+        "missing": missing,
+        "emitted": emitted,
+    }
+
+
+# ---------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------
+
+def run_checks() -> dict:
+    # Concatenate all TS/TSX source into one string for React — we
+    # don't care which file a handler lives in, only that it exists.
+    react_src = "\n".join(p.read_text(encoding="utf-8", errors="replace") for p in _ts_files())
+    standalone_src = _standalone_src()
+
+    findings = []
+    for gesture in GESTURE_SEQUENCE:
+        react = resolve_gesture(react_src, gesture, "react")
+        standalone = resolve_gesture(standalone_src, gesture, "standalone")
+
+        react_diff = _check_order(gesture["expected_events"], react["events"])
+        sa_diff = _check_order(gesture["expected_events"], standalone["events"])
+
+        findings.append({
+            "gesture": gesture["name"],
+            "expected_events": gesture["expected_events"],
+            "react": {
+                "found_via": react["found_via"],
+                "emitted": react["events"],
+                "ordered_ok": react_diff["ordered_ok"],
+                "missing": react_diff["missing"],
+            },
+            "standalone": {
+                "found_via": standalone["found_via"],
+                "emitted": standalone["events"],
+                "ordered_ok": sa_diff["ordered_ok"],
+                "missing": sa_diff["missing"],
+            },
+        })
+
+    return {"gestures": findings}
+
+
+def render_human(report: dict) -> str:
+    out: list[str] = []
+    out.append("GESTURE-SEQUENCE PARITY REPORT (Layer-3 static)")
+    out.append("=" * 72)
+    out.append("See scripts/parity_e2e/e2e_parity.spec.ts for the runtime equivalent.")
+    out.append("")
+
+    fails = 0
+    for f in report["gestures"]:
+        header = f"  {f['gesture']}  expects: {', '.join(f['expected_events'])}"
+        out.append(header)
+        for side in ("react", "standalone"):
+            info = f[side]
+            tag = "OK" if info["ordered_ok"] else "FAIL"
+            if tag == "FAIL":
+                fails += 1
+            marker = "✅" if tag == "OK" else "❌"
+            via = info["found_via"] or "(not found)"
+            emitted = ", ".join(info["emitted"]) or "(none)"
+            out.append(f"     {marker} {side:10s} via={via!s:28s} emitted=[{emitted}]")
+            if info["missing"]:
+                out.append(f"        missing: {info['missing']}")
+        out.append("")
+
+    total = sum(1 for _ in report["gestures"]) * 2
+    passed = total - fails
+    out.append(f"Summary: {passed}/{total} gesture-side parity checks passed.")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = parser.parse_args()
+
+    report = run_checks()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_human(report))
+
+    hard_fail = any(
+        not g["react"]["ordered_ok"] or not g["standalone"]["ordered_ok"]
+        for g in report["gestures"]
+    )
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_invariants.py
+++ b/scripts/check_invariants.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# SPDX-License-Identifier: MPL-2.0
+"""Layer-4 (static) — user-observable invariants.
+
+Layers 1–3a / 3b all passed green while shipping six real bugs to
+the user.  Each bug belongs to a class the earlier layers can't
+catch by construction:
+
+  - visual threshold values (palette, dim opacity)
+  - conditional rendering gates (when does X render?)
+  - field-semantic interpretation (max_rho_line vs topology target)
+  - auto-effects ordering (tab auto-switch, auto-zoom, deselect-stay)
+  - loading-state hygiene (spinner released when?)
+  - rendering performance (memoization guards)
+
+Full runtime coverage requires a browser (Layer 3b Playwright).  This
+script takes the cheapest subset: STATIC invariants expressible as
+source-level patterns.  For each invariant we encode:
+
+  - a unique name,
+  - the React source expected to satisfy it + a regex proving it does,
+  - the standalone_interface.html source expected to satisfy it + a
+    matching regex,
+  - a human description of WHY the invariant matters and what user-
+    facing bug it regressions prevented.
+
+A failing check means one side drifted from the invariant; the
+output lists both file paths and the regex that missed.
+
+Run::
+
+    python scripts/check_invariants.py            # human text
+    python scripts/check_invariants.py --json     # CI-friendly
+
+Exits non-zero on any FAIL finding.
+
+Scope: this check catches what CAN be proven statically.  Pin
+severity rendering ("red iff rho > MF"), loading-state release
+timing, and auto-effect ordering all need browser execution to
+assert RUNTIME behaviour — those live in the Vitest spec-
+conformance + specific regression tests, and in the Playwright
+Layer 3b spec.  Layer 4 is the first gate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRONTEND_SRC = REPO_ROOT / "frontend" / "src"
+STANDALONE = REPO_ROOT / "standalone_interface.html"
+
+
+class Invariant:
+    """A single source-level assertion with a React side and a
+    standalone side.  Each side has ``file_hint`` (file or file glob),
+    ``pattern`` (regex to satisfy) and optional ``must_not`` (regex
+    whose presence is a failure, e.g. for "no hardcoded 0.9 threshold").
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        react: dict,
+        standalone: dict,
+        severity: str = "FAIL",
+    ):
+        self.name = name
+        self.description = description
+        self.react = react
+        self.standalone = standalone
+        self.severity = severity  # FAIL or WARN
+
+
+def _search_in_paths(
+    paths: Iterable[Path],
+    pattern: str,
+    flags: int = 0,
+) -> tuple[Path | None, re.Match | None]:
+    rx = re.compile(pattern, flags)
+    for p in paths:
+        try:
+            src = p.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            continue
+        m = rx.search(src)
+        if m:
+            return p, m
+    return None, None
+
+
+def _paths_for_hint(hint: str) -> list[Path]:
+    if "*" in hint:
+        return sorted((REPO_ROOT / Path(hint)).parent.glob(Path(hint).name))
+    p = REPO_ROOT / hint
+    if p.is_dir():
+        return sorted(p.rglob("*.ts")) + sorted(p.rglob("*.tsx"))
+    return [p] if p.exists() else []
+
+
+INVARIANTS: list[Invariant] = [
+    Invariant(
+        name="pin_severity_uses_monitoringFactor",
+        description=(
+            "Pin severity palette must be threshold-parameterised by "
+            "monitoringFactor (red > MF, orange > MF-0.05, else green). "
+            "Hardcoding 0.9 / 1.0 silently misclassifies 'still "
+            "overloaded' cards as orange when MF != 0.95 (user bug, "
+            "commit 56643a8)."
+        ),
+        react={
+            "file_hint": "frontend/src/utils/svgUtils.ts",
+            # React's computeActionSeverity must reference monitoringFactor + the -0.05 band.
+            "pattern": r"computeActionSeverity[\s\S]*?monitoringFactor\s*-\s*0\.05",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            "pattern": r"computeActionSeverity\s*=\s*\([^)]*monitoringFactor[^)]*\)[\s\S]*?monitoringFactor\s*-\s*0\.05",
+            # Red-flag: a hardcoded 1.0 or 0.9 rho comparison INSIDE
+            # the function body.  `[\s\S]{0,600}?` keeps the scan
+            # bounded so we don't cross into unrelated helpers; the
+            # legitimate body is ~400 chars.
+            "must_not": r"computeActionSeverity\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]{0,600}?rho\s*[<>]=?\s*(?:0\.9\b|1\.0\b)",
+        },
+    ),
+    Invariant(
+        name="combined_pairs_filter_estimated",
+        description=(
+            "Dashed-line combined-pair connections must render only "
+            "for SIMULATED pairs — not for recommender estimation-only "
+            "entries marked `is_estimated: true`.  Without this "
+            "filter, the Overview is pre-polluted with curves before "
+            "the user has opened the Combine modal (commit 56643a8)."
+        ),
+        react={
+            # The React side relies on STORAGE separation — estimated
+            # pairs live in `combined_actions`, simulated ones move to
+            # `actions` after simulation.  `buildCombinedActionPins`
+            # iterates only `actions`.  Check that storage split.
+            "file_hint": "frontend/src/utils/svgUtils.ts",
+            "pattern": r"buildCombinedActionPins[\s\S]*?Object\.entries\(actions\)",
+        },
+        standalone={
+            # Standalone flattens both into `result.actions` so it
+            # needs an explicit `is_estimated` filter.
+            "file_hint": "standalone_interface.html",
+            "pattern": r"computeCombinedActionPins[\s\S]*?action\.is_estimated\s*===\s*true",
+        },
+    ),
+    Invariant(
+        name="pin_resolver_is_topology_first",
+        description=(
+            "Pin anchor resolver must consult the action's TOPOLOGY "
+            "target (lines via getActionTargetLines → VLs via "
+            "getActionTargetVoltageLevels) BEFORE falling back to "
+            "max_rho_line — per docs/action-overview-diagram.md § "
+            "'Pin anchor resolution'.  Reversing the order silently "
+            "drops simulated action cards whose post-action max_rho_line "
+            "happens not to be in the N-1 metadata (commit 5030b6c)."
+        ),
+        react={
+            "file_hint": "frontend/src/utils/svgUtils.ts",
+            # In resolveActionAnchor: getActionTargetLines appears
+            # before max_rho_line.
+            "pattern": r"resolveActionAnchor[\s\S]*?getActionTargetLines[\s\S]*?max_rho_line",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            "pattern": r"resolveActionAnchor[\s\S]*?getActionTargetLines[\s\S]*?max_rho_line",
+        },
+    ),
+    Invariant(
+        name="display_prioritized_switches_to_action_tab",
+        description=(
+            "`handleDisplayPrioritizedActions` must call setActiveTab('action') "
+            "so the operator lands on the Overview pin view the "
+            "moment the suggestions are merged.  Without this, the "
+            "button silently appends cards to the sidebar with no "
+            "visual cue and the user doesn't see the map (commit 3c7863b)."
+        ),
+        react={
+            "file_hint": "frontend/src/hooks/useAnalysis.ts",
+            "pattern": r"handleDisplayPrioritizedActions[\s\S]*?setActiveTab\s*\?\.\s*\(\s*['\"]action['\"]\s*\)",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            "pattern": r"handleDisplayPrioritizedActions[\s\S]*?setActiveTab\s*\(\s*['\"]action['\"]\s*\)",
+        },
+    ),
+    Invariant(
+        name="deselect_stays_on_action_tab",
+        description=(
+            "`handleActionSelect` deselect path (actionId === selectedActionId "
+            "and !force) must NOT call setActiveTab('n-1') — the user "
+            "should fall through to the Overview on the same tab "
+            "(PR #93 / commit dbc05f8).  Otherwise unselecting a "
+            "pin snaps the view to N-1 and loses the pin map."
+        ),
+        react={
+            "file_hint": "frontend/src/hooks/useDiagrams.ts",
+            # React's handleActionSelect: the deselect branch doesn't setActiveTab.
+            # We assert the deselect branch exists AND doesn't reference setActiveTab.
+            "pattern": r"action_deselected",  # sanity — handler exists
+            "must_not": r"action_deselected[\s\S]{0,400}?setActiveTab\s*\(\s*['\"]n-1['\"]\s*\)",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            "pattern": r"action_deselected",
+            "must_not": r"action_deselected[\s\S]{0,400}?setActiveTab\s*\(\s*['\"]n-1['\"]\s*\)",
+        },
+    ),
+    Invariant(
+        name="simulate_button_releases_before_diagram",
+        description=(
+            "Manual-action + combined-action simulation handlers must "
+            "reset `simulatingActionId` BEFORE awaiting the action-"
+            "variant-diagram fetch — otherwise the Simulate button "
+            "stays in spinner state for the whole 5-6 s diagram "
+            "round-trip even though the action CARD has already "
+            "landed (commit dbc05f8).  We check for the reset call "
+            "appearing OUTSIDE a finally clause in handleAddManualAction."
+        ),
+        react={
+            # React uses the `simulate-and-variant-diagram` stream
+            # endpoint + separate loading flags so the button is tied
+            # to the simulate call, not the diagram.  We just sanity-
+            # check the stream endpoint is wired.
+            "file_hint": "frontend/src/api.ts",
+            "pattern": r"simulate-and-variant-diagram",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            # setSimulatingActionId(null) must appear before the
+            # action-variant-diagram fetch inside handleAddManualAction.
+            "pattern": r"handleAddManualAction[\s\S]*?setSimulatingActionId\(null\)[\s\S]*?/api/action-variant-diagram",
+        },
+    ),
+    Invariant(
+        name="overview_svg_clone_is_memoized",
+        description=(
+            "The Action Overview must memoise the 25 MB N-1 SVG clone "
+            "— re-cloning on every re-render costs ~200-500 ms on the "
+            "PyPSA-EUR France grid and makes pan/zoom feel frozen "
+            "(commit 967766a).  A ref-scoped cache keyed on the "
+            "source <svg> identity is the cheapest form of the "
+            "React `MemoizedSvgContainer` optimisation."
+        ),
+        react={
+            "file_hint": "frontend/src/components/MemoizedSvgContainer.tsx",
+            "pattern": r"React\.memo",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            "pattern": r"lastClonedSourceRef",
+        },
+    ),
+    Invariant(
+        name="network_diagram_fetch_uses_format_text",
+        description=(
+            "`/api/network-diagram` must be fetched via the "
+            "`format=text` variant (JSON header + raw SVG body) so "
+            "the client skips the ~500 ms JSON.parse on the multi-MB "
+            "SVG string — docs/perf-loading-parallel.md (commit dbc05f8)."
+        ),
+        react={
+            "file_hint": "frontend/src/api.ts",
+            "pattern": r"network-diagram\?format=text",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            "pattern": r"network-diagram\?format=text",
+        },
+    ),
+    Invariant(
+        name="base_nad_parallel_with_metadata_boot",
+        description=(
+            "The base NAD fetch must overlap with the "
+            "/api/branches + /api/voltage-levels + /api/nominal-voltages "
+            "Promise.all — not run sequentially after it.  /api/network-diagram "
+            "is the slowest XHR (~5-6 s pypowsybl regeneration), "
+            "serialising it adds 1-2 s to the critical path."
+        ),
+        react={
+            "file_hint": "frontend/src/App.tsx",
+            # React parallelises all four in applySettingsImmediate.
+            "pattern": r"Promise\.all\(\s*\[[\s\S]*?getBranches[\s\S]*?getNetworkDiagram",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            # Standalone's applySettings-equivalent now includes the
+            # NAD fetch in the Promise.all.
+            "pattern": r"Promise\.all\(\s*\[[\s\S]*?/api/branches[\s\S]*?_fetchNetworkDiagramTextFormat",
+        },
+    ),
+    Invariant(
+        name="action_overview_backdrop_not_over_dimmed",
+        description=(
+            "Action Overview backdrop opacity must stay high enough "
+            "that voltage-coloured edges remain readable — "
+            "aggressively dimming (0.35 or 0.55) collapses 5-SVG-unit "
+            "edges into near-invisibility on large grids (commit d3c3b59). "
+            "Spec says 0.65 rect overlay, standalone uses 0.85 on the "
+            "SVG itself; both pass — anything < 0.65 fails this guard."
+        ),
+        react={
+            # The React version uses a <rect> overlay with 0.65
+            # flood.  Check the className is used.
+            "file_hint": "frontend/src/components/ActionOverviewDiagram.tsx",
+            "pattern": r"nad-overview-dim",
+        },
+        standalone={
+            "file_hint": "standalone_interface.html",
+            # Extract the opacity value set on the cloned backdrop
+            # and reject anything under 0.65.  The regex is structured
+            # so the numeric capture is easy to validate in the checker.
+            "pattern": r"clone\.style\.opacity\s*=\s*['\"](0\.(?:[7-9]\d?|6[5-9]))['\"]",
+        },
+    ),
+]
+
+
+def check_invariant(inv: Invariant) -> dict:
+    """Run one invariant against both codebases."""
+    result = {
+        "name": inv.name,
+        "description": inv.description,
+        "severity": inv.severity,
+        "sides": {},
+        "ok": True,
+    }
+    for side, spec in (("react", inv.react), ("standalone", inv.standalone)):
+        paths = _paths_for_hint(spec["file_hint"])
+        if not paths:
+            result["sides"][side] = {
+                "status": "FAIL",
+                "reason": f"file not found: {spec['file_hint']}",
+            }
+            result["ok"] = False
+            continue
+
+        pattern = spec.get("pattern")
+        must_not = spec.get("must_not")
+        pattern_hit = must_not_hit = None
+        if pattern:
+            p, m = _search_in_paths(paths, pattern, re.DOTALL)
+            pattern_hit = (str(p.relative_to(REPO_ROOT)), m.start()) if m else None
+        if must_not:
+            p, m = _search_in_paths(paths, must_not, re.DOTALL)
+            must_not_hit = (str(p.relative_to(REPO_ROOT)), m.start()) if m else None
+
+        side_ok = (pattern is None or pattern_hit is not None) and (must_not is None or must_not_hit is None)
+        result["sides"][side] = {
+            "status": "OK" if side_ok else "FAIL",
+            "file_hint": spec["file_hint"],
+            "pattern_hit": pattern_hit,
+            "must_not_hit": must_not_hit,
+            "reason": None if side_ok else (
+                f"regex not found in any candidate path" if (pattern and pattern_hit is None)
+                else f"forbidden pattern found at {must_not_hit}" if must_not_hit
+                else "unknown"
+            ),
+        }
+        if not side_ok:
+            result["ok"] = False
+    return result
+
+
+def run_checks() -> dict:
+    findings = [check_invariant(inv) for inv in INVARIANTS]
+    return {"invariants": findings}
+
+
+def render_human(report: dict) -> str:
+    out = ["USER-OBSERVABLE INVARIANTS REPORT (Layer 4 static)", "=" * 72]
+    failed = [r for r in report["invariants"] if not r["ok"]]
+    for r in report["invariants"]:
+        status_icon = "✅" if r["ok"] else "❌"
+        out.append(f"  {status_icon} {r['name']:50s}  [{r['severity']}]")
+        if not r["ok"]:
+            out.append(f"     description: {r['description']}")
+            for side, info in r["sides"].items():
+                if info["status"] != "OK":
+                    out.append(f"       {side:10s} → {info['reason']}  ({info['file_hint']})")
+    out.append("")
+    out.append(f"Summary: {len(report['invariants']) - len(failed)}/{len(report['invariants'])} invariants satisfied.")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    report = run_checks()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_human(report))
+    hard_fail = any(
+        not r["ok"] and r["severity"] == "FAIL" for r in report["invariants"]
+    )
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_session_fidelity.py
+++ b/scripts/check_session_fidelity.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# SPDX-License-Identifier: MPL-2.0
+"""Layer-2 session-reload fidelity check.
+
+``docs/interaction-logging.md § Session reload fidelity`` documents a
+contract that EVERY field persisted into ``session.json`` must also be
+restored into the live app state on reload.  History has shown that
+this contract regresses silently — PR #88 persisted
+``n_overloads_rho`` but the React restore path dropped it on the
+floor; PRs #73 / #78 / #83 shipped ``load_shedding_details`` /
+``pst_details`` / ``lines_overloaded_after`` that the restore path
+then quietly discarded.
+
+This script takes a **curated list of critical fields** and checks,
+for each one:
+
+1. It appears in the React **save** path (``frontend/src/utils/sessionUtils.ts``).
+2. It appears in the React **restore** path (``frontend/src/hooks/useSession.ts``).
+3. It appears in the **standalone** HTML (which contains both save and
+   restore logic in one file).
+
+A field that is saved but not restored is a silent regression — the
+app will quietly lose data on reload.  The script FAILs on any such
+asymmetry so CI can gate on it.
+
+The spec table is deliberately curated rather than derived from the
+``SessionResult`` TypeScript interface.  A field in the interface is
+not automatically "critical" — some fields (e.g. ``saved_at``) are
+metadata that has no meaningful restore-side equivalent.  Growing
+this list is the right feedback loop: when a new field is added to
+``SessionResult``, the author decides whether it needs reload
+fidelity and adds it here.
+
+Run::
+
+    python scripts/check_session_fidelity.py            # human output
+    python scripts/check_session_fidelity.py --json     # CI-friendly
+
+Exits non-zero on any FAIL-level finding.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FE_SAVE_PATH = REPO_ROOT / "frontend" / "src" / "utils" / "sessionUtils.ts"
+FE_RESTORE_PATH = REPO_ROOT / "frontend" / "src" / "hooks" / "useSession.ts"
+STANDALONE = REPO_ROOT / "standalone_interface.html"
+
+# Curated list of fields that MUST survive a save/reload round-trip.
+# Each entry declares:
+# - ``field``: the JSON-on-disk key (snake_case, matching the session.json shape).
+# - ``restore_token``: a token the restore path should reference to flow
+#   the field back into live state. Usually same as ``field``; sometimes
+#   a setter name when the JSON key differs from the state variable
+#   (e.g. ``committed_network_path`` ↔ ``committedNetworkPathRef``).
+# - ``optional_on_save``: if True, missing from the save path is a WARN
+#   (the field was newly added; older sessions won't have it).
+# - ``spec``: one-line reference to where in the replay contract this
+#   field is required.
+SESSION_FIELDS = [
+    # --- Configuration (must round-trip every recommender threshold) ---
+    {"field": "network_path",
+     "restore_token": "network_path",
+     "spec": "cfg.network_path → setNetworkPath + committedNetworkPathRef"},
+    {"field": "action_file_path",
+     "restore_token": "action_file_path",
+     "spec": "cfg.action_file_path → setActionPath"},
+    {"field": "layout_path",
+     "restore_token": "layout_path",
+     "spec": "cfg.layout_path → setLayoutPath"},
+    {"field": "min_line_reconnections",
+     "restore_token": "min_line_reconnections"},
+    {"field": "min_close_coupling",
+     "restore_token": "min_close_coupling"},
+    {"field": "min_open_coupling",
+     "restore_token": "min_open_coupling"},
+    {"field": "min_line_disconnections",
+     "restore_token": "min_line_disconnections"},
+    {"field": "min_pst",
+     "restore_token": "min_pst"},
+    {"field": "min_load_shedding",
+     "restore_token": "min_load_shedding",
+     "spec": "power-reduction format (PR #73) — fallback 0.0 on older sessions"},
+    {"field": "min_renewable_curtailment_actions",
+     "restore_token": "min_renewable_curtailment_actions",
+     "spec": "power-reduction format (PR #73) — fallback 0.0 on older sessions"},
+    {"field": "n_prioritized_actions",
+     "restore_token": "n_prioritized_actions"},
+    {"field": "lines_monitoring_path",
+     "restore_token": "lines_monitoring_path"},
+    {"field": "monitoring_factor",
+     "restore_token": "monitoring_factor"},
+    {"field": "pre_existing_overload_threshold",
+     "restore_token": "pre_existing_overload_threshold"},
+    {"field": "ignore_reconnections",
+     "restore_token": "ignore_reconnections"},
+    {"field": "pypowsybl_fast_mode",
+     "restore_token": "pypowsybl_fast_mode"},
+
+    # --- Contingency ---
+    {"field": "disconnected_element",
+     "restore_token": "disconnected_element",
+     "spec": "contingency.disconnected_element → setSelectedBranch + committedBranchRef"},
+    {"field": "selected_overloads",
+     "restore_token": "selected_overloads"},
+    {"field": "monitor_deselected",
+     "restore_token": "monitor_deselected"},
+
+    # --- Overloads (incl. sticky-header rho ratios added by PR #88) ---
+    # Save-only-OK: the live UI rebuilds these from a fresh N-1 diagram
+    # fetch triggered by `setSelectedBranch` after restore, so the
+    # on-disk arrays are only for inspection / offline replay agents.
+    # See docs/interaction-logging.md § Session reload fidelity.
+    {"field": "n_overloads",
+     "restore_token": "n_overloads",
+     "save_only_ok": True,
+     "spec": "re-derived from fresh N-1 diagram on reload (save for inspection only)"},
+    {"field": "n1_overloads",
+     "restore_token": "n1_overloads",
+     "save_only_ok": True,
+     "spec": "re-derived from fresh N-1 diagram on reload (save for inspection only)"},
+    {"field": "resolved_overloads",
+     "restore_token": "resolved_overloads"},
+    {"field": "n_overloads_rho",
+     "restore_token": "n_overloads_rho",
+     "optional_on_save": True,
+     "save_only_ok": True,
+     "spec": "sticky sidebar rho (PR #88) — re-derived on reload, save for inspection"},
+    {"field": "n1_overloads_rho",
+     "restore_token": "n1_overloads_rho",
+     "optional_on_save": True,
+     "save_only_ok": True,
+     "spec": "sticky sidebar rho (PR #88) — re-derived on reload, save for inspection"},
+
+    # --- Analysis-result enrichment (commonly-dropped fields) ---
+    # These were the class of field that was silently dropped by
+    # handleRestoreSession before PRs #73/#78/#83 landed — the editor
+    # cards rendered empty after reload until the user re-ran
+    # analysis. Each one MUST be referenced in restore code.
+    {"field": "load_shedding_details",
+     "restore_token": "load_shedding_details",
+     "spec": "SavedActionEntry → live ActionDetail.load_shedding_details"},
+    {"field": "curtailment_details",
+     "restore_token": "curtailment_details",
+     "spec": "SavedActionEntry → live ActionDetail.curtailment_details"},
+    {"field": "pst_details",
+     "restore_token": "pst_details",
+     "spec": "SavedActionEntry → live ActionDetail.pst_details (PST editor)"},
+    {"field": "lines_overloaded_after",
+     "restore_token": "lines_overloaded_after",
+     "spec": "post-action NAD/SLD overload halos (PR #83)"},
+    {"field": "action_topology",
+     "restore_token": "action_topology"},
+
+    # --- Interaction log ---
+    {"field": "interaction_log",
+     "restore_token": "interaction_log",
+     "optional_on_save": True,
+     "spec": "replay-ready gesture log (written as interaction_log.json alongside)"},
+]
+
+
+def load(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def check_field_presence(
+    field: dict,
+    sources: dict[str, str],
+) -> dict:
+    """For one curated field, check presence in each codebase surface."""
+    save_pat = re.compile(r"\b" + re.escape(field["field"]) + r"\b")
+    restore_pat = re.compile(r"\b" + re.escape(field["restore_token"]) + r"\b")
+    result = {"field": field["field"], "spec": field.get("spec", ""),
+              "optional_on_save": field.get("optional_on_save", False)}
+    for name, src in sources.items():
+        pat = save_pat if name.endswith("_save") else restore_pat
+        matches = [
+            (src.count("\n", 0, m.start()) + 1)
+            for m in pat.finditer(src)
+        ]
+        result[name] = matches
+    return result
+
+
+def run_checks() -> dict:
+    fe_save = load(FE_SAVE_PATH)
+    fe_restore = load(FE_RESTORE_PATH)
+    sa = load(STANDALONE)
+
+    sources = {
+        "fe_save": fe_save,
+        "fe_restore": fe_restore,
+        # The standalone combines save and restore in one file; the
+        # same token search works for both directions, but we report
+        # them separately so the absence of either direction is
+        # visible in the output.
+        "sa_save": sa,
+        "sa_restore": sa,
+    }
+
+    findings = []
+    for field in SESSION_FIELDS:
+        res = check_field_presence(field, sources)
+        # Evaluate round-trip for each codebase. A field is a
+        # regression candidate if it is saved but never restored.
+        fe_saved = bool(res["fe_save"])
+        fe_restored = bool(res["fe_restore"])
+        sa_saved = bool(res["sa_save"])
+        sa_restored = bool(res["sa_restore"])
+
+        optional = bool(field.get("optional_on_save"))
+        save_only_ok = bool(field.get("save_only_ok"))
+        fe_status = _classify(fe_saved, fe_restored, optional, save_only_ok)
+        sa_status = _classify(sa_saved, sa_restored, optional, save_only_ok)
+
+        findings.append({
+            "field": res["field"],
+            "spec": res["spec"],
+            "fe_save_lines": res["fe_save"],
+            "fe_restore_lines": res["fe_restore"],
+            "sa_save_lines": res["sa_save"],
+            "sa_restore_lines": res["sa_restore"],
+            "fe_status": fe_status,
+            "sa_status": sa_status,
+        })
+
+    return {"findings": findings}
+
+
+def _classify(saved: bool, restored: bool, optional: bool, save_only_ok: bool) -> str:
+    if saved and restored:
+        return "ok"
+    if saved and not restored:
+        # Save-only fields are intentional (re-derived from a fresh
+        # backend fetch on reload) — report as "save_only" rather
+        # than "regression" so the script doesn't bark on them.
+        return "save_only" if save_only_ok else "regression"
+    if not saved and not restored:
+        return "missing"     # warn — field declared but neither side implements
+    # Not saved but restored — unusual; could be a default fallback.
+    # Flag as warn so authors see it.
+    if optional:
+        return "optional_missing"
+    return "restore_only"
+
+
+def render_human(report: dict) -> str:
+    out: list[str] = []
+    out.append("SESSION-RELOAD FIDELITY REPORT")
+    out.append("=" * 72)
+
+    fe_regressions = [f for f in report["findings"] if f["fe_status"] == "regression"]
+    sa_regressions = [f for f in report["findings"] if f["sa_status"] == "regression"]
+    fe_missing = [f for f in report["findings"] if f["fe_status"] == "missing"]
+    sa_missing = [f for f in report["findings"] if f["sa_status"] == "missing"]
+
+    if fe_regressions:
+        out.append(f"[FAIL] {len(fe_regressions)} fields the React frontend PERSISTS "
+                   f"but never RESTORES (silent reload regression):")
+        for f in fe_regressions:
+            lines = ", ".join(str(n) for n in f["fe_save_lines"][:3])
+            out.append(f"   - {f['field']:35s}  (saved at sessionUtils.ts:{lines})")
+            if f["spec"]:
+                out.append(f"        spec: {f['spec']}")
+        out.append("")
+
+    if sa_regressions:
+        out.append(f"[FAIL] {len(sa_regressions)} fields the standalone PERSISTS "
+                   f"but never RESTORES:")
+        for f in sa_regressions:
+            lines = ", ".join(str(n) for n in f["sa_save_lines"][:3])
+            out.append(f"   - {f['field']:35s}  (saved at standalone_interface.html:{lines})")
+            if f["spec"]:
+                out.append(f"        spec: {f['spec']}")
+        out.append("")
+
+    if fe_missing:
+        out.append(f"[WARN] {len(fe_missing)} required fields are absent from BOTH "
+                   f"React save and restore paths:")
+        for f in fe_missing:
+            out.append(f"   - {f['field']}")
+            if f["spec"]:
+                out.append(f"        spec: {f['spec']}")
+        out.append("")
+
+    if sa_missing:
+        out.append(f"[WARN] {len(sa_missing)} required fields are absent from the "
+                   f"standalone (neither saved nor restored):")
+        for f in sa_missing:
+            out.append(f"   - {f['field']}")
+            if f["spec"]:
+                out.append(f"        spec: {f['spec']}")
+        out.append("")
+
+    restore_only = [f for f in report["findings"] if f["fe_status"] == "restore_only"]
+    if restore_only:
+        out.append(f"[FAIL] {len(restore_only)} fields the React frontend RESTORES "
+                   f"but never SAVES — the field will always be `undefined` on "
+                   f"reload since it was never written to session.json:")
+        for f in restore_only:
+            lines = ", ".join(str(n) for n in f["fe_restore_lines"][:3])
+            out.append(f"   - {f['field']:35s}  (restore at useSession.ts:{lines})")
+            if f["spec"]:
+                out.append(f"        spec: {f['spec']}")
+        out.append("")
+
+    sa_restore_only = [f for f in report["findings"] if f["sa_status"] == "restore_only"]
+    if sa_restore_only:
+        out.append(f"[FAIL] {len(sa_restore_only)} fields the standalone RESTORES "
+                   f"but never SAVES:")
+        for f in sa_restore_only:
+            lines = ", ".join(str(n) for n in f["sa_restore_lines"][:3])
+            out.append(f"   - {f['field']:35s}  (restore at standalone_interface.html:{lines})")
+        out.append("")
+
+    if not (fe_regressions or sa_regressions):
+        out.append("[OK] All curated session fields round-trip through both codebases.")
+
+    # Summary counts
+    total = len(report["findings"])
+    fe_ok = sum(1 for f in report["findings"] if f["fe_status"] == "ok")
+    sa_ok = sum(1 for f in report["findings"] if f["sa_status"] == "ok")
+    out.append("")
+    out.append(f"Summary: {fe_ok}/{total} fields round-trip on React, "
+               f"{sa_ok}/{total} on standalone.")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = parser.parse_args()
+
+    report = run_checks()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_human(report))
+
+    hard_fail = any(
+        f["fe_status"] in ("regression", "restore_only")
+        or f["sa_status"] in ("regression", "restore_only")
+        for f in report["findings"]
+    )
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# SPDX-License-Identifier: MPL-2.0
+"""Layer-1 static parity check: frontend/ vs standalone_interface.html.
+
+Extracts canonical inventories from the React source (the source of
+truth) and diffs them against the standalone HTML mirror. Emits a
+CI-friendly report with file:line anchors on every failure.
+
+Three inventories checked today:
+
+1. ``InteractionType`` union (``frontend/src/types.ts``) — every event
+   type the React app claims the standalone must support.
+2. Backend API paths (``frontend/src/api.ts``) — every endpoint wired
+   into the React HTTP client must also be wired into the standalone.
+3. ``SettingsState`` interface (``frontend/src/hooks/useSettings.ts``)
+   — every field the Settings modal exposes must be mirrored.
+
+For each ``interactionLogger.record('TYPE', { key1, key2, ... })``
+call site, we also collect the union of detail keys emitted per
+event type in BOTH codebases and diff them — catches the
+``voltage_range_changed { min_kv, max_kv }`` vs. spec
+``{ min, max }`` class of regression.
+
+Run::
+
+    python scripts/check_standalone_parity.py            # human output
+    python scripts/check_standalone_parity.py --json     # CI-friendly
+
+Exits non-zero on any FAIL-level finding so the script can gate CI.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRONTEND_SRC = REPO_ROOT / "frontend" / "src"
+STANDALONE = REPO_ROOT / "standalone_interface.html"
+TYPES_TS = FRONTEND_SRC / "types.ts"
+API_TS = FRONTEND_SRC / "api.ts"
+USE_SETTINGS_TS = FRONTEND_SRC / "hooks" / "useSettings.ts"
+
+
+# ---------------------------------------------------------------------
+# Extractors (React source → canonical sets)
+# ---------------------------------------------------------------------
+
+def extract_interaction_types(ts_path: Path) -> set[str]:
+    """Parse the ``InteractionType`` union from types.ts.
+
+    We only need the set of string literals between
+    ``export type InteractionType =`` and the terminating ``;``.
+    Comments, whitespace, and ``|`` separators are tolerated.
+    """
+    src = ts_path.read_text(encoding="utf-8")
+    m = re.search(r"export type InteractionType\s*=\s*(.*?);", src, re.DOTALL)
+    if not m:
+        raise RuntimeError(f"InteractionType union not found in {ts_path}")
+    body = m.group(1)
+    # Drop line comments and block comments.
+    body = re.sub(r"//[^\n]*", "", body)
+    body = re.sub(r"/\*.*?\*/", "", body, flags=re.DOTALL)
+    return set(re.findall(r"'([a-z0-9_]+)'", body))
+
+
+def extract_api_paths(api_path: Path) -> set[str]:
+    """Pull every ``/api/...`` path out of the axios client.
+
+    Matches the template-literal form the repo uses throughout, e.g.
+    ``${API_BASE_URL}/api/run-analysis-step1``.
+    """
+    src = api_path.read_text(encoding="utf-8")
+    paths = set(re.findall(r"/api/[A-Za-z0-9_\-]+", src))
+    return paths
+
+
+def extract_settings_state_fields(hook_path: Path) -> set[str]:
+    """Parse field names from the exported ``SettingsState`` interface.
+
+    We only keep fields that have a paired ``set<Name>`` setter in the
+    same interface — this is the useSettings convention and it filters
+    out inline function-type signatures (e.g. ``buildConfigRequest:
+    () => { network_path: string; ... }``) whose return-type body would
+    otherwise leak snake-case identifiers into the extracted set.
+    """
+    src = hook_path.read_text(encoding="utf-8")
+    m = re.search(r"export interface SettingsState\s*\{(.*?)^\}", src, re.DOTALL | re.MULTILINE)
+    if not m:
+        raise RuntimeError(f"SettingsState interface not found in {hook_path}")
+    body = m.group(1)
+    body = re.sub(r"//[^\n]*", "", body)
+    body = re.sub(r"/\*.*?\*/", "", body, flags=re.DOTALL)
+    # Pair-based extraction: a field ``foo: T;`` counts only if
+    # ``setFoo: (v: T) => void;`` also appears in the body.
+    setters = set(re.findall(r"\bset([A-Z][A-Za-z0-9_]*)\s*:\s*\(", body))
+    setter_targets = {s[0].lower() + s[1:] for s in setters}
+    fields: set[str] = set()
+    for name in re.findall(r"^\s*([a-z][A-Za-z0-9_]*)\s*:\s*", body, re.MULTILINE):
+        if name in setter_targets:
+            fields.add(name)
+    return fields
+
+
+RECORD_CALL = re.compile(
+    r"interactionLogger\.record\(\s*['\"]([a-z0-9_]+)['\"]\s*(?:,\s*(\{[^{}]*?\}|\w+))?",
+    re.DOTALL,
+)
+RECORD_COMPLETION_CALL = re.compile(
+    r"interactionLogger\.recordCompletion\(\s*['\"]([a-z0-9_]+)['\"]",
+)
+# Match only property-start positions inside an object literal so we
+# capture keys (not value identifiers).  Both explicit and JS shorthand
+# properties are supported:
+#   { name: value, ... }   → name
+#   { name, ... }          → name   (shorthand, followed by `,`)
+#   { name }               → name   (shorthand, followed by `}`)
+# The leading ``[{,]`` anchor forces "first token of a property".
+DETAIL_KEY = re.compile(
+    r"[{,]\s*"
+    r"([a-zA-Z_][a-zA-Z0-9_]*)"
+    r"\s*(?=[:,}]|$)"
+)
+
+
+def walk_record_calls(
+    root: Path,
+    patterns: Iterable[str],
+    exclude: Iterable[str] = (),
+) -> tuple[dict[str, set[str]], dict[str, list[tuple[str, int]]]]:
+    """Collect ``{event_type: set(detail_keys)}`` + file:line anchors.
+
+    For each ``interactionLogger.record('type', { a, b: 1, ... })``:
+    - event_type → 'type'
+    - detail_keys → {'a', 'b'} (keys of the object-literal argument
+      when it is an object literal; if the argument is a bare
+      identifier, the keys are skipped — the call still counts toward
+      presence but not toward schema diffing).
+    """
+    keys_by_type: dict[str, set[str]] = defaultdict(set)
+    sites_by_type: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    excluded = tuple(exclude)
+
+    files: list[Path] = []
+    for pattern in patterns:
+        files.extend(root.rglob(pattern))
+    for path in sorted(set(files)):
+        rel = str(path.relative_to(REPO_ROOT))
+        if any(ex in rel for ex in excluded):
+            continue
+        src = path.read_text(encoding="utf-8", errors="replace")
+        # Use line-by-line search so we can cheaply attach line numbers.
+        for m in RECORD_CALL.finditer(src):
+            event_type = m.group(1)
+            details_src = m.group(2) or ""
+            line_no = src.count("\n", 0, m.start()) + 1
+            sites_by_type[event_type].append((rel, line_no))
+            if details_src.startswith("{"):
+                # Pass the whole literal (outer braces included) so the
+                # DETAIL_KEY anchor recognises the first property —
+                # stripping the outer ``{`` would drop the leading key
+                # of multi-property objects.
+                for km in DETAIL_KEY.finditer(details_src):
+                    keys_by_type[event_type].add(km.group(1))
+    return keys_by_type, sites_by_type
+
+
+def walk_record_completion_calls(
+    root: Path,
+    patterns: Iterable[str],
+    exclude: Iterable[str] = (),
+) -> set[str]:
+    """Return the set of event types that appear in ``recordCompletion(...)``
+    calls. The start side is already handled by :func:`walk_record_calls`.
+    """
+    seen: set[str] = set()
+    excluded = tuple(exclude)
+    for pattern in patterns:
+        for path in root.rglob(pattern):
+            rel = str(path.relative_to(REPO_ROOT))
+            if any(ex in rel for ex in excluded):
+                continue
+            src = path.read_text(encoding="utf-8", errors="replace")
+            for m in RECORD_COMPLETION_CALL.finditer(src):
+                seen.add(m.group(1))
+    return seen
+
+
+# ---------------------------------------------------------------------
+# Extractors (standalone HTML → standalone inventories)
+# ---------------------------------------------------------------------
+
+def walk_standalone_record_calls(
+    html_path: Path,
+) -> tuple[dict[str, set[str]], dict[str, list[tuple[str, int]]]]:
+    """Same contract as :func:`walk_record_calls` but for the
+    single-file standalone HTML. The standalone inlines React-like JSX
+    + JS, so ``interactionLogger.record(...)`` literals look identical
+    to the frontend ones. We re-use the same regex.
+    """
+    keys_by_type: dict[str, set[str]] = defaultdict(set)
+    sites_by_type: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    src = html_path.read_text(encoding="utf-8", errors="replace")
+    for m in RECORD_CALL.finditer(src):
+        event_type = m.group(1)
+        details_src = m.group(2) or ""
+        line_no = src.count("\n", 0, m.start()) + 1
+        sites_by_type[event_type].append((str(html_path.name), line_no))
+        if details_src.startswith("{"):
+            # Pass the whole literal, including outer braces. The
+            # DETAIL_KEY anchor needs the leading ``{`` to recognise
+            # the first property — stripping it would drop the first
+            # key from multi-property objects.
+            for km in DETAIL_KEY.finditer(details_src):
+                keys_by_type[event_type].add(km.group(1))
+    return keys_by_type, sites_by_type
+
+
+def extract_standalone_api_paths(html_path: Path) -> set[str]:
+    """Return ``/api/...`` paths referenced in the standalone HTML.
+
+    The standalone uses both ``fetch`` and ``axios`` / string literals;
+    grepping the literal path is enough.
+    """
+    src = html_path.read_text(encoding="utf-8", errors="replace")
+    return set(re.findall(r"/api/[A-Za-z0-9_\-]+", src))
+
+
+def extract_standalone_setting_fields(html_path: Path) -> set[str]:
+    """Best-effort extraction of ``useState`` field identifiers in the
+    standalone that plausibly correspond to Settings state.
+
+    The standalone does not expose a ``SettingsState`` type, so we
+    sniff for ``const [fieldName, setFieldName] = useState(...)`` and
+    intersect with the canonical SettingsState field names. Fields
+    the frontend exposes but that do not appear here are flagged as
+    potentially missing.
+    """
+    src = html_path.read_text(encoding="utf-8", errors="replace")
+    names = set(re.findall(r"const\s+\[\s*([A-Za-z][A-Za-z0-9_]*)\s*,\s*set", src))
+    return names
+
+
+# ---------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------
+
+def fmt_sites(sites: list[tuple[str, int]], limit: int = 3) -> str:
+    head = sites[:limit]
+    rest = len(sites) - len(head)
+    base = ", ".join(f"{p}:{ln}" for p, ln in head)
+    return base + (f" (+{rest} more)" if rest > 0 else "")
+
+
+def run_checks() -> dict:
+    """Execute every check and return a structured dict of findings.
+
+    Top-level keys::
+
+        {
+          "missing_event_types":   [...],
+          "orphan_event_types":    [...],        # in HTML, not in union
+          "missing_completion":    [...],        # in FE, not in HTML
+          "detail_key_drift":      [{...}, ...], # per-event detail diff
+          "missing_api_paths":     [...],
+          "missing_settings":      [...],
+        }
+    """
+    canonical_events = extract_interaction_types(TYPES_TS)
+    canonical_api = extract_api_paths(API_TS)
+    canonical_settings = extract_settings_state_fields(USE_SETTINGS_TS)
+
+    # Exclude all test files so the inventories reflect production
+    # call sites only — `*.test.ts` / `*.test.tsx` emit events with
+    # placeholder shapes (`{ path: '/data' }`) that would pollute the
+    # details-key diff.
+    fe_keys, fe_sites = walk_record_calls(
+        FRONTEND_SRC,
+        ("*.ts", "*.tsx"),
+        exclude=(".test.ts", ".test.tsx"),
+    )
+    fe_completion = walk_record_completion_calls(
+        FRONTEND_SRC,
+        ("*.ts", "*.tsx"),
+        exclude=(".test.ts", ".test.tsx"),
+    )
+
+    sa_keys, sa_sites = walk_standalone_record_calls(STANDALONE)
+    sa_completion = set()  # populated below if any recordCompletion calls present
+    sa_src = STANDALONE.read_text(encoding="utf-8", errors="replace")
+    for m in RECORD_COMPLETION_CALL.finditer(sa_src):
+        sa_completion.add(m.group(1))
+
+    fe_event_types = set(fe_sites.keys())
+    sa_event_types = set(sa_sites.keys())
+
+    # Union membership — a canonical type the frontend emits but the
+    # standalone never does.
+    missing_event_types = sorted(
+        t for t in canonical_events
+        if t in fe_event_types and t not in sa_event_types
+    )
+
+    # Standalone references a type the union has dropped or never had.
+    orphan_event_types = sorted(t for t in sa_event_types if t not in canonical_events)
+
+    # Async-completion gap — types where frontend calls
+    # `recordCompletion(type)` but standalone never does.
+    missing_completion = sorted(t for t in fe_completion if t not in sa_completion)
+
+    # Per-event detail-key drift. Only compare events whose frontend
+    # call site provides an object literal — when the React handler
+    # passes a bare identifier (e.g. ``record('config_loaded',
+    # buildConfigInteractionDetails())``) the regex cannot see into
+    # the return value and the extracted key set would be empty,
+    # producing false "drift" signals against a standalone that
+    # correctly emits all documented keys.
+    detail_key_drift: list[dict] = []
+    for t in sorted(fe_event_types & sa_event_types & canonical_events):
+        fe = fe_keys.get(t, set())
+        sa = sa_keys.get(t, set())
+        if not fe:
+            continue  # frontend details are in a bare identifier
+        if fe and sa and fe != sa:
+            detail_key_drift.append({
+                "event_type": t,
+                "frontend_keys": sorted(fe),
+                "standalone_keys": sorted(sa),
+                "missing_in_standalone": sorted(fe - sa),
+                "extra_in_standalone": sorted(sa - fe),
+                "frontend_sites": fe_sites[t][:3],
+                "standalone_sites": sa_sites[t][:3],
+            })
+
+    sa_api = extract_standalone_api_paths(STANDALONE)
+    missing_api_paths = sorted(
+        p for p in canonical_api
+        if p not in sa_api
+        # Filter picker / PDF static routes handled outside axios
+        and p not in {"/api/pick-path"}
+    )
+
+    sa_settings = extract_standalone_setting_fields(STANDALONE)
+    # The React side uses camelCase (``networkPath``); the standalone
+    # historically mirrors the API payload (``network_path``) and uses
+    # that as the useState key. Compare on a normalised form (lower +
+    # underscores stripped) so we don't flag the convention drift as a
+    # parity failure.
+
+    def _norm(name: str) -> str:
+        return re.sub(r"_", "", name).lower()
+
+    sa_norm = {_norm(s) for s in sa_settings}
+    missing_settings = sorted(
+        s for s in canonical_settings
+        if _norm(s) not in sa_norm
+    )
+
+    return {
+        "canonical_event_count": len(canonical_events),
+        "frontend_event_count": len(fe_event_types),
+        "standalone_event_count": len(sa_event_types),
+        "missing_event_types": [
+            {"type": t, "frontend_sites": fe_sites[t][:3]}
+            for t in missing_event_types
+        ],
+        "orphan_event_types": [
+            {"type": t, "standalone_sites": sa_sites[t][:3]}
+            for t in orphan_event_types
+        ],
+        "missing_completion": missing_completion,
+        "detail_key_drift": detail_key_drift,
+        "missing_api_paths": missing_api_paths,
+        "missing_settings": missing_settings,
+    }
+
+
+def render_human(report: dict) -> str:
+    out: list[str] = []
+    out.append("STANDALONE PARITY REPORT")
+    out.append("=" * 72)
+    out.append(
+        f"InteractionType union: {report['canonical_event_count']} types. "
+        f"Frontend emits {report['frontend_event_count']}, "
+        f"standalone emits {report['standalone_event_count']}."
+    )
+    out.append("")
+
+    fail = False
+
+    # ---- Missing event types
+    m = report["missing_event_types"]
+    if m:
+        fail = True
+        out.append(f"[FAIL] {len(m)} event types emitted by the frontend but "
+                   f"not by the standalone:")
+        for entry in m:
+            out.append(f"   - {entry['type']:35s}  (fe: {fmt_sites(entry['frontend_sites'])})")
+        out.append("")
+
+    # ---- Orphan event types
+    o = report["orphan_event_types"]
+    if o:
+        fail = True
+        out.append(f"[FAIL] {len(o)} event types emitted by the standalone but "
+                   f"not declared in InteractionType:")
+        for entry in o:
+            out.append(f"   - {entry['type']:35s}  (sa: {fmt_sites(entry['standalone_sites'])})")
+        out.append("")
+
+    # ---- recordCompletion gap
+    mc = report["missing_completion"]
+    if mc:
+        fail = True
+        out.append(f"[FAIL] {len(mc)} async wait-point *_completed events emitted "
+                   f"by the frontend but never in the standalone:")
+        for t in mc:
+            out.append(f"   - {t}")
+        out.append("")
+
+    # ---- Detail-key drift
+    d = report["detail_key_drift"]
+    if d:
+        fail = True
+        out.append(f"[FAIL] {len(d)} events whose `details` object-literal keys "
+                   f"diverge between frontend and standalone:")
+        for entry in d:
+            out.append(f"   - {entry['event_type']}")
+            out.append(f"        frontend:   {{{', '.join(entry['frontend_keys'])}}}")
+            out.append(f"        standalone: {{{', '.join(entry['standalone_keys'])}}}")
+            if entry["missing_in_standalone"]:
+                out.append(f"        missing:    {entry['missing_in_standalone']}")
+            if entry["extra_in_standalone"]:
+                out.append(f"        extra:      {entry['extra_in_standalone']}")
+        out.append("")
+
+    # ---- API-path gap
+    ma = report["missing_api_paths"]
+    if ma:
+        fail = True
+        out.append(f"[FAIL] {len(ma)} API paths referenced by the frontend but "
+                   f"not by the standalone:")
+        for p in ma:
+            out.append(f"   - {p}")
+        out.append("")
+
+    # ---- Settings-field gap
+    ms = report["missing_settings"]
+    if ms:
+        fail = True
+        out.append(f"[WARN] {len(ms)} SettingsState fields whose identifier was "
+                   f"not found in the standalone (best-effort grep):")
+        for s in ms:
+            out.append(f"   - {s}")
+        out.append("")
+
+    if not fail:
+        out.append("[OK] standalone_interface.html is in full Layer-1 parity with frontend/.")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    parser.add_argument(
+        "--allow-warn", action="store_true",
+        help="exit 0 even if there are [WARN] findings (FAILs still exit 1)",
+    )
+    args = parser.parse_args()
+
+    report = run_checks()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_human(report))
+
+    hard_fail = (
+        report["missing_event_types"]
+        or report["orphan_event_types"]
+        or report["missing_completion"]
+        or report["detail_key_drift"]
+        or report["missing_api_paths"]
+    )
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -49,6 +49,128 @@ USE_SETTINGS_TS = FRONTEND_SRC / "hooks" / "useSettings.ts"
 
 
 # ---------------------------------------------------------------------
+# Spec table — the replay contract from docs/interaction-logging.md
+# ---------------------------------------------------------------------
+#
+# Encoded per event type as `(required_keys, optional_keys)`. Both are
+# `frozenset` so the dict stays cheap to hash. Optional keys are
+# fields the spec marks "only populated when ..." (e.g.
+# `pending_branch` for `contingency_confirmed`) — they MAY be present
+# without being flagged as an extra.
+#
+# Source of truth: docs/interaction-logging.md § "Replay Contract:
+# Required Details Per Event Type". When the spec changes, update
+# this table in the same PR — the three-way-diff check (`--spec`)
+# compares FE and SA emissions against this.
+#
+# Events whose frontend details are passed via a bare identifier
+# (e.g. ``record('config_loaded', buildConfigInteractionDetails())``)
+# have SA compared to spec but FE can only be compared by a separate
+# static-analysis pass that resolves the identifier's return shape;
+# we don't attempt that here and mark FE as "deferred".
+
+_CONFIG_FIELDS = frozenset({
+    "network_path", "action_file_path", "layout_path", "output_folder_path",
+    "min_line_reconnections", "min_close_coupling", "min_open_coupling",
+    "min_line_disconnections", "min_pst", "min_load_shedding",
+    "min_renewable_curtailment_actions", "n_prioritized_actions",
+    "lines_monitoring_path", "monitoring_factor",
+    "pre_existing_overload_threshold", "ignore_reconnections",
+    "pypowsybl_fast_mode",
+})
+
+
+def _spec_row(required: set[str], optional: set[str] = frozenset()) -> dict:
+    return {"required": frozenset(required), "optional": frozenset(optional)}
+
+
+SPEC_DETAILS: dict[str, dict] = {
+    # --- Configuration & Study Loading ---
+    "config_loaded":           _spec_row(_CONFIG_FIELDS),
+    "settings_opened":         _spec_row({"tab"}),
+    "settings_tab_changed":    _spec_row({"from_tab", "to_tab"}),
+    "settings_applied":        _spec_row(_CONFIG_FIELDS),
+    "settings_cancelled":      _spec_row(set()),
+    "path_picked":             _spec_row({"type", "path"}),
+    # --- Contingency ---
+    "contingency_selected":    _spec_row({"element"}),
+    "contingency_confirmed":   _spec_row({"type"}, optional={"pending_branch"}),
+    # --- Two-Step Analysis ---
+    "analysis_step1_started":   _spec_row({"element"}),
+    "analysis_step1_completed": _spec_row({
+        "element", "overloads_found", "n_overloads",
+        "can_proceed", "dc_fallback", "message",
+    }),
+    "overload_toggled":         _spec_row({"overload", "selected"}),
+    "analysis_step2_started":   _spec_row({
+        "element", "selected_overloads", "all_overloads", "monitor_deselected",
+    }),
+    "analysis_step2_completed": _spec_row({
+        "n_actions", "action_ids", "dc_fallback", "message", "pdf_url",
+    }),
+    "prioritized_actions_displayed": _spec_row({"n_actions"}),
+    # --- Action ---
+    "action_selected":          _spec_row({"action_id"}),
+    "action_deselected":        _spec_row({"previous_action_id"}),
+    "action_favorited":         _spec_row({"action_id"}),
+    "action_unfavorited":       _spec_row({"action_id"}),
+    "action_rejected":          _spec_row({"action_id"}),
+    "action_unrejected":        _spec_row({"action_id"}),
+    "manual_action_simulated":  _spec_row({"action_id"}),
+    "action_mw_resimulated":    _spec_row({"action_id", "target_mw"}),
+    "pst_tap_resimulated":      _spec_row({"action_id", "target_tap"}),
+    # --- Combined Actions ---
+    "combine_modal_opened":     _spec_row(set()),
+    "combine_modal_closed":     _spec_row(set()),
+    "combine_pair_toggled":     _spec_row({"action_id", "selected"}),
+    "combine_pair_estimated":   _spec_row({
+        "action1_id", "action2_id",
+        "estimated_max_rho", "estimated_max_rho_line",
+    }),
+    "combine_pair_simulated":   _spec_row({
+        "combined_id", "action1_id", "action2_id", "simulated_max_rho",
+    }),
+    # --- Visualization ---
+    "diagram_tab_changed":      _spec_row({"tab"}),
+    "tab_detached":             _spec_row({"tab"}),
+    "tab_reattached":           _spec_row({"tab"}),
+    "tab_tied":                 _spec_row({"tab"}),
+    "tab_untied":               _spec_row({"tab"}),
+    "view_mode_changed":        _spec_row({"mode", "tab", "scope"}),
+    "voltage_range_changed":    _spec_row({"min", "max"}),
+    "asset_clicked":            _spec_row({"action_id", "asset_name", "tab"}),
+    "zoom_in":                  _spec_row({"tab"}),
+    "zoom_out":                 _spec_row({"tab"}),
+    "zoom_reset":               _spec_row({"tab"}),
+    "inspect_query_changed":    _spec_row({"query"}, optional={"target_tab"}),
+    # --- Action Overview Diagram ---
+    "overview_shown":           _spec_row({"has_pins", "pin_count"}),
+    "overview_hidden":          _spec_row(set()),
+    "overview_pin_clicked":     _spec_row({"action_id"}),
+    "overview_pin_double_clicked": _spec_row({"action_id"}),
+    "overview_popover_closed":  _spec_row({"reason"}),
+    "overview_zoom_in":         _spec_row(set()),
+    "overview_zoom_out":        _spec_row(set()),
+    "overview_zoom_fit":        _spec_row(set()),
+    "overview_inspect_changed": _spec_row({"query", "action"}),
+    # --- SLD Overlay ---
+    "sld_overlay_opened":       _spec_row({"vl_name", "action_id"}),
+    "sld_overlay_tab_changed":  _spec_row({"tab", "vl_name"}),
+    "sld_overlay_closed":       _spec_row(set()),
+    # --- Session Management ---
+    "session_saved":            _spec_row({"output_folder"}),
+    "session_reload_modal_opened": _spec_row(set()),
+    "session_reloaded":         _spec_row({"session_name"}),
+}
+
+# Event types whose frontend details argument is a bare identifier or
+# a function call — the regex cannot see inside them. The SA side is
+# still checked against the spec; the FE side is reported as
+# "deferred" rather than a false-positive mismatch.
+_FE_DEFERRED_TYPES = frozenset({"config_loaded", "settings_applied"})
+
+
+# ---------------------------------------------------------------------
 # Extractors (React source → canonical sets)
 # ---------------------------------------------------------------------
 
@@ -338,6 +460,59 @@ def run_checks() -> dict:
                 "standalone_sites": sa_sites[t][:3],
             })
 
+    # Three-way diff vs the replay-contract spec
+    # (docs/interaction-logging.md § Replay Contract). Distinct from the
+    # FE-vs-SA drift: both codebases can agree yet still drift from the
+    # contract, and conversely one side can be correct while the other
+    # drifts. Encoding the spec here lets the report attribute each
+    # finding to the side that needs to move.
+    fe_spec_drift: list[dict] = []
+    sa_spec_drift: list[dict] = []
+    missing_spec_rows: list[str] = []
+    for t in sorted(canonical_events):
+        spec = SPEC_DETAILS.get(t)
+        if spec is None:
+            missing_spec_rows.append(t)
+            continue
+        required = spec["required"]
+        optional = spec["optional"]
+        known = required | optional
+
+        # Frontend side.
+        if t in fe_event_types and t not in _FE_DEFERRED_TYPES:
+            fe = fe_keys.get(t, set())
+            # Empty object literal is a valid emission — only flag a
+            # missing-required gap when the event actually carries a
+            # non-empty shape or the spec requires anything.
+            fe_missing = sorted(required - fe) if (fe or required) else []
+            fe_extras = sorted(fe - known)
+            if fe_missing or fe_extras:
+                fe_spec_drift.append({
+                    "event_type": t,
+                    "spec_required": sorted(required),
+                    "spec_optional": sorted(optional),
+                    "frontend_keys": sorted(fe),
+                    "missing_required": fe_missing,
+                    "unknown_extras": fe_extras,
+                    "frontend_sites": fe_sites[t][:3],
+                })
+
+        # Standalone side.
+        if t in sa_event_types:
+            sa = sa_keys.get(t, set())
+            sa_missing = sorted(required - sa) if (sa or required) else []
+            sa_extras = sorted(sa - known)
+            if sa_missing or sa_extras:
+                sa_spec_drift.append({
+                    "event_type": t,
+                    "spec_required": sorted(required),
+                    "spec_optional": sorted(optional),
+                    "standalone_keys": sorted(sa),
+                    "missing_required": sa_missing,
+                    "unknown_extras": sa_extras,
+                    "standalone_sites": sa_sites[t][:3],
+                })
+
     sa_api = extract_standalone_api_paths(STANDALONE)
     missing_api_paths = sorted(
         p for p in canonical_api
@@ -376,6 +551,9 @@ def run_checks() -> dict:
         ],
         "missing_completion": missing_completion,
         "detail_key_drift": detail_key_drift,
+        "fe_spec_drift": fe_spec_drift,
+        "sa_spec_drift": sa_spec_drift,
+        "missing_spec_rows": missing_spec_rows,
         "missing_api_paths": missing_api_paths,
         "missing_settings": missing_settings,
     }
@@ -440,6 +618,53 @@ def render_human(report: dict) -> str:
                 out.append(f"        extra:      {entry['extra_in_standalone']}")
         out.append("")
 
+    # ---- FE-vs-spec drift
+    fs = report["fe_spec_drift"]
+    if fs:
+        fail = True
+        out.append(f"[FAIL] {len(fs)} events where the frontend drifts from the "
+                   f"replay-contract spec (docs/interaction-logging.md):")
+        for entry in fs:
+            out.append(f"   - {entry['event_type']}")
+            out.append(f"        spec required: {{{', '.join(entry['spec_required'])}}}")
+            if entry["spec_optional"]:
+                out.append(f"        spec optional: {{{', '.join(entry['spec_optional'])}}}")
+            out.append(f"        frontend:      {{{', '.join(entry['frontend_keys'])}}}")
+            if entry["missing_required"]:
+                out.append(f"        missing:       {entry['missing_required']}")
+            if entry["unknown_extras"]:
+                out.append(f"        unknown extras: {entry['unknown_extras']}")
+            out.append(f"        fe sites:      {fmt_sites(entry['frontend_sites'])}")
+        out.append("")
+
+    # ---- SA-vs-spec drift
+    ss = report["sa_spec_drift"]
+    if ss:
+        fail = True
+        out.append(f"[FAIL] {len(ss)} events where the standalone drifts from the "
+                   f"replay-contract spec (docs/interaction-logging.md):")
+        for entry in ss:
+            out.append(f"   - {entry['event_type']}")
+            out.append(f"        spec required: {{{', '.join(entry['spec_required'])}}}")
+            if entry["spec_optional"]:
+                out.append(f"        spec optional: {{{', '.join(entry['spec_optional'])}}}")
+            out.append(f"        standalone:    {{{', '.join(entry['standalone_keys'])}}}")
+            if entry["missing_required"]:
+                out.append(f"        missing:       {entry['missing_required']}")
+            if entry["unknown_extras"]:
+                out.append(f"        unknown extras: {entry['unknown_extras']}")
+            out.append(f"        sa sites:      {fmt_sites(entry['standalone_sites'])}")
+        out.append("")
+
+    # ---- Spec rows still missing from SPEC_DETAILS
+    mr = report.get("missing_spec_rows") or []
+    if mr:
+        out.append(f"[WARN] {len(mr)} InteractionType values have no SPEC_DETAILS "
+                   f"entry — extend the spec table in this script:")
+        for t in mr:
+            out.append(f"   - {t}")
+        out.append("")
+
     # ---- API-path gap
     ma = report["missing_api_paths"]
     if ma:
@@ -465,9 +690,114 @@ def render_human(report: dict) -> str:
     return "\n".join(out)
 
 
+def render_markdown(report: dict) -> str:
+    """Render the findings as Markdown tables suitable for pasting
+    into ``CLAUDE.md`` (§ "Machine-grounded findings").
+
+    This is what the ``--emit-markdown`` flag prints. The intent is
+    that the audit table in the root CLAUDE.md is NEVER hand-edited
+    — it is always regenerated from this function's output, so the
+    doc and the script can never drift.
+    """
+    out: list[str] = []
+    out.append(
+        f"_Generated by `scripts/check_standalone_parity.py`._ "
+        f"InteractionType union: **{report['canonical_event_count']}** types. "
+        f"Frontend emits **{report['frontend_event_count']}**, "
+        f"standalone emits **{report['standalone_event_count']}**."
+    )
+    out.append("")
+
+    me = report["missing_event_types"]
+    if me:
+        out.append(f"#### Event types emitted by the frontend but NOT by the standalone ({len(me)})")
+        out.append("")
+        out.append("| Event type | React source |")
+        out.append("|---|---|")
+        for entry in me:
+            sites = fmt_sites(entry["frontend_sites"])
+            out.append(f"| `{entry['type']}` | `{sites}` |")
+        out.append("")
+
+    oe = report["orphan_event_types"]
+    if oe:
+        out.append(f"#### Event types emitted by the standalone but NOT in `InteractionType` ({len(oe)})")
+        out.append("")
+        out.append("| Event type | Standalone source |")
+        out.append("|---|---|")
+        for entry in oe:
+            sites = fmt_sites(entry["standalone_sites"])
+            out.append(f"| `{entry['type']}` | `{sites}` |")
+        out.append("")
+
+    fs = report["fe_spec_drift"]
+    if fs:
+        out.append(f"#### Frontend drifts from the replay-contract spec ({len(fs)})")
+        out.append("")
+        out.append("| Event | Spec required | Frontend emits | Missing | React source |")
+        out.append("|---|---|---|---|---|")
+        for entry in fs:
+            req = ", ".join(entry["spec_required"])
+            fe = ", ".join(entry["frontend_keys"]) or "(empty)"
+            missing = ", ".join(entry["missing_required"]) or "—"
+            sites = fmt_sites(entry["frontend_sites"])
+            out.append(f"| `{entry['event_type']}` | `{{{req}}}` | `{{{fe}}}` | `{missing}` | `{sites}` |")
+        out.append("")
+
+    ss = report["sa_spec_drift"]
+    if ss:
+        out.append(f"#### Standalone drifts from the replay-contract spec ({len(ss)})")
+        out.append("")
+        out.append("| Event | Spec required | Standalone emits | Missing | Standalone source |")
+        out.append("|---|---|---|---|---|")
+        for entry in ss:
+            req = ", ".join(entry["spec_required"])
+            sa = ", ".join(entry["standalone_keys"]) or "(empty)"
+            missing = ", ".join(entry["missing_required"]) or "—"
+            sites = fmt_sites(entry["standalone_sites"])
+            out.append(f"| `{entry['event_type']}` | `{{{req}}}` | `{{{sa}}}` | `{missing}` | `{sites}` |")
+        out.append("")
+
+    d = report["detail_key_drift"]
+    if d:
+        out.append(f"#### FE ↔ SA details-key drift (no spec row) ({len(d)})")
+        out.append("")
+        out.append("| Event | Frontend | Standalone |")
+        out.append("|---|---|---|")
+        for entry in d:
+            fe = ", ".join(entry["frontend_keys"]) or "(empty)"
+            sa = ", ".join(entry["standalone_keys"]) or "(empty)"
+            out.append(f"| `{entry['event_type']}` | `{{{fe}}}` | `{{{sa}}}` |")
+        out.append("")
+
+    ma = report["missing_api_paths"]
+    if ma:
+        out.append(f"#### API paths referenced by the frontend but not by the standalone ({len(ma)})")
+        out.append("")
+        for p in ma:
+            out.append(f"- `{p}`")
+        out.append("")
+
+    mc = report["missing_completion"]
+    if mc:
+        out.append(f"#### `recordCompletion(...)` events emitted by the frontend but not the standalone ({len(mc)})")
+        out.append("")
+        for t in mc:
+            out.append(f"- `{t}`")
+        out.append("")
+
+    if not out:
+        out.append("_No findings — `standalone_interface.html` is in full Layer-1 parity with `frontend/`._")
+    return "\n".join(out)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    parser.add_argument(
+        "--emit-markdown", action="store_true",
+        help="render a Markdown report suitable for pasting into CLAUDE.md",
+    )
     parser.add_argument(
         "--allow-warn", action="store_true",
         help="exit 0 even if there are [WARN] findings (FAILs still exit 1)",
@@ -477,6 +807,8 @@ def main() -> int:
     report = run_checks()
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.emit_markdown:
+        print(render_markdown(report))
     else:
         print(render_human(report))
 
@@ -485,6 +817,8 @@ def main() -> int:
         or report["orphan_event_types"]
         or report["missing_completion"]
         or report["detail_key_drift"]
+        or report["fe_spec_drift"]
+        or report["sa_spec_drift"]
         or report["missing_api_paths"]
     )
     return 1 if hard_fail else 0

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -231,12 +231,104 @@ def extract_settings_state_fields(hook_path: Path) -> set[str]:
 
 
 RECORD_CALL = re.compile(
-    r"interactionLogger\.record\(\s*['\"]([a-z0-9_]+)['\"]\s*(?:,\s*(\{[^{}]*?\}|\w+))?",
-    re.DOTALL,
+    r"interactionLogger\.record\(\s*['\"]([a-z0-9_]+)['\"]",
 )
 RECORD_COMPLETION_CALL = re.compile(
     r"interactionLogger\.recordCompletion\(\s*['\"]([a-z0-9_]+)['\"]",
 )
+
+
+def _extract_second_arg(src: str, after: int) -> tuple[str, int] | None:
+    """Starting at `src[after] == ','`, return the source slice of the
+    second argument to ``interactionLogger.record`` and the offset
+    past it.  Handles balanced ``{}`` nesting (so JSX and inline
+    expressions like ``Object.keys({}).length`` don't truncate the
+    capture), and handles bare identifiers / method calls (returns
+    them verbatim so the caller can note it's "deferred").
+
+    Returns None if the call has no second argument.
+    """
+    i = after
+    # Expect `,` followed by whitespace, then the arg.
+    if i >= len(src) or src[i] != ",":
+        return None
+    i += 1
+    while i < len(src) and src[i].isspace():
+        i += 1
+    if i >= len(src):
+        return None
+    start = i
+    if src[i] == "{":
+        # Balance braces; strings and comments can harbour unbalanced
+        # braces so we skip them explicitly.
+        depth = 0
+        while i < len(src):
+            c = src[i]
+            if c == "{":
+                depth += 1
+                i += 1
+            elif c == "}":
+                depth -= 1
+                i += 1
+                if depth == 0:
+                    return (src[start:i], i)
+            elif c in "\"'":
+                # Skip string literal
+                quote = c
+                i += 1
+                while i < len(src) and src[i] != quote:
+                    if src[i] == "\\":
+                        i += 2
+                    else:
+                        i += 1
+                i += 1
+            elif c == "`":
+                # Template literal — just skip to the matching `
+                i += 1
+                while i < len(src) and src[i] != "`":
+                    if src[i] == "\\":
+                        i += 2
+                    else:
+                        i += 1
+                i += 1
+            elif src[i:i + 2] == "//":
+                while i < len(src) and src[i] != "\n":
+                    i += 1
+            elif src[i:i + 2] == "/*":
+                i += 2
+                while i < len(src) and src[i:i + 2] != "*/":
+                    i += 1
+                i += 2
+            else:
+                i += 1
+        return None
+    # Bare identifier / call expression — read until top-level `)` or
+    # `,` at paren-depth 0.
+    paren_depth = 0
+    while i < len(src):
+        c = src[i]
+        if c == "(":
+            paren_depth += 1
+        elif c == ")":
+            if paren_depth == 0:
+                break
+            paren_depth -= 1
+        elif c == "," and paren_depth == 0:
+            break
+        i += 1
+    return (src[start:i], i)
+
+
+def _strip_comments(src: str) -> str:
+    """Remove ``//``-line and ``/* */``-block comments so they don't
+    pollute the DETAIL_KEY walk. (The tokenizer above already skips
+    comments while walking braces, but the body passed to DETAIL_KEY
+    is the raw slice — stripping here is the simplest way to keep
+    the key walker honest against call-site comments.)
+    """
+    src = re.sub(r"//[^\n]*", "", src)
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    return src
 # Match only property-start positions inside an object literal so we
 # capture keys (not value identifiers).  Both explicit and JS shorthand
 # properties are supported:
@@ -280,15 +372,19 @@ def walk_record_calls(
         # Use line-by-line search so we can cheaply attach line numbers.
         for m in RECORD_CALL.finditer(src):
             event_type = m.group(1)
-            details_src = m.group(2) or ""
             line_no = src.count("\n", 0, m.start()) + 1
             sites_by_type[event_type].append((rel, line_no))
+            second = _extract_second_arg(src, m.end())
+            if second is None:
+                continue
+            details_src, _end = second
             if details_src.startswith("{"):
-                # Pass the whole literal (outer braces included) so the
-                # DETAIL_KEY anchor recognises the first property —
-                # stripping the outer ``{`` would drop the leading key
-                # of multi-property objects.
-                for km in DETAIL_KEY.finditer(details_src):
+                # Strip comments before the key walk — a comment between
+                # ``{`` and the first property would otherwise hide the
+                # first key (the anchor ``[{,]\s*`` can't skip across
+                # arbitrary non-whitespace text).
+                cleaned = _strip_comments(details_src)
+                for km in DETAIL_KEY.finditer(cleaned):
                     keys_by_type[event_type].add(km.group(1))
     return keys_by_type, sites_by_type
 
@@ -324,22 +420,22 @@ def walk_standalone_record_calls(
     """Same contract as :func:`walk_record_calls` but for the
     single-file standalone HTML. The standalone inlines React-like JSX
     + JS, so ``interactionLogger.record(...)`` literals look identical
-    to the frontend ones. We re-use the same regex.
+    to the frontend ones. We re-use the same extractor.
     """
     keys_by_type: dict[str, set[str]] = defaultdict(set)
     sites_by_type: dict[str, list[tuple[str, int]]] = defaultdict(list)
     src = html_path.read_text(encoding="utf-8", errors="replace")
     for m in RECORD_CALL.finditer(src):
         event_type = m.group(1)
-        details_src = m.group(2) or ""
         line_no = src.count("\n", 0, m.start()) + 1
         sites_by_type[event_type].append((str(html_path.name), line_no))
+        second = _extract_second_arg(src, m.end())
+        if second is None:
+            continue
+        details_src, _end = second
         if details_src.startswith("{"):
-            # Pass the whole literal, including outer braces. The
-            # DETAIL_KEY anchor needs the leading ``{`` to recognise
-            # the first property — stripping it would drop the first
-            # key from multi-property objects.
-            for km in DETAIL_KEY.finditer(details_src):
+            cleaned = _strip_comments(details_src)
+            for km in DETAIL_KEY.finditer(cleaned):
                 keys_by_type[event_type].add(km.group(1))
     return keys_by_type, sites_by_type
 

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -546,6 +546,24 @@ def run_checks() -> dict:
         if not fe:
             continue  # frontend details are in a bare identifier
         if fe and sa and fe != sa:
+            # A diff that is spec-conformant on both sides (only
+            # optional keys are present on one side but not the other)
+            # is not real drift — skip it rather than flag it as a
+            # parity failure.  The spec marks the difference as
+            # intentional, typically when one codebase supports a
+            # feature the other doesn't (e.g. detached-tab overlays).
+            spec = SPEC_DETAILS.get(t)
+            if spec is not None:
+                required = spec["required"]
+                optional = spec["optional"]
+                symmetric_diff = (fe ^ sa)
+                # Benign if every differing key is either optional or
+                # both sides have all required keys.
+                fe_ok = required <= fe
+                sa_ok = required <= sa
+                all_diffs_optional = symmetric_diff <= optional
+                if fe_ok and sa_ok and all_diffs_optional:
+                    continue
             detail_key_drift.append({
                 "event_type": t,
                 "frontend_keys": sorted(fe),

--- a/scripts/parity_e2e/.gitignore
+++ b/scripts/parity_e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+artefacts.json

--- a/scripts/parity_e2e/e2e_parity.spec.ts
+++ b/scripts/parity_e2e/e2e_parity.spec.ts
@@ -1,0 +1,407 @@
+/**
+ * Layer-3 parity E2E spec.
+ *
+ * Drives BOTH the React frontend (`frontend/dist/`, served statically)
+ * AND the standalone (`standalone_interface.html`, loaded via
+ * `file://`) through an identical canonical gesture sequence.  Both
+ * runs hit a MOCKED backend via `page.route('/api/** / *', ...)` — so
+ * the spec is independent of pypowsybl / expert_op4grid_recommender,
+ * and can run in any CI environment where Playwright can install a
+ * browser.
+ *
+ * After each run the spec captures:
+ *   - The ordered list of `interactionLogger.record(...)` events.
+ *   - The `session.json` payload that `buildSessionResult` writes
+ *     when the user clicks Save.
+ *
+ * It then diffs the two runs along three axes:
+ *   1. Event-type sequence (order-sensitive).
+ *   2. `details` keys per event (order-insensitive).
+ *   3. `session.json` shape (top-level + nested field presence;
+ *      values are ignored because timestamps / durations differ).
+ *
+ * The spec is the authoritative "behavioural" check that complements
+ * the static Layer-1 (`scripts/check_standalone_parity.py`) and the
+ * session-reload fidelity Layer-2 (`scripts/check_session_fidelity.py`).
+ *
+ * ----------------------------------------------------------------
+ * Running locally
+ * ----------------------------------------------------------------
+ *
+ *   # Prereq: a browser for Playwright to drive.
+ *   cd scripts/parity_e2e
+ *   npm install
+ *   npx playwright install chromium
+ *
+ *   # Build the React app once (so we can serve its /dist statically).
+ *   cd ../../frontend
+ *   npm install && npm run build
+ *
+ *   cd ../scripts/parity_e2e
+ *   npx playwright test
+ *
+ * ----------------------------------------------------------------
+ * CI wiring
+ * ----------------------------------------------------------------
+ *
+ *   - uses: actions/checkout@v4
+ *   - uses: actions/setup-node@v4
+ *   - run: cd frontend && npm ci && npm run build
+ *   - run: cd scripts/parity_e2e && npm ci
+ *   - run: cd scripts/parity_e2e && npx playwright install --with-deps chromium
+ *   - run: cd scripts/parity_e2e && npx playwright test
+ *
+ * The spec is deliberately kept at per-PR cost (~90 s) — see
+ * `scripts/PARITY_README.md` for why we don't run it on every
+ * commit and what it catches that Layers 1 + 2 miss.
+ */
+import { test, expect, type Page, type Route, type Browser } from '@playwright/test';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+
+// ---------------------------------------------------------------------
+// Mock backend — minimal, just enough that both UIs can run the
+// canonical gesture sequence without crashing.
+// ---------------------------------------------------------------------
+
+const MOCK_BRANCHES = ['LINE_A', 'LINE_B', 'LINE_C'];
+const MOCK_VLS = ['VL_1', 'VL_2'];
+const MOCK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <g id="nad">
+    <g class="nad-vl" id="VL_1"><circle cx="30" cy="30" r="5"/></g>
+    <g class="nad-vl" id="VL_2"><circle cx="70" cy="70" r="5"/></g>
+  </g>
+</svg>`;
+
+async function registerMockBackend(page: Page): Promise<void> {
+  await page.route('**/api/config', (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'success',
+        message: 'loaded',
+        total_lines_count: MOCK_BRANCHES.length,
+        monitored_lines_count: MOCK_BRANCHES.length,
+        action_dict_file_name: 'mock_actions.json',
+        action_dict_stats: { reco: 1, disco: 2, pst: 0, open_coupling: 0, close_coupling: 0, total: 3 },
+      }),
+    })
+  );
+
+  await page.route('**/api/branches', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        branches: MOCK_BRANCHES,
+        name_map: Object.fromEntries(MOCK_BRANCHES.map(b => [b, b])),
+      }),
+    })
+  );
+
+  await page.route('**/api/voltage-levels', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        voltage_levels: MOCK_VLS,
+        name_map: Object.fromEntries(MOCK_VLS.map(v => [v, v])),
+      }),
+    })
+  );
+
+  await page.route('**/api/nominal-voltages', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        mapping: Object.fromEntries(MOCK_VLS.map(v => [v, 400])),
+        unique_kv: [400],
+      }),
+    })
+  );
+
+  // Base NAD — React uses `format=text` so the body is a JSON header
+  // line + raw SVG body (see api.ts::getNetworkDiagram).
+  await page.route('**/api/network-diagram**', (route) => {
+    const header = JSON.stringify({
+      metadata: {},
+      lines_overloaded: [],
+      lines_overloaded_rho: [],
+    });
+    const body = `${header}\n${MOCK_SVG}`;
+    route.fulfill({ status: 200, contentType: 'text/plain; charset=utf-8', body });
+  });
+
+  await page.route('**/api/n1-diagram', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        svg: MOCK_SVG,
+        metadata: {},
+        lines_overloaded: ['LINE_B'],
+        lines_overloaded_rho: [1.15],
+        flow_deltas: {},
+        reactive_flow_deltas: {},
+        asset_deltas: {},
+        lf_converged: true,
+        lf_status: 'CONVERGED',
+      }),
+    })
+  );
+
+  await page.route('**/api/run-analysis-step1', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        lines_overloaded: ['LINE_B'],
+        message: '1 overloaded line detected',
+        can_proceed: true,
+      }),
+    })
+  );
+
+  // NDJSON stream — two events.
+  await page.route('**/api/run-analysis-step2', (route) => {
+    const pdfEvent = JSON.stringify({ type: 'pdf', pdf_url: '/results/pdf/mock.pdf' });
+    const resultEvent = JSON.stringify({
+      type: 'result',
+      actions: {
+        disco_LINE_C: {
+          description_unitaire: 'Disconnect LINE_C',
+          rho_before: [1.15], rho_after: [0.85],
+          max_rho: 0.85, max_rho_line: 'LINE_B',
+          is_rho_reduction: true,
+        },
+      },
+      action_scores: {},
+      lines_overloaded: ['LINE_B'],
+      combined_actions: {},
+      message: '1 action found',
+      dc_fallback: false,
+    });
+    route.fulfill({
+      status: 200, contentType: 'application/x-ndjson',
+      body: `${pdfEvent}\n${resultEvent}\n`,
+    });
+  });
+
+  await page.route('**/api/action-variant-diagram', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        svg: MOCK_SVG, metadata: {}, action_id: 'disco_LINE_C',
+        flow_deltas: {}, reactive_flow_deltas: {}, asset_deltas: {},
+        lf_converged: true, lf_status: 'CONVERGED',
+      }),
+    })
+  );
+
+  await page.route('**/api/save-session', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        session_folder: '/tmp/session_mock',
+        pdf_copied: false,
+      }),
+    })
+  );
+
+  await page.route('**/api/user-config', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        network_path: '', action_file_path: '', layout_path: '',
+        output_folder_path: '', lines_monitoring_path: '',
+        min_line_reconnections: 2.0, min_close_coupling: 3.0,
+        min_open_coupling: 2.0, min_line_disconnections: 3.0,
+        min_pst: 1.0, min_load_shedding: 0.0,
+        min_renewable_curtailment_actions: 0.0,
+        n_prioritized_actions: 10, monitoring_factor: 0.95,
+        pre_existing_overload_threshold: 0.02,
+        ignore_reconnections: false, pypowsybl_fast_mode: true,
+      }),
+    })
+  );
+
+  await page.route('**/api/config-file-path', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ config_file_path: '/tmp/config.json' }),
+    })
+  );
+}
+
+// ---------------------------------------------------------------------
+// Interaction-log capture
+// ---------------------------------------------------------------------
+
+async function captureInteractionLog(page: Page): Promise<Array<Record<string, unknown>>> {
+  // Both UIs expose `interactionLogger` on `window` (React via a
+  // `useEffect` bridge, standalone via its inline class definition).
+  // If the React app doesn't expose it, uncomment the helper below
+  // and add `window.__interactionLogger = interactionLogger` inside
+  // a `useEffect` in App.tsx guarded by `process.env.VITEST === 'e2e'`.
+  return await page.evaluate(() => {
+    // @ts-expect-error — interactionLogger is a runtime singleton.
+    const logger = window.interactionLogger || window.__interactionLogger;
+    return logger ? logger.getLog() : [];
+  });
+}
+
+// ---------------------------------------------------------------------
+// Canonical gesture sequence — the same 11 steps on both UIs.
+// ---------------------------------------------------------------------
+
+async function runCanonicalSession(page: Page): Promise<{
+  events: Array<Record<string, unknown>>;
+  sessionPayload: unknown;
+}> {
+  // 1. Load Study — the UI reads a cached config on mount and (in
+  //    the React app) auto-opens Settings if paths are blank. For
+  //    this test we preset paths via localStorage then click Load.
+  await page.evaluate(() => {
+    localStorage.setItem('networkPath', '/mock/network.xiidm');
+    localStorage.setItem('actionPath', '/mock/actions.json');
+    localStorage.setItem('layoutPath', '/mock/grid_layout.json');
+    localStorage.setItem('outputFolderPath', '/mock/output');
+  });
+  await page.reload();
+  await page.getByRole('button', { name: /Load Study/i }).click();
+  await page.waitForResponse((r) => r.url().includes('/api/network-diagram'));
+
+  // 2. Select contingency LINE_A.
+  const contingencyInput = page.getByPlaceholder(/Search line\/bus/i);
+  await contingencyInput.fill('LINE_A');
+  await contingencyInput.press('Enter');
+  await page.waitForResponse((r) => r.url().includes('/api/n1-diagram'));
+
+  // 3. Run step 1.
+  await page.getByRole('button', { name: /Detect Overloads/i }).click();
+  await page.waitForResponse((r) => r.url().includes('/api/run-analysis-step1'));
+
+  // 4. Toggle overload LINE_B off then on (exercises the checkbox).
+  const olCheckbox = page.getByLabel(/LINE_B/);
+  await olCheckbox.uncheck();
+  await olCheckbox.check();
+
+  // 5. Run step 2.
+  await page.getByRole('button', { name: /Resolve|Run Analysis/i }).click();
+  await page.waitForResponse((r) => r.url().includes('/api/run-analysis-step2'));
+
+  // 6. Display prioritized actions (if a separate button exists;
+  //    otherwise the action feed populates automatically).
+  const displayBtn = page.getByRole('button', { name: /Display Prioritized/i });
+  if (await displayBtn.count() > 0) await displayBtn.click();
+
+  // 7. Select (click) the first action card.
+  const actionCard = page.locator('[data-action-id="disco_LINE_C"]').first();
+  if (await actionCard.count() > 0) {
+    await actionCard.click();
+    await page.waitForResponse((r) => r.url().includes('/api/action-variant-diagram'));
+  }
+
+  // 8. Favorite the action.
+  const starBtn = page.locator('[aria-label*="favorite"]').first();
+  if (await starBtn.count() > 0) await starBtn.click();
+
+  // 9. Change tab to N, then back to N-1.
+  await page.getByRole('button', { name: /^N$/ }).click();
+  await page.getByRole('button', { name: /^N-1$/ }).click();
+
+  // 10. Zoom in/out on the active tab.
+  const zoomIn = page.locator('[aria-label*="zoom in" i]').first();
+  const zoomOut = page.locator('[aria-label*="zoom out" i]').first();
+  if (await zoomIn.count() > 0) await zoomIn.click();
+  if (await zoomOut.count() > 0) await zoomOut.click();
+
+  // 11. Save session.
+  await page.getByRole('button', { name: /Save Results|Save Session/i }).click();
+  const saveResponse = await page.waitForResponse((r) =>
+    r.url().includes('/api/save-session') && r.request().method() === 'POST'
+  );
+
+  const requestBody = saveResponse.request().postData();
+  const sessionPayload = requestBody
+    ? JSON.parse(JSON.parse(requestBody).json_content || '{}')
+    : null;
+
+  const events = await captureInteractionLog(page);
+  return { events, sessionPayload };
+}
+
+// ---------------------------------------------------------------------
+// Normaliser + diff helpers
+// ---------------------------------------------------------------------
+
+interface NormalisedEvent {
+  type: string;
+  detailKeys: string[];
+}
+
+function normaliseEvents(events: Array<Record<string, unknown>>): NormalisedEvent[] {
+  return events.map((e) => ({
+    type: String(e.type),
+    detailKeys: Object.keys((e.details ?? {}) as Record<string, unknown>).sort(),
+  }));
+}
+
+function collectFieldPaths(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object') return [];
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const p = prefix ? `${prefix}.${k}` : k;
+    out.push(p);
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out.push(...collectFieldPaths(v, p));
+    }
+  }
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------
+// Tests — one spec, two runs, three assertions.
+// ---------------------------------------------------------------------
+
+interface Artefacts {
+  events: NormalisedEvent[];
+  sessionFields: string[];
+}
+
+async function runUI(browser: Browser, url: string): Promise<Artefacts> {
+  const page = await browser.newPage();
+  await registerMockBackend(page);
+  await page.goto(url);
+  const { events, sessionPayload } = await runCanonicalSession(page);
+  await page.close();
+  return {
+    events: normaliseEvents(events),
+    sessionFields: collectFieldPaths(sessionPayload),
+  };
+}
+
+test.describe('Layer-3 parity: React frontend vs standalone HTML', () => {
+  test('identical event-type sequence on the canonical gesture script', async ({ browser }) => {
+    const REACT_URL = process.env.REACT_URL ?? 'http://localhost:4173/';
+    const STANDALONE_URL = process.env.STANDALONE_URL
+      ?? `file://${path.resolve(__dirname, '../../standalone_interface.html')}`;
+
+    const react = await runUI(browser, REACT_URL);
+    const standalone = await runUI(browser, STANDALONE_URL);
+
+    // Persist artefacts for post-mortem.
+    await fs.writeFile('artefacts.json', JSON.stringify({ react, standalone }, null, 2));
+
+    // 1. Event-type sequence — order-sensitive.
+    const reactSeq = react.events.map((e) => e.type);
+    const standaloneSeq = standalone.events.map((e) => e.type);
+    expect.soft(standaloneSeq).toEqual(reactSeq);
+
+    // 2. Details-keys per event — order-insensitive.
+    for (let i = 0; i < Math.min(react.events.length, standalone.events.length); i++) {
+      expect.soft(standalone.events[i].detailKeys, `event #${i} (${react.events[i].type})`)
+        .toEqual(react.events[i].detailKeys);
+    }
+
+    // 3. Session-payload field paths.
+    expect.soft(standalone.sessionFields).toEqual(react.sessionFields);
+  });
+});

--- a/scripts/parity_e2e/package-lock.json
+++ b/scripts/parity_e2e/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "parity_e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "parity_e2e",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/parity_e2e/package.json
+++ b/scripts/parity_e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "costudy4grid-parity-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Layer-3 E2E parity spec: React frontend vs standalone_interface.html",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "install-browser": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0"
+  }
+}

--- a/scripts/parity_e2e/playwright.config.ts
+++ b/scripts/parity_e2e/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from '@playwright/test';
+import * as path from 'node:path';
+
+/**
+ * Playwright config for the Layer-3 parity spec.
+ *
+ * The spec serves the built React app via a tiny static server
+ * (see webServer below) and loads the standalone HTML straight from
+ * the repo via file://, so no pypowsybl backend is required.
+ */
+export default defineConfig({
+  testDir: __dirname,
+  testMatch: '*parity.spec.ts',
+  timeout: 90_000,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:4173/',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: {
+    // `vite preview` serves the production build. If the build is
+    // missing, fail fast rather than run against a stale dist.
+    command: 'npm --prefix ../../frontend run preview -- --port 4173 --strictPort',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    cwd: path.resolve(__dirname),
+  },
+  projects: [
+    { name: 'chromium', use: { channel: 'chromium' } },
+  ],
+});

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1597,7 +1597,37 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             return null;
         };
 
-        const computeActionOverviewPins = (actions, metaIndex) => {
+        // Pure pin-severity classifier.  Mirrors React's
+        // `computeActionSeverity` (frontend/src/utils/svgUtils.ts):
+        //   non_convergence / is_islanded → grey
+        //   max_rho missing      → green if is_rho_reduction else red
+        //   max_rho > MF         → red    (still overloaded)
+        //   max_rho > MF - 0.05  → orange (low margin)
+        //   else                 → green
+        // monitoringFactor is the operational threshold the user set
+        // in the Configurations tab — defaults to 0.95.  Hardcoding
+        // 0.9 / 1.0 boundaries (the previous bug) silently classed
+        // "still overloaded at 97%" cards as orange instead of red
+        // when the user had set MF=0.95.
+        const computeActionSeverity = (details, monitoringFactor) => {
+            if (!details) return 'grey';
+            if (details.non_convergence || details.is_islanded) return 'grey';
+            const rho = details.max_rho != null
+                ? details.max_rho
+                : (details.estimated_max_rho != null ? details.estimated_max_rho : null);
+            if (rho == null) return details.is_rho_reduction ? 'green' : 'red';
+            if (rho > monitoringFactor) return 'red';
+            if (rho > monitoringFactor - 0.05) return 'orange';
+            return 'green';
+        };
+        const SEVERITY_COLOR = {
+            green:  '#28a745',
+            orange: '#f0ad4e',
+            red:    '#dc3545',
+            grey:   '#9ca3af',
+        };
+
+        const computeActionOverviewPins = (actions, metaIndex, monitoringFactor = 0.95) => {
             if (!actions || !metaIndex) return [];
             const ids = Object.keys(actions);
             const pins = [];
@@ -1613,22 +1643,16 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 if (id.includes('+')) continue;
                 const anchor = resolveActionAnchor(id, action, metaIndex);
                 if (!anchor) continue;
+                const severity = computeActionSeverity(action, monitoringFactor);
                 const rho = typeof action.max_rho === 'number'
                     ? action.max_rho
                     : (typeof action.estimated_max_rho === 'number' ? action.estimated_max_rho : NaN);
-                // Severity palette mirrors ActionCard (docs/action-overview-diagram.md):
-                //   green    rho <= 0.9 (safe)
-                //   orange   0.9 < rho <= 1.0 (near limit)
-                //   red      rho > 1.0 (still overloaded)
-                //   grey     rho unavailable (divergent / islanded / not yet simulated)
-                let color = '#9ca3af';
-                if (Number.isFinite(rho)) {
-                    color = rho <= 0.9 ? '#28a745' : rho <= 1.0 ? '#f0ad4e' : '#dc3545';
-                }
                 pins.push({
                     id,
                     x: anchor.x, y: anchor.y,
-                    rho, rank: i + 1, color,
+                    rho, rank: i + 1,
+                    color: SEVERITY_COLOR[severity],
+                    severity,
                     description: action.description_unitaire || '',
                     max_rho_line: action.max_rho_line || action.estimated_max_rho_line || id,
                 });
@@ -1636,19 +1660,23 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             return pins;
         };
 
-        // Build curves for combined-pair (A+B) entries.  Each pair is
-        // rendered as a dashed line connecting the two constituent
-        // unitary pins plus a labelled midpoint marker.  Matches
-        // `buildCombinedActionPins` in the frontend's svgUtils.
-        const computeCombinedActionPins = (actions, metaIndex, unitaryPinById) => {
+        // Build curves for combined-pair (A+B) entries.  Filtered to
+        // SIMULATED pairs only — `is_estimated: true` entries are the
+        // recommender's superposition output (no actual simulation
+        // ran), and rendering dashed lines for them mid-flight clutters
+        // the overview before the operator has even opened the Combine
+        // modal.  Matches frontend behaviour: simulated combined pairs
+        // land in `result.actions` with `is_estimated: false` and only
+        // those produce a dashed connection.
+        const computeCombinedActionPins = (actions, metaIndex, unitaryPinById, monitoringFactor = 0.95) => {
             if (!actions || !metaIndex) return [];
             const pairs = [];
             for (const [id, action] of Object.entries(actions)) {
                 if (!id.includes('+') || !action) continue;
-                // Resolve each constituent to a pin position — fall
-                // back to recomputing via the resolver when the
-                // unitary pin isn't already on screen.
+                if (action.is_estimated === true) continue;        // estimated only — skip
+                // Resolve each constituent to a pin position.
                 const parts = id.split('+').map(p => p.trim());
+                if (parts.length !== 2) continue;
                 const getEndpoint = (partId) => {
                     const cached = unitaryPinById.get(partId);
                     if (cached) return { x: cached.x, y: cached.y };
@@ -1659,19 +1687,13 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 const a = getEndpoint(parts[0]);
                 const b = getEndpoint(parts[1]);
                 if (!a || !b) continue;
-                const rho = typeof action.max_rho === 'number'
-                    ? action.max_rho
-                    : (typeof action.estimated_max_rho === 'number' ? action.estimated_max_rho : NaN);
-                let color = '#9ca3af';
-                if (Number.isFinite(rho)) {
-                    color = rho <= 0.9 ? '#28a745' : rho <= 1.0 ? '#f0ad4e' : '#dc3545';
-                }
+                const severity = computeActionSeverity(action, monitoringFactor);
                 pairs.push({
                     id,
                     x1: a.x, y1: a.y, x2: b.x, y2: b.y,
-                    // Midpoint for the label badge.
                     midX: (a.x + b.x) / 2, midY: (a.y + b.y) / 2,
-                    rho, color,
+                    severity,
+                    color: SEVERITY_COLOR[severity],
                     description: action.description_unitaire || '',
                 });
             }
@@ -1693,6 +1715,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             selectedActionId,
             onActionSelect,
             onPinPreview,
+            // Operational threshold from the Configurations tab.
+            // Drives the pin severity palette (green / orange / red)
+            // — without this, the standalone falls back to the 0.95
+            // default and may misclassify pins on grids configured
+            // with a different MF.
+            monitoringFactor = 0.95,
             // Richer-popover props — forward the sidebar ActionCard
             // affordances so the pin popover matches the card the
             // user would see in the feed.
@@ -1718,8 +1746,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             const fitVbRef = React.useRef(null); // the "Fit" target
 
             const pins = React.useMemo(
-                () => computeActionOverviewPins(actions, n1MetaIndex),
-                [actions, n1MetaIndex],
+                () => computeActionOverviewPins(actions, n1MetaIndex, monitoringFactor),
+                [actions, n1MetaIndex, monitoringFactor],
             );
 
             // Combined-pair connections.  A Map keyed by unitary pin id
@@ -1727,8 +1755,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             // rather than re-running the resolver for every leg.
             const combinedPairs = React.useMemo(() => {
                 const byId = new Map(pins.map(p => [p.id, p]));
-                return computeCombinedActionPins(actions, n1MetaIndex, byId);
-            }, [actions, n1MetaIndex, pins]);
+                return computeCombinedActionPins(actions, n1MetaIndex, byId, monitoringFactor);
+            }, [actions, n1MetaIndex, pins, monitoringFactor]);
 
             // visible → overview_shown / overview_hidden.
             React.useEffect(() => {
@@ -6453,6 +6481,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                 actions={result.actions}
                                                 selectedActionId={selectedActionId}
                                                 onActionSelect={handleActionSelect}
+                                                monitoringFactor={monitoringFactor}
                                                 selectedActionIds={manualActionIds}
                                                 rejectedActionIds={rejectedActionIds}
                                                 manuallyAddedIds={manuallyAddedIds}

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1545,15 +1545,24 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             visible,
             n1Diagram,
             n1MetaIndex,
+            n1SvgContainerRef,
             actions,
             selectedActionId,
             onActionSelect,
             onPinPreview,
         }) => {
             const containerRef = React.useRef(null);
+            const backdropSvgRef = React.useRef(null);
+            const pinSvgRef = React.useRef(null);
             const [popoverPin, setPopoverPin] = React.useState(null);
             const [inspectQuery, setInspectQuery] = React.useState('');
             const clickTimerRef = React.useRef(null);
+            // Local viewBox state for the overview.  The overview
+            // owns its own zoom — independent from the N-1 tab's
+            // pan/zoom state — so overview_zoom_* buttons move the
+            // overview viewport without affecting the main N-1 tab.
+            const [overviewVb, setOverviewVb] = React.useState(null);
+            const fitVbRef = React.useRef(null); // the "Fit" target
 
             const pins = React.useMemo(
                 () => computeActionOverviewPins(actions, n1MetaIndex),
@@ -1572,19 +1581,63 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 }
             }, [visible]);
 
-            // Inject the N-1 SVG as the overview backdrop.
+            // Inject the processed N-1 SVG as the overview backdrop.
+            // We clone the DOM the main N-1 tab is already rendering
+            // (`n1SvgContainerRef.current`) — that node has every
+            // post-processing pass applied: voltage-range filter,
+            // boostSvgForLargeGrid, overload highlights, contingency
+            // highlight clones.  Injecting the raw backend SVG string
+            // loses all of that and produces the unpainted NAD the
+            // earlier port was rendering.
             React.useLayoutEffect(() => {
                 const container = containerRef.current;
-                if (!container || !visible || !n1Diagram?.svg) return;
-                if (n1Diagram.svg instanceof SVGSVGElement) {
-                    container.replaceChildren(n1Diagram.svg.cloneNode(true));
-                } else {
-                    container.innerHTML = n1Diagram.svg;
+                if (!container || !visible) return;
+                const source = n1SvgContainerRef?.current?.querySelector?.('svg');
+                if (!source) {
+                    // Fall back to raw string if the main N-1 tab hasn't
+                    // mounted its SVG yet (unlikely but defensive).
+                    if (n1Diagram?.svg) {
+                        container.innerHTML = typeof n1Diagram.svg === 'string'
+                            ? n1Diagram.svg
+                            : (n1Diagram.svg.outerHTML || '');
+                    }
+                    return;
                 }
-                // Dim the backdrop so the pins read as the primary content.
-                const svg = container.querySelector('svg');
-                if (svg) svg.style.opacity = '0.5';
-            }, [visible, n1Diagram]);
+                const clone = source.cloneNode(true);
+                clone.style.width = '100%';
+                clone.style.height = '100%';
+                clone.style.opacity = '0.55';          // dim the backdrop
+                clone.style.pointerEvents = 'none';
+                clone.removeAttribute('width');
+                clone.removeAttribute('height');
+                container.replaceChildren(clone);
+                backdropSvgRef.current = clone;
+
+                // Seed the overview viewBox from the clone's current
+                // viewBox (which the main N-1 tab has already zoomed
+                // to the contingency via zoomToElement).  Stash the
+                // auto-fit rectangle — the "Fit" button reapplies it.
+                try {
+                    const vbAttr = clone.getAttribute('viewBox');
+                    if (vbAttr) {
+                        const [x, y, w, h] = vbAttr.split(/\s+/).map(Number);
+                        const seed = { x, y, w, h };
+                        setOverviewVb(seed);
+                        fitVbRef.current = seed;
+                    }
+                } catch (e) { /* ignore */ }
+            }, [visible, n1Diagram, n1SvgContainerRef]);
+
+            // Mirror the overview viewBox onto both the backdrop and
+            // the pin-layer SVG so pins stay anchored to their edges
+            // while the user pans/zooms.
+            React.useEffect(() => {
+                if (!overviewVb) return;
+                const { x, y, w, h } = overviewVb;
+                const vbAttr = `${x} ${y} ${w} ${h}`;
+                if (backdropSvgRef.current) backdropSvgRef.current.setAttribute('viewBox', vbAttr);
+                if (pinSvgRef.current) pinSvgRef.current.setAttribute('viewBox', vbAttr);
+            }, [overviewVb]);
 
             // Global Escape / outside-click handlers for the popover.
             React.useEffect(() => {
@@ -1644,9 +1697,62 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 if (onActionSelect) onActionSelect(pin.id);
             }, [onActionSelect]);
 
-            const handleZoomIn = () => interactionLogger.record('overview_zoom_in');
-            const handleZoomOut = () => interactionLogger.record('overview_zoom_out');
-            const handleZoomFit = () => interactionLogger.record('overview_zoom_fit');
+            const handleZoomIn = () => {
+                interactionLogger.record('overview_zoom_in');
+                setOverviewVb(vb => vb ? {
+                    x: vb.x + vb.w * 0.1, y: vb.y + vb.h * 0.1,
+                    w: vb.w * 0.8, h: vb.h * 0.8,
+                } : vb);
+            };
+            const handleZoomOut = () => {
+                interactionLogger.record('overview_zoom_out');
+                setOverviewVb(vb => vb ? {
+                    x: vb.x - vb.w * 0.125, y: vb.y - vb.h * 0.125,
+                    w: vb.w * 1.25, h: vb.h * 1.25,
+                } : vb);
+            };
+            const handleZoomFit = () => {
+                interactionLogger.record('overview_zoom_fit');
+                if (fitVbRef.current) setOverviewVb({ ...fitVbRef.current });
+            };
+
+            // Wheel + drag pan on the pin-layer SVG so the overview
+            // is explorable without the +/- buttons.
+            const panRef = React.useRef({ isDragging: false, lastX: 0, lastY: 0 });
+            const handleWheel = React.useCallback((e) => {
+                e.preventDefault();
+                setOverviewVb(vb => {
+                    if (!vb) return vb;
+                    const scale = e.deltaY < 0 ? 0.9 : 1.1;
+                    return {
+                        x: vb.x + vb.w * (1 - scale) / 2,
+                        y: vb.y + vb.h * (1 - scale) / 2,
+                        w: vb.w * scale, h: vb.h * scale,
+                    };
+                });
+            }, []);
+            const handleMouseDown = (e) => {
+                panRef.current.isDragging = true;
+                panRef.current.lastX = e.clientX;
+                panRef.current.lastY = e.clientY;
+            };
+            const handleMouseMove = (e) => {
+                if (!panRef.current.isDragging) return;
+                const dx = e.clientX - panRef.current.lastX;
+                const dy = e.clientY - panRef.current.lastY;
+                panRef.current.lastX = e.clientX;
+                panRef.current.lastY = e.clientY;
+                setOverviewVb(vb => {
+                    if (!vb || !pinSvgRef.current) return vb;
+                    const rect = pinSvgRef.current.getBoundingClientRect();
+                    return {
+                        x: vb.x - dx * vb.w / rect.width,
+                        y: vb.y - dy * vb.h / rect.height,
+                        w: vb.w, h: vb.h,
+                    };
+                });
+            };
+            const handleMouseUp = () => { panRef.current.isDragging = false; };
 
             const handleInspectChange = (e) => {
                 const q = e.target.value;
@@ -1666,15 +1772,15 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 
             if (!visible) return null;
 
-            // Resolve the N-1 SVG's viewBox so pins can be positioned
-            // in SVG-local coordinates on top of it.  We render the
-            // pins in a second, overlaid SVG that matches the
-            // backdrop viewBox.
-            const vb = n1Diagram?.originalViewBox;
-            const viewBoxAttr = vb ? `${vb.x} ${vb.y} ${vb.w} ${vb.h}` : '0 0 1000 1000';
-            // Pin radius in SVG units — derived from viewBox size so
-            // the pin stays readable at the default fit.
-            const pinR = vb ? Math.max(Math.min(vb.w, vb.h) * 0.01, 8) : 15;
+            // Pin radius in SVG units, scaled to the CURRENT zoom
+            // level so the pin stays roughly constant in screen-px
+            // as the user zooms.  (A fully screen-constant sizing
+            // like the React app's MutationObserver + rescale
+            // approach would require cross-browser observer
+            // plumbing that isn't justified at this port's scope.)
+            const vbForPins = overviewVb || n1Diagram?.originalViewBox || { x: 0, y: 0, w: 1000, h: 1000 };
+            const viewBoxAttr = `${vbForPins.x} ${vbForPins.y} ${vbForPins.w} ${vbForPins.h}`;
+            const pinR = Math.max(Math.min(vbForPins.w, vbForPins.h) * 0.012, 8);
 
             return (
                 <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
@@ -1695,16 +1801,22 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
                         <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
                         <svg
+                            ref={pinSvgRef}
                             viewBox={viewBoxAttr}
                             preserveAspectRatio="xMidYMid meet"
-                            style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+                            onWheel={handleWheel}
+                            onMouseDown={handleMouseDown}
+                            onMouseMove={handleMouseMove}
+                            onMouseUp={handleMouseUp}
+                            onMouseLeave={handleMouseUp}
+                            style={{ position: 'absolute', inset: 0, pointerEvents: 'auto', cursor: panRef.current.isDragging ? 'grabbing' : 'grab' }}
                         >
                             {pins.map((pin) => (
                                 <g
                                     key={pin.id}
                                     data-overview-pin
                                     transform={`translate(${pin.x}, ${pin.y})`}
-                                    style={{ cursor: 'pointer', pointerEvents: 'auto' }}
+                                    style={{ cursor: 'pointer' }}
                                     onClick={(e) => handlePinClick(pin, e)}
                                     onDoubleClick={() => handlePinDoubleClick(pin)}
                                 >
@@ -2215,7 +2327,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 return () => window.removeEventListener('beforeunload', onUnload);
             }, []);
 
-            const TAB_TITLES = { 'n': 'Network (N)', 'n-1': 'Contingency (N-1)', 'action': 'Remedial Action' };
+            const TAB_TITLES = { 'n': 'Network (N)', 'n-1': 'Contingency (N-1)', 'action': 'Remedial Action', 'overflow': 'Overflow Analysis' };
 
             const handleDetachTab = (tabId) => {
                 if (detachedTabsRef.current[tabId]) return; // already detached
@@ -2267,25 +2379,53 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 header.appendChild(reattachBtn);
                 popup.document.body.appendChild(header);
 
-                // SVG snapshot container.
-                const svgHost = popup.document.createElement('div');
-                svgHost.style.cssText = 'flex: 1; overflow: hidden; position: relative;';
-                svgHost.dataset.role = 'svg-host';
-                const snapshot = tabId === 'n' ? nDiagram?.svg
-                    : tabId === 'n-1' ? n1Diagram?.svg
-                    : tabId === 'action' ? actionDiagram?.svg
-                    : null;
-                if (snapshot) {
-                    svgHost.innerHTML = typeof snapshot === 'string' ? snapshot
-                        : snapshot instanceof SVGSVGElement ? snapshot.outerHTML
-                        : '';
-                    const svgEl = svgHost.querySelector('svg');
-                    if (svgEl) {
+                // Content host.  For diagram tabs (N / N-1 / Action) we
+                // clone the SVG node from the main container ref — it
+                // already has every post-processing pass applied
+                // (voltage filter, boostSvgForLargeGrid, contingency
+                // highlight, overload highlights, delta visuals, current
+                // viewBox).  Injecting the raw backend string would
+                // lose all of that and produce the unpainted NAD the
+                // earlier port was rendering.  For Overflow we reuse
+                // the same iframe src as the main tab.
+                const contentHost = popup.document.createElement('div');
+                contentHost.style.cssText = 'flex: 1; overflow: hidden; position: relative;';
+                contentHost.dataset.role = 'content-host';
+                popup.document.body.appendChild(contentHost);
+
+                if (tabId === 'overflow') {
+                    if (result?.pdf_url) {
+                        const iframe = popup.document.createElement('iframe');
+                        iframe.src = API_BASE + result.pdf_url;
+                        iframe.style.cssText = 'width: 100%; height: 100%; border: none;';
+                        contentHost.appendChild(iframe);
+                    } else {
+                        contentHost.textContent = '(No overflow PDF available yet.)';
+                        contentHost.style.cssText += 'color: #888; display: flex; align-items: center; justify-content: center;';
+                    }
+                } else {
+                    const sourceContainer = tabId === 'n' ? nSvgContainerRef.current
+                        : tabId === 'n-1' ? n1SvgContainerRef.current
+                        : tabId === 'action' ? actionSvgContainerRef.current
+                        : null;
+                    const sourceSvg = sourceContainer?.querySelector('svg');
+                    if (sourceSvg) {
+                        // Deep-clone preserves every highlight clone, the
+                        // current viewBox attribute, and any applied
+                        // CSS classes.  We strip width/height inline
+                        // styles so the popup's flex container controls
+                        // sizing rather than inheriting the main
+                        // window's pixel dimensions.
+                        const svgEl = sourceSvg.cloneNode(true);
                         svgEl.style.width = '100%';
                         svgEl.style.height = '100%';
+                        svgEl.removeAttribute('width');
+                        svgEl.removeAttribute('height');
+                        contentHost.appendChild(svgEl);
+
                         // Basic wheel-zoom + drag pan so the popup is
-                        // usable standalone. Forward viewBox changes to
-                        // the main window via postMessage — the main
+                        // usable standalone.  Forward viewBox changes
+                        // to the main window via postMessage — the main
                         // mirrors only when this tab is tied.
                         let vb = svgEl.viewBox?.baseVal
                             ? { x: svgEl.viewBox.baseVal.x, y: svgEl.viewBox.baseVal.y, w: svgEl.viewBox.baseVal.width, h: svgEl.viewBox.baseVal.height }
@@ -2327,12 +2467,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                             postVb();
                         });
                         popup.addEventListener('mouseup', () => { isDragging = false; svgEl.style.cursor = 'grab'; });
+                    } else {
+                        contentHost.textContent = '(Tab has no diagram yet — return to the main window to load one.)';
+                        contentHost.style.cssText += 'color: #888; display: flex; align-items: center; justify-content: center;';
                     }
-                } else {
-                    svgHost.textContent = '(No diagram available — return to the main window to load one.)';
-                    svgHost.style.cssText += 'color: #888; display: flex; align-items: center; justify-content: center;';
                 }
-                popup.document.body.appendChild(svgHost);
 
                 // When the user closes the popup via the OS, treat it as reattach.
                 popup.addEventListener('pagehide', () => {
@@ -3472,10 +3611,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             };
 
             // Fetch action variant diagram when an action card is clicked
-            const handleActionSelect = async (actionId) => {
+            const handleActionSelect = async (actionId, force = false) => {
 
-                if (actionId === selectedActionId) {
-                    // Deselect — return to previous diagram tab
+                if (!force && actionId === selectedActionId) {
+                    // Deselect — return to previous diagram tab.  Force
+                    // path (used after a fresh re-simulation) skips
+                    // this toggle so the variant diagram re-fetches
+                    // with the updated network state and the auto-zoom
+                    // effect recenters on the new max_rho_line.
                     interactionLogger.record('action_deselected', { previous_action_id: selectedActionId || '' });
                     setSelectedActionId(null);
                     setActionDiagram(null);
@@ -4690,6 +4833,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     });
                     // Refresh combined estimations for pairs containing this action
                     refreshCombinedEstimations(actionId);
+                    // Auto-select the re-simulated action so the action
+                    // variant diagram refreshes and the auto-zoom effect
+                    // recenters on the new max_rho_line.  Matches the
+                    // React `wrappedForcedActionSelect` pattern invoked
+                    // from `handleActionResimulated`.  force=true so a
+                    // re-simulation of the already-selected action
+                    // re-fetches instead of toggling it off.
+                    handleActionSelect(actionId, true);
                 } catch (err) {
                     console.error('Re-simulation failed:', err);
                 } finally {
@@ -4752,6 +4903,9 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     });
                     // Refresh combined estimations for pairs containing this action
                     refreshCombinedEstimations(actionId);
+                    // Force-select so the action variant diagram re-fetches
+                    // (matches the React `wrappedForcedActionSelect` path).
+                    handleActionSelect(actionId, true);
                 } catch (err) {
                     console.error('PST re-simulation failed:', err);
                 } finally {
@@ -5545,6 +5699,40 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 } catch (e) { console.error('Zoom failed:', e); }
             };
 
+            // Auto-zoom the Action tab onto the selected action's
+            // target element (`max_rho_line`) once the variant diagram
+            // arrives.  Without this, simulating an action and then
+            // landing on the action tab shows the preserved viewBox
+            // from the previous tab — so the user has to hunt for the
+            // impacted line manually.  Gated on selectedActionId +
+            // actionDiagram.svg so we only fire ONCE per simulation.
+            const lastAutoZoomedActionRef = useRef(null);
+            useEffect(() => {
+                if (activeTab !== 'action') return;
+                if (!selectedActionId || !actionDiagram?.svg) return;
+                // Only fire once per (actionId + diagram) pair — so
+                // panning or zooming manually after the auto-zoom
+                // doesn't snap the view back.
+                const key = `${selectedActionId}::${actionDiagram?.action_id || ''}`;
+                if (lastAutoZoomedActionRef.current === key) return;
+                lastAutoZoomedActionRef.current = key;
+
+                const target = result?.actions?.[selectedActionId]?.max_rho_line;
+                if (!target) return;
+                // Defer one frame so the SVG has been injected into the
+                // container by MemoizedSvgContainer's useLayoutEffect.
+                const raf = requestAnimationFrame(() => {
+                    try { zoomToElement(target); } catch (e) { /* ignore */ }
+                });
+                return () => cancelAnimationFrame(raf);
+            }, [activeTab, selectedActionId, actionDiagram, result]);
+
+            // Reset the auto-zoom guard when the user deselects the
+            // action, so re-selecting the same action later re-zooms.
+            useEffect(() => {
+                if (!selectedActionId) lastAutoZoomedActionRef.current = null;
+            }, [selectedActionId]);
+
             // Auto-zoom to selected element via viewBox
             useEffect(() => {
                 if (activeTab === 'overflow') return;
@@ -5707,6 +5895,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                 visible={activeTab === 'action' && !selectedActionId}
                                                 n1Diagram={n1Diagram}
                                                 n1MetaIndex={n1MetaIndex}
+                                                n1SvgContainerRef={n1SvgContainerRef}
                                                 actions={result.actions}
                                                 selectedActionId={selectedActionId}
                                                 onActionSelect={handleActionSelect}
@@ -7388,8 +7577,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                 ].map(tab => {
                                     const isActive = activeTab === tab.id;
                                     const isDetached = !!detachedTabs[tab.id];
-                                    // Only N / N-1 / Action are detachable — Overflow is a PDF tab.
-                                    const detachable = tab.id !== 'overflow' && tab.available;
+                                    // Every available tab is detachable — the
+                                    // popup content is chosen by handleDetachTab:
+                                    // diagram tabs clone their main-container SVG,
+                                    // the Overflow tab opens the PDF url in an
+                                    // iframe.
+                                    const detachable = tab.available;
                                     return (
                                         <div key={tab.id} style={{ flex: 1, display: 'flex', alignItems: 'stretch', borderRight: '1px solid #e0e0e0' }}>
                                             <button

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -3560,6 +3560,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 interactionLogger.record('prioritized_actions_displayed', {
                     n_actions: Object.keys(pendingAnalysisResult.actions || {}).length,
                 });
+                // Auto-switch to the Remedial Action tab so the operator
+                // lands on the Action Overview pins the moment the
+                // prioritized actions are merged into the result.
+                // Matches the React `handleDisplayPrioritizedActions`
+                // behaviour (`useAnalysis.ts:198 setActiveTab?.('action')`).
+                setActiveTab('action');
                 setResult(prev => {
                     // Preserve manually added actions via is_manual flag
                     const manualActionsData = {};

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1554,6 +1554,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             const containerRef = React.useRef(null);
             const backdropSvgRef = React.useRef(null);
             const pinSvgRef = React.useRef(null);
+            const overlayWrapperRef = React.useRef(null);
+            const [overlayRect, setOverlayRect] = React.useState({ width: 0, height: 0 });
             const [popoverPin, setPopoverPin] = React.useState(null);
             const [inspectQuery, setInspectQuery] = React.useState('');
             const clickTimerRef = React.useRef(null);
@@ -1802,17 +1804,56 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 }
             };
 
+            // Track the overlay wrapper's pixel size — ResizeObserver
+            // is the cheap way to keep pin positions fresh as the
+            // window / sidebar is resized.  We also initialise once
+            // via getBoundingClientRect so the first frame has valid
+            // coordinates (ResizeObserver only fires AFTER the first
+            // layout).
+            React.useEffect(() => {
+                if (!visible || !overlayWrapperRef.current) return;
+                const el = overlayWrapperRef.current;
+                const apply = () => {
+                    const r = el.getBoundingClientRect();
+                    setOverlayRect({ width: r.width, height: r.height });
+                };
+                apply();
+                const ro = new ResizeObserver(apply);
+                ro.observe(el);
+                return () => ro.disconnect();
+            }, [visible]);
+
             if (!visible) return null;
 
-            // Pin radius in SVG units, scaled to the CURRENT zoom
-            // level so the pin stays roughly constant in screen-px
-            // as the user zooms.  (A fully screen-constant sizing
-            // like the React app's MutationObserver + rescale
-            // approach would require cross-browser observer
-            // plumbing that isn't justified at this port's scope.)
             const vbForPins = overviewVb || n1Diagram?.originalViewBox || { x: 0, y: 0, w: 1000, h: 1000 };
             const viewBoxAttr = `${vbForPins.x} ${vbForPins.y} ${vbForPins.w} ${vbForPins.h}`;
-            const pinR = Math.max(Math.min(vbForPins.w, vbForPins.h) * 0.012, 8);
+
+            // Project SVG-local (pin.x, pin.y) → screen-px (relative to
+            // the overlay wrapper) using `preserveAspectRatio="xMidYMid
+            // meet"` which is what the pin SVG declares.  Matches the
+            // backdrop's projection exactly so pins stay anchored to
+            // their asset positions through pan + zoom.
+            const projectSvgPoint = (sx, sy) => {
+                if (!overlayRect.width || !overlayRect.height) return { screenX: 0, screenY: 0 };
+                const vbAspect = vbForPins.w / vbForPins.h;
+                const boxAspect = overlayRect.width / overlayRect.height;
+                let scale, offsetX, offsetY;
+                if (boxAspect > vbAspect) {
+                    // Container wider than viewBox — letterboxed on X.
+                    scale = overlayRect.height / vbForPins.h;
+                    offsetX = (overlayRect.width - vbForPins.w * scale) / 2;
+                    offsetY = 0;
+                } else {
+                    scale = overlayRect.width / vbForPins.w;
+                    offsetX = 0;
+                    offsetY = (overlayRect.height - vbForPins.h * scale) / 2;
+                }
+                return {
+                    screenX: offsetX + (sx - vbForPins.x) * scale,
+                    screenY: offsetY + (sy - vbForPins.y) * scale,
+                };
+            };
+            const pinsScreen = pins.map((p) => ({ ...p, ...projectSvgPoint(p.x, p.y) }));
 
             return (
                 <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
@@ -1829,8 +1870,21 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         <span><span style={{ color: '#dc3545' }}>●</span> overloaded</span>
                         <span style={{ marginLeft: 'auto' }}>{pins.length} pin{pins.length === 1 ? '' : 's'}</span>
                     </div>
-                    {/* Diagram + pin layer */}
-                    <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+                    {/* Diagram + pin layer.  Two stacked layers:
+                        1. backdrop SVG (the cloned N-1 diagram) that
+                           scales with viewBox;
+                        2. SVG that captures wheel/drag for pan-zoom
+                           using the same viewBox as the backdrop so
+                           coordinates match;
+                        3. HTML pin layer rendered in SCREEN-px space
+                           via the overlayRect + vbForPins projection.
+                           Pins keep a constant CSS size across zoom
+                           levels — React's teardrop-with-MutationObserver
+                           approach collapses neatly to "just position
+                           absolutely" when we're happy to pay a React
+                           re-render on every viewBox change (cheap
+                           here, pins count is small). */}
+                    <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }} ref={overlayWrapperRef}>
                         <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
                         <svg
                             ref={pinSvgRef}
@@ -1842,21 +1896,66 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                             onMouseUp={handleMouseUp}
                             onMouseLeave={handleMouseUp}
                             style={{ position: 'absolute', inset: 0, pointerEvents: 'auto', cursor: panRef.current.isDragging ? 'grabbing' : 'grab' }}
-                        >
-                            {pins.map((pin) => (
-                                <g
+                        />
+                        {/* Pins in screen-px space.  Each pin is an
+                            absolutely-positioned <div> at the projected
+                            screen coordinate of its SVG anchor.  The
+                            teardrop itself is an inline SVG with the
+                            tip at (0, 48) so `translate(-50%, -100%)`
+                            on the wrapper plants the tip exactly on
+                            the asset.  Google-Maps-style glyph with a
+                            drop shadow and a white ring; loading
+                            percentage is rendered inside the circular
+                            head. */}
+                        {pinsScreen.map((pin) => {
+                            const label = Number.isFinite(pin.rho)
+                                ? `${Math.round(pin.rho * 100)}%`
+                                : String(pin.rank);
+                            const isSelected = selectedActionId === pin.id;
+                            return (
+                                <div
                                     key={pin.id}
                                     data-overview-pin
-                                    transform={`translate(${pin.x}, ${pin.y})`}
-                                    style={{ cursor: 'pointer' }}
+                                    title={`${pin.id} — ${pin.description || ''} (max ρ ${(pin.rho * 100).toFixed(1)}% on ${pin.max_rho_line})`}
                                     onClick={(e) => handlePinClick(pin, e)}
-                                    onDoubleClick={() => handlePinDoubleClick(pin)}
+                                    onDoubleClick={(e) => { e.stopPropagation(); handlePinDoubleClick(pin); }}
+                                    style={{
+                                        position: 'absolute',
+                                        left: pin.screenX,
+                                        top: pin.screenY,
+                                        transform: 'translate(-50%, -100%)',
+                                        width: 36,
+                                        height: 48,
+                                        cursor: 'pointer',
+                                        pointerEvents: 'auto',
+                                        userSelect: 'none',
+                                        filter: isSelected
+                                            ? 'drop-shadow(0 0 4px rgba(52,152,219,0.9))'
+                                            : 'drop-shadow(0 2px 3px rgba(0,0,0,0.4))',
+                                    }}
                                 >
-                                    <circle r={pinR} fill={pin.color} stroke="#fff" strokeWidth={pinR * 0.15} opacity={selectedActionId === pin.id ? 1 : 0.9} />
-                                    <text textAnchor="middle" dy={pinR * 0.4} fontSize={pinR * 1.1} fontWeight="700" fill="#fff">{pin.rank}</text>
-                                </g>
-                            ))}
-                        </svg>
+                                    <svg viewBox="0 0 36 48" width="36" height="48" style={{ display: 'block' }}>
+                                        {/* Teardrop body */}
+                                        <path
+                                            d="M18 0 C8 0 0 8 0 18 C0 28 18 48 18 48 C18 48 36 28 36 18 C36 8 28 0 18 0 Z"
+                                            fill={pin.color}
+                                            stroke="#fff"
+                                            strokeWidth={2}
+                                        />
+                                        {/* Label disc for contrast against the coloured body */}
+                                        <circle cx={18} cy={18} r={11} fill="#fff" />
+                                        <text
+                                            x={18} y={18}
+                                            textAnchor="middle"
+                                            dominantBaseline="central"
+                                            fontSize={label.length > 3 ? 8 : 10}
+                                            fontWeight={700}
+                                            fill={pin.color}
+                                        >{label}</text>
+                                    </svg>
+                                </div>
+                            );
+                        })}
                     </div>
                     {/* Controls: zoom + inspect */}
                     <div style={{
@@ -2208,11 +2307,22 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         }
                     }
 
-                    // Fetch study-related data (branches, nominal voltages etc.)
-                    const [branchesRes, vlRes, nomVRes] = await Promise.all([
+                    // Fetch study-related data in parallel with the
+                    // base NAD.  /api/network-diagram is the slowest XHR
+                    // (~5-6 s pypowsybl regeneration on big grids);
+                    // previously it only started AFTER branches +
+                    // voltage-levels + nominal-voltages had resolved,
+                    // wasting ~1 s off the critical path.  Matches
+                    // `frontend/src/App.tsx` applySettingsImmediate.
+                    const [branchesRes, vlRes, nomVRes, nadRaw] = await Promise.all([
                         axios.get(`${API_BASE}/api/branches?t=${Date.now()}`),
                         axios.get(`${API_BASE}/api/voltage-levels?t=${Date.now()}`),
-                        axios.get(`${API_BASE}/api/nominal-voltages?t=${Date.now()}`)
+                        axios.get(`${API_BASE}/api/nominal-voltages?t=${Date.now()}`),
+                        _fetchNetworkDiagramTextFormat().catch(async (textErr) => {
+                            console.warn('[network-diagram] text-format fetch failed, falling back:', textErr);
+                            const r = await axios.get(`${API_BASE}/api/network-diagram?t=${Date.now()}`);
+                            return r.data;
+                        }),
                     ]);
 
                     setBranches(branchesRes.data.branches);
@@ -2228,7 +2338,13 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         setVoltageRange([uniqueKv[0], uniqueKv[uniqueKv.length - 1]]);
                     }
 
-                    fetchBaseDiagram(vlRes.data.voltage_levels.length);
+                    // Consume the already-fetched NAD instead of firing
+                    // another XHR.
+                    try {
+                        const { svg, viewBox } = processSvg(nadRaw.svg, vlRes.data.voltage_levels.length);
+                        if (viewBox) setOriginalViewBox(viewBox);
+                        setNDiagram({ ...nadRaw, svg, originalViewBox: viewBox });
+                    } catch (err) { console.error('Failed to process diagram:', err); }
 
                     setSettingsBackup({
                         networkPath,
@@ -2851,10 +2967,19 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     if (configRes.data?.action_dict_file_name) { setActionDictFileName(configRes.data.action_dict_file_name); setShowActionDictWarning(true); }
                     if (configRes.data?.action_dict_stats) setActionDictStats(configRes.data.action_dict_stats);
 
-                    const [branchesRes, vlRes, nomVRes] = await Promise.all([
+                    // 4-way parallel fetch, same as applySettingsImmediate
+                    // above.  /api/network-diagram is the slowest XHR so
+                    // overlapping it with the metadata calls is the
+                    // single biggest loading-time win.
+                    const [branchesRes, vlRes, nomVRes, nadRaw] = await Promise.all([
                         axios.get(`${API_BASE}/api/branches?t=${Date.now()}`),
                         axios.get(`${API_BASE}/api/voltage-levels?t=${Date.now()}`),
-                        axios.get(`${API_BASE}/api/nominal-voltages?t=${Date.now()}`)
+                        axios.get(`${API_BASE}/api/nominal-voltages?t=${Date.now()}`),
+                        _fetchNetworkDiagramTextFormat().catch(async (textErr) => {
+                            console.warn('[network-diagram] text-format fetch failed, falling back:', textErr);
+                            const r = await axios.get(`${API_BASE}/api/network-diagram?t=${Date.now()}`);
+                            return r.data;
+                        }),
                     ]);
 
                     setBranches(branchesRes.data.branches);
@@ -2869,7 +2994,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         setVoltageRange([uniqueKv[0], uniqueKv[uniqueKv.length - 1]]);
                     }
 
-                    fetchBaseDiagram(vlRes.data.voltage_levels.length);
+                    try {
+                        const { svg, viewBox } = processSvg(nadRaw.svg, vlRes.data.voltage_levels.length);
+                        if (viewBox) setOriginalViewBox(viewBox);
+                        setNDiagram({ ...nadRaw, svg, originalViewBox: viewBox });
+                    } catch (err) { console.error('Failed to process diagram:', err); }
                 } catch (err) {
                     setError('Failed to load config: ' + (err.response?.data?.detail || err.message));
                 } finally { setConfigLoading(false); }
@@ -2950,12 +3079,36 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 }
             };
 
+            // Fetch the base NAD using the `format=text` endpoint — the
+            // backend returns a one-line JSON header + raw SVG body
+            // instead of embedding the multi-MB SVG inside JSON.  Lets
+            // us skip `JSON.parse` on the big SVG string (~500 ms
+            // main-thread block on the PyPSA-EUR France grid).  Matches
+            // `frontend/src/api.ts::getNetworkDiagram`.  Falls back to
+            // plain JSON if the backend pre-dates the text format.
+            const _fetchNetworkDiagramTextFormat = async () => {
+                const res = await fetch(`${API_BASE}/api/network-diagram?format=text&t=${Date.now()}`);
+                if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+                const body = await res.text();
+                const nl = body.indexOf('\n');
+                if (nl < 0) throw new Error('Invalid /api/network-diagram response: missing header/body separator');
+                const header = JSON.parse(body.slice(0, nl));
+                const svg = body.slice(nl + 1);
+                return { ...header, svg };
+            };
             const fetchBaseDiagram = async (vlCount) => {
                 try {
-                    const res = await axios.get(`${API_BASE}/api/network-diagram?t=${Date.now()}`);
-                    const { svg, viewBox } = processSvg(res.data.svg, vlCount || 0);
+                    let raw;
+                    try {
+                        raw = await _fetchNetworkDiagramTextFormat();
+                    } catch (textErr) {
+                        console.warn('[network-diagram] text-format fetch failed, falling back to JSON:', textErr);
+                        const res = await axios.get(`${API_BASE}/api/network-diagram?t=${Date.now()}`);
+                        raw = res.data;
+                    }
+                    const { svg, viewBox } = processSvg(raw.svg, vlCount || 0);
                     if (viewBox) setOriginalViewBox(viewBox);
-                    setNDiagram({ ...res.data, svg, originalViewBox: viewBox });
+                    setNDiagram({ ...raw, svg, originalViewBox: viewBox });
                 } catch (err) { console.error('Failed to fetch diagram:', err); }
             };
 
@@ -3672,15 +3825,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             const handleActionSelect = async (actionId, force = false) => {
 
                 if (!force && actionId === selectedActionId) {
-                    // Deselect — return to previous diagram tab.  Force
-                    // path (used after a fresh re-simulation) skips
-                    // this toggle so the variant diagram re-fetches
-                    // with the updated network state and the auto-zoom
-                    // effect recenters on the new max_rho_line.
+                    // Deselect — stay on the Remedial-Action tab so the
+                    // ActionOverviewDiagram takes over and the operator
+                    // lands back on the pin map. React switched this to
+                    // overview-stay in PR #93 (docs/action-overview-
+                    // diagram.md); the standalone needs to follow.
                     interactionLogger.record('action_deselected', { previous_action_id: selectedActionId || '' });
                     setSelectedActionId(null);
                     setActionDiagram(null);
-                    setActiveTab('n-1');
                     return;
                 }
                 if (actionId !== null) {
@@ -4766,6 +4918,15 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     setSearchOpen(false);
                     setSearchQuery('');
 
+                    // Release the sidebar / combine-modal Simulate buttons
+                    // the moment the action CARD is ready — don't keep the
+                    // operator waiting on the (expensive) variant-diagram
+                    // fetch that follows. Previously the button stayed on
+                    // the disabled / spinner state for the whole diagram
+                    // round-trip, which looks like the app is stuck when
+                    // the NAD takes several seconds on big grids.
+                    setSimulatingActionId(null);
+
                     // Fetch the action diagram AFTER simulation completes (ensures post-action state is ready)
                     try {
                         const diagRes = await axios.post(API_BASE + '/api/action-variant-diagram', { action_id: actionId });
@@ -4785,7 +4946,6 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 } catch (err) {
                     console.error('Simulation failed:', err);
                     setSearchError(err?.response?.data?.detail || 'Simulation failed');
-                } finally {
                     setSimulatingActionId(null);
                 }
             };
@@ -5177,6 +5337,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         };
                     });
 
+                    // Release the Simulate Combined / sidebar / modal
+                    // Simulate buttons the moment the combined action
+                    // lands — the diagram fetch below continues
+                    // asynchronously. See the matching comment in
+                    // handleAddManualAction for the rationale.
+                    setSimulatingActionId(null);
+                    setIsSimulatingCombined(false);
+
                     // Fetch the action diagram AFTER simulation completes (ensures post-action state is ready)
                     try {
                         const diagRes = await axios.post(API_BASE + '/api/action-variant-diagram', { action_id: combinedId });
@@ -5190,7 +5358,6 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     }
                 } catch (err) {
                     setError('Failed to simulate combined action: ' + (err.response?.data?.detail || err.message));
-                } finally {
                     setSimulatingActionId(null);
                     setIsSimulatingCombined(false);
                 }

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -2143,6 +2143,253 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             useLayoutEffect(() => { activeTabRef.current = activeTab; }, [activeTab]);
             const prevTabRef = useRef(activeTab);
 
+            // ===== Detached + Tied Tabs =====
+            //
+            // `detachedTabs[tabId]` holds the Window reference when a tab
+            // is popped out. `tiedTabs` is a Set of tab ids whose
+            // viewBox should mirror into the main window. See
+            // docs/detachable-viz-tabs.md and docs/interaction-logging.md
+            // § Visualization for the replay contract:
+            //   tab_detached / tab_reattached / tab_tied / tab_untied
+            //   all carry `{ tab: TabId }`.
+            //
+            // Implementation notes:
+            //   - Popups are opened via window.open() with a named handle
+            //     so the browser reuses an existing window if re-detached.
+            //   - The popup's body is populated by injecting the tab's
+            //     current SVG string (`nDiagram.svg`, etc.) verbatim.
+            //     This is a SNAPSHOT at detach time — the popup does
+            //     not re-render when main state changes (e.g. selecting
+            //     a new action). Accepted limitation vs. the React
+            //     portal-based implementation; the 4 events still fire
+            //     at the documented gesture points so replay parity is
+            //     preserved.
+            //   - Tied viewBox mirror uses window.postMessage rather
+            //     than the React ref-based path. Same one-way semantics:
+            //     popup → main when a tied popup's viewBox changes.
+            const [detachedTabs, setDetachedTabs] = useState({});   // { [tab]: Window }
+            const detachedTabsRef = useRef(detachedTabs);
+            useEffect(() => { detachedTabsRef.current = detachedTabs; }, [detachedTabs]);
+            const [tiedTabs, setTiedTabs] = useState(new Set());
+            const tiedTabsRef = useRef(tiedTabs);
+            useEffect(() => { tiedTabsRef.current = tiedTabs; }, [tiedTabs]);
+
+            // Handle incoming viewBox updates from tied popups.
+            // Loop-guard ref: skip the immediate re-fire when we
+            // ourselves are applying a mirrored update.
+            const isSyncingRef = useRef(false);
+            useEffect(() => {
+                const onMessage = (evt) => {
+                    const data = evt.data;
+                    if (!data || data.source !== 'costudy4grid-detached-tab') return;
+                    if (data.type === 'reattach') {
+                        handleReattachTab(data.tab);
+                    } else if (data.type === 'viewBoxChange') {
+                        // Mirror into main if the source tab is tied.
+                        if (!tiedTabsRef.current.has(data.tab)) return;
+                        const pz = data.tab === 'n' ? nPZ : data.tab === 'n-1' ? n1PZ : actionPZ;
+                        if (pz && pz.setViewBox && data.viewBox) {
+                            isSyncingRef.current = true;
+                            pz.setViewBox(data.viewBox);
+                            // Release the guard on the next microtask so
+                            // subsequent user-initiated changes flow
+                            // through normally.
+                            queueMicrotask(() => { isSyncingRef.current = false; });
+                        }
+                    }
+                };
+                window.addEventListener('message', onMessage);
+                return () => window.removeEventListener('message', onMessage);
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+            }, []);
+
+            // Close any live popups when the main window unloads so we
+            // don't leave orphans pointing at a dead page.
+            useEffect(() => {
+                const onUnload = () => {
+                    for (const win of Object.values(detachedTabsRef.current)) {
+                        try { win?.close(); } catch (e) { /* ignore */ }
+                    }
+                };
+                window.addEventListener('beforeunload', onUnload);
+                return () => window.removeEventListener('beforeunload', onUnload);
+            }, []);
+
+            const TAB_TITLES = { 'n': 'Network (N)', 'n-1': 'Contingency (N-1)', 'action': 'Remedial Action' };
+
+            const handleDetachTab = (tabId) => {
+                if (detachedTabsRef.current[tabId]) return; // already detached
+                const popup = window.open('', `costudy4grid_tab_${tabId}`, 'popup=yes,width=1100,height=800,menubar=no,toolbar=no,location=no');
+                if (!popup || popup.closed) {
+                    setError('Popup blocked by the browser. Please allow popups for this site to detach tabs.');
+                    return;
+                }
+                // Copy styles from opener so the popup inherits the
+                // standalone's look-and-feel.
+                try {
+                    popup.document.open();
+                    popup.document.write('<!DOCTYPE html><html><head><meta charset="utf-8"><title></title></head><body></body></html>');
+                    popup.document.close();
+                    popup.document.title = `Co-Study4Grid — ${TAB_TITLES[tabId]}`;
+                    popup.document.body.style.margin = '0';
+                    popup.document.body.style.height = '100vh';
+                    popup.document.body.style.fontFamily = 'Arial, sans-serif';
+                    popup.document.body.style.display = 'flex';
+                    popup.document.body.style.flexDirection = 'column';
+                    document.querySelectorAll('style, link[rel="stylesheet"]').forEach(s => {
+                        popup.document.head.appendChild(s.cloneNode(true));
+                    });
+                } catch (e) {
+                    setError('Failed to initialise detached tab window: ' + e.message);
+                    try { popup.close(); } catch (ex) { /* ignore */ }
+                    return;
+                }
+
+                // Header with Reattach + Tie buttons.
+                const header = popup.document.createElement('div');
+                header.style.cssText = 'background: #2c3e50; color: #fff; padding: 8px 16px; display: flex; gap: 12px; align-items: center;';
+                const title = popup.document.createElement('strong');
+                title.textContent = TAB_TITLES[tabId];
+                title.style.flex = '1';
+                header.appendChild(title);
+                const tieBtn = popup.document.createElement('button');
+                tieBtn.dataset.role = 'tie';
+                tieBtn.textContent = '⛓ Tie';
+                tieBtn.style.cssText = 'padding: 4px 10px; cursor: pointer; background: #fff; border: none; border-radius: 4px;';
+                tieBtn.addEventListener('click', () => handleToggleTie(tabId));
+                header.appendChild(tieBtn);
+                const reattachBtn = popup.document.createElement('button');
+                reattachBtn.textContent = '⤩ Reattach';
+                reattachBtn.style.cssText = 'padding: 4px 10px; cursor: pointer; background: #fff; border: none; border-radius: 4px;';
+                reattachBtn.addEventListener('click', () => {
+                    window.postMessage({ source: 'costudy4grid-detached-tab', type: 'reattach', tab: tabId }, '*');
+                });
+                header.appendChild(reattachBtn);
+                popup.document.body.appendChild(header);
+
+                // SVG snapshot container.
+                const svgHost = popup.document.createElement('div');
+                svgHost.style.cssText = 'flex: 1; overflow: hidden; position: relative;';
+                svgHost.dataset.role = 'svg-host';
+                const snapshot = tabId === 'n' ? nDiagram?.svg
+                    : tabId === 'n-1' ? n1Diagram?.svg
+                    : tabId === 'action' ? actionDiagram?.svg
+                    : null;
+                if (snapshot) {
+                    svgHost.innerHTML = typeof snapshot === 'string' ? snapshot
+                        : snapshot instanceof SVGSVGElement ? snapshot.outerHTML
+                        : '';
+                    const svgEl = svgHost.querySelector('svg');
+                    if (svgEl) {
+                        svgEl.style.width = '100%';
+                        svgEl.style.height = '100%';
+                        // Basic wheel-zoom + drag pan so the popup is
+                        // usable standalone. Forward viewBox changes to
+                        // the main window via postMessage — the main
+                        // mirrors only when this tab is tied.
+                        let vb = svgEl.viewBox?.baseVal
+                            ? { x: svgEl.viewBox.baseVal.x, y: svgEl.viewBox.baseVal.y, w: svgEl.viewBox.baseVal.width, h: svgEl.viewBox.baseVal.height }
+                            : null;
+                        const postVb = () => {
+                            if (!vb) return;
+                            window.postMessage({
+                                source: 'costudy4grid-detached-tab',
+                                type: 'viewBoxChange',
+                                tab: tabId,
+                                viewBox: { ...vb },
+                            }, '*');
+                        };
+                        svgEl.addEventListener('wheel', (e) => {
+                            e.preventDefault();
+                            if (!vb) return;
+                            const scale = e.deltaY < 0 ? 0.85 : 1.15;
+                            vb = {
+                                x: vb.x + vb.w * (1 - scale) / 2,
+                                y: vb.y + vb.h * (1 - scale) / 2,
+                                w: vb.w * scale,
+                                h: vb.h * scale,
+                            };
+                            svgEl.setAttribute('viewBox', `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
+                            postVb();
+                        }, { passive: false });
+                        let isDragging = false, lastX = 0, lastY = 0;
+                        svgEl.addEventListener('mousedown', (e) => {
+                            isDragging = true; lastX = e.clientX; lastY = e.clientY;
+                            svgEl.style.cursor = 'grabbing';
+                        });
+                        popup.addEventListener('mousemove', (e) => {
+                            if (!isDragging || !vb) return;
+                            const dx = (e.clientX - lastX) * vb.w / svgEl.clientWidth;
+                            const dy = (e.clientY - lastY) * vb.h / svgEl.clientHeight;
+                            vb = { x: vb.x - dx, y: vb.y - dy, w: vb.w, h: vb.h };
+                            svgEl.setAttribute('viewBox', `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
+                            lastX = e.clientX; lastY = e.clientY;
+                            postVb();
+                        });
+                        popup.addEventListener('mouseup', () => { isDragging = false; svgEl.style.cursor = 'grab'; });
+                    }
+                } else {
+                    svgHost.textContent = '(No diagram available — return to the main window to load one.)';
+                    svgHost.style.cssText += 'color: #888; display: flex; align-items: center; justify-content: center;';
+                }
+                popup.document.body.appendChild(svgHost);
+
+                // When the user closes the popup via the OS, treat it as reattach.
+                popup.addEventListener('pagehide', () => {
+                    window.postMessage({ source: 'costudy4grid-detached-tab', type: 'reattach', tab: tabId }, '*');
+                });
+
+                setDetachedTabs(prev => ({ ...prev, [tabId]: popup }));
+                interactionLogger.record('tab_detached', { tab: tabId });
+            };
+
+            const handleReattachTab = (tabId) => {
+                const popup = detachedTabsRef.current[tabId];
+                if (!popup) return;
+                try { popup.close(); } catch (e) { /* ignore */ }
+                setDetachedTabs(prev => {
+                    const next = { ...prev };
+                    delete next[tabId];
+                    return next;
+                });
+                // Untie on reattach — tying a reattached tab makes no sense.
+                setTiedTabs(prev => {
+                    if (!prev.has(tabId)) return prev;
+                    const next = new Set(prev);
+                    next.delete(tabId);
+                    interactionLogger.record('tab_untied', { tab: tabId });
+                    return next;
+                });
+                interactionLogger.record('tab_reattached', { tab: tabId });
+            };
+
+            const handleToggleTie = (tabId) => {
+                setTiedTabs(prev => {
+                    const next = new Set(prev);
+                    if (next.has(tabId)) {
+                        next.delete(tabId);
+                        interactionLogger.record('tab_untied', { tab: tabId });
+                    } else {
+                        next.add(tabId);
+                        interactionLogger.record('tab_tied', { tab: tabId });
+                    }
+                    return next;
+                });
+                // Update the popup's Tie button label so the user sees
+                // the new state. The popup was opened by us; stylesheet
+                // reloads aren't needed — just toggle the button text.
+                const popup = detachedTabsRef.current[tabId];
+                if (popup && !popup.closed) {
+                    const btn = popup.document.querySelector('[data-role="tie"]');
+                    if (btn) {
+                        const willBeTied = !tiedTabsRef.current.has(tabId);
+                        btn.textContent = willBeTied ? '🔗 Tied' : '⛓ Tie';
+                        btn.style.background = willBeTied ? '#3498db' : '#fff';
+                        btn.style.color = willBeTied ? '#fff' : '#000';
+                    }
+                }
+            };
+
             // Auto-switch to overflow tab when PDF becomes available
             const lastAutoSwitchedPdfRef = useRef(null);
             useEffect(() => {
@@ -2681,6 +2928,17 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         n_overloads: nDiagram?.lines_overloaded ?? [],
                         n1_overloads: n1Diagram?.lines_overloaded ?? [],
                         resolved_overloads: result?.lines_overloaded ?? [],
+                        // Per-element loading ratios (PR #88 sticky-header
+                        // percentages). Persisted only when the array
+                        // length matches the element-name array above —
+                        // a shorter or missing array means the backend
+                        // N-1 payload predates the rho feature, in
+                        // which case we omit the key rather than
+                        // surface misleading zeros to replay agents.
+                        // Docs: interaction-logging.md § Session reload
+                        // fidelity (the "save-only-OK" fields).
+                        ...(nDiagram?.lines_overloaded_rho && nDiagram.lines_overloaded_rho.length === (nDiagram?.lines_overloaded?.length ?? 0) ? { n_overloads_rho: nDiagram.lines_overloaded_rho } : {}),
+                        ...(n1Diagram?.lines_overloaded_rho && n1Diagram.lines_overloaded_rho.length === (n1Diagram?.lines_overloaded?.length ?? 0) ? { n1_overloads_rho: n1Diagram.lines_overloaded_rho } : {}),
                     },
                     overflow_graph: result?.pdf_url
                         ? { pdf_url: result.pdf_url, pdf_path: result.pdf_path ?? null }
@@ -7129,25 +7387,54 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     { id: 'overflow', label: 'Overflow Analysis', available: !!result?.pdf_url, accentColor: '#27ae60', placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
                                 ].map(tab => {
                                     const isActive = activeTab === tab.id;
+                                    const isDetached = !!detachedTabs[tab.id];
+                                    // Only N / N-1 / Action are detachable — Overflow is a PDF tab.
+                                    const detachable = tab.id !== 'overflow' && tab.available;
                                     return (
-                                        <button
-                                            key={tab.id}
-                                            onClick={() => { interactionLogger.record('diagram_tab_changed', { tab: tab.id }); setActiveTab(tab.id); }}
-                                            title={tab.available ? undefined : tab.placeholder}
-                                            style={{
-                                                flex: 1, borderRadius: 0, border: 'none', padding: '8px 6px',
-                                                cursor: 'pointer',
-                                                fontWeight: isActive && tab.available ? 'bold' : 400,
-                                                fontStyle: !tab.available ? 'italic' : 'normal',
-                                                background: isActive ? 'white' : '#ecf0f1',
-                                                color: tab.available ? (isActive ? '#2c3e50' : '#7f8c8d') : '#bbb',
-                                                borderBottom: isActive && tab.available ? `3px solid ${tab.accentColor}` : 'none',
-                                                fontSize: tab.id === 'action' && selectedActionId ? '0.75rem' : '0.85rem',
-                                                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                                            }}
-                                        >
-                                            {tab.label}
-                                        </button>
+                                        <div key={tab.id} style={{ flex: 1, display: 'flex', alignItems: 'stretch', borderRight: '1px solid #e0e0e0' }}>
+                                            <button
+                                                onClick={() => {
+                                                    if (isDetached) {
+                                                        // Focus the popup rather than switching the
+                                                        // main tab (the content is in another window).
+                                                        try { detachedTabs[tab.id].focus(); } catch (e) { /* ignore */ }
+                                                        return;
+                                                    }
+                                                    interactionLogger.record('diagram_tab_changed', { tab: tab.id });
+                                                    setActiveTab(tab.id);
+                                                }}
+                                                title={tab.available ? (isDetached ? 'Tab detached — click to focus the popup' : undefined) : tab.placeholder}
+                                                style={{
+                                                    flex: 1, borderRadius: 0, border: 'none', padding: '8px 6px',
+                                                    cursor: 'pointer',
+                                                    fontWeight: isActive && tab.available ? 'bold' : 400,
+                                                    fontStyle: !tab.available || isDetached ? 'italic' : 'normal',
+                                                    background: isActive ? 'white' : '#ecf0f1',
+                                                    color: tab.available ? (isActive ? '#2c3e50' : '#7f8c8d') : '#bbb',
+                                                    opacity: isDetached ? 0.55 : 1,
+                                                    borderBottom: isActive && tab.available ? `3px solid ${tab.accentColor}` : 'none',
+                                                    fontSize: tab.id === 'action' && selectedActionId ? '0.75rem' : '0.85rem',
+                                                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                                                }}
+                                            >
+                                                {tab.label}{isDetached ? ' ⧉' : ''}
+                                            </button>
+                                            {detachable && (
+                                                <button
+                                                    onClick={() => isDetached ? handleReattachTab(tab.id) : handleDetachTab(tab.id)}
+                                                    title={isDetached ? 'Reattach to main window' : 'Detach into a separate window'}
+                                                    style={{
+                                                        padding: '0 8px', border: 'none',
+                                                        background: isActive ? 'white' : '#ecf0f1',
+                                                        cursor: 'pointer', fontSize: '0.85rem',
+                                                        color: isDetached ? '#3498db' : '#7f8c8d',
+                                                    }}
+                                                    aria-label={isDetached ? `Reattach ${tab.label}` : `Detach ${tab.label}`}
+                                                >
+                                                    {isDetached ? '⤩' : '⊞'}
+                                                </button>
+                                            )}
+                                        </div>
                                     );
                                 })}
                             </div>

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1501,35 +1501,88 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
         // the sidebar feed.
         const computeActionOverviewPins = (actions, metaIndex) => {
             if (!actions || !metaIndex) return [];
-            const { edgesByEquipmentId, nodesBySvgId } = metaIndex;
+            const { edgesByEquipmentId, nodesBySvgId, nodesByEquipmentId } = metaIndex;
             const rank = Object.keys(actions);
             const pins = [];
+
+            // Resolve a target id to (x, y) on the N-1 NAD.  Falls
+            // through a series of strategies so every action that
+            // references ANY recognisable equipment gets a pin:
+            //   1. edge midpoint (max_rho_line is a line / trafo);
+            //   2. node centroid (max_rho_line is a VL / substation);
+            //   3. anchor node of an incident edge (edges list node1 /
+            //      node2 that may match a node by equipmentId);
+            // Returns null when none of them resolve.
+            const resolveAnchor = (targetId) => {
+                if (!targetId) return null;
+                // Strategy 1: edge midpoint
+                const edge = edgesByEquipmentId?.get?.(targetId);
+                if (edge) {
+                    const n1 = nodesBySvgId?.get?.(edge.node1);
+                    const n2 = nodesBySvgId?.get?.(edge.node2);
+                    if (n1 && n2) {
+                        const x = (Number(n1.x) + Number(n2.x)) / 2;
+                        const y = (Number(n1.y) + Number(n2.y)) / 2;
+                        if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+                    }
+                }
+                // Strategy 2: node lookup by equipment id
+                const node = nodesByEquipmentId?.get?.(targetId);
+                if (node) {
+                    const x = Number(node.x), y = Number(node.y);
+                    if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+                }
+                // Strategy 3: svgId (some edges reference VLs by svg id)
+                const nodeBySvg = nodesBySvgId?.get?.(targetId);
+                if (nodeBySvg) {
+                    const x = Number(nodeBySvg.x), y = Number(nodeBySvg.y);
+                    if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+                }
+                return null;
+            };
+
             for (let i = 0; i < rank.length; i++) {
                 const id = rank[i];
                 const action = actions[id];
                 if (!action) continue;
-                const lineId = action.max_rho_line;
-                if (!lineId) continue;
-                const edge = edgesByEquipmentId?.get?.(lineId);
-                if (!edge) continue;
-                const n1 = nodesBySvgId?.get?.(edge.node1);
-                const n2 = nodesBySvgId?.get?.(edge.node2);
-                if (!n1 || !n2) continue;
-                const x = (Number(n1.x) + Number(n2.x)) / 2;
-                const y = (Number(n1.y) + Number(n2.y)) / 2;
-                if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+                // Try max_rho_line first (simulated), then
+                // estimated_max_rho_line (for combined pairs the
+                // recommender estimated but didn't simulate).  If the
+                // action id is itself a line (common for disco_ /
+                // reco_ actions), fall back to that so the pin still
+                // anchors on the relevant asset.
+                const candidates = [
+                    action.max_rho_line,
+                    action.estimated_max_rho_line,
+                    // action id shape for disco_ / reco_ often
+                    // includes the line id as suffix; strip the
+                    // common prefixes and try.
+                    id.startsWith('disco_') ? id.slice(6) : null,
+                    id.startsWith('reco_') ? id.slice(5) : null,
+                ].filter(Boolean);
+                let anchor = null;
+                for (const c of candidates) {
+                    anchor = resolveAnchor(c);
+                    if (anchor) break;
+                }
+                if (!anchor) continue;
+
                 // Severity palette: green < 0.9, orange < 1.0, red otherwise.
-                const rho = typeof action.max_rho === 'number' ? action.max_rho : 0;
-                const color = rho < 0.9 ? '#28a745' : rho < 1.0 ? '#f0ad4e' : '#dc3545';
+                const rho = typeof action.max_rho === 'number'
+                    ? action.max_rho
+                    : (typeof action.estimated_max_rho === 'number' ? action.estimated_max_rho : NaN);
+                const color = Number.isFinite(rho)
+                    ? (rho < 0.9 ? '#28a745' : rho < 1.0 ? '#f0ad4e' : '#dc3545')
+                    : '#9e9e9e'; // grey when we don't have a rho yet
                 pins.push({
                     id,
-                    x,
-                    y,
+                    x: anchor.x,
+                    y: anchor.y,
                     rho,
                     rank: i + 1,
                     color,
                     description: action.description_unitaire || '',
-                    max_rho_line: lineId,
+                    max_rho_line: action.max_rho_line || action.estimated_max_rho_line || id,
                 });
             }
             return pins;
@@ -1550,6 +1603,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             selectedActionId,
             onActionSelect,
             onPinPreview,
+            // Richer-popover props — forward the sidebar ActionCard
+            // affordances so the pin popover matches the card the
+            // user would see in the feed.
+            selectedActionIds,
+            rejectedActionIds,
+            manuallyAddedIds,
+            onFavorite,
+            onReject,
         }) => {
             const containerRef = React.useRef(null);
             const backdropSvgRef = React.useRef(null);
@@ -1591,6 +1652,15 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             // highlight clones.  Injecting the raw backend SVG string
             // loses all of that and produces the unpainted NAD the
             // earlier port was rendering.
+            //
+            // Performance: `cloneNode(true)` on the PyPSA-EUR France
+            // SVG is ~200-500 ms on cold cache.  We keep a ref-scoped
+            // cache keyed by the source <svg> identity — tab switches
+            // and unrelated re-renders skip the clone entirely, only
+            // paying the cost when the underlying n1Diagram actually
+            // changes.  This is the standalone equivalent of React's
+            // `MemoizedSvgContainer` (PR #79).
+            const lastClonedSourceRef = React.useRef(null);
             React.useLayoutEffect(() => {
                 const container = containerRef.current;
                 if (!container || !visible) return;
@@ -1605,6 +1675,13 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     }
                     return;
                 }
+                // Skip the expensive clone when the source SVG node is
+                // the same one we already injected.  We still re-pin the
+                // backdropSvgRef each time so overviewVb updates land.
+                if (lastClonedSourceRef.current === source && backdropSvgRef.current && container.contains(backdropSvgRef.current)) {
+                    return;
+                }
+                lastClonedSourceRef.current = source;
                 const clone = source.cloneNode(true);
                 clone.style.width = '100%';
                 clone.style.height = '100%';
@@ -1974,53 +2051,128 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                             style={{ padding: '2px 6px', border: '1px solid #ccc', borderRadius: 4, fontSize: '12px', marginLeft: 6, width: 180 }}
                         />
                     </div>
-                    {/* Popover (single-click preview) */}
-                    {popoverPin && (
-                        <div
-                            data-overview-popover
-                            style={{
-                                position: 'fixed',
-                                left: popoverPin.screenX,
-                                top: Math.max(12, popoverPin.screenY - 140),
-                                transform: 'translateX(-50%)',
-                                background: '#fff',
-                                border: '1px solid #ccc',
-                                borderRadius: 6,
-                                padding: '10px 12px',
-                                boxShadow: '0 4px 16px rgba(0,0,0,0.2)',
-                                minWidth: 220,
-                                zIndex: 200,
-                                fontSize: '13px',
-                            }}
-                        >
-                            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
-                                <strong style={{ flex: 1 }}>{popoverPin.id}</strong>
-                                <button
-                                    onClick={() => {
-                                        interactionLogger.record('overview_popover_closed', { reason: 'close_button' });
-                                        setPopoverPin(null);
-                                    }}
-                                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '14px' }}
-                                    aria-label="Close popover"
-                                >✕</button>
-                            </div>
-                            <div style={{ color: '#555', marginBottom: 4 }}>{popoverPin.description || '(no description)'}</div>
-                            <div style={{ fontSize: '12px', color: '#777' }}>
-                                Max ρ <strong>{(popoverPin.rho * 100).toFixed(1)}%</strong> on {popoverPin.max_rho_line}
-                            </div>
-                            <button
-                                onClick={() => {
-                                    interactionLogger.record('overview_pin_double_clicked', { action_id: popoverPin.id });
-                                    setPopoverPin(null);
-                                    if (onActionSelect) onActionSelect(popoverPin.id);
-                                }}
+                    {/* Popover (single-click preview) — richer layout
+                        matching the sidebar ActionCard: status badges,
+                        max-ρ breakdown, star / reject / view buttons.
+                        Full ActionCard reuse would require extracting
+                        the card body into a shared component; this
+                        inline version carries the same affordances at
+                        lower scope. */}
+                    {popoverPin && (() => {
+                        const action = actions?.[popoverPin.id] || {};
+                        const isFavorited = selectedActionIds?.has?.(popoverPin.id);
+                        const isRejected = rejectedActionIds?.has?.(popoverPin.id);
+                        const isManual = manuallyAddedIds?.has?.(popoverPin.id);
+                        const rho = Number.isFinite(popoverPin.rho) ? popoverPin.rho : null;
+                        const statusBadge = !Number.isFinite(popoverPin.rho)
+                            ? { text: 'Not simulated', bg: '#e2e3e5', fg: '#383d41' }
+                            : rho < 0.9
+                                ? { text: 'Solves overload', bg: '#d4edda', fg: '#155724' }
+                                : rho < 1.0
+                                    ? { text: 'Solved — low margin', bg: '#fff3cd', fg: '#856404' }
+                                    : { text: 'Still overloaded', bg: '#f8d7da', fg: '#721c24' };
+                        const lineOverloadedAfter = Array.isArray(action.lines_overloaded_after)
+                            ? action.lines_overloaded_after
+                            : null;
+                        return (
+                            <div
+                                data-overview-popover
                                 style={{
-                                    marginTop: 8, padding: '4px 10px', background: '#3498db', color: '#fff',
-                                    border: 'none', borderRadius: 4, cursor: 'pointer', width: '100%',
+                                    position: 'fixed',
+                                    left: popoverPin.screenX,
+                                    top: Math.max(12, popoverPin.screenY - 220),
+                                    transform: 'translateX(-50%)',
+                                    background: '#fff',
+                                    border: '1px solid #ccc',
+                                    borderRadius: 6,
+                                    padding: '12px 14px',
+                                    boxShadow: '0 4px 16px rgba(0,0,0,0.2)',
+                                    minWidth: 280, maxWidth: 360,
+                                    zIndex: 200,
+                                    fontSize: '13px',
                                 }}
-                            >View action</button>
-                        </div>
-                    )}
+                            >
+                                {/* Header row — id + status badges + close */}
+                                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6, marginBottom: 8 }}>
+                                    <strong style={{ flex: 1, wordBreak: 'break-all', fontSize: '12px' }}>
+                                        #{popoverPin.rank} — {popoverPin.id}
+                                    </strong>
+                                    <button
+                                        onClick={() => {
+                                            interactionLogger.record('overview_popover_closed', { reason: 'close_button' });
+                                            setPopoverPin(null);
+                                        }}
+                                        style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '16px', color: '#888', padding: 0, lineHeight: 1 }}
+                                        aria-label="Close popover"
+                                    >✕</button>
+                                </div>
+                                {/* Status badges */}
+                                <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginBottom: 8 }}>
+                                    <span style={{
+                                        background: statusBadge.bg, color: statusBadge.fg,
+                                        padding: '2px 8px', borderRadius: 10, fontSize: '11px', fontWeight: 600,
+                                    }}>{statusBadge.text}</span>
+                                    {isManual && <span style={{ background: '#cfe2ff', color: '#084298', padding: '2px 8px', borderRadius: 10, fontSize: '11px' }}>Manual</span>}
+                                    {isFavorited && <span style={{ background: '#fff3cd', color: '#856404', padding: '2px 8px', borderRadius: 10, fontSize: '11px' }}>⭐ Starred</span>}
+                                    {isRejected && <span style={{ background: '#f8d7da', color: '#721c24', padding: '2px 8px', borderRadius: 10, fontSize: '11px' }}>❌ Rejected</span>}
+                                </div>
+                                {/* Description */}
+                                <div style={{ color: '#333', marginBottom: 8, lineHeight: 1.35 }}>
+                                    {popoverPin.description || '(no description)'}
+                                </div>
+                                {/* Metrics */}
+                                <div style={{ fontSize: '12px', color: '#555', marginBottom: 8 }}>
+                                    {rho != null ? (
+                                        <div>
+                                            Max loading <strong>{(rho * 100).toFixed(1)}%</strong> on <em>{popoverPin.max_rho_line}</em>
+                                        </div>
+                                    ) : (
+                                        <div style={{ color: '#888' }}>Loading not yet simulated.</div>
+                                    )}
+                                    {lineOverloadedAfter && lineOverloadedAfter.length > 0 && (
+                                        <div style={{ marginTop: 4, color: '#856404' }}>
+                                            Residual overloads: {lineOverloadedAfter.slice(0, 3).join(', ')}
+                                            {lineOverloadedAfter.length > 3 ? ` (+${lineOverloadedAfter.length - 3})` : ''}
+                                        </div>
+                                    )}
+                                </div>
+                                {/* Action row: favorite / reject / view */}
+                                <div style={{ display: 'flex', gap: 6 }}>
+                                    <button
+                                        onClick={() => { if (onFavorite) onFavorite(popoverPin.id); }}
+                                        title={isFavorited ? 'Un-star this action' : 'Star this action'}
+                                        style={{
+                                            flex: 'none', padding: '4px 10px',
+                                            background: isFavorited ? '#ffc107' : '#f8f9fa',
+                                            color: isFavorited ? '#000' : '#333',
+                                            border: '1px solid #ccc', borderRadius: 4, cursor: 'pointer',
+                                        }}
+                                    >{isFavorited ? '★' : '☆'}</button>
+                                    <button
+                                        onClick={() => { if (onReject) onReject(popoverPin.id); }}
+                                        title={isRejected ? 'Un-reject this action' : 'Reject this action'}
+                                        style={{
+                                            flex: 'none', padding: '4px 10px',
+                                            background: isRejected ? '#dc3545' : '#f8f9fa',
+                                            color: isRejected ? '#fff' : '#333',
+                                            border: '1px solid #ccc', borderRadius: 4, cursor: 'pointer',
+                                        }}
+                                    >✕</button>
+                                    <button
+                                        onClick={() => {
+                                            interactionLogger.record('overview_pin_double_clicked', { action_id: popoverPin.id });
+                                            setPopoverPin(null);
+                                            if (onActionSelect) onActionSelect(popoverPin.id);
+                                        }}
+                                        style={{
+                                            flex: 1, padding: '4px 10px', background: '#3498db', color: '#fff',
+                                            border: 'none', borderRadius: 4, cursor: 'pointer', fontWeight: 600,
+                                        }}
+                                    >View action</button>
+                                </div>
+                            </div>
+                        );
+                    })()}
                 </div>
             );
         };
@@ -2635,6 +2787,65 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                             postVb();
                         });
                         popup.addEventListener('mouseup', () => { isDragging = false; svgEl.style.cursor = 'grab'; });
+
+                        // If we're detaching the Action Overview, render
+                        // the pin layer inside the popup too.  Pins are
+                        // positioned in SCREEN-px via the same
+                        // `xMidYMid meet` projection the pin SVG uses in
+                        // main, recomputed on every pan/zoom in the
+                        // popup so they stay anchored to their asset
+                        // through the popup's viewBox changes.  Clicks
+                        // in the popup are no-ops — action selection
+                        // remains a main-window gesture.
+                        if (actionFallbackToN1 && result?.actions) {
+                            const pinLayer = popup.document.createElement('div');
+                            pinLayer.style.cssText = 'position: absolute; inset: 0; pointer-events: none;';
+                            contentHost.appendChild(pinLayer);
+                            const overviewPins = computeActionOverviewPins(result.actions, n1MetaIndex);
+                            const renderPopupPins = () => {
+                                if (!vb) return;
+                                const rect = svgEl.getBoundingClientRect();
+                                if (!rect.width || !rect.height) return;
+                                const vbAspect = vb.w / vb.h;
+                                const boxAspect = rect.width / rect.height;
+                                let scale, offsetX, offsetY;
+                                if (boxAspect > vbAspect) {
+                                    scale = rect.height / vb.h;
+                                    offsetX = (rect.width - vb.w * scale) / 2;
+                                    offsetY = 0;
+                                } else {
+                                    scale = rect.width / vb.w;
+                                    offsetX = 0;
+                                    offsetY = (rect.height - vb.h * scale) / 2;
+                                }
+                                pinLayer.replaceChildren();
+                                for (const pin of overviewPins) {
+                                    const sx = offsetX + (pin.x - vb.x) * scale;
+                                    const sy = offsetY + (pin.y - vb.y) * scale;
+                                    const wrap = popup.document.createElement('div');
+                                    wrap.title = `${pin.id} — max ρ ${(pin.rho * 100).toFixed(1)}%`;
+                                    wrap.style.cssText = `position:absolute;left:${sx}px;top:${sy}px;transform:translate(-50%, -100%);width:28px;height:38px;pointer-events:none;filter:drop-shadow(0 2px 3px rgba(0,0,0,0.4));`;
+                                    const label = Number.isFinite(pin.rho) ? `${Math.round(pin.rho * 100)}%` : String(pin.rank);
+                                    wrap.innerHTML = `
+                                        <svg viewBox="0 0 36 48" width="28" height="38" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M18 0 C8 0 0 8 0 18 C0 28 18 48 18 48 C18 48 36 28 36 18 C36 8 28 0 18 0 Z" fill="${pin.color}" stroke="#fff" stroke-width="2"/>
+                                            <circle cx="18" cy="18" r="11" fill="#fff"/>
+                                            <text x="18" y="18" text-anchor="middle" dominant-baseline="central" font-size="${label.length > 3 ? 8 : 10}" font-weight="700" fill="${pin.color}">${label}</text>
+                                        </svg>`;
+                                    pinLayer.appendChild(wrap);
+                                }
+                            };
+                            // Re-project on every popup pan/zoom + any
+                            // resize (window drag, layout change).
+                            svgEl.addEventListener('wheel', () => popup.requestAnimationFrame(renderPopupPins));
+                            popup.addEventListener('mousemove', () => popup.requestAnimationFrame(renderPopupPins));
+                            popup.addEventListener('mouseup', () => popup.requestAnimationFrame(renderPopupPins));
+                            popup.addEventListener('resize', () => popup.requestAnimationFrame(renderPopupPins));
+                            // Initial paint deferred until the SVG has
+                            // been laid out (its getBoundingClientRect
+                            // returns 0/0 synchronously after insertion).
+                            popup.requestAnimationFrame(renderPopupPins);
+                        }
                     } else {
                         contentHost.textContent = '(Tab has no diagram yet — return to the main window to load one.)';
                         contentHost.style.cssText += 'color: #888; display: flex; align-items: center; justify-content: center;';
@@ -6124,6 +6335,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                 actions={result.actions}
                                                 selectedActionId={selectedActionId}
                                                 onActionSelect={handleActionSelect}
+                                                selectedActionIds={manualActionIds}
+                                                rejectedActionIds={rejectedActionIds}
+                                                manuallyAddedIds={manuallyAddedIds}
+                                                onFavorite={handleActionFavorite}
+                                                onReject={handleActionReject}
                                             />
                                             : <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#999' }}>Select an action card to view its network variant</div>
                                         )

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1499,93 +1499,183 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
         // needs for Layer 1/3a parity.  If the edge can't be resolved,
         // the action is dropped from the overlay and only appears in
         // the sidebar feed.
-        const computeActionOverviewPins = (actions, metaIndex) => {
-            if (!actions || !metaIndex) return [];
+        // Resolve a single unitary action to an (x, y) anchor on the
+        // N-1 NAD.  Mirrors `resolveActionAnchor` in
+        // frontend/src/utils/svgUtils.ts (PR #92) — the primary anchor
+        // is what the action TARGETS (lines / VLs from topology), NOT
+        // max_rho_line.  max_rho_line is the line that carries the
+        // worst loading AFTER the action, which is often different
+        // from the one the operator actually acts on.
+        //
+        // Resolution order:
+        //   1. Load-shedding / curtailment details → affected
+        //      load / generator's voltage_level_id.
+        //   2. Line targets via getActionTargetLines → edge midpoint
+        //      (or one endpoint if the other isn't resolvable).
+        //   3. VL targets via getActionTargetVoltageLevels → node (x, y).
+        //   4. Fallback: max_rho_line → edge midpoint.
+        //   5. Fallback: estimated_max_rho_line (for combined pairs
+        //      the recommender estimated but didn't simulate).
+        const resolveActionAnchor = (actionId, details, metaIndex) => {
+            if (!details || !metaIndex) return null;
             const { edgesByEquipmentId, nodesBySvgId, nodesByEquipmentId } = metaIndex;
-            const rank = Object.keys(actions);
-            const pins = [];
+            const lookupNode = (key) =>
+                (nodesBySvgId?.get?.(key)) || (nodesByEquipmentId?.get?.(key));
+            const isFinite2 = (n) => Number.isFinite(n?.x) && Number.isFinite(n?.y);
 
-            // Resolve a target id to (x, y) on the N-1 NAD.  Falls
-            // through a series of strategies so every action that
-            // references ANY recognisable equipment gets a pin:
-            //   1. edge midpoint (max_rho_line is a line / trafo);
-            //   2. node centroid (max_rho_line is a VL / substation);
-            //   3. anchor node of an incident edge (edges list node1 /
-            //      node2 that may match a node by equipmentId);
-            // Returns null when none of them resolve.
-            const resolveAnchor = (targetId) => {
-                if (!targetId) return null;
-                // Strategy 1: edge midpoint
-                const edge = edgesByEquipmentId?.get?.(targetId);
-                if (edge) {
-                    const n1 = nodesBySvgId?.get?.(edge.node1);
-                    const n2 = nodesBySvgId?.get?.(edge.node2);
-                    if (n1 && n2) {
-                        const x = (Number(n1.x) + Number(n2.x)) / 2;
-                        const y = (Number(n1.y) + Number(n2.y)) / 2;
-                        if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+            // 1. Load-shedding / curtailment details → affected load/gen VL.
+            if (Array.isArray(details.load_shedding_details)) {
+                for (const d of details.load_shedding_details) {
+                    if (d?.voltage_level_id) {
+                        const n = nodesByEquipmentId?.get?.(d.voltage_level_id);
+                        if (isFinite2(n)) return { x: Number(n.x), y: Number(n.y) };
                     }
                 }
-                // Strategy 2: node lookup by equipment id
-                const node = nodesByEquipmentId?.get?.(targetId);
-                if (node) {
-                    const x = Number(node.x), y = Number(node.y);
-                    if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+            }
+            if (Array.isArray(details.curtailment_details)) {
+                for (const d of details.curtailment_details) {
+                    if (d?.voltage_level_id) {
+                        const n = nodesByEquipmentId?.get?.(d.voltage_level_id);
+                        if (isFinite2(n)) return { x: Number(n.x), y: Number(n.y) };
+                    }
                 }
-                // Strategy 3: svgId (some edges reference VLs by svg id)
-                const nodeBySvg = nodesBySvgId?.get?.(targetId);
-                if (nodeBySvg) {
-                    const x = Number(nodeBySvg.x), y = Number(nodeBySvg.y);
-                    if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
-                }
-                return null;
-            };
+            }
 
-            for (let i = 0; i < rank.length; i++) {
-                const id = rank[i];
+            // 2. Line targets via getActionTargetLines.
+            try {
+                const lineTargets = getActionTargetLines(details, actionId, edgesByEquipmentId);
+                for (const lineName of lineTargets || []) {
+                    const edge = edgesByEquipmentId?.get?.(lineName);
+                    if (!edge) continue;
+                    const n1 = lookupNode(edge.node1);
+                    const n2 = lookupNode(edge.node2);
+                    if (isFinite2(n1) && isFinite2(n2)) {
+                        return { x: (Number(n1.x) + Number(n2.x)) / 2, y: (Number(n1.y) + Number(n2.y)) / 2 };
+                    }
+                    if (isFinite2(n1)) return { x: Number(n1.x), y: Number(n1.y) };
+                    if (isFinite2(n2)) return { x: Number(n2.x), y: Number(n2.y) };
+                }
+            } catch (e) { /* defensive — ignore resolver errors */ }
+
+            // 3. VL targets via getActionTargetVoltageLevels.
+            try {
+                const vlTargets = getActionTargetVoltageLevels(details, actionId, nodesByEquipmentId);
+                for (const vlName of vlTargets || []) {
+                    const node = nodesByEquipmentId?.get?.(vlName);
+                    if (isFinite2(node)) return { x: Number(node.x), y: Number(node.y) };
+                }
+            } catch (e) { /* ignore */ }
+
+            // 4. Last-resort fallback on max_rho_line (the line the
+            //    action redistributes onto, not the one it affects).
+            //    Only used when topology resolution failed entirely.
+            const mrl = details.max_rho_line;
+            if (mrl) {
+                const edge = edgesByEquipmentId?.get?.(mrl);
+                if (edge) {
+                    const n1 = lookupNode(edge.node1);
+                    const n2 = lookupNode(edge.node2);
+                    if (isFinite2(n1) && isFinite2(n2)) {
+                        return { x: (Number(n1.x) + Number(n2.x)) / 2, y: (Number(n1.y) + Number(n2.y)) / 2 };
+                    }
+                }
+            }
+
+            // 5. For estimated-only combined pairs without topology,
+            //    estimated_max_rho_line is all we have.
+            const emrl = details.estimated_max_rho_line;
+            if (emrl) {
+                const edge = edgesByEquipmentId?.get?.(emrl);
+                if (edge) {
+                    const n1 = lookupNode(edge.node1);
+                    const n2 = lookupNode(edge.node2);
+                    if (isFinite2(n1) && isFinite2(n2)) {
+                        return { x: (Number(n1.x) + Number(n2.x)) / 2, y: (Number(n1.y) + Number(n2.y)) / 2 };
+                    }
+                }
+            }
+            return null;
+        };
+
+        const computeActionOverviewPins = (actions, metaIndex) => {
+            if (!actions || !metaIndex) return [];
+            const ids = Object.keys(actions);
+            const pins = [];
+            for (let i = 0; i < ids.length; i++) {
+                const id = ids[i];
                 const action = actions[id];
                 if (!action) continue;
-                // Try max_rho_line first (simulated), then
-                // estimated_max_rho_line (for combined pairs the
-                // recommender estimated but didn't simulate).  If the
-                // action id is itself a line (common for disco_ /
-                // reco_ actions), fall back to that so the pin still
-                // anchors on the relevant asset.
-                const candidates = [
-                    action.max_rho_line,
-                    action.estimated_max_rho_line,
-                    // action id shape for disco_ / reco_ often
-                    // includes the line id as suffix; strip the
-                    // common prefixes and try.
-                    id.startsWith('disco_') ? id.slice(6) : null,
-                    id.startsWith('reco_') ? id.slice(5) : null,
-                ].filter(Boolean);
-                let anchor = null;
-                for (const c of candidates) {
-                    anchor = resolveAnchor(c);
-                    if (anchor) break;
-                }
+                // Skip combined-action entries (key contains '+').  They
+                // are rendered separately by computeCombinedActionPins
+                // below as curves connecting their constituent unitary
+                // pins.  Matches frontend/src/utils/svgUtils.ts's
+                // `buildActionOverviewPins` contract.
+                if (id.includes('+')) continue;
+                const anchor = resolveActionAnchor(id, action, metaIndex);
                 if (!anchor) continue;
-
-                // Severity palette: green < 0.9, orange < 1.0, red otherwise.
                 const rho = typeof action.max_rho === 'number'
                     ? action.max_rho
                     : (typeof action.estimated_max_rho === 'number' ? action.estimated_max_rho : NaN);
-                const color = Number.isFinite(rho)
-                    ? (rho < 0.9 ? '#28a745' : rho < 1.0 ? '#f0ad4e' : '#dc3545')
-                    : '#9e9e9e'; // grey when we don't have a rho yet
+                // Severity palette mirrors ActionCard (docs/action-overview-diagram.md):
+                //   green    rho <= 0.9 (safe)
+                //   orange   0.9 < rho <= 1.0 (near limit)
+                //   red      rho > 1.0 (still overloaded)
+                //   grey     rho unavailable (divergent / islanded / not yet simulated)
+                let color = '#9ca3af';
+                if (Number.isFinite(rho)) {
+                    color = rho <= 0.9 ? '#28a745' : rho <= 1.0 ? '#f0ad4e' : '#dc3545';
+                }
                 pins.push({
                     id,
-                    x: anchor.x,
-                    y: anchor.y,
-                    rho,
-                    rank: i + 1,
-                    color,
+                    x: anchor.x, y: anchor.y,
+                    rho, rank: i + 1, color,
                     description: action.description_unitaire || '',
                     max_rho_line: action.max_rho_line || action.estimated_max_rho_line || id,
                 });
             }
             return pins;
+        };
+
+        // Build curves for combined-pair (A+B) entries.  Each pair is
+        // rendered as a dashed line connecting the two constituent
+        // unitary pins plus a labelled midpoint marker.  Matches
+        // `buildCombinedActionPins` in the frontend's svgUtils.
+        const computeCombinedActionPins = (actions, metaIndex, unitaryPinById) => {
+            if (!actions || !metaIndex) return [];
+            const pairs = [];
+            for (const [id, action] of Object.entries(actions)) {
+                if (!id.includes('+') || !action) continue;
+                // Resolve each constituent to a pin position — fall
+                // back to recomputing via the resolver when the
+                // unitary pin isn't already on screen.
+                const parts = id.split('+').map(p => p.trim());
+                const getEndpoint = (partId) => {
+                    const cached = unitaryPinById.get(partId);
+                    if (cached) return { x: cached.x, y: cached.y };
+                    const partDetail = actions[partId];
+                    if (!partDetail) return null;
+                    return resolveActionAnchor(partId, partDetail, metaIndex);
+                };
+                const a = getEndpoint(parts[0]);
+                const b = getEndpoint(parts[1]);
+                if (!a || !b) continue;
+                const rho = typeof action.max_rho === 'number'
+                    ? action.max_rho
+                    : (typeof action.estimated_max_rho === 'number' ? action.estimated_max_rho : NaN);
+                let color = '#9ca3af';
+                if (Number.isFinite(rho)) {
+                    color = rho <= 0.9 ? '#28a745' : rho <= 1.0 ? '#f0ad4e' : '#dc3545';
+                }
+                pairs.push({
+                    id,
+                    x1: a.x, y1: a.y, x2: b.x, y2: b.y,
+                    // Midpoint for the label badge.
+                    midX: (a.x + b.x) / 2, midY: (a.y + b.y) / 2,
+                    rho, color,
+                    description: action.description_unitaire || '',
+                });
+            }
+            return pairs;
         };
 
         // Minimal Action Overview component.  Shown on the Action tab
@@ -1631,6 +1721,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 () => computeActionOverviewPins(actions, n1MetaIndex),
                 [actions, n1MetaIndex],
             );
+
+            // Combined-pair connections.  A Map keyed by unitary pin id
+            // lets `computeCombinedActionPins` reuse the unitary anchors
+            // rather than re-running the resolver for every leg.
+            const combinedPairs = React.useMemo(() => {
+                const byId = new Map(pins.map(p => [p.id, p]));
+                return computeCombinedActionPins(actions, n1MetaIndex, byId);
+            }, [actions, n1MetaIndex, pins]);
 
             // visible → overview_shown / overview_hidden.
             React.useEffect(() => {
@@ -1973,7 +2071,27 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                             onMouseUp={handleMouseUp}
                             onMouseLeave={handleMouseUp}
                             style={{ position: 'absolute', inset: 0, pointerEvents: 'auto', cursor: panRef.current.isDragging ? 'grabbing' : 'grab' }}
-                        />
+                        >
+                            {/* Combined-pair connections — dashed line
+                                between constituent unitary pins, with a
+                                severity-coloured chip at the midpoint
+                                showing the combined max ρ.  Stroke
+                                width uses `vector-effect: non-scaling-
+                                stroke` so the line stays 2 screen-px
+                                regardless of zoom. */}
+                            {combinedPairs.map((pair) => (
+                                <g key={pair.id} data-combined-pair={pair.id} opacity={0.85}>
+                                    <line
+                                        x1={pair.x1} y1={pair.y1}
+                                        x2={pair.x2} y2={pair.y2}
+                                        stroke={pair.color}
+                                        strokeWidth={2}
+                                        strokeDasharray="6,6"
+                                        vectorEffect="non-scaling-stroke"
+                                    />
+                                </g>
+                            ))}
+                        </svg>
                         {/* Pins in screen-px space.  Each pin is an
                             absolutely-positioned <div> at the projected
                             screen coordinate of its SVG anchor.  The

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1606,22 +1606,54 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 const clone = source.cloneNode(true);
                 clone.style.width = '100%';
                 clone.style.height = '100%';
-                clone.style.opacity = '0.55';          // dim the backdrop
+                // Light dimming only — pypowsybl edges are already
+                // thin at full extent; aggressive opacity hides them.
+                // The pin layer above provides enough visual contrast
+                // without further fading the network.
+                clone.style.opacity = '0.85';
                 clone.style.pointerEvents = 'none';
                 clone.removeAttribute('width');
                 clone.removeAttribute('height');
                 container.replaceChildren(clone);
                 backdropSvgRef.current = clone;
 
-                // Seed the overview viewBox from the clone's current
-                // viewBox (which the main N-1 tab has already zoomed
-                // to the contingency via zoomToElement).  Stash the
-                // auto-fit rectangle — the "Fit" button reapplies it.
+                // Seed the overview viewBox to a bounding box that
+                // includes EVERY pin (with 5 % padding) so the
+                // operator sees the full prioritized-actions map at
+                // once.  Falls back to the cloned SVG's existing
+                // viewBox when there are no pins (analysis hasn't
+                // produced any actions yet).  The same rectangle is
+                // stashed as the "Fit" target — clicking the Fit
+                // button restores it.
                 try {
-                    const vbAttr = clone.getAttribute('viewBox');
-                    if (vbAttr) {
-                        const [x, y, w, h] = vbAttr.split(/\s+/).map(Number);
-                        const seed = { x, y, w, h };
+                    let seed = null;
+                    if (pins.length > 0) {
+                        let xMin = Infinity, yMin = Infinity, xMax = -Infinity, yMax = -Infinity;
+                        for (const p of pins) {
+                            if (p.x < xMin) xMin = p.x;
+                            if (p.y < yMin) yMin = p.y;
+                            if (p.x > xMax) xMax = p.x;
+                            if (p.y > yMax) yMax = p.y;
+                        }
+                        // Pad so pin glyphs aren't clipped at the
+                        // border, and enforce a minimum extent so a
+                        // single-pin overview doesn't zoom infinitely.
+                        const w = Math.max(xMax - xMin, 200);
+                        const h = Math.max(yMax - yMin, 200);
+                        seed = {
+                            x: xMin - w * 0.1,
+                            y: yMin - h * 0.1,
+                            w: w * 1.2,
+                            h: h * 1.2,
+                        };
+                    } else {
+                        const vbAttr = clone.getAttribute('viewBox');
+                        if (vbAttr) {
+                            const [x, y, w, h] = vbAttr.split(/\s+/).map(Number);
+                            seed = { x, y, w, h };
+                        }
+                    }
+                    if (seed) {
                         setOverviewVb(seed);
                         fitVbRef.current = seed;
                     }
@@ -2404,19 +2436,39 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         contentHost.style.cssText += 'color: #888; display: flex; align-items: center; justify-content: center;';
                     }
                 } else {
+                    // For the Action tab in Overview mode (no action selected
+                    // → no action variant SVG yet) fall back to the N-1
+                    // backdrop the overview is rendering on top of.  The
+                    // popup loses the pin layer (it's React state-driven and
+                    // would need its own IPC channel to hydrate in the
+                    // popup), but at least the underlying network shows up.
+                    const actionFallbackToN1 = tabId === 'action' && !actionSvgContainerRef.current?.querySelector('svg');
                     const sourceContainer = tabId === 'n' ? nSvgContainerRef.current
                         : tabId === 'n-1' ? n1SvgContainerRef.current
-                        : tabId === 'action' ? actionSvgContainerRef.current
+                        : tabId === 'action' ? (actionFallbackToN1 ? n1SvgContainerRef.current : actionSvgContainerRef.current)
                         : null;
                     const sourceSvg = sourceContainer?.querySelector('svg');
+                    if (actionFallbackToN1 && sourceSvg) {
+                        const note = popup.document.createElement('div');
+                        note.style.cssText = 'background: #fff3cd; color: #856404; padding: 6px 12px; font-size: 0.8rem; border-bottom: 1px solid #ffc107; text-align: center;';
+                        note.textContent = 'Action Overview popped out — N-1 backdrop only. Pin overlay stays in the main window.';
+                        popup.document.body.insertBefore(note, contentHost);
+                    }
                     if (sourceSvg) {
-                        // Deep-clone preserves every highlight clone, the
-                        // current viewBox attribute, and any applied
-                        // CSS classes.  We strip width/height inline
-                        // styles so the popup's flex container controls
-                        // sizing rather than inheriting the main
-                        // window's pixel dimensions.
-                        const svgEl = sourceSvg.cloneNode(true);
+                        // Cross-document SVG copy.  `cloneNode(true)` keeps
+                        // the node bound to the SOURCE document — when
+                        // appended to a popup, the embedded `<style>` block
+                        // (where pypowsybl defines `--nad-vl-color` per
+                        // voltage class) doesn't always re-evaluate, so
+                        // edges fall back to `lightgrey` and the popup
+                        // renders nodes-only.  Round-tripping through
+                        // serialised XML forces the popup's parser to
+                        // build a fresh node bound to the popup's
+                        // document, so the embedded styles take effect.
+                        const xmlString = new XMLSerializer().serializeToString(sourceSvg);
+                        const popupParser = new popup.DOMParser();
+                        const popupDoc = popupParser.parseFromString(xmlString, 'image/svg+xml');
+                        const svgEl = popupDoc.documentElement;
                         svgEl.style.width = '100%';
                         svgEl.style.height = '100%';
                         svgEl.removeAttribute('width');
@@ -7578,7 +7630,18 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                 {[
                                     { id: 'n', label: 'Network (N)', available: !!nDiagram?.svg, accentColor: '#3498db', placeholder: 'Configure a network path to load the base-case diagram.' },
                                     { id: 'n-1', label: 'Contingency (N-1)', available: !!n1Diagram?.svg, accentColor: '#e74c3c', placeholder: 'Select a contingency element from the dropdown to view the N-1 state.' },
-                                    { id: 'action', label: selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial Action', available: !!actionDiagram?.svg, accentColor: '#ff4081', placeholder: 'Select an action card from the suggestions panel to view its effect on the network.' },
+                                    {
+                                        id: 'action',
+                                        label: selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial Action',
+                                        // Available when EITHER an action variant is loaded
+                                        // OR the Action Overview can render (analysis has
+                                        // produced prioritized actions).  Without the
+                                        // overview branch the detach button stays hidden
+                                        // while the user is browsing pins.
+                                        available: !!actionDiagram?.svg || (!!result?.actions && Object.keys(result.actions).length > 0),
+                                        accentColor: '#ff4081',
+                                        placeholder: 'Select an action card from the suggestions panel to view its effect on the network.',
+                                    },
                                     { id: 'overflow', label: 'Overflow Analysis', available: !!result?.pdf_url, accentColor: '#27ae60', placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
                                 ].map(tab => {
                                     const isActive = activeTab === tab.id;

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1689,6 +1689,10 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     if (!window.confirm("Applying new settings will clear current analysis results. Do you want to continue?")) {
                         return;
                     }
+                    // Replay contract (docs/interaction-logging.md):
+                    //   { type: 'applySettings' } — user confirmed
+                    //   the "Applying new settings…" dialog.
+                    interactionLogger.record('contingency_confirmed', { type: 'applySettings' });
                 }
 
                 // If config file path changed, switch it first
@@ -2040,7 +2044,15 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             const pickPath = async (type, setter) => {
                 try {
                     const res = await axios.get(`${API_BASE}/api/pick-path?type=${type}&t=${Date.now()}`);
-                    if (res.data.path) setter(res.data.path);
+                    if (res.data.path) {
+                        // Replay contract (docs/interaction-logging.md):
+                        //   { type: 'file'|'dir', path: string }.
+                        //   The setter field is implicit from the
+                        //   preceding UI context (which field had
+                        //   focus before the picker opened).
+                        interactionLogger.record('path_picked', { type, path: res.data.path });
+                        setter(res.data.path);
+                    }
                 } catch (err) { setError('Failed to open file picker'); }
             };
 
@@ -2049,10 +2061,19 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                     if (!window.confirm("Loading a new study will clear current analysis results. Do you want to continue?")) {
                         return;
                     }
+                    // Replay contract (docs/interaction-logging.md):
+                    //   { type: 'loadStudy' } — user confirmed the
+                    //   "Loading a new study will clear…" dialog.
+                    interactionLogger.record('contingency_confirmed', { type: 'loadStudy' });
                 }
                 interactionLogger.clear();
                 interactionLogger.record('config_loaded', {
+                    // Full 17-field replay contract
+                    // (docs/interaction-logging.md § Config & Study Loading).
+                    // `output_folder_path` was previously missing — a
+                    // replay agent could not restore the save location.
                     network_path: networkPath, action_file_path: actionPath, layout_path: layoutPath,
+                    output_folder_path: outputFolderPath,
                     min_line_reconnections: minLineReconnections, min_close_coupling: minCloseCoupling,
                     min_open_coupling: minOpenCoupling, min_line_disconnections: minLineDisconnections,
                     min_pst: minPst, min_load_shedding: minLoadShedding, min_renewable_curtailment_actions: minRenewableCurtailmentActions,
@@ -2145,7 +2166,8 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 }
             };
             const handleManualZoomIn = () => {
-                interactionLogger.record('zoom_in');
+                // Replay contract (docs/interaction-logging.md): { tab }.
+                interactionLogger.record('zoom_in', { tab: activeTab });
                 const currentPZ = activeTab === 'action' ? actionPZ : activeTab === 'n' ? nPZ : n1PZ;
                 const vb = currentPZ?.viewBox;
                 if (currentPZ && vb) {
@@ -2160,7 +2182,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             };
 
             const handleManualZoomOut = () => {
-                interactionLogger.record('zoom_out');
+                interactionLogger.record('zoom_out', { tab: activeTab });
                 const currentPZ = activeTab === 'action' ? actionPZ : activeTab === 'n' ? nPZ : n1PZ;
                 const vb = currentPZ?.viewBox;
                 if (currentPZ && vb) {
@@ -2175,7 +2197,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             };
 
             const handleManualReset = () => {
-                interactionLogger.record('zoom_reset');
+                interactionLogger.record('zoom_reset', { tab: activeTab });
                 setInspectQuery('');
 
                 const currentPZ = activeTab === 'action' ? actionPZ : activeTab === 'n' ? nPZ : n1PZ;
@@ -2281,7 +2303,15 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                         setSelectedBranch(committedBranchRef.current);
                         return;
                     }
-                    // User confirmed — clear analysis state
+                    // User confirmed — clear analysis state + log the
+                    // confirmation gesture so replay agents know
+                    // whether the user said OK or Cancel.
+                    // Replay contract (docs/interaction-logging.md):
+                    //   { type: 'contingency', pending_branch: string }
+                    interactionLogger.record('contingency_confirmed', {
+                        type: 'contingency',
+                        pending_branch: selectedBranch,
+                    });
                     clearContingencyState();
                 }
 
@@ -2430,8 +2460,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 
                 if (outputFolderPath) {
                     try {
+                        // Replay contract (docs/interaction-logging.md):
+                        //   { output_folder }. The session_name was carried
+                        //   historically but is derivable from the
+                        //   timestamp — a replay agent regenerates it.
                         interactionLogger.record('session_saved', {
-                            session_name: sessionName,
                             output_folder: outputFolderPath,
                         });
                         const res = await axios.post(API_BASE + '/api/save-session', {
@@ -2474,10 +2507,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 try {
                     const res = await axios.get(`${API_BASE}/api/list-sessions?folder_path=${encodeURIComponent(outputFolderPath)}&t=${Date.now()}`);
                     setSessionList(res.data.sessions);
-                    interactionLogger.record('session_reload_modal_opened', {
-                        output_folder: outputFolderPath,
-                        available_sessions: res.data.sessions,
-                    });
+                    // Replay contract (docs/interaction-logging.md):
+                    //   {} — the list of available sessions is async
+                    //   and deliberately not part of the event payload
+                    //   (replay consults /api/list-sessions fresh).
+                    interactionLogger.record('session_reload_modal_opened');
                 } catch (err) {
                     setError('Failed to list sessions: ' + (err.response?.data?.detail || err.message));
                     setShowReloadModal(false);
@@ -3031,7 +3065,10 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 
             // ===== Asset Click (from action card badges / rho line names) =====
             const handleAssetClick = (actionId, assetName, tab = 'action') => {
-                interactionLogger.record('asset_clicked', { asset_name: assetName, action_id: actionId, target_tab: tab });
+                // Replay contract (docs/interaction-logging.md):
+                //   { action_id, asset_name, tab }
+                // where `tab` is the destination tab for the zoom.
+                interactionLogger.record('asset_clicked', { action_id: actionId, asset_name: assetName, tab });
                 setInspectQuery(assetName);
                 if (tab === 'n') {
                     setActiveTab('n');
@@ -3053,7 +3090,10 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 if (!assetName) return;
                 const tab = activeTabRef.current;
                 if (tab === 'overflow') return;
-                interactionLogger.record('asset_clicked', { asset_name: assetName, action_id: '', target_tab: tab });
+                // Sticky-sidebar zoom: action_id='' means "zoom in place
+                // on the current tab without selecting an action"
+                // (docs/interaction-logging.md § Visualization).
+                interactionLogger.record('asset_clicked', { action_id: '', asset_name: assetName, tab });
                 setInspectQuery(assetName);
             };
 
@@ -3073,8 +3113,13 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 } else {
                     initialTab = 'n';
                 }
+                // Replay contract (docs/interaction-logging.md):
+                //   { vl_name, action_id }. The initial_tab is implicit
+                //   from the current diagram tab; a replay agent will
+                //   observe the next sld_overlay_tab_changed event if
+                //   the user moves away from it.
                 interactionLogger.record('sld_overlay_opened', {
-                    vl_name: vlName, action_id: actionId || null, initial_tab: initialTab,
+                    vl_name: vlName, action_id: actionId || null,
                 });
                 setVlOverlay({ vlName, actionId, svg: null, viewBox: null, sldMetadata: null, loading: true, error: null, tab: initialTab });
                 fetchSldVariant(vlName, actionId, initialTab);
@@ -3820,7 +3865,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                 const actionId = canonicalizeId(rawActionId);
                 if (!selectedBranch) { setSearchError('Run an analysis first'); return; }
                 if (simulatingActionId) return; // Prevent concurrent simulations
-                interactionLogger.record('manual_action_simulated', { action_id: actionId, description: '' });
+                interactionLogger.record('manual_action_simulated', { action_id: actionId });
                 console.log('[handleAddManualAction] Starting simulation for:', actionId);
                 setSimulatingActionId(actionId);
                 setSearchError('');
@@ -3967,6 +4012,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             // Re-simulate an existing action with a new target MW value
             const handleResimulate = async (actionId, newTargetMw) => {
                 if (!selectedBranch) return;
+                // Replay contract (docs/interaction-logging.md):
+                //   { action_id, target_mw } — the raw user-entered MW
+                //   (backend may clamp). Wait-point: card refreshes
+                //   with new rho_after + load_shedding / curtailment
+                //   details; the card stays in its current bucket.
+                interactionLogger.record('action_mw_resimulated', { action_id: actionId, target_mw: newTargetMw });
                 setResimulatingId(actionId);
                 try {
                     const actionDetail = result?.actions?.[actionId];
@@ -4024,6 +4075,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             // Re-simulate an existing PST action with a new tap position
             const handleResimulateTap = async (actionId, newTap) => {
                 if (!selectedBranch) return;
+                // Replay contract (docs/interaction-logging.md):
+                //   { action_id, target_tap } — the raw user-entered tap
+                //   integer. Backend clamps to [low_tap, high_tap].
+                //   Wait-point: pst_details.tap_position is updated.
+                interactionLogger.record('pst_tap_resimulated', { action_id: actionId, target_tap: newTap });
                 setResimulatingId(actionId);
                 try {
                     const actionDetail = result?.actions?.[actionId];
@@ -5067,7 +5123,11 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                 const kv = Math.exp(logV);
                                                 const snapped = uniqueVoltages.reduce((best, uv) => Math.abs(Math.log(uv) - logV) < Math.abs(Math.log(best) - logV) ? uv : best);
                                                 if (snapped <= voltageRange[1]) {
-                                                    interactionLogger.record('voltage_range_changed', { min_kv: snapped, max_kv: voltageRange[1] });
+                                                    // Replay contract (docs/interaction-logging.md):
+                                                    //   { min, max } in kV. Previously emitted
+                                                    //   { min_kv, max_kv } — a replay agent reading
+                                                    //   `details.min` would see undefined.
+                                                    interactionLogger.record('voltage_range_changed', { min: snapped, max: voltageRange[1] });
                                                     setVoltageRange([snapped, voltageRange[1]]);
                                                 }
                                             }}
@@ -5080,7 +5140,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                 const logV = parseFloat(e.target.value) || 0;
                                                 const snapped = uniqueVoltages.reduce((best, uv) => Math.abs(Math.log(uv) - logV) < Math.abs(Math.log(best) - logV) ? uv : best);
                                                 if (snapped >= voltageRange[0]) {
-                                                    interactionLogger.record('voltage_range_changed', { min_kv: voltageRange[0], max_kv: snapped });
+                                                    interactionLogger.record('voltage_range_changed', { min: voltageRange[0], max: snapped });
                                                     setVoltageRange([voltageRange[0], snapped]);
                                                 }
                                             }}
@@ -5145,7 +5205,13 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                     onMouseDown={e => e.stopPropagation()} // Prevent dragging when clicking tabs
                                                     onClick={(e) => {
                                                         e.stopPropagation();
-                                                        interactionLogger.record('sld_overlay_tab_changed', { from_tab: vlOverlay.tab, to_tab: tabMode });
+                                                        // Replay contract (docs/interaction-logging.md):
+                                                        //   { tab: SldTab, vl_name: string }.
+                                                        // The destination tab is what a replay agent
+                                                        // needs; the previous tab is recoverable from
+                                                        // the preceding sld_overlay_opened / _tab_changed
+                                                        // event in the log.
+                                                        interactionLogger.record('sld_overlay_tab_changed', { tab: tabMode, vl_name: vlOverlay.vlName });
                                                         fetchSldVariant(vlOverlay.vlName, vlOverlay.actionId, tabMode);
                                                     }}
                                                     style={{
@@ -5629,8 +5695,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     <h3 style={{ margin: 0, borderBottom: '1px solid #eee', paddingBottom: '10px' }}>Recommender Settings</h3>
 
                                     <div style={{ display: 'flex', borderBottom: '1px solid #eee', marginBottom: '15px' }}>
+                                        {/* Replay contract (docs/interaction-logging.md):
+                                              { from_tab, to_tab } — only emitted when from_tab !== to_tab.
+                                            Wraps setSettingsTab so every tab click lands in the log. */}
                                         <button
-                                            onClick={() => setSettingsTab('paths')}
+                                            onClick={() => {
+                                                if (settingsTab !== 'paths') interactionLogger.record('settings_tab_changed', { from_tab: settingsTab, to_tab: 'paths' });
+                                                setSettingsTab('paths');
+                                            }}
                                             style={{
                                                 flex: 1, padding: '10px', cursor: 'pointer', background: 'none',
                                                 border: 'none', borderBottom: settingsTab === 'paths' ? '2px solid #3498db' : 'none',
@@ -5641,7 +5713,10 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                             Paths
                                         </button>
                                         <button
-                                            onClick={() => setSettingsTab('recommender')}
+                                            onClick={() => {
+                                                if (settingsTab !== 'recommender') interactionLogger.record('settings_tab_changed', { from_tab: settingsTab, to_tab: 'recommender' });
+                                                setSettingsTab('recommender');
+                                            }}
                                             style={{
                                                 flex: 1, padding: '10px', cursor: 'pointer', background: 'none',
                                                 border: 'none', borderBottom: settingsTab === 'recommender' ? '2px solid #3498db' : 'none',
@@ -5652,7 +5727,10 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                             Recommender
                                         </button>
                                         <button
-                                            onClick={() => setSettingsTab('configurations')}
+                                            onClick={() => {
+                                                if (settingsTab !== 'configurations') interactionLogger.record('settings_tab_changed', { from_tab: settingsTab, to_tab: 'configurations' });
+                                                setSettingsTab('configurations');
+                                            }}
                                             style={{
                                                 flex: 1, padding: '10px', cursor: 'pointer', background: 'none',
                                                 border: 'none', borderBottom: settingsTab === 'configurations' ? '2px solid #3498db' : 'none',
@@ -6672,7 +6750,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     return (
                                         <button
                                             key={tab.id}
-                                            onClick={() => { interactionLogger.record('diagram_tab_changed', { from_tab: activeTab, to_tab: tab.id }); setActiveTab(tab.id); }}
+                                            onClick={() => { interactionLogger.record('diagram_tab_changed', { tab: tab.id }); setActiveTab(tab.id); }}
                                             title={tab.available ? undefined : tab.placeholder}
                                             style={{
                                                 flex: 1, borderRadius: 0, border: 'none', padding: '8px 6px',
@@ -6759,7 +6837,15 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                             backgroundColor: '#fff',
                                         }}>
                                             <button
-                                                onClick={() => { interactionLogger.record('view_mode_changed', { mode: 'network' }); setActionViewMode('network'); }}
+                                                onClick={() => {
+                                                    // Replay contract (docs/interaction-logging.md):
+                                                    //   { mode, tab, scope }.
+                                                    // Flow/Impacts toggle only appears on the action
+                                                    // tab today; the standalone has no detached-tab
+                                                    // support, so scope is always 'main'.
+                                                    interactionLogger.record('view_mode_changed', { mode: 'network', tab: 'action', scope: 'main' });
+                                                    setActionViewMode('network');
+                                                }}
                                                 style={{
                                                     padding: '4px 12px', border: 'none', cursor: 'pointer',
                                                     backgroundColor: actionViewMode === 'network' ? '#007bff' : '#fff',
@@ -6770,7 +6856,10 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                 Flows
                                             </button>
                                             <button
-                                                onClick={() => { interactionLogger.record('view_mode_changed', { mode: 'delta' }); setActionViewMode('delta'); }}
+                                                onClick={() => {
+                                                    interactionLogger.record('view_mode_changed', { mode: 'delta', tab: 'action', scope: 'main' });
+                                                    setActionViewMode('delta');
+                                                }}
                                                 style={{
                                                     padding: '4px 12px', border: 'none', borderLeft: '1px solid #ccc', cursor: 'pointer',
                                                     backgroundColor: actionViewMode === 'delta' ? '#007bff' : '#fff',
@@ -6817,7 +6906,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                                 <input
                                                     list="inspectables"
                                                     value={inspectQuery}
-                                                    onChange={e => setInspectQuery(e.target.value)}
+                                                    onChange={e => {
+                                                        // Replay contract (docs/interaction-logging.md):
+                                                        //   { query: string }.
+                                                        interactionLogger.record('inspect_query_changed', { query: e.target.value });
+                                                        setInspectQuery(e.target.value);
+                                                    }}
                                                     placeholder="🔍 Inspect..."
                                                     style={{
                                                         padding: '5px 10px',

--- a/standalone_interface.html
+++ b/standalone_interface.html
@@ -1487,6 +1487,301 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
             return { svg, viewBox: vb };
         };
 
+        // ===== Action Overview helpers =====
+        //
+        // Resolve each prioritized action to an anchor (x, y) on the
+        // N-1 NAD so it can be rendered as a pin. The React app has a
+        // full multi-strategy resolver (`buildActionOverviewPins` in
+        // `frontend/src/utils/svgUtils.ts`) that handles combined pairs,
+        // load-shedding, curtailment, PST, etc.  This port implements
+        // the common case — anchor at the midpoint of the
+        // ``max_rho_line`` edge — which covers every event this UI
+        // needs for Layer 1/3a parity.  If the edge can't be resolved,
+        // the action is dropped from the overlay and only appears in
+        // the sidebar feed.
+        const computeActionOverviewPins = (actions, metaIndex) => {
+            if (!actions || !metaIndex) return [];
+            const { edgesByEquipmentId, nodesBySvgId } = metaIndex;
+            const rank = Object.keys(actions);
+            const pins = [];
+            for (let i = 0; i < rank.length; i++) {
+                const id = rank[i];
+                const action = actions[id];
+                if (!action) continue;
+                const lineId = action.max_rho_line;
+                if (!lineId) continue;
+                const edge = edgesByEquipmentId?.get?.(lineId);
+                if (!edge) continue;
+                const n1 = nodesBySvgId?.get?.(edge.node1);
+                const n2 = nodesBySvgId?.get?.(edge.node2);
+                if (!n1 || !n2) continue;
+                const x = (Number(n1.x) + Number(n2.x)) / 2;
+                const y = (Number(n1.y) + Number(n2.y)) / 2;
+                if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+                // Severity palette: green < 0.9, orange < 1.0, red otherwise.
+                const rho = typeof action.max_rho === 'number' ? action.max_rho : 0;
+                const color = rho < 0.9 ? '#28a745' : rho < 1.0 ? '#f0ad4e' : '#dc3545';
+                pins.push({
+                    id,
+                    x,
+                    y,
+                    rho,
+                    rank: i + 1,
+                    color,
+                    description: action.description_unitaire || '',
+                    max_rho_line: lineId,
+                });
+            }
+            return pins;
+        };
+
+        // Minimal Action Overview component.  Shown on the Action tab
+        // when analysis has run and no action card is currently
+        // selected.  Emits the 9 `overview_*` events from the replay
+        // contract at the documented gesture points — see the Layer
+        // 1/3a checks in `scripts/check_standalone_parity.py` and the
+        // canonical sequence in `scripts/parity_e2e/e2e_parity.spec.ts`.
+        const ActionOverviewDiagram = ({
+            visible,
+            n1Diagram,
+            n1MetaIndex,
+            actions,
+            selectedActionId,
+            onActionSelect,
+            onPinPreview,
+        }) => {
+            const containerRef = React.useRef(null);
+            const [popoverPin, setPopoverPin] = React.useState(null);
+            const [inspectQuery, setInspectQuery] = React.useState('');
+            const clickTimerRef = React.useRef(null);
+
+            const pins = React.useMemo(
+                () => computeActionOverviewPins(actions, n1MetaIndex),
+                [actions, n1MetaIndex],
+            );
+
+            // visible → overview_shown / overview_hidden.
+            React.useEffect(() => {
+                if (visible) {
+                    interactionLogger.record('overview_shown', {
+                        has_pins: pins.length > 0,
+                        pin_count: pins.length,
+                    });
+                } else {
+                    interactionLogger.record('overview_hidden');
+                }
+            }, [visible]);
+
+            // Inject the N-1 SVG as the overview backdrop.
+            React.useLayoutEffect(() => {
+                const container = containerRef.current;
+                if (!container || !visible || !n1Diagram?.svg) return;
+                if (n1Diagram.svg instanceof SVGSVGElement) {
+                    container.replaceChildren(n1Diagram.svg.cloneNode(true));
+                } else {
+                    container.innerHTML = n1Diagram.svg;
+                }
+                // Dim the backdrop so the pins read as the primary content.
+                const svg = container.querySelector('svg');
+                if (svg) svg.style.opacity = '0.5';
+            }, [visible, n1Diagram]);
+
+            // Global Escape / outside-click handlers for the popover.
+            React.useEffect(() => {
+                if (!popoverPin) return;
+                const onKey = (e) => {
+                    if (e.key === 'Escape') {
+                        interactionLogger.record('overview_popover_closed', { reason: 'escape' });
+                        setPopoverPin(null);
+                    }
+                };
+                const onMouseDown = (e) => {
+                    const target = e.target;
+                    const isPopover = target.closest && target.closest('[data-overview-popover]');
+                    const isPin = target.closest && target.closest('[data-overview-pin]');
+                    if (isPopover || isPin) return;
+                    interactionLogger.record('overview_popover_closed', { reason: 'outside_click' });
+                    setPopoverPin(null);
+                };
+                window.addEventListener('keydown', onKey);
+                window.addEventListener('mousedown', onMouseDown);
+                return () => {
+                    window.removeEventListener('keydown', onKey);
+                    window.removeEventListener('mousedown', onMouseDown);
+                };
+            }, [popoverPin]);
+
+            const handlePinClick = React.useCallback((pin, evt) => {
+                // 250 ms debounce so a double-click cancels the
+                // single-click popover path (same pattern React uses).
+                if (clickTimerRef.current) {
+                    clearTimeout(clickTimerRef.current);
+                    clickTimerRef.current = null;
+                }
+                const rect = evt.currentTarget.getBoundingClientRect();
+                clickTimerRef.current = setTimeout(() => {
+                    interactionLogger.record('overview_pin_clicked', { action_id: pin.id });
+                    setPopoverPin({
+                        id: pin.id,
+                        screenX: rect.left + rect.width / 2,
+                        screenY: rect.top,
+                        description: pin.description,
+                        rho: pin.rho,
+                        max_rho_line: pin.max_rho_line,
+                    });
+                    if (onPinPreview) onPinPreview(pin.id);
+                    clickTimerRef.current = null;
+                }, 250);
+            }, [onPinPreview]);
+
+            const handlePinDoubleClick = React.useCallback((pin) => {
+                if (clickTimerRef.current) {
+                    clearTimeout(clickTimerRef.current);
+                    clickTimerRef.current = null;
+                }
+                interactionLogger.record('overview_pin_double_clicked', { action_id: pin.id });
+                setPopoverPin(null);
+                if (onActionSelect) onActionSelect(pin.id);
+            }, [onActionSelect]);
+
+            const handleZoomIn = () => interactionLogger.record('overview_zoom_in');
+            const handleZoomOut = () => interactionLogger.record('overview_zoom_out');
+            const handleZoomFit = () => interactionLogger.record('overview_zoom_fit');
+
+            const handleInspectChange = (e) => {
+                const q = e.target.value;
+                setInspectQuery(q);
+                // Match React's logic: only log when the query EXACTLY
+                // matches a pin id (focus) or is cleared.  Intermediate
+                // keystrokes that don't match are deliberately not
+                // logged so the interaction log doesn't fill with
+                // noise from partial typing.
+                const exact = pins.find((p) => p.id === q);
+                if (exact) {
+                    interactionLogger.record('overview_inspect_changed', { query: q, action: 'focus' });
+                } else if (q === '') {
+                    interactionLogger.record('overview_inspect_changed', { query: '', action: 'cleared' });
+                }
+            };
+
+            if (!visible) return null;
+
+            // Resolve the N-1 SVG's viewBox so pins can be positioned
+            // in SVG-local coordinates on top of it.  We render the
+            // pins in a second, overlaid SVG that matches the
+            // backdrop viewBox.
+            const vb = n1Diagram?.originalViewBox;
+            const viewBoxAttr = vb ? `${vb.x} ${vb.y} ${vb.w} ${vb.h}` : '0 0 1000 1000';
+            // Pin radius in SVG units — derived from viewBox size so
+            // the pin stays readable at the default fit.
+            const pinR = vb ? Math.max(Math.min(vb.w, vb.h) * 0.01, 8) : 15;
+
+            return (
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+                    {/* Header strip — severity legend */}
+                    <div style={{
+                        background: '#e9ecef', padding: '6px 12px',
+                        fontSize: '0.8rem', color: '#495057',
+                        borderBottom: '1px solid #ccc',
+                        display: 'flex', gap: '12px', alignItems: 'center',
+                    }}>
+                        <strong>Remedial Action overview</strong>
+                        <span><span style={{ color: '#28a745' }}>●</span> safe</span>
+                        <span><span style={{ color: '#f0ad4e' }}>●</span> near limit</span>
+                        <span><span style={{ color: '#dc3545' }}>●</span> overloaded</span>
+                        <span style={{ marginLeft: 'auto' }}>{pins.length} pin{pins.length === 1 ? '' : 's'}</span>
+                    </div>
+                    {/* Diagram + pin layer */}
+                    <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+                        <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+                        <svg
+                            viewBox={viewBoxAttr}
+                            preserveAspectRatio="xMidYMid meet"
+                            style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+                        >
+                            {pins.map((pin) => (
+                                <g
+                                    key={pin.id}
+                                    data-overview-pin
+                                    transform={`translate(${pin.x}, ${pin.y})`}
+                                    style={{ cursor: 'pointer', pointerEvents: 'auto' }}
+                                    onClick={(e) => handlePinClick(pin, e)}
+                                    onDoubleClick={() => handlePinDoubleClick(pin)}
+                                >
+                                    <circle r={pinR} fill={pin.color} stroke="#fff" strokeWidth={pinR * 0.15} opacity={selectedActionId === pin.id ? 1 : 0.9} />
+                                    <text textAnchor="middle" dy={pinR * 0.4} fontSize={pinR * 1.1} fontWeight="700" fill="#fff">{pin.rank}</text>
+                                </g>
+                            ))}
+                        </svg>
+                    </div>
+                    {/* Controls: zoom + inspect */}
+                    <div style={{
+                        position: 'absolute', bottom: 12, left: 12,
+                        display: 'flex', gap: '6px', alignItems: 'center',
+                        background: '#fff', border: '1px solid #ccc',
+                        borderRadius: 6, padding: '4px 8px', boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+                    }}>
+                        <button onClick={handleZoomIn} title="Zoom in" style={{ padding: '2px 8px', cursor: 'pointer' }}>+</button>
+                        <button onClick={handleZoomOut} title="Zoom out" style={{ padding: '2px 8px', cursor: 'pointer' }}>−</button>
+                        <button onClick={handleZoomFit} title="Fit" style={{ padding: '2px 8px', cursor: 'pointer' }}>⤢ Fit</button>
+                        <input
+                            value={inspectQuery}
+                            onChange={handleInspectChange}
+                            placeholder="🔍 Focus action id…"
+                            style={{ padding: '2px 6px', border: '1px solid #ccc', borderRadius: 4, fontSize: '12px', marginLeft: 6, width: 180 }}
+                        />
+                    </div>
+                    {/* Popover (single-click preview) */}
+                    {popoverPin && (
+                        <div
+                            data-overview-popover
+                            style={{
+                                position: 'fixed',
+                                left: popoverPin.screenX,
+                                top: Math.max(12, popoverPin.screenY - 140),
+                                transform: 'translateX(-50%)',
+                                background: '#fff',
+                                border: '1px solid #ccc',
+                                borderRadius: 6,
+                                padding: '10px 12px',
+                                boxShadow: '0 4px 16px rgba(0,0,0,0.2)',
+                                minWidth: 220,
+                                zIndex: 200,
+                                fontSize: '13px',
+                            }}
+                        >
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+                                <strong style={{ flex: 1 }}>{popoverPin.id}</strong>
+                                <button
+                                    onClick={() => {
+                                        interactionLogger.record('overview_popover_closed', { reason: 'close_button' });
+                                        setPopoverPin(null);
+                                    }}
+                                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '14px' }}
+                                    aria-label="Close popover"
+                                >✕</button>
+                            </div>
+                            <div style={{ color: '#555', marginBottom: 4 }}>{popoverPin.description || '(no description)'}</div>
+                            <div style={{ fontSize: '12px', color: '#777' }}>
+                                Max ρ <strong>{(popoverPin.rho * 100).toFixed(1)}%</strong> on {popoverPin.max_rho_line}
+                            </div>
+                            <button
+                                onClick={() => {
+                                    interactionLogger.record('overview_pin_double_clicked', { action_id: popoverPin.id });
+                                    setPopoverPin(null);
+                                    if (onActionSelect) onActionSelect(popoverPin.id);
+                                }}
+                                style={{
+                                    marginTop: 8, padding: '4px 10px', background: '#3498db', color: '#fff',
+                                    border: 'none', borderRadius: 4, cursor: 'pointer', width: '100%',
+                                }}
+                            >View action</button>
+                        </div>
+                    )}
+                </div>
+            );
+        };
+
         const MemoizedSvgContainer = React.memo(({ svg, containerRef, display, tabId, style = {} }) => {
             if (!svg) return null;
             React.useLayoutEffect(() => {
@@ -2969,44 +3264,116 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                 const actionDetail = result?.actions?.[actionId];
                                 actionContent = actionDetail?.action_topology || null;
                             }
-                            const simRes = await axios.post(API_BASE + '/api/simulate-manual-action', {
-                                action_id: actionId, disconnected_element: selectedBranch,
-                                action_content: actionContent,
-                                lines_overloaded: result?.lines_overloaded?.length > 0 ? result.lines_overloaded : null,
-                            });
-                            const detail = simRes.data;
-                            // Update the action detail with fresh simulation data,
-                            // but preserve existing rho values from the original analysis
-                            // (the simulation may use different monitored line indices)
-                            setResult(prev => {
-                                if (!prev) return prev;
-                                const existing = prev.actions[actionId] || {};
-                                const hasRho = existing.rho_before?.length > 0;
-                                return {
-                                    ...prev,
-                                    actions: {
-                                        ...prev.actions,
-                                        [actionId]: {
-                                            ...existing,
-                                            description_unitaire: existing.description_unitaire || detail.description_unitaire,
-                                            rho_before: hasRho ? existing.rho_before : detail.rho_before,
-                                            rho_after: hasRho ? existing.rho_after : detail.rho_after,
-                                            max_rho: hasRho ? existing.max_rho : detail.max_rho,
-                                            max_rho_line: hasRho ? existing.max_rho_line : detail.max_rho_line,
-                                            is_rho_reduction: hasRho ? existing.is_rho_reduction : detail.is_rho_reduction,
-                                            non_convergence: detail.non_convergence,
-                                            is_islanded: detail.is_islanded,
-                                            n_components: detail.n_components,
-                                            disconnected_mw: detail.disconnected_mw,
-                                            load_shedding_details: detail.load_shedding_details,
+                            // Use the combined NDJSON stream endpoint so
+                            // the sidebar card updates with the metrics
+                            // event ~5 s before the post-action SVG
+                            // arrives.  Falls back to two sequential
+                            // calls if the stream endpoint is
+                            // unavailable (older backend).
+                            let streamed = false;
+                            try {
+                                const streamRes = await fetch(API_BASE + '/api/simulate-and-variant-diagram', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({
+                                        action_id: actionId,
+                                        disconnected_element: selectedBranch,
+                                        action_content: actionContent,
+                                        lines_overloaded: result?.lines_overloaded?.length > 0 ? result.lines_overloaded : null,
+                                        mode: 'network',
+                                    }),
+                                });
+                                if (streamRes.ok && streamRes.body) {
+                                    streamed = true;
+                                    const reader = streamRes.body.getReader();
+                                    const decoder = new TextDecoder();
+                                    let buffer = '';
+                                    while (true) {
+                                        const { value, done } = await reader.read();
+                                        if (done) break;
+                                        buffer += decoder.decode(value, { stream: true });
+                                        const lines = buffer.split('\n');
+                                        buffer = lines.pop();
+                                        for (const line of lines) {
+                                            if (!line.trim()) continue;
+                                            let evt;
+                                            try { evt = JSON.parse(line); } catch { continue; }
+                                            if (evt.type === 'metrics') {
+                                                const detail = evt;
+                                                setResult(prev => {
+                                                    if (!prev) return prev;
+                                                    const existing = prev.actions[actionId] || {};
+                                                    const hasRho = existing.rho_before?.length > 0;
+                                                    return {
+                                                        ...prev,
+                                                        actions: {
+                                                            ...prev.actions,
+                                                            [actionId]: {
+                                                                ...existing,
+                                                                description_unitaire: existing.description_unitaire || detail.description_unitaire,
+                                                                rho_before: hasRho ? existing.rho_before : detail.rho_before,
+                                                                rho_after: hasRho ? existing.rho_after : detail.rho_after,
+                                                                max_rho: hasRho ? existing.max_rho : detail.max_rho,
+                                                                max_rho_line: hasRho ? existing.max_rho_line : detail.max_rho_line,
+                                                                is_rho_reduction: hasRho ? existing.is_rho_reduction : detail.is_rho_reduction,
+                                                                non_convergence: detail.non_convergence,
+                                                                is_islanded: detail.is_islanded,
+                                                                n_components: detail.n_components,
+                                                                disconnected_mw: detail.disconnected_mw,
+                                                                load_shedding_details: detail.load_shedding_details,
+                                                            },
+                                                        },
+                                                    };
+                                                });
+                                            } else if (evt.type === 'diagram') {
+                                                const { svg, viewBox } = processSvg(evt.svg, voltageLevels.length);
+                                                setActionDiagram({ ...evt, svg, originalViewBox: viewBox });
+                                            } else if (evt.type === 'error') {
+                                                throw new Error(evt.message || 'stream error');
+                                            }
+                                        }
+                                    }
+                                }
+                            } catch (streamErr) {
+                                console.warn('[simulate-and-variant-diagram] stream failed, falling back to sequential calls:', streamErr);
+                                streamed = false;
+                            }
+                            if (!streamed) {
+                                const simRes = await axios.post(API_BASE + '/api/simulate-manual-action', {
+                                    action_id: actionId, disconnected_element: selectedBranch,
+                                    action_content: actionContent,
+                                    lines_overloaded: result?.lines_overloaded?.length > 0 ? result.lines_overloaded : null,
+                                });
+                                const detail = simRes.data;
+                                setResult(prev => {
+                                    if (!prev) return prev;
+                                    const existing = prev.actions[actionId] || {};
+                                    const hasRho = existing.rho_before?.length > 0;
+                                    return {
+                                        ...prev,
+                                        actions: {
+                                            ...prev.actions,
+                                            [actionId]: {
+                                                ...existing,
+                                                description_unitaire: existing.description_unitaire || detail.description_unitaire,
+                                                rho_before: hasRho ? existing.rho_before : detail.rho_before,
+                                                rho_after: hasRho ? existing.rho_after : detail.rho_after,
+                                                max_rho: hasRho ? existing.max_rho : detail.max_rho,
+                                                max_rho_line: hasRho ? existing.max_rho_line : detail.max_rho_line,
+                                                is_rho_reduction: hasRho ? existing.is_rho_reduction : detail.is_rho_reduction,
+                                                non_convergence: detail.non_convergence,
+                                                is_islanded: detail.is_islanded,
+                                                n_components: detail.n_components,
+                                                disconnected_mw: detail.disconnected_mw,
+                                                load_shedding_details: detail.load_shedding_details,
+                                            },
                                         },
-                                    },
-                                };
-                            });
-                            // Now try fetching the diagram again
-                            const res2 = await axios.post(API_BASE + '/api/action-variant-diagram', { action_id: actionId });
-                            const { svg, viewBox } = processSvg(res2.data.svg, voltageLevels.length);
-                            setActionDiagram({ ...res2.data, svg, originalViewBox: viewBox });
+                                    };
+                                });
+                                const res2 = await axios.post(API_BASE + '/api/action-variant-diagram', { action_id: actionId });
+                                const { svg, viewBox } = processSvg(res2.data.svg, voltageLevels.length);
+                                setActionDiagram({ ...res2.data, svg, originalViewBox: viewBox });
+                            }
                         } catch (simErr) {
                             console.error('Failed to simulate and fetch diagram for', actionId, simErr);
                             setError('Failed to load action diagram for ' + actionId);
@@ -5072,7 +5439,22 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
                                     <MemoizedSvgContainer svg={actionDiagram.svg} containerRef={actionSvgContainerRef} display="block" tabId="action" />
                                     : (selectedActionId ?
                                         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#999' }}>Failed to load diagram for action {selectedActionId}</div>
-                                        : <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#999' }}>Select an action card to view its network variant</div>
+                                        : (result?.actions && Object.keys(result.actions).length > 0 ?
+                                            /* Action Overview — shown when analysis has run but no
+                                               action card is selected.  Pins on the N-1 NAD let
+                                               the operator preview and navigate to each
+                                               prioritized action without trawling the sidebar
+                                               feed linearly. */
+                                            <ActionOverviewDiagram
+                                                visible={activeTab === 'action' && !selectedActionId}
+                                                n1Diagram={n1Diagram}
+                                                n1MetaIndex={n1MetaIndex}
+                                                actions={result.actions}
+                                                selectedActionId={selectedActionId}
+                                                onActionSelect={handleActionSelect}
+                                            />
+                                            : <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#999' }}>Select an action card to view its network variant</div>
+                                        )
                                     )
                                 )
                             }


### PR DESCRIPTION
## Summary

Three backend wins on `get_network_diagram()` — the NAD step of the Load Study critical path — measured on `bare_env_20240828T0100Z` (13 MB baseline SVG, ~10 k branches):

- `_get_element_max_currents` vectorised (was `df.iterrows()` on ~12 k lines+transfos → numpy mask + `np.maximum(|i1|, |i2|)`). Also narrows the pypowsybl query to `attributes=['i1','i2']`, mirroring `_get_overloaded_lines`.
- `_load_layout` gains an **instance-level cache** keyed by `(path, mtime)`. Repeated NAD generations in the same process skip the JSON parse + DataFrame rebuild; invalidation is automatic on file edit.
- `_default_nad_parameters()` switched to a **minimal-render** config matching the documented user needs (P at line endpoints, VL nodes, nominal-voltage colouring, client-side highlight overlays): `bus_legend`, `substation_description_displayed`, `voltage_level_details`, `injections_added` all `False`; `power_value_precision` to `0`.

## Measured impact (warm median, `benchmarks/bench_nad_n_state.py`)

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| `get_network_diagram()` total | 3.30 s | **2.85 s** | **−0.45 s (−13.8 %)** |
| SVG size | 13.2 MB | **12.0 MB** | **−1.2 MB (−9 %)** |
| NAD pypowsybl only | 2.30 s | 2.38 s | +0.08 (noise) |
| Post-processing | ~1.0 s | ~0.47 s | **−0.53 s** |

The NAD step (pypowsybl JVM work) is unchanged. All the gain comes from halving the Python post-processing block (vectorisation) and shaving the NAD-render payload (minimal toggles).

## Rejected alternatives (documented)

- **Regex NaN-strip** (`re.sub` instead of lxml parse+serialise): +0.4 s regression on 13 MB SVG — lxml C-path beats Python `re` backtracking. Section "Attempt #3" in the new doc.
- **Auto-focus on contingency selection**: conflicts with the existing design (`docs/spatial_lod_architecture_proposal.md:298-303`, commit `75210d1`). Noted in an architectural warning block in the new doc so the question isn't re-opened.
- **`injections_added=True`** (previously listed as a need): measured at +1.0 s / +10.9 MB on this grid — kept `False`, cost documented for future toggle-behind-Settings discussions.

## Files

- `expert_backend/services/diagram_mixin.py` — the three code changes
- `expert_backend/tests/test_diagram_mixin.py` — 9 new unit tests (minimal-render defaults, layout cache hit / mtime invalidation, vectorised max-currents on basic / NaN / empty inputs + query narrowing assertion)
- `benchmarks/bench_nad_n_state.py` — 3-run N-state NAD profile, follows the env-var convention
- `benchmarks/bench_nad_toggles.py` — `NadParameters` per-toggle impact matrix
- `benchmarks/README.md` — new entries added to the scripts table
- `docs/perf-nad-profile-bare-env.md` — full write-up with baseline / after-#1+#4 / after-#6 numbers, per-toggle isolation, rejected alternatives, and the cumulative table

## Test plan

- [x] `pytest expert_backend/tests/test_diagram_mixin.py` — 13/13 pass
- [x] Full backend suite: 389 pass, 1 pre-existing failure (`test_combined_actions_scenario::test_independent_actions_simulation`, unrelated to this change — same failure on `HEAD^`)
- [x] `benchmarks/bench_nad_n_state.py` run on `bare_env_20240828T0100Z` → warm median 2.845 s, SVG 12.02 MB
- [x] `benchmarks/bench_nad_toggles.py` matrix confirms per-toggle deltas match the doc
- [ ] Visual sanity check in the frontend (bus_legend + substation_description absent, P values at line endpoints intact, overloaded lines still highlight)
- [ ] Review the `injections_added=False` decision against any UX that relied on load/gen symbols being visible in the NAD (currently none in the frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)