### PR TITLE
Fix flow delta freshness and halo stacking on Remedial Action tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,56 @@ extractions (N-1 fetch + highlight pipeline).
   `changed_switches` now captured before flow extraction so mock
   networks with missing flows still return the switch diff; switch
   diff + delta math split into independent `try/except` blocks.
+- **Halo layering on N-1 / Remedial Action NADs** (commit `f7a3834`):
+  contingency clone is now appended FIRST (bottom), overload halos
+  SECOND, action-target halo LAST (top) on the shared
+  `#nad-background-layer`. Reverses the post-`action-variant-diagram-patch`
+  regression where the yellow contingency halo painted over the
+  pink action halo. Code-level guard in
+  `frontend/src/utils/svgUtils.test.ts::Halo layering order` +
+  hook-level guard in `frontend/src/hooks/useDiagramHighlights.test.ts`.
+- **Action Overview filter banner compaction** (commit `f7a3834`):
+  filters laid out on a single horizontal row
+  (`flex-wrap: nowrap`); the max-loading slider is replaced with a
+  compact integer-percent number input (0–300 %, step 1) so the
+  whole banner fits on one line.
+- **No-relevant-action warning in Manual Selection** (commit `f7a3834`):
+  when "Analyze & Suggest" produced action scores but the chosen
+  type filter yields zero scored actions, the dropdown now surfaces
+  a yellow `Warning: no relevant action detected with regards to
+  overflow analysis` banner above the fallback full-action list
+  instead of silently misleading the operator.
+- **"Make a first guess" gating after analysis** (commit `f7a3834`):
+  the pre-analysis shortcut is hidden once "Analyze & Suggest" is
+  running, has produced action scores, or any action sits in the
+  feed. The button only re-appears after a state reset
+  (contingency change, study reload).
+- **SLD Impacts persistence on pan / zoom** (commit `f7a3834`,
+  follow-up `ec17587`): the SLD delta painter is now a
+  `useLayoutEffect` running every render, self-gated via signature
+  + DOM-presence probe. Catches the
+  `dangerouslySetInnerHTML`-reconciliation wipe that used to strand
+  the overlay on Flows rendering until a tab switch, AND eliminates
+  the impact/flow blink during continuous drags by running between
+  React's commit and the browser paint instead of after.
+- **SLD action-variant flow snapshot ordering** (commits `f679646`
+  + `e5c89fb`): `get_action_variant_sld` now captures
+  `action_flows` / `action_assets` BEFORE switching the shared base
+  network to the N-1 variant, then delegates to `_snapshot_n1_state`
+  for the N-1 reference — byte-for-byte the same cadence the
+  (already-correct) NAD sibling endpoint uses. The previous
+  ordering read both snapshots from the N-1 variant after the
+  variant flip, producing all-zero deltas with no colouring on
+  every cell of the Remedial Action SLD Impacts view (operator-
+  reported on `node_merging_PYMONP3` / contingency
+  `P.SAOL31RONCI`). Diagnostic logging added so a future stale-flow
+  regression in upstream `expert_op4grid_recommender` shows up as
+  `max|Δp1|=0.00` in the backend log line.
+- **Spurious f-string prefixes** (commit `46b12a4`): two assertion
+  messages tagged `f""` without `{…}` placeholders tripped
+  `ruff F541` on CI; cascaded into the
+  "Publish report to workflow summary" step which expected
+  `reports/code-quality.md` to exist.
 
 ### Documentation
 

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -870,11 +870,23 @@ class DiagramMixin:
             n.set_working_variant(original_variant)
 
     def get_action_variant_sld(self, action_id: str, voltage_level_id: str) -> dict:
-        """Single Line Diagram in the post-action state, with flow deltas vs N-1."""
+        """Single Line Diagram in the post-action state, with flow deltas vs N-1.
+
+        Mirrors `get_action_variant_diagram` (the NAD sibling that
+        already computes correct action-vs-N-1 deltas) as closely as
+        possible — same variant-switch cadence, same helper
+        (`_snapshot_n1_state`), same argument order into
+        `compute_deltas`. The only endpoint-specific extras are the
+        SLD-rendering call + `changed_switches` diff. Keeping the two
+        sides structurally identical means any future fix to the
+        flow-delta pipeline only needs to land in one place.
+        """
         actions = self._require_action(action_id)
         obs = actions[action_id]["observation"]
         nm = obs._network_manager
-        nm.set_working_variant(obs._variant_id)
+        action_variant_id = obs._variant_id
+        nm.set_working_variant(action_variant_id)
+
         network = nm.network
         sld = network.get_single_line_diagram(voltage_level_id)
         svg, sld_metadata = extract_sld_svg_and_metadata(sld)
@@ -887,44 +899,61 @@ class DiagramMixin:
         }
         self._attach_convergence_from_obs(result, obs)
 
-        # Capture the switch-state diff and action-variant flow snapshots
-        # BEFORE touching the base network's working variant — the base
-        # network mutualises the same underlying pypowsybl.Network as
-        # `nm.network` (see `_get_base_network` / the grid2op-shared-
-        # network doc), so switching its variant to N-1 below also
-        # flips `network`'s view. Reading `action_flows` after that
-        # switch would yield N-1 flows on both sides and render every
-        # delta as 0.0 — the exact symptom the operator reported when
-        # the Remedial Action SLD Impacts showed `Δ 0.0` with no
-        # colouring on every cell.
+        # Capture the action-variant switch snapshot NOW — still on the
+        # action variant, pypowsybl DataFrames are live views that
+        # reflect whatever variant is currently active when accessed.
+        # `.copy()` forces pandas to materialise the values in this
+        # frame, independent of any subsequent variant flip on the
+        # shared handle. Same rationale as the NAD-patch endpoint (see
+        # the comment on `action_switches_snap` in
+        # `get_action_variant_diagram_patch`).
         try:
-            action_switches_df = network.get_switches()
+            action_switches_snap = network.get_switches(attributes=["open"]).copy()
         except Exception as e:
-            logger.debug("Suppressed exception: %s", e)
-            action_switches_df = None
+            logger.debug("Suppressed exception while snapshotting switches: %s", e)
+            action_switches_snap = None
 
+        # Flow + asset snapshots — identical call order to
+        # `get_action_variant_diagram`. `get_network_flows` /
+        # `get_asset_flows` already return plain dicts materialised
+        # from pandas `.to_dict()`, so the snapshots are safe to hold
+        # across the subsequent variant switch inside
+        # `_snapshot_n1_state`.
         try:
             action_flows = get_network_flows(network)
             action_assets = get_asset_flows(network)
-        except Exception as e:
-            logger.warning("Warning: Failed to capture action-variant flows: %s", e)
-            action_flows = None
-            action_assets = None
+            # `_snapshot_n1_state` saves the current working variant
+            # (ACTION), flips to N-1 to read, then restores to ACTION
+            # — exactly the cadence used by the NAD sibling endpoint.
+            n1_flows, n1_assets = self._snapshot_n1_state(self._last_disconnected_element)
 
-        n1_network = self._get_base_network()
-        original_variant_n1 = n1_network.get_working_variant_id()
-        n1_network.set_working_variant(self._get_n1_variant(self._last_disconnected_element))
-        try:
-            result["changed_switches"] = self._diff_switches(action_switches_df, n1_network)
-        except Exception as e:
-            logger.warning("Warning: Failed to diff switches: %s", e)
-            result["changed_switches"] = {}
-
-        try:
-            if action_flows is None or action_assets is None:
-                raise RuntimeError("action-variant flow snapshot missing")
-            n1_flows = self._get_n1_flows(self._last_disconnected_element)
-            n1_assets = get_asset_flows(n1_network)
+            # Diagnostic: confirm the snapshots really do differ. If
+            # max |Δp1| is 0 for every branch, the upstream action
+            # simulation either did not actually modify the pypowsybl
+            # variant (grid2op-cached result, no-op action, …) or
+            # `obs._variant_id` points to the same variant as the N-1
+            # reference. Either way the frontend will render the
+            # cell-free "Δ +0.0" / grey Impacts view the operator
+            # reported — and the fix won't be in this function.
+            try:
+                p1_after = (action_flows or {}).get("p1") or {}
+                p1_before = (n1_flows or {}).get("p1") or {}
+                common = set(p1_after.keys()) & set(p1_before.keys())
+                max_abs = 0.0
+                top5: list = []
+                if common:
+                    diffs = [(bid, float(p1_after[bid]) - float(p1_before[bid])) for bid in common]
+                    diffs.sort(key=lambda t: abs(t[1]), reverse=True)
+                    max_abs = abs(diffs[0][1]) if diffs else 0.0
+                    top5 = [(bid, round(d, 2)) for bid, d in diffs[:5]]
+                logger.info(
+                    "[SLD action-variant] action_id=%s vl=%s action_variant=%s "
+                    "branches=%d common=%d max|Δp1|=%.2f top5=%s",
+                    action_id, voltage_level_id, action_variant_id,
+                    len(p1_after), len(common), max_abs, top5,
+                )
+            except Exception as diag_e:
+                logger.debug("[SLD action-variant] flow-diff diagnostic failed: %s", diag_e)
 
             deltas = compute_deltas(action_flows, n1_flows, voltage_level_ids=[voltage_level_id])
             result["flow_deltas"] = deltas["flow_deltas"]
@@ -935,10 +964,40 @@ class DiagramMixin:
             result["flow_deltas"] = {}
             result["reactive_flow_deltas"] = {}
             result["asset_deltas"] = {}
-        finally:
-            n1_network.set_working_variant(original_variant_n1)
+
+        # Switch-diff comes AFTER `_snapshot_n1_state` (which restores
+        # the working variant to ACTION). The `action_switches_snap`
+        # we captured at the top is a materialised copy so the diff
+        # is variant-independent — we just need the N-1 half, which
+        # we re-read with a short-lived variant flip + restore.
+        try:
+            result["changed_switches"] = self._diff_action_switches_vs_n1(
+                action_switches_snap, self._last_disconnected_element,
+            )
+        except Exception as e:
+            logger.warning("Warning: Failed to diff switches: %s", e)
+            result["changed_switches"] = {}
 
         return result
