### PR TITLE
Add dynamic reconnection action support and cleanup unused prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,226 @@ and the project (informally) follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.6.5] — 2026-04-22
+
+Follow-up release to **0.6.0** consolidating the SVG-DOM-recycling
+perf work on the N-1 / Action tabs, the Action Overview filtering &
+unsimulated-pin layer, the continuous code-quality gate with five
+decomposition passes, and the second round of App.tsx hook
+extractions (N-1 fetch + highlight pipeline).
+
+### Highlights
+
+- **SVG DOM recycling** (`/api/n1-diagram-patch`,
+  `/api/action-variant-diagram-patch`): ~80 % faster N-1 / action
+  tab switches on large grids by cloning the already-mounted
+  N-state `SVGSVGElement` and patching only the per-branch delta
+  instead of re-fetching & re-parsing the full 12–28 MB NAD SVG.
+  See `docs/performance/history/svg-dom-recycling.md`.
+- **Action Overview filters & unsimulated pins**: severity
+  category toggles (green / orange / red / grey), threshold
+  slider, action-type chip filter, and a new dimmed/dashed pin
+  layer for scored-but-not-yet-simulated actions — double-click
+  to simulate. Filter state is shared between the overview and
+  the sidebar feed so both views stay in lock-step.
+- **Code-quality gate + decomposition sweep**: new continuous
+  reporter (`scripts/code_quality_report.py`) and CI gate
+  (`scripts/check_code_quality.py`) driving five behaviour-preserving
+  decomposition passes — `simulate_manual_action` (599 → 146 LoC),
+  `compute_superposition` (285 → 108), `svgUtils.ts` (1807 → 60 +
+  8 focused modules), `analysis_mixin.py` (1116 → 509 + 4 modules),
+  `diagram_mixin.py` (974 → 469 + 7 modules).
+
+### Added
+
+- **Patch endpoints for diagram recycling** (PR #108):
+  `/api/n1-diagram-patch` and `/api/action-variant-diagram-patch`
+  return SVG-less per-branch deltas (+ VL-subtree splices for
+  topology-changing actions). Frontend `utils/svgPatch.ts` clones
+  the N SVG in-place, patches dashed contingency lines, absolute
+  flow labels, and concentric rings for coupling / node-merging /
+  node-splitting actions. Graceful fallback to the full NAD for
+  every unsupported edge case.
+- **Action Overview filters** (PR #105, #107): new
+  `ActionOverviewFilters` type with category toggles, threshold
+  cap, unsimulated visibility flag and action-type chip. New
+  `actionPassesOverviewFilter()` predicate + `classifyActionType()` /
+  `matchesActionTypeFilter()` module so the overview, the feed and
+  the Explore Pairs table share identical filtering logic.
+- **Unsimulated action pins** (PR #105): dimmed/dashed pin layer on
+  the Action Overview diagram for scored-but-not-yet-simulated
+  actions, with hover tooltips showing score + ranking and
+  double-click to trigger `simulate_manual_action`.
+- **Shared `ActionTypeFilterChips` component** (PR #109): single
+  reusable chip row driving the Manual Selection dropdown, the
+  Explore Pairs tab, the Action Overview and the Action Feed.
+- **Protected constituent pins**: when a combined action passes the
+  filter, its constituent unitary pins remain visible (dimmed)
+  even if they individually fail the filter — preserving context.
+- **Dynamic `reco_` reconnection actions**: `simulate_manual_action`
+  now auto-builds reconnection topology (both ends to bus 1) for
+  `reco_*` action IDs that aren't in the loaded action dictionary,
+  matching the existing `curtail_ / load_shedding_ / pst_` dynamic
+  creation path.
+- **Continuous code-quality tooling** (PR #104):
+  `scripts/code_quality_report.py` (AST scan → JSON + Markdown
+  metrics), `scripts/check_code_quality.py` (CI gate on LoC
+  ceilings, 0 `print()` / `@ts-ignore` / `any`),
+  `.github/workflows/code-quality.yml` + CircleCI job publishing
+  the Markdown report to `$GITHUB_STEP_SUMMARY`.
+- **Layer-4 invariants** now point at the extracted svgUtils
+  modules (`pin_severity_uses_monitoringFactor`,
+  `combined_pairs_filter_estimated`,
+  `pin_resolver_is_topology_first`).
+- **`CONTRIBUTING.md`**, **`.editorconfig`**, **`.env.example`**,
+  **`pyproject.toml [tool.ruff]`** (narrow E9 / F ruleset) and
+  `quality` extras group.
+- **66 + 61 + 68 + 39 new unit tests** across
+  `test_simulation_helpers.py`, `utils/svg/*.test.ts`,
+  `test_analysis_helpers.py`, `test_diagram_helpers.py`;
+  22 + 12 specs for the new svgPatch helpers and 8 new endpoint
+  tests for the patch routes.
+
+### Changed
+
+- **App.tsx hook extraction, Phase 2** (PR #109): new
+  `hooks/useN1Fetch.ts` (svgPatch fast-path + `/api/n1-diagram`
+  fallback + contingency-change confirm routing) and
+  `hooks/useDiagramHighlights.ts` (per-tab Flow/Impacts view-mode
+  state + `applyHighlightsForTab` DOM-mutation pass). Sidebar
+  extracted into `components/AppSidebar.tsx`,
+  `components/SidebarSummary.tsx`, `components/StatusToasts.tsx`.
+  `App.tsx`: 1575 → ~1150 lines.
+- **Backend decomposition** (PR #104, #106):
+  - `expert_backend/services/simulation_helpers.py` — 14
+    stateless helpers extracted from `simulate_manual_action` +
+    `compute_superposition`.
+  - `expert_backend/services/analysis/` — `action_enrichment.py`,
+    `mw_start_scoring.py`, `analysis_runner.py`, `pdf_watcher.py`.
+  - `expert_backend/services/diagram/` — `layout_cache.py`,
+    `nad_params.py`, `nad_render.py`, `sld_render.py`,
+    `overloads.py`, `flows.py`, `deltas.py`.
+  - Public API / method signatures unchanged; `@patch`
+    compatibility preserved via dependency injection.
+- **Frontend decomposition** (PR #104): `svgUtils.ts` 1807-line
+  omnibus split into 8 focused modules under `frontend/src/utils/svg/`
+  (`idMap.ts`, `metadataIndex.ts`, `svgBoost.ts`, `fitRect.ts`,
+  `deltaVisuals.ts`, `actionPinData.ts`, `highlights.ts`,
+  `actionPinRender.ts`) + a 60-line barrel that re-exports
+  everything so no caller changed. `App.tsx` (1370 LoC) remains
+  the largest non-exempt file by design.
+- **Docs reorganised** (PR #103) into
+  `docs/{features,performance/{,history/},architecture,proposals,data}/`
+  with per-folder README indexes. Three overlapping rendering-LoD
+  proposals consolidated into
+  `docs/proposals/rendering-lod-strategies.md`. Obsolete
+  `test_ui_regressions.py` references cleaned up across the
+  backend tests, benchmarks and scripts.
+- **CORS origins** now configurable via `CORS_ALLOWED_ORIGINS` env
+  var (PR #104); unused `GZipMiddleware` import removed; legacy
+  `print()` / `traceback.print_exc()` calls in `main.py` replaced
+  with structured logging (`logger.warning` / `logger.exception`);
+  one bare `except: pass` now logs the suppressed exception.
+- **Frontend deps**: unused `framer-motion` and `lucide-react`
+  removed from `package.json`.
+- **Action-type filter unification** across Manual Selection,
+  Explore Pairs, Action Feed and Action Overview (PR #109 +
+  follow-up commits `025f4a0` / `e107057` / `1e53db3`): each
+  surface owns its own local chip state, but all consume the
+  shared `DEFAULT_ACTION_OVERVIEW_FILTERS` constant and the
+  shared `classifyActionType` / `matchesActionTypeFilter`
+  helpers.
+
+### Performance
+
+- **Patch-based N-1 diagram switching** (PR #108, benched on
+  `bare_env_20240828T0100Z`, ~10 k branches, ~12 MB SVG,
+  contingency `ARGIAL71CANTE`, warm median of 3):
+
+  | Endpoint | Cold | Warm | Payload |
+  |---|---|---|---|
+  | `/api/n1-diagram` (full)      | 3.01 s | 2.39 s | 27.1 MB |
+  | `/api/n1-diagram-patch` (new) | 0.49 s | 0.50 s |  5.5 MB |
+  | **Δ** | **−83.8 %** | **−79.1 %** | 20.3 % of full |
+
+- **Action tab switching** mirrored on
+  `/api/action-variant-diagram-patch` with the same recycled-DOM
+  pattern, dashed-class toggling for `disco_*` / `reco_*`, and
+  VL-subtree splicing for coupling / node-merging / node-splitting.
+- **Quick wins from the decomposition sweep**:
+  `network_service.py::get_load_voltage_levels_bulk` was returning
+  `{}` without populating the dict (now mirrors
+  `get_generator_types_bulk`); 9 f-string placeholders
+  auto-fixed via `ruff --fix`.
+
+### Fixed
+
+- **Dynamic reconnection action simulation**: reconnection actions
+  generated by `expert_op4grid_recommender` but not in the loaded
+  action dictionary (e.g. `reco_CAZARL72MARSI` from the Explore
+  Pairs tab) no longer raise `ValueError: Action … not found in
+  the loaded action dictionary or recent analysis`. The fix mirrors
+  the dynamic-creation path already in place for load-shedding,
+  curtailment and PST actions.
+- **Line halo on combined `disco + coupling` actions** (PR #108,
+  commit `b84732a`): split-on-`+` + per-part coupling check so the
+  disco line in `disco_X+coupling_Y` gets its pink halo on both the
+  diagram and the action card badge.
+- **Blank flash + stale-response guard on svgPatch** (PR #108,
+  commit `c48a0da`): the previous cloned DOM stays mounted during
+  the patch-fetch window, and late patch responses arriving after
+  a newer click are discarded.
+- **Node-merging classifier** — "Ouverture … dans le poste" is now
+  correctly classified as DISCO, not OPEN coupling (PR #105,
+  commit `f356c2e`).
+- **Popover viewport detection & combined-action pin protection**
+  (PR #105, commit `d277597`): improved popover placement when
+  near viewport edges; combined-action pins now protect their
+  constituent pins from being hidden by the severity / threshold
+  filters.
+- **Standalone parity**: versioned snapshot bumped to v0.7 with
+  patch-endpoint references (PR #107, commit `adae7ac`);
+  `scripts/check_standalone_parity.py` now resolves the standalone
+  path intelligently with fallback to versioned snapshots.
+- **`ActionFeed` unused-prop lint error**: `onOverviewFiltersChange`
+  is no longer destructured when it isn't consumed, removing the
+  `@typescript-eslint/no-unused-vars` error.
+- **Hidden ordering bug in `get_action_variant_sld`** (PR #104):
+  `changed_switches` now captured before flow extraction so mock
+  networks with missing flows still return the switch diff; switch
+  diff + delta math split into independent `try/except` blocks.
+
+### Documentation
+
+- New: `docs/performance/history/svg-dom-recycling.md` — full
+  retrospective with benchmarks, fallback matrix and 6 Do's/Don'ts.
+- Updated: `docs/performance/rendering-optimization-plan.md` with a
+  new "SVG DOM Recycling" section.
+- New consolidated proposal:
+  `docs/proposals/rendering-lod-strategies.md`.
+- New indexes: `docs/README.md`, `docs/performance/history/README.md`.
+- Refreshed: `CLAUDE.md` (root, frontend, expert_backend),
+  `README.md`, `CONTRIBUTING.md`, `benchmarks/README.md`,
+  `scripts/PARITY_README.md`, `frontend/PARITY_AUDIT.md`, the CI
+  workflow (`parity.yml`, new `code-quality.yml`) and the CircleCI
+  config.
+- Updated: `docs/architecture/code-quality-analysis.md` with five
+  new delta sections covering each decomposition pass and the new
+  continuous-reporting tooling.
+- Updated: `docs/features/action-overview-diagram.md` with the new
+  filter UI and unsimulated-pin layer.
+
+### Removed
+
+- Obsolete rendering-LoD docs (`nad_optimization.md`,
+  `spatial_lod_architecture_proposal.md`,
+  `network_rendering_profiling_recommendations.md`) merged into
+  the consolidated `docs/proposals/rendering-lod-strategies.md`.
+- `framer-motion` and `lucide-react` from `frontend/package.json`
+  (unused).
+
+---
+
 ## [0.6.0] — 2026-04-20
 
 Follow-up release to **0.5.0** consolidating the standalone-parity
@@ -303,6 +523,7 @@ the authoritative reference for pre-0.5.0 work.
 
 ---
 
-[Unreleased]: https://github.com/marota/Co-Study4Grid/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/marota/Co-Study4Grid/compare/0.6.5...HEAD
+[0.6.5]: https://github.com/marota/Co-Study4Grid/releases/tag/0.6.5
 [0.6.0]: https://github.com/marota/Co-Study4Grid/releases/tag/0.6.0
 [0.5.0]: https://github.com/marota/Co-Study4Grid/releases/tag/0.5.0

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -337,7 +337,7 @@ class SimulationMixin:
     def _create_dynamic_actions_if_needed(
         self, action_ids, recent_actions, obs_n1, nm, target_mw
     ):
-        """Auto-create heuristic actions for curtail_ / load_shedding_ / pst_tap_ prefixes."""
+        """Auto-create heuristic actions for curtail_ / load_shedding_ / pst_tap_ / reco_ prefixes."""
         for aid in action_ids:
             if aid in self._dict_action or aid in recent_actions:
                 continue
@@ -347,6 +347,8 @@ class SimulationMixin:
                 self._create_dynamic_load_shedding(aid, target_mw, obs_n1)
             elif aid.startswith("pst_tap_") or aid.startswith("pst_"):
                 self._create_dynamic_pst(aid, nm)
+            elif aid.startswith("reco_"):
+                self._create_dynamic_reconnection(aid)
 
     def _create_dynamic_curtailment(self, aid, target_mw, obs_n1):
         gen_name = aid[len("curtail_"):]
@@ -417,6 +419,19 @@ class SimulationMixin:
         entry["description_unitaire"] = f"Variation PST {pst_id}"
         self._dict_action[aid] = entry
         logger.info("[simulate_manual_action] Created dynamic PST action '%s'", aid)
+
+    def _create_dynamic_reconnection(self, aid):
+        line_name = aid[len("reco_"):]
+        # Reconnect both ends of the line to bus 1.
+        topo = {
+            "lines_or_bus": {line_name: 1},
+            "lines_ex_bus": {line_name: 1},
+        }
+        entry = self._build_action_entry_from_topology(aid, topo)
+        entry["description"] = f"Line reconnection: '{line_name}'"
+        entry["description_unitaire"] = f"Reconnexion '{line_name}'"
+        self._dict_action[aid] = entry
+        logger.info("[simulate_manual_action] Created dynamic reconnection action '%s'", aid)
 
     def _promote_recent_actions_to_dict(self, action_ids, recent_actions):
         """Promote heuristic actions found on `_last_result.prioritized_actions`

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -116,7 +116,6 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     onActionDiagramPrimed,
     voltageLevelsLength,
     overviewFilters,
-    onOverviewFiltersChange,
 }) => {
     const [searchOpen, setSearchOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');


### PR DESCRIPTION
## Summary
This PR adds support for auto-creating dynamic reconnection actions with the `reco_` prefix in the simulation service, and removes an unused prop from the ActionFeed component.

## Key Changes

### Backend (simulation_mixin.py)
- Updated `_create_dynamic_actions_if_needed()` to handle `reco_` prefixed action IDs for line reconnection
- Implemented new `_create_dynamic_reconnection()` method that:
  - Extracts the line name from the action ID
  - Creates a topology action that reconnects both ends of the line to bus 1
  - Builds the action entry with appropriate French and English descriptions
  - Logs the action creation for debugging

### Frontend (ActionFeed.tsx)
- Removed unused `onOverviewFiltersChange` prop from the ActionFeed component signature

## Implementation Details
The reconnection action follows the same pattern as existing dynamic actions (curtailment, load shedding, PST tap adjustments). It leverages the existing `_build_action_entry_from_topology()` helper to construct the action entry with proper topology modifications for line reconnection.

https://claude.ai/code/session_01Tzp2fdUas3Y9vNZy6dxxuC