+
+    def _diff_action_switches_vs_n1(self, action_switches_snap, disconnected_element: str) -> dict:
+        """Diff a pre-captured action-variant switch snapshot against the live N-1 variant.
+
+        Centralises the save/switch/read/restore dance so
+        `get_action_variant_sld` doesn't have to interleave variant
+        management with the flow-delta pipeline. Returns `{}` on any
+        failure — switches are informational, they must not break the
+        SLD response.
+        """
+        if action_switches_snap is None:
+            return {}
+        n = self._get_base_network()
+        original_variant = n.get_working_variant_id()
+        try:
+            n.set_working_variant(self._get_n1_variant(disconnected_element))
+            return self._diff_switches(action_switches_snap, n)
+        finally:
+            n.set_working_variant(original_variant)
 
     # ------------------------------------------------------------------
     # Private orchestrator helpers

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -887,14 +887,29 @@ class DiagramMixin:
         }
         self._attach_convergence_from_obs(result, obs)
 
-        # Capture the switch-state diff BEFORE attempting flow deltas —
-        # if flow extraction fails on a mock/malformed network, we still
-        # want `changed_switches` populated on the response.
+        # Capture the switch-state diff and action-variant flow snapshots
+        # BEFORE touching the base network's working variant — the base
+        # network mutualises the same underlying pypowsybl.Network as
+        # `nm.network` (see `_get_base_network` / the grid2op-shared-
+        # network doc), so switching its variant to N-1 below also
+        # flips `network`'s view. Reading `action_flows` after that
+        # switch would yield N-1 flows on both sides and render every
+        # delta as 0.0 — the exact symptom the operator reported when
+        # the Remedial Action SLD Impacts showed `Δ 0.0` with no
+        # colouring on every cell.
         try:
             action_switches_df = network.get_switches()
         except Exception as e:
             logger.debug("Suppressed exception: %s", e)
             action_switches_df = None
+
+        try:
+            action_flows = get_network_flows(network)
+            action_assets = get_asset_flows(network)
+        except Exception as e:
+            logger.warning("Warning: Failed to capture action-variant flows: %s", e)
+            action_flows = None
+            action_assets = None
 
         n1_network = self._get_base_network()
         original_variant_n1 = n1_network.get_working_variant_id()
@@ -906,8 +921,8 @@ class DiagramMixin:
             result["changed_switches"] = {}
 
         try:
-            action_flows = get_network_flows(network)
-            action_assets = get_asset_flows(network)
+            if action_flows is None or action_assets is None:
+                raise RuntimeError("action-variant flow snapshot missing")
             n1_flows = self._get_n1_flows(self._last_disconnected_element)
             n1_assets = get_asset_flows(n1_network)
 

--- a/expert_backend/tests/test_sld_highlight.py
+++ b/expert_backend/tests/test_sld_highlight.py
@@ -435,4 +435,170 @@ class TestEnrichActionsTopologyFields:
         assert topo["substations"] == {}
 
 
-        assert topo["substations"] == {}
+# ---------------------------------------------------------------------------
+# Regression: action-variant flow snapshot must be captured BEFORE the base
+# network's working variant is flipped to N-1.
+#
+# The base network (`self._get_base_network()`) mutualises the same
+# underlying pypowsybl.Network object as `obs._network_manager.network` via
+# the grid2op-shared-network path (see `recommender_service._get_base_network`
+# and `docs/performance/history/grid2op-shared-network.md`). Setting
+# `n1_network.set_working_variant(...)` therefore also changes the variant
+# visible through `network`. If `action_flows = get_network_flows(network)`
+# runs AFTER that switch, both `action_flows` and `n1_flows` read from the
+# SAME N-1 variant → every delta comes back as 0.0 with no colouring on
+# the SLD, the exact symptom the operator reported on the Remedial Action
+# Impacts view.
+#
+# The fix reads `action_flows` / `action_assets` BEFORE touching
+# `n1_network`. This test locks that ordering in by having the fake network
+# return DIFFERENT flow snapshots depending on which working variant is
+# active, and asserting the resulting deltas are non-zero.
+# ---------------------------------------------------------------------------
+
+class TestActionVariantSldDeltaFreshness:
+    """Regression guard: SLD Impacts show non-zero deltas on the Remedial Action tab."""
+
+    def _build_obs_mock(self, nm):
+        obs = MagicMock()
+        obs._variant_id = "action_var"
+        obs._last_info = {"exception": None}
+        obs._network_manager = nm
+        return obs
+
+    def test_action_flows_snapshot_is_taken_before_n1_variant_switch(self):
+        """Flow deltas are non-zero when the shared network's variant flip
+        would otherwise turn `action_flows` into `n1_flows`."""
+        # Shared pypowsybl.Network double: `get_network_flows` /
+        # `get_asset_flows` return DIFFERENT snapshots based on the
+        # current working variant. That's the real-world behaviour we
+        # reproduce here — a single Network object whose output
+        # changes on `set_working_variant`.
+        shared_net = MagicMock()
+        shared_net._current_variant = "action_var"
+
+        def _set_variant(v):
+            shared_net._current_variant = v
+        shared_net.set_working_variant.side_effect = _set_variant
+        shared_net.get_working_variant_id.return_value = "orig"
+        shared_net.get_switches.return_value = _make_switch_df({"SW_A": False})
+        shared_net.get_single_line_diagram.return_value = MagicMock()
+
+        action_branch_flows = {"p1": {"LINE_A": 120.0}, "p2": {"LINE_A": -118.0},
+                               "q1": {"LINE_A": 5.0}, "q2": {"LINE_A": -4.8},
+                               "vl1": {"LINE_A": "VL_TEST"}, "vl2": {"LINE_A": "VL_OTHER"}}
+        n1_branch_flows = {"p1": {"LINE_A": 90.0}, "p2": {"LINE_A": -88.0},
+                           "q1": {"LINE_A": 3.0}, "q2": {"LINE_A": -2.9},
+                           "vl1": {"LINE_A": "VL_TEST"}, "vl2": {"LINE_A": "VL_OTHER"}}
+        action_asset_flows = {"LOAD_X": {"p": 50.0, "q": 10.0}}
+        n1_asset_flows = {"LOAD_X": {"p": 40.0, "q": 8.0}}
+
+        nm = MagicMock()
+        nm.network = shared_net
+        # When nm.set_working_variant(id) is called, it also flips the
+        # shared net's variant — mirroring real pypowsybl behaviour.
+        nm.set_working_variant.side_effect = _set_variant
+
+        obs = self._build_obs_mock(nm)
+
+        compute_deltas_spy = MagicMock(return_value={
+            "flow_deltas": {"LINE_A": {"delta": 30.0, "category": "positive", "flip_arrow": False}},
+            "reactive_flow_deltas": {"LINE_A": {"delta": 2.0, "category": "positive", "flip_arrow": False}},
+        })
+        compute_asset_deltas_spy = MagicMock(return_value={
+            "LOAD_X": {"delta_p": 10.0, "delta_q": 2.0, "category": "positive"},
+        })
+
+        # Patch the module-level helpers the mixin imports directly
+        # (get_network_flows / get_asset_flows / compute_deltas /
+        # compute_asset_deltas from `services.diagram.*`). Each
+        # helper consults `shared_net._current_variant` to return the
+        # variant-appropriate snapshot.
+        def _get_network_flows(net):
+            assert net is shared_net
+            if shared_net._current_variant == "action_var":
+                return action_branch_flows
+            return n1_branch_flows
+
+        def _get_asset_flows(net):
+            assert net is shared_net
+            if shared_net._current_variant == "action_var":
+                return action_asset_flows
+            return n1_asset_flows
+
+        service = _make_service_with_last_result("ACT_IMPACT", obs)
+        # `_get_n1_flows` is easiest to stub directly to return the
+        # N-1 snapshot — otherwise it would try to switch the variant
+        # on shared_net and we'd need to wire its restore semantics.
+        service._get_n1_flows = lambda contingency: n1_branch_flows
+        service._get_n1_variant = lambda contingency: "n1_var"
+        service._diff_switches = lambda a, b: {}
+
+        with patch("expert_backend.services.diagram_mixin.get_network_flows", side_effect=_get_network_flows), \
+             patch("expert_backend.services.diagram_mixin.get_asset_flows", side_effect=_get_asset_flows), \
+             patch("expert_backend.services.diagram_mixin.compute_deltas", compute_deltas_spy), \
+             patch("expert_backend.services.diagram_mixin.compute_asset_deltas", compute_asset_deltas_spy), \
+             patch("expert_backend.services.diagram_mixin.extract_sld_svg_and_metadata",
+                   return_value=("<svg/>", None)), \
+             patch.object(RecommenderService, "_get_base_network", return_value=shared_net), \
+             patch.object(RecommenderService, "_attach_convergence_from_obs", lambda self, *a, **kw: None):
+            result = service.get_action_variant_sld("ACT_IMPACT", "VL_TEST")
+
+        # compute_deltas must have been fed with the ACTION variant's
+        # flows (p1=120 on LINE_A) — NOT the N-1 flows (p1=90).
+        args, kwargs = compute_deltas_spy.call_args
+        after_flows = args[0] if args else kwargs.get("after_flows")
+        before_flows = args[1] if len(args) > 1 else kwargs.get("before_flows")
+        assert after_flows["p1"]["LINE_A"] == 120.0, (
+            f"Expected action-variant flows (p1=120) to reach compute_deltas, "
+            f"got {after_flows['p1']['LINE_A']} — if this is 90 the action "
+            f"snapshot was taken AFTER the N-1 variant switch."
+        )
+        assert before_flows["p1"]["LINE_A"] == 90.0
+
+        # Asset deltas were computed from the action snapshot too.
+        asset_args, _ = compute_asset_deltas_spy.call_args
+        after_assets = asset_args[0]
+        before_assets = asset_args[1]
+        assert after_assets["LOAD_X"]["p"] == 50.0
+        assert before_assets["LOAD_X"]["p"] == 40.0
+
+        # Response carries non-zero deltas — the user-visible outcome.
+        assert result["flow_deltas"]["LINE_A"]["delta"] == 30.0
+        assert result["asset_deltas"]["LOAD_X"]["delta_p"] == 10.0
+
+    def test_falls_back_to_empty_deltas_when_action_snapshot_fails(self):
+        """If capturing the action-variant flows raises, the endpoint still
+        returns a well-formed response with empty delta maps — same
+        contract as before the fix."""
+        shared_net = MagicMock()
+        shared_net.get_working_variant_id.return_value = "orig"
+        shared_net.get_switches.return_value = _make_switch_df({})
+        shared_net.get_single_line_diagram.return_value = MagicMock()
+
+        nm = MagicMock()
+        nm.network = shared_net
+        obs = self._build_obs_mock(nm)
+
+        def _raise_flows(_):
+            raise RuntimeError("simulated pypowsybl failure")
+
+        service = _make_service_with_last_result("ACT_FAIL", obs)
+        service._get_n1_variant = lambda contingency: "n1_var"
+        service._diff_switches = lambda a, b: {}
+
+        with patch("expert_backend.services.diagram_mixin.get_network_flows", side_effect=_raise_flows), \
+             patch("expert_backend.services.diagram_mixin.get_asset_flows", side_effect=_raise_flows), \
+             patch("expert_backend.services.diagram_mixin.extract_sld_svg_and_metadata",
+                   return_value=("<svg/>", None)), \
+             patch.object(RecommenderService, "_get_base_network", return_value=shared_net), \
+             patch.object(RecommenderService, "_attach_convergence_from_obs", lambda self, *a, **kw: None):
+            result = service.get_action_variant_sld("ACT_FAIL", "VL_TEST")
+
+        assert result["flow_deltas"] == {}
+        assert result["reactive_flow_deltas"] == {}
+        assert result["asset_deltas"] == {}
+        # The well-formed shape is preserved — no missing keys the
+        # frontend would crash on.
+        assert "svg" in result
+        assert "changed_switches" in result

--- a/expert_backend/tests/test_sld_highlight.py
+++ b/expert_backend/tests/test_sld_highlight.py
@@ -567,6 +567,85 @@ class TestActionVariantSldDeltaFreshness:
         assert result["flow_deltas"]["LINE_A"]["delta"] == 30.0
         assert result["asset_deltas"]["LOAD_X"]["delta_p"] == 10.0
 
+    def test_sld_deltas_match_nad_deltas_for_same_action(self):
+        """For a given (action, N-1) pair the SLD and NAD endpoints must
+        compute the same delta for a branch — both read from identical
+        flow snapshots and feed them through the same `compute_deltas`
+        helper. If the SLD endpoint silently reads action_flows AFTER
+        the N-1 variant switch, its delta collapses to 0 while the NAD
+        delta stays at +30 — the user-visible divergence the operator
+        reported (NAD Impacts show '+30.7' on the same branch that the
+        SLD renders as 'Δ +0.0')."""
+        shared_net = MagicMock()
+        shared_net._current_variant = "action_var"
+
+        def _set_variant(v):
+            shared_net._current_variant = v
+        shared_net.set_working_variant.side_effect = _set_variant
+        shared_net.get_working_variant_id.return_value = "orig"
+        shared_net.get_switches.return_value = _make_switch_df({})
+        shared_net.get_single_line_diagram.return_value = MagicMock()
+
+        nm = MagicMock()
+        nm.network = shared_net
+        nm.set_working_variant.side_effect = _set_variant
+        obs = self._build_obs_mock(nm)
+
+        action_branch_flows = {"p1": {"LINE_A": 120.0}, "p2": {"LINE_A": -118.0},
+                               "q1": {"LINE_A": 5.0}, "q2": {"LINE_A": -4.8},
+                               "vl1": {"LINE_A": "VL_TEST"}, "vl2": {"LINE_A": "VL_OTHER"}}
+        n1_branch_flows = {"p1": {"LINE_A": 90.0}, "p2": {"LINE_A": -88.0},
+                           "q1": {"LINE_A": 3.0}, "q2": {"LINE_A": -2.9},
+                           "vl1": {"LINE_A": "VL_TEST"}, "vl2": {"LINE_A": "VL_OTHER"}}
+        action_asset_flows = {"LOAD_X": {"p": 50.0, "q": 10.0}}
+        n1_asset_flows = {"LOAD_X": {"p": 40.0, "q": 8.0}}
+
+        def _get_network_flows(net):
+            if shared_net._current_variant == "action_var":
+                return action_branch_flows
+            return n1_branch_flows
+
+        def _get_asset_flows(net):
+            if shared_net._current_variant == "action_var":
+                return action_asset_flows
+            return n1_asset_flows
+
+        service = _make_service_with_last_result("ACT_PARITY", obs)
+        service._get_n1_flows = lambda contingency: n1_branch_flows
+        service._get_n1_variant = lambda contingency: "n1_var"
+        service._diff_switches = lambda a, b: {}
+        # Mock `_snapshot_n1_state` to use the same underlying snapshots
+        # the NAD endpoint relies on so the two endpoints see the same
+        # "before" values.
+        service._snapshot_n1_state = lambda contingency: (n1_branch_flows, n1_asset_flows)
+        service._generate_diagram = lambda network, voltage_level_ids=None, depth=0: {"svg": "<svg/>"}
+
+        # Real compute_deltas — we want the actual math.
+        with patch("expert_backend.services.diagram_mixin.get_network_flows", side_effect=_get_network_flows), \
+             patch("expert_backend.services.diagram_mixin.get_asset_flows", side_effect=_get_asset_flows), \
+             patch("expert_backend.services.diagram_mixin.extract_sld_svg_and_metadata",
+                   return_value=("<svg/>", None)), \
+             patch.object(RecommenderService, "_get_base_network", return_value=shared_net), \
+             patch.object(RecommenderService, "_attach_convergence_from_obs", lambda self, *a, **kw: None):
+            sld = service.get_action_variant_sld("ACT_PARITY", "VL_TEST")
+            # Re-activate the action variant for the NAD call (the SLD
+            # call leaves the shared network on `orig` after its
+            # finally-block restore).
+            shared_net._current_variant = "action_var"
+            nad = service.get_action_variant_diagram("ACT_PARITY", voltage_level_ids=["VL_TEST"])
+
+        sld_delta = sld["flow_deltas"].get("LINE_A", {}).get("delta")
+        nad_delta = nad["flow_deltas"].get("LINE_A", {}).get("delta")
+        assert sld_delta == nad_delta, (
+            f"SLD and NAD endpoints disagree on LINE_A delta: "
+            f"sld={sld_delta} vs nad={nad_delta}. SLD is probably reading "
+            f"action_flows AFTER the N-1 variant switch."
+        )
+        assert sld_delta != 0, (
+            f"Delta is 0 on both endpoints — flow snapshots were likely "
+            f"read from the same variant twice."
+        )
+
     def test_falls_back_to_empty_deltas_when_action_snapshot_fails(self):
         """If capturing the action-variant flows raises, the endpoint still
         returns a well-formed response with empty delta maps — same

--- a/expert_backend/tests/test_sld_highlight.py
+++ b/expert_backend/tests/test_sld_highlight.py
@@ -642,8 +642,8 @@ class TestActionVariantSldDeltaFreshness:
             f"action_flows AFTER the N-1 variant switch."
         )
         assert sld_delta != 0, (
-            f"Delta is 0 on both endpoints — flow snapshots were likely "
-            f"read from the same variant twice."
+            "Delta is 0 on both endpoints — flow snapshots were likely "
+            "read from the same variant twice."
         )
 
     def test_falls_back_to_empty_deltas_when_action_snapshot_fails(self):

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -105,6 +105,82 @@ describe('ActionFeed', () => {
         expect(screen.getByPlaceholderText(/Search action by ID/)).toBeInTheDocument();
     });
 
+    describe('"Make a first guess" gating after Analyze & Suggest', () => {
+        // Product rule: once the user has triggered Analyze & Suggest
+        // (or it's currently running, or its result is pending
+        // display), the pre-analysis "Make a first guess" shortcut is
+        // suppressed. It should reappear only after a state reset
+        // (contingency change, study reload) clears actionScores /
+        // pendingAnalysisResult / actions.
+
+        it('hides the button while analysis is in progress', () => {
+            render(<ActionFeed {...defaultProps} analysisLoading={true} />);
+            expect(screen.queryByTestId('make-first-guess-button')).not.toBeInTheDocument();
+        });
+
+        it('hides the button while a pending analysis result is awaiting display', () => {
+            const pending = {
+                actions: {},
+                lines_overloaded: [],
+                action_scores: {},
+            } as unknown as AnalysisResult;
+            render(<ActionFeed {...defaultProps} pendingAnalysisResult={pending} />);
+            expect(screen.queryByTestId('make-first-guess-button')).not.toBeInTheDocument();
+        });
+
+        it('hides the button when action scores are present (analysis completed)', () => {
+            const actionScores = {
+                line_disconnection: { scores: { 'disco_A': 1.0 }, params: {} },
+            };
+            render(<ActionFeed {...defaultProps} actionScores={actionScores} />);
+            expect(screen.queryByTestId('make-first-guess-button')).not.toBeInTheDocument();
+        });
+
+        it('hides the button when the actions dict is non-empty (at least one simulated action)', () => {
+            const actions = {
+                manually_added: {
+                    description_unitaire: 'Manual',
+                    action_topology: emptyTopo,
+                    is_manual: true,
+                } as unknown as ActionDetail,
+            };
+            render(<ActionFeed {...defaultProps} actions={actions} />);
+            expect(screen.queryByTestId('make-first-guess-button')).not.toBeInTheDocument();
+        });
+
+        it('still shows the button when actionScores is an empty object (analysis never ran)', () => {
+            // The defaultProps already use `actionScores: {}` which is
+            // the initial "analysis has not produced anything yet"
+            // state — a truthy but empty object. The button must still
+            // appear.
+            render(<ActionFeed {...defaultProps} actionScores={{}} />);
+            expect(screen.getByTestId('make-first-guess-button')).toBeInTheDocument();
+        });
+
+        it('re-appears after a simulated reset (all analysis-related state cleared)', () => {
+            const { rerender } = render(
+                <ActionFeed
+                    {...defaultProps}
+                    actionScores={{ line_disconnection: { scores: { 'disco_A': 1.0 }, params: {} } }}
+                />,
+            );
+            expect(screen.queryByTestId('make-first-guess-button')).not.toBeInTheDocument();
+
+            // Simulate state reset: parent clears result/actionScores
+            // (emulating resetAllState on contingency/study change).
+            rerender(
+                <ActionFeed
+                    {...defaultProps}
+                    actionScores={{}}
+                    pendingAnalysisResult={null}
+                    analysisLoading={false}
+                    actions={{}}
+                />,
+            );
+            expect(screen.getByTestId('make-first-guess-button')).toBeInTheDocument();
+        });
+    });
+
     it('keeps a manually added action in Selected and shows the overlap warning when it is ALSO suggested by the analysis', () => {
         // Regression: a user "first guess" that coincides with a
         // recommender suggestion used to silently vanish from the

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -802,29 +802,44 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 ) : (
                     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', margin: '5px 0 15px 0' }}>
                         <p style={{ color: '#666', fontStyle: 'italic', fontSize: '13px', margin: 0 }}>Select an action manually or from suggested ones.</p>
-                        <button
-                            onClick={handleOpenSearch}
-                            data-testid="make-first-guess-button"
-                            style={{
-                                padding: '10px',
-                                backgroundColor: '#f8f9fa',
-                                border: '1px dashed #007bff',
-                                color: '#007bff',
-                                borderRadius: '8px',
-                                cursor: 'pointer',
-                                fontWeight: 600,
-                                fontSize: '14px',
-                                transition: 'all 0.2s',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                gap: '8px',
-                            }}
-                            onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#e7f1ff'; }}
-                            onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#f8f9fa'; }}
-                        >
-                            <span style={{ fontSize: '16px' }}>💡</span> Make a first guess
-                        </button>
+                        {/* "Make a first guess" is a pre-analysis shortcut.
+                            Once the operator has launched "Analyze & Suggest"
+                            (or the analysis has completed / is pending
+                            display), we stop offering the shortcut so the
+                            UI funnels the user through the Manual Selection
+                            dropdown (which now carries the score table).
+                            The button re-appears only after a full reset
+                            (contingency change, study reload) — at which
+                            point `actionScores` / `pendingAnalysisResult` /
+                            `actions` are all cleared by `resetAllState`. */}
+                        {!analysisLoading
+                            && !pendingAnalysisResult
+                            && (!actionScores || Object.keys(actionScores).length === 0)
+                            && Object.keys(actions).length === 0 && (
+                            <button
+                                onClick={handleOpenSearch}
+                                data-testid="make-first-guess-button"
+                                style={{
+                                    padding: '10px',
+                                    backgroundColor: '#f8f9fa',
+                                    border: '1px dashed #007bff',
+                                    color: '#007bff',
+                                    borderRadius: '8px',
+                                    cursor: 'pointer',
+                                    fontWeight: 600,
+                                    fontSize: '14px',
+                                    transition: 'all 0.2s',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    gap: '8px',
+                                }}
+                                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#e7f1ff'; }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#f8f9fa'; }}
+                            >
+                                <span style={{ fontSize: '16px' }}>💡</span> Make a first guess
+                            </button>
+                        )}
                     </div>
                 )}
             </div>

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -952,7 +952,11 @@ describe('ActionOverviewDiagram', () => {
             expect(secondCall[0].categories).toEqual({ green: true, orange: true, red: true, grey: true });
         });
 
-        it('threshold slider update fires onFiltersChange with the new threshold', () => {
+        it('threshold numeric input update fires onFiltersChange with the new threshold', () => {
+            // The threshold widget is a compact integer-% number
+            // input (0–300 %); the form's source-of-truth value is a
+            // fraction (1.0 = 100 %). Typing "100" in the input must
+            // push { threshold: 1.0 } through onFiltersChange.
             const onFiltersChange = vi.fn();
             const { getByTestId } = render(
                 <ActionOverviewDiagram
@@ -961,8 +965,8 @@ describe('ActionOverviewDiagram', () => {
                     onFiltersChange={onFiltersChange}
                 />,
             );
-            const slider = getByTestId('filter-threshold').querySelector('input[type="range"]') as HTMLInputElement;
-            fireEvent.change(slider, { target: { value: '1.0' } });
+            const input = getByTestId('filter-threshold-input') as HTMLInputElement;
+            fireEvent.change(input, { target: { value: '100' } });
             expect(onFiltersChange).toHaveBeenCalledTimes(1);
             expect(onFiltersChange.mock.calls[0][0].threshold).toBeCloseTo(1.0);
         });

--- a/frontend/src/components/ActionOverviewDiagram.test.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.test.tsx
@@ -971,6 +971,64 @@ describe('ActionOverviewDiagram', () => {
             expect(onFiltersChange.mock.calls[0][0].threshold).toBeCloseTo(1.0);
         });
 
+        it('threshold input is a compact integer-% number widget rendering the current fraction as a %', () => {
+            // Regression: the widget replaced the old range slider.
+            // It must be `type="number"`, must bound to 0–300 % with
+            // step=1, and must surface the fractional threshold
+            // multiplied by 100 as its value.
+            const { getByTestId, queryByTestId } = render(
+                <ActionOverviewDiagram
+                    {...defaultProps()}
+                    filters={{ categories: allCategories, threshold: 1.5, showUnsimulated: false }}
+                />,
+            );
+            const input = getByTestId('filter-threshold-input') as HTMLInputElement;
+            expect(input.type).toBe('number');
+            expect(input.min).toBe('0');
+            expect(input.max).toBe('300');
+            expect(input.step).toBe('1');
+            expect(input.value).toBe('150');
+            // The old slider must NOT be present anymore.
+            expect(queryByTestId('filter-threshold')?.querySelector('input[type="range"]')).toBeFalsy();
+        });
+
+        it('threshold input clamps values outside 0–300 %', () => {
+            const onFiltersChange = vi.fn();
+            const { getByTestId } = render(
+                <ActionOverviewDiagram
+                    {...defaultProps()}
+                    filters={{ categories: allCategories, threshold: 1.5, showUnsimulated: false }}
+                    onFiltersChange={onFiltersChange}
+                />,
+            );
+            const input = getByTestId('filter-threshold-input') as HTMLInputElement;
+            fireEvent.change(input, { target: { value: '999' } });
+            expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ threshold: 3.0 }));
+            fireEvent.change(input, { target: { value: '-50' } });
+            expect(onFiltersChange).toHaveBeenLastCalledWith(expect.objectContaining({ threshold: 0 }));
+        });
+
+        it('header lays out filters on a single horizontal row (nowrap)', () => {
+            // Regression: the compacted banner must not wrap onto a
+            // second line. We check the computed flex-wrap value of
+            // the header container plus the presence of every filter
+            // control as a direct child of that row.
+            const { getByTestId } = render(
+                <ActionOverviewDiagram
+                    {...defaultProps()}
+                    filters={{ categories: allCategories, threshold: 1.5, showUnsimulated: false }}
+                />,
+            );
+            const header = getByTestId('action-overview-header');
+            expect(header.style.flexWrap).toBe('nowrap');
+            // The severity toggles, threshold, unsimulated checkbox,
+            // and action-type chips all sit as children/descendants of
+            // the single row — no nested wrapping <div> is introduced.
+            expect(header.querySelector('[data-testid="filter-category-green"]')).toBeTruthy();
+            expect(header.querySelector('[data-testid="filter-threshold-input"]')).toBeTruthy();
+            expect(header.querySelector('[data-testid="filter-show-unsimulated"]')).toBeTruthy();
+        });
+
         it('disabling the red category hides red-severity pins from the overview', () => {
             // defaultProps has one red pin (coupling_VL_FAR max_rho=1.1) and
             // one green pin (disco_LINE_A max_rho=0.5).

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -857,23 +857,24 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                 data-testid="action-overview-header"
                 style={{
                     flexShrink: 0,
-                    padding: '6px 14px',
+                    padding: '4px 10px',
                     display: 'flex',
                     alignItems: 'center',
-                    flexWrap: 'wrap',
-                    gap: '10px',
-                    rowGap: '6px',
+                    flexWrap: 'nowrap',
+                    gap: '6px',
                     fontSize: '12px',
                     background: '#f8fafc',
                     borderBottom: '1px solid #e2e8f0',
                     color: '#334155',
+                    overflowX: 'auto',
+                    whiteSpace: 'nowrap',
                 }}
             >
                 {hasAnyAction && (
                     <span
                         data-testid="overview-pin-counter"
                         title={`${pins.length} pin${pins.length === 1 ? '' : 's'} on the N-1 network${unsimulatedPins.length > 0 ? ` (+ ${unsimulatedPins.length} un-simulated)` : ''}`}
-                        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontWeight: 600, color: '#1f2937' }}
+                        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontWeight: 600, color: '#1f2937', flexShrink: 0 }}
                     >
                         <span aria-hidden>{'\uD83D\uDCCD'}</span>
                         <span style={{ fontVariantNumeric: 'tabular-nums' }}>
@@ -882,98 +883,107 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                         </span>
                     </span>
                 )}
-                <div style={{ display: 'flex', gap: '10px', alignItems: 'center', flexWrap: 'wrap' }}>
-                    <CategoryToggle
-                        testId="filter-category-green"
-                        color="#28a745" label="Solves overload"
-                        enabled={activeFilters.categories.green}
-                        onToggle={() => toggleCategory('green')}
-                    />
-                    <CategoryToggle
-                        testId="filter-category-orange"
-                        color="#f0ad4e" label="Low margin"
-                        enabled={activeFilters.categories.orange}
-                        onToggle={() => toggleCategory('orange')}
-                    />
-                    <CategoryToggle
-                        testId="filter-category-red"
-                        color="#dc3545" label="Still overloaded"
-                        enabled={activeFilters.categories.red}
-                        onToggle={() => toggleCategory('red')}
-                    />
-                    <CategoryToggle
-                        testId="filter-category-grey"
-                        color="#9ca3af" label="Divergent / islanded"
-                        enabled={activeFilters.categories.grey}
-                        onToggle={() => toggleCategory('grey')}
-                    />
-                    <button
-                        data-testid="filter-select-all"
-                        type="button"
-                        onClick={() => setAllCategories(true)}
-                        title="Enable all categories"
-                        style={filterChipButtonStyle}
-                    >
-                        All
-                    </button>
-                    <button
-                        data-testid="filter-select-none"
-                        type="button"
-                        onClick={() => setAllCategories(false)}
-                        title="Disable all categories"
-                        style={filterChipButtonStyle}
-                    >
-                        None
-                    </button>
-                    <label
-                        data-testid="filter-threshold"
-                        style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
-                        title="Hide actions whose max loading rate exceeds this threshold"
-                    >
-                        <span style={{ color: '#475569' }}>Max loading</span>
-                        <input
-                            type="range"
-                            min={0.5}
-                            max={3}
-                            step={0.05}
-                            value={activeFilters.threshold}
-                            onChange={e => setThreshold(parseFloat(e.target.value))}
-                            style={{ width: 110 }}
-                        />
-                        <span style={{ minWidth: 38, textAlign: 'right', fontVariantNumeric: 'tabular-nums', color: '#1f2937', fontWeight: 600 }}>
-                            {`${Math.round(activeFilters.threshold * 100)}%`}
-                        </span>
-                    </label>
-                    <label
-                        data-testid="filter-show-unsimulated"
-                        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}
-                        title="Show scored-but-not-yet-simulated actions as dimmed pins. Double-click a dimmed pin to run its simulation."
-                    >
-                        <input
-                            type="checkbox"
-                            checked={activeFilters.showUnsimulated}
-                            onChange={toggleUnsimulated}
-                        />
-                        <span style={{ color: '#475569' }}>Show unsimulated</span>
-                    </label>
-                    {/* Vertical separator + action-type chips
-                        inline on the same row. */}
-                    <span
-                        aria-hidden
+                <CategoryToggle
+                    testId="filter-category-green"
+                    color="#28a745" label="Solves overload"
+                    enabled={activeFilters.categories.green}
+                    onToggle={() => toggleCategory('green')}
+                />
+                <CategoryToggle
+                    testId="filter-category-orange"
+                    color="#f0ad4e" label="Low margin"
+                    enabled={activeFilters.categories.orange}
+                    onToggle={() => toggleCategory('orange')}
+                />
+                <CategoryToggle
+                    testId="filter-category-red"
+                    color="#dc3545" label="Still overloaded"
+                    enabled={activeFilters.categories.red}
+                    onToggle={() => toggleCategory('red')}
+                />
+                <CategoryToggle
+                    testId="filter-category-grey"
+                    color="#9ca3af" label="Divergent / islanded"
+                    enabled={activeFilters.categories.grey}
+                    onToggle={() => toggleCategory('grey')}
+                />
+                <button
+                    data-testid="filter-select-all"
+                    type="button"
+                    onClick={() => setAllCategories(true)}
+                    title="Enable all categories"
+                    style={filterChipButtonStyle}
+                >
+                    All
+                </button>
+                <button
+                    data-testid="filter-select-none"
+                    type="button"
+                    onClick={() => setAllCategories(false)}
+                    title="Disable all categories"
+                    style={filterChipButtonStyle}
+                >
+                    None
+                </button>
+                <label
+                    data-testid="filter-threshold"
+                    style={{ display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0 }}
+                    title="Hide actions whose max loading rate (%) exceeds this threshold"
+                >
+                    <span style={{ color: '#475569' }}>Max loading</span>
+                    <input
+                        data-testid="filter-threshold-input"
+                        type="number"
+                        min={0}
+                        max={300}
+                        step={1}
+                        value={Math.round(activeFilters.threshold * 100)}
+                        onChange={e => {
+                            const raw = parseInt(e.target.value, 10);
+                            if (!Number.isFinite(raw)) return;
+                            const clamped = Math.max(0, Math.min(300, raw));
+                            setThreshold(clamped / 100);
+                        }}
                         style={{
-                            display: 'inline-block',
-                            width: 1,
-                            height: 18,
-                            background: '#cbd5e1',
-                            margin: '0 2px',
+                            width: 52,
+                            padding: '2px 4px',
+                            fontSize: 12,
+                            fontVariantNumeric: 'tabular-nums',
+                            border: '1px solid #cbd5e1',
+                            borderRadius: 4,
+                            textAlign: 'right',
                         }}
                     />
-                    <ActionTypeFilterChips
-                        testIdPrefix="overview-action-type-filter"
-                        value={activeFilters.actionType}
-                        onChange={setActionType}
+                    <span style={{ color: '#475569' }}>%</span>
+                </label>
+                <label
+                    data-testid="filter-show-unsimulated"
+                    style={{ display: 'inline-flex', alignItems: 'center', gap: 4, cursor: 'pointer', flexShrink: 0 }}
+                    title="Show scored-but-not-yet-simulated actions as dimmed pins. Double-click a dimmed pin to run its simulation."
+                >
+                    <input
+                        type="checkbox"
+                        checked={activeFilters.showUnsimulated}
+                        onChange={toggleUnsimulated}
                     />
-                </div>
+                    <span style={{ color: '#475569' }}>Show unsimulated</span>
+                </label>
+                <span
+                    aria-hidden
+                    style={{
+                        display: 'inline-block',
+                        width: 1,
+                        height: 18,
+                        background: '#cbd5e1',
+                        margin: '0 2px',
+                        flexShrink: 0,
+                    }}
+                />
+                <ActionTypeFilterChips
+                    testIdPrefix="overview-action-type-filter"
+                    value={activeFilters.actionType}
+                    onChange={setActionType}
+                />
             </div>
 
             {/* SVG body: the pan/zoom container. Wheel + drag work
@@ -1242,6 +1252,7 @@ const filterChipButtonStyle: React.CSSProperties = {
     cursor: 'pointer',
     fontSize: 12,
     fontWeight: 600,
+    flexShrink: 0,
 };
 
 /**
@@ -1275,6 +1286,7 @@ const CategoryToggle: React.FC<{
             fontSize: 12,
             color: enabled ? '#1f2937' : '#94a3b8',
             opacity: enabled ? 1 : 0.65,
+            flexShrink: 0,
         }}
     >
         <span

--- a/frontend/src/components/ActionSearchDropdown.test.tsx
+++ b/frontend/src/components/ActionSearchDropdown.test.tsx
@@ -312,4 +312,108 @@ describe('ActionSearchDropdown', () => {
             expect(input.value).toBe('');
         });
     });
+
+    // Regression: once "Analyze & Suggest" has produced action scores,
+    // applying a type filter may filter the score list down to zero.
+    // Previously the dropdown silently fell back to the full network
+    // action list, which misled the operator into thinking the
+    // analysis recommended any of those actions. A yellow warning
+    // banner must now tell them that no scored action matched the
+    // selected type. The banner is suppressed when the analysis
+    // hasn't been run (actionScores undefined) or when the 'all'
+    // filter is active, to avoid false positives.
+    describe('no-relevant-action warning (after analyze & suggest)', () => {
+        it('shows the warning when actionScores are non-empty but the type filter hides them all', () => {
+            const actionScores = {
+                pst_tap_change: {
+                    scores: { 'pst-A': 5 },
+                    params: {},
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    // Type filter is RECO but the only scored action is a PST.
+                    actionTypeFilter="reco"
+                    scoredActionsList={[]}
+                    actionScores={actionScores}
+                />,
+            );
+            const banner = screen.getByTestId('no-relevant-action-warning');
+            expect(banner).toBeInTheDocument();
+            expect(banner.textContent).toMatch(/no relevant action detected/i);
+        });
+
+        it('does NOT show the warning when actionScores is undefined (analysis not yet run)', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    actionTypeFilter="reco"
+                    scoredActionsList={[]}
+                    actionScores={undefined}
+                />,
+            );
+            expect(screen.queryByTestId('no-relevant-action-warning')).not.toBeInTheDocument();
+        });
+
+        it('does NOT show the warning when actionScores is empty (analysis ran but produced nothing)', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    actionTypeFilter="reco"
+                    scoredActionsList={[]}
+                    actionScores={{}}
+                />,
+            );
+            expect(screen.queryByTestId('no-relevant-action-warning')).not.toBeInTheDocument();
+        });
+
+        it('does NOT show the warning under the `all` filter (user is not filtering by type)', () => {
+            const actionScores = {
+                pst_tap_change: { scores: { 'pst-A': 5 }, params: {} },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    actionTypeFilter="all"
+                    scoredActionsList={[]}
+                    actionScores={actionScores}
+                />,
+            );
+            expect(screen.queryByTestId('no-relevant-action-warning')).not.toBeInTheDocument();
+        });
+
+        it('does NOT show the warning when there is at least one scored action after filtering', () => {
+            const actionScores = {
+                pst_tap_change: { scores: { 'pst-A': 5 }, params: {} },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    actionTypeFilter="pst"
+                    scoredActionsList={[
+                        { type: 'pst_tap_change', actionId: 'pst-A', score: 5, mwStart: null },
+                    ]}
+                    actionScores={actionScores}
+                />,
+            );
+            expect(screen.queryByTestId('no-relevant-action-warning')).not.toBeInTheDocument();
+        });
+
+        it('does NOT show the warning while the user is typing in the search box', () => {
+            const actionScores = {
+                pst_tap_change: { scores: { 'pst-A': 5 }, params: {} },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    searchQuery="foo"
+                    actionTypeFilter="reco"
+                    scoredActionsList={[]}
+                    actionScores={actionScores}
+                />,
+            );
+            expect(screen.queryByTestId('no-relevant-action-warning')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/frontend/src/components/ActionSearchDropdown.tsx
+++ b/frontend/src/components/ActionSearchDropdown.tsx
@@ -145,6 +145,37 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                             />
                         )}
 
+                        {/* No-relevant-action warning: analysis ran
+                            (actionScores present) but the selected type
+                            filter yields zero scored actions, so we fall
+                            back to the full network action list below.
+                            The banner tells the operator that nothing from
+                            the analysis recommends actions of this type. */}
+                        {!searchQuery
+                            && scoredActionsList.length === 0
+                            && actionTypeFilter !== 'all'
+                            && !!actionScores
+                            && Object.values(actionScores).some(d =>
+                                d && typeof d === 'object'
+                                && Object.keys((d as { scores?: Record<string, number> }).scores ?? {}).length > 0
+                            ) && (
+                            <div
+                                data-testid="no-relevant-action-warning"
+                                style={{
+                                    margin: '6px 8px',
+                                    padding: '6px 8px',
+                                    background: '#fff3cd',
+                                    border: '1px solid #ffeeba',
+                                    borderRadius: 4,
+                                    color: '#856404',
+                                    fontSize: 12,
+                                    lineHeight: 1.35,
+                                }}
+                            >
+                                ⚠️ Warning: no relevant action detected with regards to overflow analysis
+                            </div>
+                        )}
+
                         {/* Search Results */}
                         {(!searchQuery && scoredActionsList.length === 0 && filteredActions.length === 0) && (
                             <div style={{ padding: '10px', textAlign: 'center', color: '#888', fontSize: '13px' }}>

--- a/frontend/src/components/SldOverlay.test.tsx
+++ b/frontend/src/components/SldOverlay.test.tsx
@@ -839,5 +839,65 @@ describe('SldOverlay', () => {
             expect(label.getAttribute('data-original-text')).toBe(originalAttr);
             expect(label.getAttribute('data-original-text')).toBe('100');
         });
+
+        // Regression: dragging the substation glyph in the SLD with the
+        // mouse fires a stream of `setOverlayTransform` updates, each
+        // re-rendering the component. The user reported a visible
+        // impact↔flow blink during the drag that stabilised on impact
+        // only when the mouse was released. Root cause: the delta
+        // painter was a `useEffect`, which runs AFTER the browser
+        // paints — so each rapid re-render produced a single-frame
+        // flash of the un-painted (Flows) state between commit and
+        // effect-flush. Promoting it to `useLayoutEffect` runs the
+        // painter synchronously between commit and paint, so the
+        // browser only ever sees the post-paint impact state. This
+        // test locks in the architectural choice by source-level
+        // inspection (jsdom can't reproduce the real paint cycle, but
+        // a future refactor flipping it back to `useEffect` would
+        // also re-introduce the blink).
+        it('delta painter uses useLayoutEffect, not useEffect (no blink between commit and paint)', () => {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const fs = require('fs');
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const path = require('path');
+            const src = fs.readFileSync(
+                path.resolve(__dirname, 'SldOverlay.tsx'),
+                'utf-8',
+            ) as string;
+            const sigDeclIdx = src.indexOf('const appliedDeltaSigRef');
+            expect(sigDeclIdx).toBeGreaterThan(-1);
+            // The `useLayoutEffect(...)` invocation MUST sit on the
+            // line immediately after the sig-ref declaration — that's
+            // the delta painter. If anyone flips it back to
+            // `useEffect`, the rapid pan re-renders will once again
+            // expose the un-painted Flows state for a single frame
+            // between React's commit and the post-paint effect flush.
+            const after = src.slice(sigDeclIdx, sigDeclIdx + 400);
+            expect(after).toMatch(/useLayoutEffect\s*\(/);
+            expect(after).not.toMatch(/^\s*useEffect\s*\(/m);
+        });
+
+        it('delta classes survive a sequence of pan-driven rerenders without ever vanishing', () => {
+            // Behavioural complement to the source-inspection test
+            // above. Even if a future refactor changed the effect
+            // implementation, the delta DOM state must NEVER be
+            // momentarily absent between successive renders. Mirrors
+            // what happens when the operator drags the SLD: a stream
+            // of `setOverlayTransform` updates → many cheap re-renders.
+            const overlay = buildDeltaOverlay();
+            const { container, rerender } = render(
+                <SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />,
+            );
+            const queryDelta = () => container.querySelector('.sld-delta-positive');
+            expect(queryDelta()).toBeTruthy();
+            // Re-render 8× in quick succession (any pan gesture fires
+            // dozens of these per second).
+            for (let i = 0; i < 8; i += 1) {
+                rerender(<SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />);
+                // Probe immediately after each commit — the delta
+                // class MUST still be there, never transiently null.
+                expect(queryDelta()).toBeTruthy();
+            }
+        });
     });
 });

--- a/frontend/src/components/SldOverlay.test.tsx
+++ b/frontend/src/components/SldOverlay.test.tsx
@@ -710,4 +710,134 @@ describe('SldOverlay', () => {
             expect(container.querySelectorAll('.sld-highlight-clone.sld-highlight-action').length).toBe(1);
         });
     });
+
+    // Regression: the delta-flow painter used to run only when a dep
+    // in its useEffect's dep list changed. But React reconciles the
+    // `dangerouslySetInnerHTML` wrapper during pan/zoom updates
+    // (overlayTransform state changes) — re-injecting the SVG and
+    // wiping every `sld-delta-*` class and `data-original-text`
+    // attribute the painter had planted. None of the deps changed,
+    // so the effect didn't re-run — the overlay stayed stuck on the
+    // Flows rendering until a tab switch forced a re-fetch. The
+    // fix converts the painter into a self-gating every-render pass
+    // with a signature + DOM-presence probe (mirrors the highlight
+    // layoutEffect immediately below it).
+    describe('Impacts delta persistence across pan/re-render (regression)', () => {
+        const buildDeltaOverlay = (): VlOverlay => ({
+            vlName: 'VL_400',
+            actionId: 'act-1',
+            // Minimal SLD fixture: one extern-cell containing a
+            // feeder group + an active-power label. Enough for the
+            // painter to find the cell, tag it with
+            // `sld-delta-positive`, and rewrite the numeric label.
+            svg:
+                '<svg xmlns="http://www.w3.org/2000/svg">'
+                + '<g class="sld-extern-cell">'
+                + '<g id="feeder-lineA"></g>'
+                + '<g class="sld-active-power"><text class="sld-label">100</text></g>'
+                + '</g>'
+                + '</svg>',
+            sldMetadata: JSON.stringify({
+                feederInfos: [{ id: 'feeder-lineA', equipmentId: 'LINE_A' }],
+            }),
+            loading: false,
+            error: null,
+            tab: 'action' as SldTab,
+            flow_deltas: {
+                LINE_A: { delta: 5.5, category: 'positive', flip_arrow: false },
+            },
+        });
+
+        it('paints delta classes + delta text on initial render (actionViewMode=delta)', () => {
+            const overlay = buildDeltaOverlay();
+            const { container } = render(
+                <SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />,
+            );
+            expect(container.querySelector('.sld-extern-cell.sld-delta-positive')).toBeTruthy();
+            const label = container.querySelector('.sld-active-power .sld-label');
+            expect(label).toBeTruthy();
+            expect(label!.textContent).toMatch(/Δ/); // delta symbol "Δ"
+            expect(label!.getAttribute('data-original-text')).toBe('100');
+            expect(label!.classList.contains('sld-delta-text-positive')).toBe(true);
+        });
+
+        it('re-paints delta state after a pan reconciliation wipes it from the DOM', () => {
+            const overlay = buildDeltaOverlay();
+            const { container, rerender } = render(
+                <SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />,
+            );
+            // Guard: initial paint landed.
+            expect(container.querySelector('.sld-delta-positive')).toBeTruthy();
+
+            // Simulate React's reconciliation of the
+            // `dangerouslySetInnerHTML` wrapper during pan — every
+            // delta class & data-original-text gets dropped.
+            container.querySelectorAll('.sld-delta-positive, .sld-delta-text-positive').forEach(el => {
+                el.classList.remove('sld-delta-positive', 'sld-delta-text-positive');
+            });
+            container.querySelectorAll('[data-original-text]').forEach(el => {
+                el.removeAttribute('data-original-text');
+            });
+            // Also restore the label text so the sig-gate can detect
+            // the wipe via the DOM-presence probe.
+            const lbl = container.querySelector('.sld-active-power .sld-label')!;
+            lbl.textContent = '100';
+
+            expect(container.querySelector('.sld-delta-positive')).toBeNull();
+
+            // A pan-triggered rerender (transform state in SldOverlay
+            // changes, props stay identical). The self-gating effect
+            // must detect the wipe and repaint.
+            rerender(
+                <SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />,
+            );
+
+            expect(container.querySelector('.sld-extern-cell.sld-delta-positive')).toBeTruthy();
+            const labelAfter = container.querySelector('.sld-active-power .sld-label')!;
+            expect(labelAfter.textContent).toMatch(/Δ/);
+            expect(labelAfter.getAttribute('data-original-text')).toBe('100');
+            expect(labelAfter.classList.contains('sld-delta-text-positive')).toBe(true);
+        });
+
+        it('clears delta state when toggling back to Flows (actionViewMode=network)', () => {
+            const overlay = buildDeltaOverlay();
+            const { container, rerender } = render(
+                <SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />,
+            );
+            expect(container.querySelector('.sld-delta-positive')).toBeTruthy();
+
+            rerender(
+                <SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="network" />,
+            );
+            // Flows mode — no delta paint should remain on the cell.
+            expect(container.querySelector('.sld-delta-positive')).toBeNull();
+            // Original numeric label restored.
+            const label = container.querySelector('.sld-active-power .sld-label')!;
+            expect(label.textContent).toBe('100');
+            expect(label.getAttribute('data-original-text')).toBeNull();
+        });
+
+        it('is idempotent across consecutive rerenders with identical props (no sig thrash)', () => {
+            const overlay = buildDeltaOverlay();
+            const { container, rerender } = render(
+                <SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />,
+            );
+            const originalAttr = container.querySelector('.sld-active-power .sld-label')!.getAttribute('data-original-text');
+            // Consecutive re-renders must not stack up "Δ Δ Δ" prefixes
+            // on the label — the painter's reset step runs before
+            // every repaint, so the text stays "Δ +5.5" whatever the
+            // render count is.
+            rerender(<SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />);
+            rerender(<SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />);
+            rerender(<SldOverlay {...defaultProps} vlOverlay={overlay} actionViewMode="delta" />);
+            const label = container.querySelector('.sld-active-power .sld-label')!;
+            // Exactly one Δ prefix — no accumulation.
+            const deltaCount = (label.textContent ?? '').split('Δ').length - 1;
+            expect(deltaCount).toBe(1);
+            // data-original-text preserved (not re-captured from the
+            // already-Δ-prefixed label, which would corrupt it).
+            expect(label.getAttribute('data-original-text')).toBe(originalAttr);
+            expect(label.getAttribute('data-original-text')).toBe('100');
+        });
+    });
 });

--- a/frontend/src/components/SldOverlay.tsx
+++ b/frontend/src/components/SldOverlay.tsx
@@ -50,18 +50,17 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
     // The cell ancestor (sld-extern-cell) wraps BOTH the feeder symbol AND the connecting
     // wire (sld-wire), so we must apply the delta class one level up to color the full branch.
     //
-    // The hook intentionally runs on EVERY render and self-gates via a
-    // signature + a DOM-presence probe. Same rationale as the highlight
-    // layoutEffect below: a pan/zoom update fires `setOverlayTransform`
-    // which re-renders SldOverlay. React may reconcile the
-    // `dangerouslySetInnerHTML` div and replace its children, wiping
-    // out every delta class and `data-original-text` we painted on the
-    // SVG. A deps-based useEffect would miss that wipe (none of its
-    // deps changed) and leave the overlay stuck on Flows rendering
-    // until a tab switch. By running every render, we detect the wipe
-    // via `deltaDomPresent` and re-apply.
+    // Runs as a useLayoutEffect — synchronously after every commit but
+    // BEFORE the browser paints. Same scheduling as the highlight
+    // layoutEffect immediately below it. A plain `useEffect` runs
+    // AFTER paint, which during continuous panning produces a visible
+    // single-frame flash of the un-painted (Flows) state between the
+    // commit and the effect — perceived as the impact/flow blink the
+    // operator reported. Self-gates via signature + DOM-presence
+    // probe so identical re-renders short-circuit instead of
+    // re-painting every cell on every pan frame.
     const appliedDeltaSigRef = useRef<string>('');
-    useEffect(() => {
+    useLayoutEffect(() => {
         const container = overlayBodyRef.current;
         if (!container) return;
 

--- a/frontend/src/components/SldOverlay.tsx
+++ b/frontend/src/components/SldOverlay.tsx
@@ -49,9 +49,47 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
     //
     // The cell ancestor (sld-extern-cell) wraps BOTH the feeder symbol AND the connecting
     // wire (sld-wire), so we must apply the delta class one level up to color the full branch.
+    //
+    // The hook intentionally runs on EVERY render and self-gates via a
+    // signature + a DOM-presence probe. Same rationale as the highlight
+    // layoutEffect below: a pan/zoom update fires `setOverlayTransform`
+    // which re-renders SldOverlay. React may reconcile the
+    // `dangerouslySetInnerHTML` div and replace its children, wiping
+    // out every delta class and `data-original-text` we painted on the
+    // SVG. A deps-based useEffect would miss that wipe (none of its
+    // deps changed) and leave the overlay stuck on Flows rendering
+    // until a tab switch. By running every render, we detect the wipe
+    // via `deltaDomPresent` and re-apply.
+    const appliedDeltaSigRef = useRef<string>('');
     useEffect(() => {
         const container = overlayBodyRef.current;
         if (!container) return;
+
+        const deltaSig = JSON.stringify({
+            svgLen: vlOverlay.svg?.length ?? 0,
+            meta: vlOverlay.sldMetadata?.length ?? 0,
+            tab: vlOverlay.tab,
+            mode: actionViewMode,
+            fd: vlOverlay.flow_deltas ? Object.keys(vlOverlay.flow_deltas).sort() : [],
+            rfd: vlOverlay.reactive_flow_deltas ? Object.keys(vlOverlay.reactive_flow_deltas).sort() : [],
+            ad: vlOverlay.asset_deltas ? Object.keys(vlOverlay.asset_deltas).sort() : [],
+        });
+        const expectDelta = actionViewMode === 'delta'
+            && !!vlOverlay.svg
+            && (!!vlOverlay.flow_deltas || !!vlOverlay.asset_deltas);
+        const deltaDomPresent = container.querySelector(
+            '.sld-delta-positive, .sld-delta-negative, .sld-delta-grey, '
+            + '.sld-delta-text-positive, .sld-delta-text-negative, .sld-delta-text-grey, '
+            + '[data-original-text]',
+        ) !== null;
+        // Short-circuit only when we already applied for the current
+        // inputs AND the DOM still reflects it (or we expect no delta
+        // state at all). Otherwise fall through and (re-)apply.
+        if (deltaSig === appliedDeltaSigRef.current
+            && (expectDelta ? deltaDomPresent : !deltaDomPresent)) {
+            return;
+        }
+        appliedDeltaSigRef.current = deltaSig;
 
         // Clear any previously applied SLD delta classes
         const SLD_DELTA_CLASSES = [
@@ -366,8 +404,11 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                 cellEl.querySelectorAll('.sld-reactive-power .sld-label').forEach(l => l.classList.add(`sld-delta-text-${catQ}`));
             }
         }
-    }, [vlOverlay.svg, vlOverlay.sldMetadata, vlOverlay.tab, actionViewMode,
-    vlOverlay.flow_deltas, vlOverlay.reactive_flow_deltas, vlOverlay.asset_deltas]);
+        // No deps on purpose: run every render and self-gate via
+        // `appliedDeltaSigRef` + DOM presence check. Catches the
+        // pan-reconciliation wipe that would otherwise strand the
+        // overlay on Flows rendering until a tab switch.
+    });
 
     // ===== Highlight impacted assets on the SLD =====
     // Uses a clone-behind technique: clones target elements and inserts them as

--- a/frontend/src/hooks/useDiagramHighlights.test.ts
+++ b/frontend/src/hooks/useDiagramHighlights.test.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDiagramHighlights } from './useDiagramHighlights';
+import type { AnalysisResult, DiagramData, MetadataIndex } from '../types';
+import type { DiagramsState } from './useDiagrams';
+
+vi.mock('../utils/svgUtils', () => ({
+    applyContingencyHighlight: vi.fn(),
+    applyDeltaVisuals: vi.fn(),
+    applyOverloadedHighlights: vi.fn(),
+    applyActionTargetHighlights: vi.fn(),
+}));
+
+vi.mock('../utils/overloadHighlights', () => ({
+    computeN1OverloadHighlights: vi.fn((analysisOverloads: string[], n1Overloads: string[] | undefined) => {
+        if (analysisOverloads && analysisOverloads.length > 0) return analysisOverloads;
+        return n1Overloads ?? [];
+    }),
+}));
+
+import {
+    applyContingencyHighlight,
+    applyDeltaVisuals,
+    applyOverloadedHighlights,
+    applyActionTargetHighlights,
+} from '../utils/svgUtils';
+
+const makeContainer = (): { current: HTMLElement } => ({
+    current: document.createElement('div'),
+});
+
+const makeMetaIndex = (): MetadataIndex => ({
+    nodesByEquipmentId: new Map(),
+    nodesBySvgId: new Map(),
+    edgesByEquipmentId: new Map(),
+    edgesByNode: new Map(),
+} as MetadataIndex);
+
+const makeDiagramsState = (overrides: Partial<DiagramsState> = {}): DiagramsState => {
+    const n1Diagram = { svg: '<svg></svg>', lines_overloaded: ['OVL_LINE'] } as unknown as DiagramData;
+    const actionDiagram = { svg: '<svg></svg>' } as unknown as DiagramData;
+    const base = {
+        activeTab: 'n-1',
+        nDiagram: { svg: '<svg></svg>' } as unknown as DiagramData,
+        n1Diagram,
+        actionDiagram,
+        actionDiagramLoading: false,
+        selectedActionId: null,
+        actionViewMode: 'network',
+        nMetaIndex: makeMetaIndex(),
+        n1MetaIndex: makeMetaIndex(),
+        actionMetaIndex: makeMetaIndex(),
+        nSvgContainerRef: makeContainer(),
+        n1SvgContainerRef: makeContainer(),
+        actionSvgContainerRef: makeContainer(),
+        setActionViewMode: vi.fn(),
+    } as unknown as DiagramsState;
+    return { ...base, ...overrides } as DiagramsState;
+};
+
+// Regression: the call order drives the DOM append order in
+// `#nad-background-layer`, which in turn drives visual stacking —
+// later-appended = drawn on top. The product spec is
+// "action halo > overload halo > contingency halo" (bottom to top).
+// Before the fix, the hook invoked overload → contingency on N-1 and
+// overload → action → contingency on the Remedial Action tab, which
+// placed the yellow contingency halo on top of the pink action halo.
+describe('useDiagramHighlights — halo call order matches product spec', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('N-1 tab invokes contingency BEFORE overload (so overload draws on top)', () => {
+        const result = {
+            lines_overloaded: ['OVL_LINE'],
+            actions: {},
+            action_scores: {},
+        } as unknown as AnalysisResult;
+        const diagrams = makeDiagramsState({ activeTab: 'n-1' });
+
+        renderHook(() => useDiagramHighlights({
+            diagrams,
+            result,
+            selectedBranch: 'CONT_LINE',
+            selectedOverloads: new Set<string>(),
+            monitoringFactor: 0.95,
+            detachedTabs: {},
+        }));
+
+        const contingencyOrder = (applyContingencyHighlight as unknown as { mock: { invocationCallOrder: number[] } })
+            .mock.invocationCallOrder[0];
+        const overloadOrder = (applyOverloadedHighlights as unknown as { mock: { invocationCallOrder: number[] } })
+            .mock.invocationCallOrder[0];
+        const deltaOrder = (applyDeltaVisuals as unknown as { mock: { invocationCallOrder: number[] } })
+            .mock.invocationCallOrder[0];
+
+        expect(contingencyOrder).toBeDefined();
+        expect(overloadOrder).toBeDefined();
+        expect(deltaOrder).toBeDefined();
+        // Contingency first (bottom), overload next (top), deltas last
+        // (decorate originals, don't affect the clone cascade).
+        expect(contingencyOrder).toBeLessThan(overloadOrder);
+        expect(overloadOrder).toBeLessThan(deltaOrder);
+    });
+
+    it('Remedial Action tab invokes contingency → overload → action (bottom → top)', () => {
+        const actionDetail = {
+            description_unitaire: "Ouvrir 'ACT_LINE'",
+            action_topology: { lines_ex_bus: { ACT_LINE: -1 } },
+            max_rho: 1.2,
+            lines_overloaded_after: ['OVL_LINE'],
+        };
+        const result = {
+            lines_overloaded: ['OVL_LINE'],
+            actions: { 'act-1': actionDetail },
+            action_scores: {},
+        } as unknown as AnalysisResult;
+        const diagrams = makeDiagramsState({
+            activeTab: 'action',
+            selectedActionId: 'act-1',
+        });
+
+        renderHook(() => useDiagramHighlights({
+            diagrams,
+            result,
+            selectedBranch: 'CONT_LINE',
+            selectedOverloads: new Set<string>(),
+            monitoringFactor: 0.95,
+            detachedTabs: {},
+        }));
+
+        const contingencyOrder = (applyContingencyHighlight as unknown as { mock: { invocationCallOrder: number[] } })
+            .mock.invocationCallOrder[0];
+        const overloadOrder = (applyOverloadedHighlights as unknown as { mock: { invocationCallOrder: number[] } })
+            .mock.invocationCallOrder[0];
+        const actionOrder = (applyActionTargetHighlights as unknown as { mock: { invocationCallOrder: number[] } })
+            .mock.invocationCallOrder[0];
+
+        expect(contingencyOrder).toBeDefined();
+        expect(overloadOrder).toBeDefined();
+        expect(actionOrder).toBeDefined();
+        // Bottom → top.
+        expect(contingencyOrder).toBeLessThan(overloadOrder);
+        expect(overloadOrder).toBeLessThan(actionOrder);
+    });
+});

--- a/frontend/src/hooks/useDiagramHighlights.ts
+++ b/frontend/src/hooks/useDiagramHighlights.ts
@@ -151,15 +151,20 @@ export function useDiagramHighlights({
         // highlight disappear in Impacts mode. Cloning first guarantees
         // the halos stay on a pristine copy of the element.
         //
+        // Stacking order (SVG draws later-appended clones ON TOP):
+        // contingency halo appended FIRST (bottom) → overload halos
+        // appended SECOND (on top). Matches the product spec
+        // "action halo > overload halo > contingency halo".
+        //
         // Overloaded lines must also be highlighted in BOTH Flows and
         // Impacts modes — the user looks at the Impacts view to see how
         // the action redistributes flows AND which lines are still
         // (or newly) overloaded; suppressing the halos in delta mode
         // hides exactly that information.
+        applyContingencyHighlight(diagrams.n1SvgContainerRef.current, diagrams.n1MetaIndex, selectedBranch);
         if (diagrams.n1MetaIndex && n1OverloadedLines.length > 0) {
           applyOverloadedHighlights(diagrams.n1SvgContainerRef.current, diagrams.n1MetaIndex, n1OverloadedLines);
         }
-        applyContingencyHighlight(diagrams.n1SvgContainerRef.current, diagrams.n1MetaIndex, selectedBranch);
         applyDeltaVisuals(diagrams.n1SvgContainerRef.current, n1Diagram, diagrams.n1MetaIndex, effectiveMode === 'delta');
       }
     }
@@ -213,13 +218,21 @@ export function useDiagramHighlights({
           }
         }
 
+        // Stacking order (SVG draws later-appended clones ON TOP):
+        // contingency halo appended FIRST (bottom), overload halos
+        // SECOND (middle), action-target halo THIRD (top). Matches
+        // the product spec "action halo > overload halo > contingency
+        // halo".
+        if (diagrams.actionSvgContainerRef.current) {
+          applyContingencyHighlight(diagrams.actionSvgContainerRef.current, diagrams.actionMetaIndex, selectedBranch);
+        }
+
         if (diagrams.actionSvgContainerRef.current && diagrams.actionMetaIndex) {
           applyOverloadedHighlights(diagrams.actionSvgContainerRef.current, diagrams.actionMetaIndex, overloadsToHighlight);
         }
 
         if (diagrams.actionSvgContainerRef.current) {
           applyActionTargetHighlights(diagrams.actionSvgContainerRef.current, diagrams.actionMetaIndex, actionDetail, selectedActionId);
-          applyContingencyHighlight(diagrams.actionSvgContainerRef.current, diagrams.actionMetaIndex, selectedBranch);
         }
       }
       else {

--- a/frontend/src/utils/svgUtils.test.ts
+++ b/frontend/src/utils/svgUtils.test.ts
@@ -1247,6 +1247,96 @@ describe('Highlight Layering', () => {
             expect(deltaIdx).toBeGreaterThan(Math.max(overloadIdx, contingencyIdx, actionTargetIdx));
         });
     });
+
+    // REGRESSION (Remedial Action tab post–action-variant-diagram-patch):
+    // The three NAD halo primitives append clones to
+    // `#nad-background-layer` in call-order; the last-appended clone
+    // draws on top (SVG paints in document order). The product
+    // spec is "action halo > overload halo > contingency halo"
+    // (bottom-to-top), so the call order must be contingency →
+    // overload → action. Before the fix, useDiagramHighlights invoked
+    // them as overload → action → contingency on the Remedial Action
+    // tab, which put the yellow contingency halo on top of the pink
+    // action halo — reversed.
+    describe('Halo layering order (contingency below overload below action)', () => {
+        const buildNAD = () => {
+            const container = document.createElement('div');
+            container.innerHTML = `
+                <svg>
+                    <g id="svg-cont" data-role="contingency"></g>
+                    <g id="svg-ovl" data-role="overload"></g>
+                    <g id="svg-act" data-role="action"></g>
+                </svg>
+            `;
+            return container;
+        };
+
+        const metaIndex = {
+            edgesByEquipmentId: new Map([
+                ['CONT_LINE', { equipmentId: 'CONT_LINE', svgId: 'svg-cont' } as EdgeMeta],
+                ['OVL_LINE', { equipmentId: 'OVL_LINE', svgId: 'svg-ovl' } as EdgeMeta],
+                ['ACT_LINE', { equipmentId: 'ACT_LINE', svgId: 'svg-act' } as EdgeMeta],
+            ]),
+            nodesByEquipmentId: new Map(),
+            nodesBySvgId: new Map(),
+            edgesByNode: new Map(),
+        } as MetadataIndex;
+
+        it('Remedial Action tab call-order (contingency → overload → action) stacks halos bottom → top', () => {
+            const container = buildNAD();
+            const actionDetail = {
+                description_unitaire: "Ouvrir 'ACT_LINE'",
+                action_topology: { lines_ex_bus: { ACT_LINE: -1 } },
+            } as unknown as ActionDetail;
+
+            // Exact order of useDiagramHighlights.applyHighlightsForTab('action'):
+            applyContingencyHighlight(container, metaIndex, 'CONT_LINE');
+            applyOverloadedHighlights(container, metaIndex, ['OVL_LINE']);
+            applyActionTargetHighlights(container, metaIndex, actionDetail, 'act-1');
+
+            const bgLayer = container.querySelector('#nad-background-layer');
+            expect(bgLayer).not.toBeNull();
+            const children = Array.from(bgLayer!.children) as Element[];
+            // First appended is drawn at the bottom; last appended is on top.
+            const classes = children.map(c => {
+                if (c.classList.contains('nad-contingency-highlight')) return 'contingency';
+                if (c.classList.contains('nad-overloaded')) return 'overload';
+                if (c.classList.contains('nad-action-target')) return 'action';
+                return 'other';
+            });
+            const contingencyIdx = classes.indexOf('contingency');
+            const overloadIdx = classes.indexOf('overload');
+            const actionIdx = classes.indexOf('action');
+            expect(contingencyIdx).toBeGreaterThanOrEqual(0);
+            expect(overloadIdx).toBeGreaterThanOrEqual(0);
+            expect(actionIdx).toBeGreaterThanOrEqual(0);
+            // Bottom → top: contingency, then overload, then action.
+            expect(contingencyIdx).toBeLessThan(overloadIdx);
+            expect(overloadIdx).toBeLessThan(actionIdx);
+        });
+
+        it('N-1 tab call-order (contingency → overload) stacks contingency below overload', () => {
+            const container = buildNAD();
+
+            // Exact order of useDiagramHighlights.applyHighlightsForTab('n-1'):
+            applyContingencyHighlight(container, metaIndex, 'CONT_LINE');
+            applyOverloadedHighlights(container, metaIndex, ['OVL_LINE']);
+
+            const bgLayer = container.querySelector('#nad-background-layer');
+            expect(bgLayer).not.toBeNull();
+            const children = Array.from(bgLayer!.children) as Element[];
+            const contingencyIdx = children.findIndex(c =>
+                c.classList.contains('nad-contingency-highlight'),
+            );
+            const overloadIdx = children.findIndex(c =>
+                c.classList.contains('nad-overloaded'),
+            );
+            expect(contingencyIdx).toBeGreaterThanOrEqual(0);
+            expect(overloadIdx).toBeGreaterThanOrEqual(0);
+            // Bottom → top: contingency, then overload.
+            expect(contingencyIdx).toBeLessThan(overloadIdx);
+        });
+    });
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary

This PR fixes two regressions affecting the Remedial Action Impacts view:

1. **Flow delta freshness**: Action-variant flow snapshots were being captured AFTER the shared network's working variant was switched to N-1, causing both action and N-1 flows to read from the same N-1 state, resulting in zero deltas and no SLD coloring.

2. **Halo stacking order**: On the Remedial Action tab, contingency and overload halos were being appended in the wrong order, placing the yellow contingency halo on top of the pink action halo instead of below it.

## Key Changes

### Backend (expert_backend)

- **diagram_mixin.py**: Restructured `get_action_variant_sld()` to mirror the NAD sibling endpoint `get_action_variant_diagram()`:
  - Capture action-variant flow and asset snapshots BEFORE switching to N-1 variant
  - Use the new `_snapshot_n1_state()` helper to safely read N-1 flows while preserving action snapshots
  - Snapshot switch state before variant switch to avoid flow extraction failures
  - Added detailed comments explaining the variant-switch cadence and shared network behavior

- **test_sld_highlight.py**: Added comprehensive regression tests:
  - `TestActionVariantSldDeltaFreshness.test_action_flows_snapshot_is_taken_before_n1_variant_switch()`: Verifies flow snapshots are captured before N-1 switch using a mock network that returns different flows per variant
  - `test_sld_deltas_match_nad_deltas_for_same_action()`: Ensures SLD and NAD endpoints compute identical deltas for the same action

### Frontend (frontend/src)

- **SldOverlay.tsx**: Converted delta painter from `useEffect` to `useLayoutEffect` with self-gating:
  - Runs synchronously after commit but before paint (same timing as highlight effect)
  - Uses signature + DOM-presence probe to skip repaints on identical re-renders
  - Prevents visible flash of un-painted state during continuous panning
  - Clears delta state when toggling back to Flows mode

- **useDiagramHighlights.ts**: Fixed halo call order on Remedial Action tab:
  - Ensures contingency halo appended first (bottom), overload second (middle), action last (top)
  - Matches product spec: "action halo > overload halo > contingency halo"

- **ActionOverviewDiagram.tsx**: Refactored threshold filter widget:
  - Replaced range slider with compact integer-% number input (0–300%)
  - Adjusted header padding and layout to prevent wrapping
  - Added horizontal scroll for filter controls on narrow viewports

- **ActionSearchDropdown.tsx**: Added warning banner for filtered-out scored actions:
  - Shows "no relevant action detected" when analysis has run but type filter hides all scored actions
  - Suppressed when analysis hasn't run or 'all' filter is active

- **ActionFeed.tsx**: Gated "Make a first guess" button:
  - Hidden while analysis is in progress, pending, or completed
  - Reappears only after state reset (contingency change, study reload)

### Tests

- **SldOverlay.test.tsx**: Added regression suite for delta persistence across pan/re-render
- **useDiagramHighlights.test.ts**: New test file verifying halo call order matches product spec
- **ActionSearchDropdown.test.tsx**: Tests for no-relevant-action warning
- **ActionFeed.test.tsx**: Tests for "Make a first guess" gating logic
- **ActionOverviewDiagram.test.tsx**: Updated threshold widget tests for number input
- **svgUtils.test.ts**: Added halo layering order regression tests

## Implementation Details

- The shared pypowsybl.Network object is mutualised between `self._get_base_network()` and `obs._network_manager.network`, so variant switches affect both references. The fix ensures action flows are captured before any variant switch.
- Flow snapshots use `.copy()` to materialise pandas DataFram

https://claude.ai/code/session_01T7TYC1HGQNMBSAqKCveFaC