### PR TITLE
Surface target max rho on user-selected overloads in pair estimation

### DIFF
--- a/expert_backend/services/analysis_mixin.py
+++ b/expert_backend/services/analysis_mixin.py
@@ -356,6 +356,14 @@ class AnalysisMixin:
             results = run_analysis_step2_discovery(context)
             self._last_result = results
 
+            enriched_actions = self._enrich_actions(
+                results["prioritized_actions"],
+                lines_overloaded_names=results.get("lines_overloaded_names"),
+            )
+            # Never leak combined-action ids into the main actions feed —
+            # those are estimations that live in `combined_actions`.
+            enriched_actions = {aid: data for aid, data in enriched_actions.items() if "+" not in aid}
+
             # Enrich each pre-computed pair with a `target_max_rho` /
             # `target_max_rho_line` scoped to the user-selected overloads
             # — the UI can show this alongside the library's global

--- a/expert_backend/services/analysis_mixin.py
+++ b/expert_backend/services/analysis_mixin.py
@@ -61,6 +61,10 @@ from expert_backend.services.analysis.mw_start_scoring import (
 )
 from expert_backend.services.analysis.pdf_watcher import find_latest_pdf
 from expert_backend.services.sanitize import sanitize_for_json
+from expert_backend.services.simulation_helpers import (
+    compute_combined_rho,
+    compute_target_max_rho,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -352,13 +356,13 @@ class AnalysisMixin:
             results = run_analysis_step2_discovery(context)
             self._last_result = results
 
-            enriched_actions = self._enrich_actions(
-                results["prioritized_actions"],
-                lines_overloaded_names=results.get("lines_overloaded_names"),
-            )
-            # Never leak combined-action ids into the main actions feed —
-            # those are estimations that live in `combined_actions`.
-            enriched_actions = {aid: data for aid, data in enriched_actions.items() if "+" not in aid}
+            # Enrich each pre-computed pair with a `target_max_rho` /
+            # `target_max_rho_line` scoped to the user-selected overloads
+            # — the UI can show this alongside the library's global
+            # `max_rho` so the operator sees the pair's effect on the
+            # contingency they're resolving even when linearisation
+            # noise puts the global max on an off-target line.
+            self._augment_combined_actions_with_target_max_rho(results, context)
 
             action_scores = self._compute_mw_start_for_scores(results.get("action_scores", {}))
 
@@ -381,6 +385,59 @@ class AnalysisMixin:
         except Exception as e:
             logger.exception("Backend Error in Analysis Resolution")
             yield {"type": "error", "message": f"Backend Error in Analysis Resolution: {str(e)}"}
+
+    def _augment_combined_actions_with_target_max_rho(self, results: dict, context: dict) -> None:
+        """Add ``target_max_rho`` / ``target_max_rho_line`` to each
+        pre-computed pair in ``results['combined_actions']``.
+
+        The target max is computed over ``context['lines_overloaded_ids']``
+        only — the user-selected overloads that the pair is meant to
+        resolve — using the same formula as the on-demand
+        ``compute_superposition`` path.  Leaves ``max_rho`` /
+        ``max_rho_line`` untouched so the global-scan warning for
+        newly-introduced overloads is preserved (see
+        ``test_superposition_max_rho_filtering_regression``).
+        """
+        combined_actions = results.get("combined_actions") or {}
+        if not combined_actions:
+            return
+        obs_start = context.get("obs_simu_defaut")
+        lines_overloaded_ids = context.get("lines_overloaded_ids") or []
+        prioritized = results.get("prioritized_actions") or {}
+        if obs_start is None or not lines_overloaded_ids:
+            return
+
+        try:
+            name_line_list = list(obs_start.name_line)
+        except Exception as e:
+            logger.debug("target max_rho: cannot read name_line: %s", e)
+            return
+        monitoring_factor = float(getattr(config, "MONITORING_FACTOR_THERMAL_LIMITS", 0.95))
+
+        for pair_id, pair in combined_actions.items():
+            if not isinstance(pair, dict) or "error" in pair:
+                continue
+            betas = pair.get("betas")
+            if not betas or len(betas) != 2:
+                continue
+            try:
+                aid1, aid2 = [p.strip() for p in pair_id.split("+", 1)]
+            except ValueError:
+                continue
+            obs1 = (prioritized.get(aid1) or {}).get("observation")
+            obs2 = (prioritized.get(aid2) or {}).get("observation")
+            if obs1 is None or obs2 is None:
+                continue
+            try:
+                rho_combined = compute_combined_rho(obs_start, obs1, obs2, list(betas))
+            except Exception as e:
+                logger.debug("target max_rho: rho_combined failed for %s: %s", pair_id, e)
+                continue
+            target_max, target_line = compute_target_max_rho(
+                rho_combined, name_line_list, list(lines_overloaded_ids),
+            )
+            pair["target_max_rho"] = target_max * monitoring_factor if target_max else 0.0
+            pair["target_max_rho_line"] = target_line
 
     @staticmethod
     def _narrow_context_to_selected_overloads(

--- a/expert_backend/services/simulation_helpers.py
+++ b/expert_backend/services/simulation_helpers.py
@@ -466,3 +466,36 @@ def compute_combined_rho(
         + betas[0] * obs_act1.rho
         + betas[1] * obs_act2.rho
     )
+
+
+def compute_target_max_rho(
+    rho_combined: np.ndarray,
+    name_line_list: Any,
+    lines_overloaded_ids: list[int],
+) -> tuple[float, str]:
+    """Pick max rho / line over the user-selected overloaded lines only.
+
+    Rationale: the global ``max_rho`` scan across every monitored line
+    has to stay broad to catch NEW overloads that the action pair may
+    introduce (see ``test_superposition_max_rho_filtering_regression``
+    which pins that behaviour).  But on lines far from either action,
+    linearisation error can put an arbitrary high-loaded line at the
+    top of the scan — a line with no relation to the contingency the
+    user is resolving.  The "target" max reports the effect ON THE
+    LINES THE USER CARES ABOUT — the contingency's actual overloads —
+    so the UI can surface it alongside the global max and give a
+    direct estimated-vs-simulated comparison on the same line set.
+
+    Returns ``(0.0, "N/A")`` when no overload ids are available or all
+    are out of range (caller should treat that as "no target info").
+    """
+    if not lines_overloaded_ids:
+        return 0.0, "N/A"
+    n_lines = len(rho_combined)
+    focus_ids = [int(i) for i in lines_overloaded_ids if 0 <= int(i) < n_lines]
+    if not focus_ids:
+        return 0.0, "N/A"
+    focus_rho = rho_combined[focus_ids]
+    argmax = int(np.argmax(focus_rho))
+    names = list(name_line_list)
+    return float(focus_rho[argmax]), str(names[focus_ids[argmax]])

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -32,6 +32,7 @@ from expert_backend.services.simulation_helpers import (
     compute_action_metrics,
     compute_combined_rho,
     compute_reduction_setpoint,
+    compute_target_max_rho,
     extract_action_topology,
     is_pst_action,
     normalise_non_convergence,
@@ -881,6 +882,10 @@ class SimulationMixin:
             max_rho = float(masked_rho[max_idx])
             max_rho_line = masked_names[max_idx]
 
+        target_max_rho, target_max_rho_line = compute_target_max_rho(
+            rho_combined, name_line_list, lines_overloaded_ids,
+        )
+
         logger.info(
             "[compute_superposition] monitored lines: %d/%d, lines_overloaded force-included: %d",
             int(np.sum(care_mask)), num_lines, len(lines_overloaded_ids),
@@ -897,6 +902,13 @@ class SimulationMixin:
         result.update({
             "max_rho": max_rho * monitoring_factor,
             "max_rho_line": max_rho_line,
+            # Max computed over the USER-SELECTED overloaded lines — the
+            # ones the pair is meant to resolve.  Lets the UI show the
+            # effect on the target contingency alongside the global
+            # `max_rho`, which may land on an off-target line due to
+            # linearisation error on lines far from either action.
+            "target_max_rho": target_max_rho * monitoring_factor if target_max_rho else 0.0,
+            "target_max_rho_line": target_max_rho_line,
             "is_rho_reduction": is_rho_reduction,
             "rho_after": (rho_combined[lines_overloaded_ids] * monitoring_factor).tolist(),
             "rho_before": (obs_start.rho[lines_overloaded_ids] * monitoring_factor).tolist(),

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -208,6 +208,21 @@ class SimulationMixin:
 
         action = self._build_combined_action_object(action_ids, env, recent_actions)
 
+        # Re-pin the working variant to N-1 immediately before the
+        # simulate call.  `_fetch_n_and_n1_observations` may have
+        # returned cached observations WITHOUT adjusting the variant
+        # (see that function's cache-hit branches at lines 314-330),
+        # so the working variant can be left on N — or wherever a
+        # previous caller left it.  `obs.simulate(action,
+        # keep_variant=True)` applies the action on top of the CURRENT
+        # working variant in-place, so if we don't pin to N-1 here the
+        # simulation can run against the N state instead of N-1.  That
+        # surfaces on the frontend as Simulated Line landing on the
+        # contingency line itself with non-zero rho (physically
+        # impossible in N-1 where the contingency is disconnected).
+        n1_variant_id = self._get_n1_variant(disconnected_element)
+        n.set_working_variant(n1_variant_id)
+
         actual_fast_mode = getattr(config, "PYPOWSYBL_FAST_MODE", False)
         obs_simu_action, _, _, info_action = obs_simu_defaut.simulate(
             action,

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -628,8 +628,19 @@ class SimulationMixin:
         original_variant = n.get_working_variant_id()
 
         # Fetch N-1 and N observations (order matters for test mocks).
-        n.set_working_variant(self._get_n1_variant(disconnected_element))
-        obs_start = env.get_obs()
+        # Prefer the N-1 observation captured at step1 when available —
+        # grid2op's ``obs.simulate(action, keep_variant=True)`` used by
+        # ``simulate_manual_action`` can mutate the shared N-1 variant,
+        # so a fresh ``env.get_obs()`` here would drift away from the
+        # baseline step2 used to pre-compute ``combined_actions`` betas.
+        # Reusing the context obs keeps the on-demand re-estimation
+        # numerically consistent with the "Computed Pairs" view.
+        ctx_obs_n1 = self._obs_n1_from_context()
+        if ctx_obs_n1 is not None:
+            obs_start = ctx_obs_n1
+        else:
+            n.set_working_variant(self._get_n1_variant(disconnected_element))
+            obs_start = env.get_obs()
         self._log_per_line_rho(action1_id, action2_id, line_idxs1, line_idxs2, obs_start, env, all_actions)
 
         monitoring_factor = getattr(config, "MONITORING_FACTOR_THERMAL_LIMITS", 0.95)
@@ -762,16 +773,32 @@ class SimulationMixin:
     ):
         """Determine the active monitoring set for the superposition result.
 
-        Prefers `_analysis_context.lines_overloaded` when available (keeps
-        the pair result aligned with the step2 analysis view); otherwise
-        recomputes from `obs_start` with the same pre-existing-worsening
-        rule as `simulate_manual_action`.
+        Prefers the analysis context's overload set when available (keeps
+        the pair result aligned with the step2 "Computed Pairs" view);
+        otherwise recomputes from `obs_start` with the same
+        pre-existing-worsening rule as `simulate_manual_action`.
+
+        Context lookup order:
+          1. ``lines_overloaded_ids`` — indices resolved by step1 against
+             the same ``name_line`` ordering (used by step2 discovery).
+          2. ``lines_overloaded_names`` — step1 populates this key.
+          3. ``lines_overloaded`` — written by session reload
+             (``restore_analysis_context``).
         """
-        ctx_overloaded = (self._analysis_context or {}).get("lines_overloaded")
+        ctx = self._analysis_context or {}
+        ctx_ids = ctx.get("lines_overloaded_ids")
+        if ctx_ids:
+            ids = [int(i) for i in ctx_ids if 0 <= int(i) < len(name_line_list)]
+            logger.info(
+                "[compute_superposition] Using analysis context lines_overloaded_ids: %d lines",
+                len(ids),
+            )
+            return ids
+        ctx_overloaded = ctx.get("lines_overloaded_names") or ctx.get("lines_overloaded")
         if ctx_overloaded:
             ids = [name_to_idx_map[l] for l in ctx_overloaded if l in name_to_idx_map]
             logger.info(
-                "[compute_superposition] Using analysis context lines_overloaded: %d lines",
+                "[compute_superposition] Using analysis context lines_overloaded names: %d lines",
                 len(ids),
             )
             return ids

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -171,7 +171,35 @@ class SimulationMixin:
         n = nm.network
         original_variant = n.get_working_variant_id()
 
-        obs, obs_simu_defaut = self._fetch_n_and_n1_observations(env, n, disconnected_element)
+        # Prefer the (obs, obs_simu_defaut) pair captured by step1 and
+        # stored on ``_analysis_context``. The grid2op ↔ pypowsybl env
+        # bridge does not re-sync ``env.get_obs()`` to
+        # ``n.set_working_variant(...)``, so a fresh fetch here can
+        # return an N-state observation even after pinning the N-1
+        # variant — the downstream ``obs.simulate(..., keep_variant=True)``
+        # would then run against the wrong baseline and the backend's
+        # max_rho drifts from the library's own simulation. Reusing the
+        # step1 obs keeps this path numerically aligned with step2 and
+        # with ``compute_superposition`` (which uses the same pattern
+        # via ``_obs_n1_from_context``).
+        ctx = self._analysis_context or {}
+        ctx_obs_n1 = self._obs_n1_from_context()
+        ctx_obs_n = ctx.get("obs")
+        used_context_obs = ctx_obs_n1 is not None and ctx_obs_n is not None
+        if used_context_obs:
+            obs, obs_simu_defaut = ctx_obs_n, ctx_obs_n1
+            # NOTE: do NOT overwrite ``obs_simu_defaut._variant_id``. The
+            # library stamped it at step1 with its own kept variant id,
+            # and ``pypowsybl_backend.observation.simulate`` clones from
+            # ``self._variant_id`` at simulate time — rewriting it to a
+            # backend-scoped variant that doesn't exist in the library's
+            # ``NetworkManager`` would raise ``Variant ... not found``.
+        else:
+            # Fallback: no step1 context (direct simulate without prior
+            # step1, or session reload — ``restore_analysis_context``
+            # doesn't serialize obs objects). The stale-obs desync still
+            # applies on this path; tracked as a follow-up.
+            obs, obs_simu_defaut = self._fetch_n_and_n1_observations(env, n, disconnected_element)
         obs_n1 = obs_simu_defaut
 
         self._create_dynamic_actions_if_needed(
@@ -208,20 +236,17 @@ class SimulationMixin:
 
         action = self._build_combined_action_object(action_ids, env, recent_actions)
 
-        # Re-pin the working variant to N-1 immediately before the
-        # simulate call.  `_fetch_n_and_n1_observations` may have
-        # returned cached observations WITHOUT adjusting the variant
-        # (see that function's cache-hit branches at lines 314-330),
-        # so the working variant can be left on N — or wherever a
-        # previous caller left it.  `obs.simulate(action,
-        # keep_variant=True)` applies the action on top of the CURRENT
-        # working variant in-place, so if we don't pin to N-1 here the
-        # simulation can run against the N state instead of N-1.  That
-        # surfaces on the frontend as Simulated Line landing on the
-        # contingency line itself with non-zero rho (physically
-        # impossible in N-1 where the contingency is disconnected).
-        n1_variant_id = self._get_n1_variant(disconnected_element)
-        n.set_working_variant(n1_variant_id)
+        # Re-pin the working variant to the backend's N-1 only on the
+        # fallback path. `_fetch_n_and_n1_observations` can return a
+        # cached obs whose associated working variant has drifted (its
+        # cache-hit branches don't touch the variant), so an
+        # ``obs.simulate(..., keep_variant=True)`` on that obs can run
+        # against the wrong variant. The context path is already safe:
+        # the library stamped ``obs_simu_defaut._variant_id`` to its own
+        # kept N-1 variant, which ``pypowsybl_backend.observation.simulate``
+        # clones from directly (independent of the working variant).
+        if not used_context_obs:
+            n.set_working_variant(self._get_n1_variant(disconnected_element))
 
         actual_fast_mode = getattr(config, "PYPOWSYBL_FAST_MODE", False)
         obs_simu_action, _, _, info_action = obs_simu_defaut.simulate(

--- a/expert_backend/tests/test_cache_synchronization.py
+++ b/expert_backend/tests/test_cache_synchronization.py
@@ -169,7 +169,153 @@ class TestCacheSynchronization:
         obs_n1._variant_id = "v1"
         service._cached_obs_n1 = obs_n1
         service._cached_obs_n1_id = "v1"
-        
+
         # If the code incorrectly did e.g. self._cached_obs_n1.some_prop = x
         # verify it stays isolated. Here we check that the object identity is preserved.
         assert service._cached_obs_n1 is obs_n1
+
+    @patch.object(RecommenderService, '_get_n1_variant')
+    @patch.object(RecommenderService, '_get_n_variant')
+    @patch.object(RecommenderService, '_get_simulation_env')
+    @patch.object(RecommenderService, '_get_base_network')
+    def test_simulate_manual_action_prefers_context_obs_over_stale_env_get_obs(
+        self, mock_get_net, mock_get_env, mock_get_n, mock_get_n1,
+    ):
+        """``simulate_manual_action`` must reuse the (obs, obs_simu_defaut)
+        captured by step1 in ``_analysis_context`` instead of re-fetching via
+        ``env.get_obs()``.
+
+        The grid2op ↔ pypowsybl env bridge does not re-sync
+        ``env.get_obs()`` with ``n.set_working_variant(...)``, so a fresh
+        fetch can return an N-state observation even after pinning the
+        N-1 variant. That surfaced as a ~46-point gap between the
+        "Max Loading (Est.)" and "Simulated Max Rho" columns in the
+        Computed Pairs modal. This test guards against the regression by
+        asserting that when step1 context is present:
+
+        1. ``env.get_obs()`` is NEVER called (no stale fetch).
+        2. The context obs is propagated to the downstream
+           ``compute_action_metrics`` via ``rho_before``.
+        3. ``obs.simulate(...)`` is called on the context ``obs_simu_defaut``
+           (not on a freshly fetched stale obs).
+        """
+        service = RecommenderService()
+        service._dict_action = {"act1": {"content": {}}}
+        service._last_result = {"prioritized_actions": {}}
+
+        mock_get_n.return_value = "n_var"
+        mock_get_n1.return_value = "n1_var"
+
+        env = MagicMock()
+        n = MagicMock()
+        nm = MagicMock()
+        nm.network = n
+        env.network_manager = nm
+        n.get_working_variant_id.return_value = "original_var"
+        mock_get_env.return_value = env
+        mock_get_net.return_value = n
+
+        # Context observations (what step1 captured). These are the
+        # "correct" N / N-1 obs the fix must propagate.
+        ctx_obs_n = MagicMock(name="ctx_obs_n")
+        ctx_obs_n.rho = [0.5]
+        ctx_obs_n.name_line = ["L1"]
+        ctx_obs_n.n_components = 1
+        ctx_obs_n1 = MagicMock(name="ctx_obs_n1")
+        ctx_obs_n1.rho = [0.9]  # overload on L1 in N-1
+        ctx_obs_n1.name_line = ["L1"]
+        ctx_obs_n1.n_components = 1
+        ctx_obs_n1._variant_id = "library_kept_variant"
+
+        obs_after = MagicMock(name="obs_after")
+        obs_after.rho = [0.7]
+        obs_after.name_line = ["L1"]
+        obs_after.n_components = 1
+        obs_after.main_component_load_mw = 100.0
+        ctx_obs_n1.simulate.return_value = (obs_after, None, None, {"exception": None})
+
+        service._analysis_context = {
+            "obs": ctx_obs_n,
+            "obs_simu_defaut": ctx_obs_n1,
+            "lines_overloaded": ["L1"],
+        }
+
+        # env.get_obs MUST NOT be called — prove it by raising if it is.
+        env.get_obs.side_effect = AssertionError(
+            "env.get_obs() called while step1 context is available — "
+            "stale-baseline regression"
+        )
+
+        with patch.object(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95), \
+             patch.object(config, 'PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD', 0.02):
+            result = service.simulate_manual_action("act1", "DISCO_A")
+
+        # 1. get_obs never called → baseline is the step1 context obs.
+        assert env.get_obs.call_count == 0
+
+        # 2. rho_before reflects ctx_obs_n1 (0.9 × monitoring_factor), not
+        #    a stale N-state value. Cross-check the published metric to
+        #    prove the context obs actually fed compute_action_metrics.
+        assert result.get("rho_before") == pytest.approx([0.9 * 0.95], abs=1e-9)
+
+        # 3. ``.simulate()`` was invoked on the context obs specifically
+        #    (not on a freshly-fetched stale obs).
+        assert ctx_obs_n1.simulate.call_count == 1
+
+    @patch.object(RecommenderService, '_get_n1_variant')
+    @patch.object(RecommenderService, '_get_n_variant')
+    @patch.object(RecommenderService, '_get_simulation_env')
+    @patch.object(RecommenderService, '_get_base_network')
+    def test_simulate_manual_action_falls_back_to_env_get_obs_without_context(
+        self, mock_get_net, mock_get_env, mock_get_n, mock_get_n1,
+    ):
+        """Without step1 context, ``simulate_manual_action`` must still
+        work via the fallback ``_fetch_n_and_n1_observations`` path and
+        the pre-simulate N-1 re-pin must fire (since the fallback's
+        cache-hit branches can leave the working variant drifted)."""
+        service = RecommenderService()
+        service._dict_action = {"act1": {"content": {}}}
+        service._last_result = {"prioritized_actions": {}}
+        service._analysis_context = None  # no step1 → fallback path
+
+        mock_get_n.return_value = "n_var"
+        mock_get_n1.return_value = "n1_var"
+
+        env = MagicMock()
+        n = MagicMock()
+        nm = MagicMock()
+        nm.network = n
+        env.network_manager = nm
+        n.get_working_variant_id.return_value = "original_var"
+        mock_get_env.return_value = env
+        mock_get_net.return_value = n
+
+        obs_n = MagicMock(name="obs_n")
+        obs_n.rho = [0.5]
+        obs_n.name_line = ["L1"]
+        obs_n.n_components = 1
+        obs_n1 = MagicMock(name="obs_n1")
+        obs_n1.rho = [0.9]
+        obs_n1.name_line = ["L1"]
+        obs_n1.n_components = 1
+        obs_after = MagicMock(name="obs_after")
+        obs_after.rho = [0.7]
+        obs_after.name_line = ["L1"]
+        obs_after.n_components = 1
+        obs_after.main_component_load_mw = 100.0
+        obs_n1.simulate.return_value = (obs_after, None, None, {"exception": None})
+
+        env.get_obs.side_effect = [obs_n, obs_n1]
+
+        with patch.object(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95), \
+             patch.object(config, 'PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD', 0.02):
+            service.simulate_manual_action("act1", "DISCO_A")
+
+        # Fallback path invokes env.get_obs twice (N + N-1).
+        assert env.get_obs.call_count == 2
+        # The pre-simulate re-pin to N-1 must fire on the fallback path.
+        targets = [c.args[0] for c in n.set_working_variant.call_args_list]
+        assert "n1_var" in targets, (
+            f"expected a pre-simulate re-pin to 'n1_var' on fallback; "
+            f"actual targets: {targets}"
+        )

--- a/expert_backend/tests/test_cache_synchronization.py
+++ b/expert_backend/tests/test_cache_synchronization.py
@@ -84,10 +84,17 @@ class TestCacheSynchronization:
         # Contingency A
         mock_get_n.return_value = "n_var"
         # Each `simulate_manual_action` call now triggers `_get_n1_variant`
-        # twice — once via the `_ensure_n1_state_ready` guard at entry
-        # (see docs/performance/history/grid2op-shared-network.md), once inside the
-        # simulation body. Two simulate calls → four side-effect values.
-        mock_get_n1.side_effect = ["n1_A", "n1_A", "n1_B", "n1_B"]
+        # three times:
+        #   1. the `_ensure_n1_state_ready` guard at entry (see
+        #      docs/performance/history/grid2op-shared-network.md),
+        #   2. the N-1 fetch inside `_fetch_n_and_n1_observations`,
+        #   3. the explicit pre-simulate pin added to guarantee the
+        #      working variant is on N-1 before
+        #      `obs.simulate(action, keep_variant=True)` runs (otherwise
+        #      cache-hit paths leave the variant on N and the combined
+        #      simulation applies the action to the wrong base state).
+        # Two simulate calls → six side-effect values.
+        mock_get_n1.side_effect = ["n1_A", "n1_A", "n1_A", "n1_B", "n1_B", "n1_B"]
         
         obs_n = MagicMock(name="obs_n")
         obs_n.rho = [0.5]

--- a/expert_backend/tests/test_combined_actions_scenario.py
+++ b/expert_backend/tests/test_combined_actions_scenario.py
@@ -369,6 +369,59 @@ def test_combined_actions_superposition(scenario_data, analysis_results):
         print(f"  {pair_key}: betas={[round(b, 4) for b in betas]}, "
               f"max_rho={pair_data['max_rho']:.3f}, rho_reduction={pair_data['is_rho_reduction']}")
 
+def test_compute_superposition_agrees_with_precomputed_pair(scenario_data, analysis_results):
+    """Regression: estimating a pair in Explore Pairs (on-demand
+    ``compute_superposition``) must return the same betas and
+    ``max_rho`` as the pre-computed "Computed Pairs" entry produced by
+    step2's ``run_analysis_step2_discovery`` for the identical pair.
+
+    Before the fix, the on-demand path fetched a fresh ``obs_start``
+    from ``env.get_obs()`` while the pre-computed path used the N-1
+    observation captured at step1. Grid2Op's
+    ``obs.simulate(action, keep_variant=True)`` (invoked by each
+    ``simulate_manual_action``) could mutate the shared N-1 variant,
+    so the fresh fetch drifted away from the step1 baseline and
+    produced very different betas (e.g. ``[3.193, 1.479]`` vs the
+    pre-computed ``[1.10, 0.92]``), sometimes flagged as "unreliable
+    superposition — betas outside [-2.0, 3.0]".
+    """
+    combined = analysis_results.get("combined_actions", {}) or {}
+    candidate = None
+    for pair_id, pair_data in combined.items():
+        if "+" not in pair_id or "error" in pair_data:
+            continue
+        betas = pair_data.get("betas")
+        if betas and all(np.isfinite(betas)):
+            candidate = (pair_id, pair_data)
+            break
+    if candidate is None:
+        pytest.skip("No non-errored combined pair produced by this scenario")
+
+    pair_id, pre = candidate
+    action1_id, action2_id = pair_id.split("+", 1)
+    contingency = scenario_data["contingency"]
+
+    on_demand = recommender_service.compute_superposition(
+        action1_id, action2_id, contingency
+    )
+    assert "error" not in on_demand, f"on-demand failed: {on_demand.get('error')}"
+
+    # Betas must agree — small floating-point tolerance for
+    # library-internal numerical paths.
+    for i, (b_pre, b_on) in enumerate(zip(pre["betas"], on_demand["betas"])):
+        assert b_pre == pytest.approx(b_on, rel=1e-3, abs=1e-3), (
+            f"Beta[{i}] drift between step2 and on-demand for {pair_id}: "
+            f"pre-computed={b_pre} vs on-demand={b_on}"
+        )
+
+    # `max_rho` is scaled by monitoring_factor in the on-demand path;
+    # compare the ratios to the corresponding max_rho_line values.
+    assert on_demand["max_rho"] == pytest.approx(pre["max_rho"], rel=5e-3, abs=5e-3), (
+        f"max_rho drift for {pair_id}: pre-computed={pre['max_rho']} vs "
+        f"on-demand={on_demand['max_rho']}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])
 

--- a/expert_backend/tests/test_superposition_service.py
+++ b/expert_backend/tests/test_superposition_service.py
@@ -512,6 +512,54 @@ def test_augment_combined_actions_with_target_max_rho_adds_target_fields():
     assert abs(pair["target_max_rho"] - 0.20 * 0.95) < 1e-3
 
 
+def test_run_analysis_step2_emits_result_event_after_target_augmentation():
+    """Regression: the real `run_analysis_step2` body must still build
+    `enriched_actions` and yield a ``{type: 'result'}`` event.  Previous
+    failure: when the target-max-rho augmentation was added we
+    accidentally removed the `enriched_actions` block, so the final
+    yield hit ``NameError: name 'enriched_actions' is not defined``
+    at runtime — a frontend-visible 500 with no test coverage because
+    the existing split-analysis test mocks the whole method at the
+    module seam."""
+    from expert_backend.services.recommender_service import RecommenderService
+    from unittest.mock import patch
+
+    svc = RecommenderService()
+    svc._analysis_context = {
+        "obs_simu_defaut": _make_obs([0.8]),
+        "lines_overloaded_ids": [0],
+        "lines_overloaded_names": ["L0"],
+        "lines_overloaded_ids_kept": [0],
+        "lines_we_care_about": ["L0"],
+    }
+    svc._analysis_context["obs_simu_defaut"].name_line = np.array(["L0"])
+
+    results = {
+        "prioritized_actions": {},
+        "action_scores": {},
+        "lines_overloaded_names": ["L0"],
+        "combined_actions": {},
+    }
+
+    with patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph",
+               side_effect=lambda ctx: ctx), \
+         patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery",
+               return_value=results), \
+         patch.object(svc, "_get_latest_pdf_path", return_value=None), \
+         patch.object(svc, "_enrich_actions", return_value={}), \
+         patch.object(svc, "_compute_mw_start_for_scores", return_value={}):
+        events = list(svc.run_analysis_step2(["L0"]))
+
+    # pdf event + result event, both typed, no error.
+    event_types = [e.get("type") for e in events]
+    assert "error" not in event_types, f"unexpected error event: {events}"
+    assert "pdf" in event_types
+    assert "result" in event_types
+    result_event = next(e for e in events if e.get("type") == "result")
+    assert result_event["actions"] == {}
+    assert result_event["lines_overloaded"] == ["L0"]
+
+
 def test_augment_combined_actions_with_target_max_rho_is_noop_without_context():
     """No-op when the analysis context is missing obs_simu_defaut or
     lines_overloaded_ids — nothing to scope the target against."""

--- a/expert_backend/tests/test_superposition_service.py
+++ b/expert_backend/tests/test_superposition_service.py
@@ -345,6 +345,86 @@ def test_compute_superposition_falls_back_to_fresh_fetch_without_context(recomme
         assert env.get_obs.call_count == 2, "expected fresh fetch for both N-1 and N in fallback path"
 
 
+def _install_fake_monitoring(recommender, lines, with_limits=None):
+    """Short-circuit `_get_monitoring_parameters` so the test does not
+    rely on the auto-mocked pypowsybl limits chain (which otherwise
+    returns an empty `branches_with_limits` and filters every line out
+    of the care_mask)."""
+    bwl = list(lines if with_limits is None else with_limits)
+    recommender._get_monitoring_parameters = MagicMock(return_value=(list(lines), bwl))
+
+
+def test_compute_superposition_emits_target_max_rho_on_overload_lines(recommender):
+    """`compute_superposition` must return ``target_max_rho`` /
+    ``target_max_rho_line`` scoped to ``lines_overloaded_ids`` — the
+    user-selected overloads the pair is meant to resolve — so the UI
+    can surface the pair's effect on the contingency alongside the
+    global ``max_rho`` (which may land on an off-target line due to
+    linearisation error).
+
+    Regression for "Estimated Max Loading: 81.9% on LOUHAL31PYMON" vs
+    "Actual Max Loading: 52.0% on BOCTOL71N.SE5" — neither line was an
+    originally-overloaded one; target_* fields let the frontend show
+    the effect on the actual overloads.
+    """
+    aid1, aid2 = "act1", "act2"
+    name_line = ["OVERLOAD_TARGET", "FARLINE"]
+    obs_n1 = _make_obs([0.4, 0.5], [40.0, 50.0])
+    obs_n1.name_line = np.array(name_line)
+    obs1 = _make_obs([0.3, 0.6], [30.0, 60.0])
+    obs1.name_line = np.array(name_line)
+    obs2 = _make_obs([0.3, 0.55], [30.0, 55.0])
+    obs2.name_line = np.array(name_line)
+    actions = {
+        aid1: {"action": MagicMock(), "observation": obs1},
+        aid2: {"action": MagicMock(), "observation": obs2},
+    }
+    _setup_superposition_env(recommender, actions, {}, name_line=name_line)
+    _install_fake_monitoring(recommender, name_line)
+    recommender._analysis_context = {
+        "obs_simu_defaut": obs_n1,
+        "lines_overloaded_ids": [0],
+    }
+
+    with patch('expert_backend.services.simulation_mixin._identify_action_elements', return_value=([0], [])), \
+         patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_sp:
+        # rho_combined at betas=[1.5, 0.5]:
+        #   OVERLOAD_TARGET: |(1-2)*0.4 + 1.5*0.3 + 0.5*0.3|  = 0.20
+        #   FARLINE        : |(1-2)*0.5 + 1.5*0.6 + 0.5*0.55| = 0.675
+        mock_sp.return_value = {"betas": [1.5, 0.5], "p_or_combined": [100.0]}
+        result = recommender.compute_superposition(aid1, aid2, "contingency")
+
+    assert result["target_max_rho_line"] == "OVERLOAD_TARGET"
+    # target_max_rho is scaled by monitoring_factor (0.95):
+    # 0.20 * 0.95 = 0.19
+    assert abs(result["target_max_rho"] - 0.20 * 0.95) < 1e-3
+
+
+def test_compute_superposition_target_max_rho_keys_always_present(recommender):
+    """The target_max_rho / target_max_rho_line fields must always be in
+    the payload so the frontend does not have to branch on their
+    existence — the frontend can detect "no target info" via
+    ``target_max_rho_line == "N/A"``."""
+    aid1, aid2 = "act1", "act2"
+    obs1 = _make_obs([0.9], [90.0])
+    obs2 = _make_obs([0.85], [85.0])
+    actions = {
+        aid1: {"action": MagicMock(), "observation": obs1},
+        aid2: {"action": MagicMock(), "observation": obs2},
+    }
+    _setup_superposition_env(recommender, actions, {})
+    _install_fake_monitoring(recommender, ["LINE1"])
+    recommender._analysis_context = None
+
+    with patch('expert_backend.services.simulation_mixin._identify_action_elements', return_value=([0], [])), \
+         patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_sp:
+        mock_sp.return_value = {"betas": [0.5, 0.5], "p_or_combined": [100.0]}
+        result = recommender.compute_superposition(aid1, aid2, "contingency")
+
+    assert "target_max_rho" in result
+    assert "target_max_rho_line" in result
+
+
 def test_superposition_lines_overloaded_reads_context_ids_or_names(recommender):
     """`_superposition_lines_overloaded` must prefer the step1-populated
     keys (``lines_overloaded_ids`` and ``lines_overloaded_names``) so the
@@ -385,6 +465,73 @@ def test_superposition_lines_overloaded_reads_context_ids_or_names(recommender):
         monitoring_factor=0.95, worsening_threshold=0.02,
     )
     assert ids == [0]
+
+
+def test_augment_combined_actions_with_target_max_rho_adds_target_fields():
+    """`AnalysisMixin._augment_combined_actions_with_target_max_rho`
+    must add ``target_max_rho`` / ``target_max_rho_line`` to each
+    library-populated pair without touching the existing ``max_rho`` /
+    ``max_rho_line`` — preserves the global-scan new-overload warning
+    while surfacing the pair's effect on the user-selected overloads.
+    """
+    svc = RecommenderService()
+
+    name_line = ["OVERLOAD_TARGET", "FARLINE"]
+    obs_start = _make_obs([0.4, 0.5])
+    obs_start.name_line = np.array(name_line)
+    obs_act1 = _make_obs([0.3, 0.6])
+    obs_act1.name_line = np.array(name_line)
+    obs_act2 = _make_obs([0.3, 0.55])
+    obs_act2.name_line = np.array(name_line)
+
+    pair_id = "act1+act2"
+    results = {
+        "prioritized_actions": {
+            "act1": {"observation": obs_act1},
+            "act2": {"observation": obs_act2},
+        },
+        "combined_actions": {
+            pair_id: {
+                "betas": [1.5, 0.5],
+                "max_rho": 0.64,
+                "max_rho_line": "FARLINE",
+            },
+        },
+    }
+    context = {"obs_simu_defaut": obs_start, "lines_overloaded_ids": [0]}
+
+    config.MONITORING_FACTOR_THERMAL_LIMITS = 0.95
+    svc._augment_combined_actions_with_target_max_rho(results, context)
+
+    pair = results["combined_actions"][pair_id]
+    # Existing fields are preserved.
+    assert pair["max_rho_line"] == "FARLINE"
+    # New target fields are scoped to lines_overloaded_ids = [0] (OVERLOAD_TARGET).
+    assert pair["target_max_rho_line"] == "OVERLOAD_TARGET"
+    # target_max_rho is the OVERLOAD_TARGET rho (0.20) scaled by 0.95.
+    assert abs(pair["target_max_rho"] - 0.20 * 0.95) < 1e-3
+
+
+def test_augment_combined_actions_with_target_max_rho_is_noop_without_context():
+    """No-op when the analysis context is missing obs_simu_defaut or
+    lines_overloaded_ids — nothing to scope the target against."""
+    svc = RecommenderService()
+
+    results = {
+        "prioritized_actions": {},
+        "combined_actions": {
+            "act1+act2": {
+                "betas": [1.0, 1.0],
+                "max_rho": 0.80,
+                "max_rho_line": "LINE_A",
+            },
+        },
+    }
+    svc._augment_combined_actions_with_target_max_rho(results, context={})
+
+    pair = results["combined_actions"]["act1+act2"]
+    assert "target_max_rho" not in pair
+    assert "target_max_rho_line" not in pair
 
 
 if __name__ == "__main__":

--- a/expert_backend/tests/test_superposition_service.py
+++ b/expert_backend/tests/test_superposition_service.py
@@ -560,6 +560,83 @@ def test_run_analysis_step2_emits_result_event_after_target_augmentation():
     assert result_event["lines_overloaded"] == ["L0"]
 
 
+def test_simulate_manual_action_pins_n1_variant_before_simulate_even_on_cache_hit():
+    """Regression: `simulate_manual_action` must set the working variant
+    to the N-1 id IMMEDIATELY BEFORE `obs.simulate(action, keep_variant=True)`,
+    regardless of whether the N / N-1 observation caches hit.
+
+    Why: `_fetch_n_and_n1_observations` only calls `set_working_variant`
+    when a cache misses.  When both caches hit (the common case after
+    step1 has run), the working variant is left on whatever the previous
+    caller positioned — often N.  `obs.simulate(action, keep_variant=True)`
+    applies the action ON TOP OF THE CURRENT WORKING VARIANT in-place,
+    so without an explicit pin to N-1 the combined-action simulation
+    can run against the N state instead of N-1, surfacing on the
+    frontend as Simulated Line landing on the contingency line itself
+    with non-zero rho (physically impossible in true N-1).
+    """
+    svc = RecommenderService()
+    svc._dict_action = {"act1": {"content": {}, "description_unitaire": "d1"}}
+    svc._last_result = {"prioritized_actions": {}}
+
+    env = MagicMock()
+    n = env.network_manager.network
+    n.get_working_variant_id.return_value = "orig"
+    env.name_line = ["L1"]
+    obs_n = MagicMock()
+    obs_n.rho = np.array([0.5])
+    obs_n.name_line = ["L1"]
+    obs_n.n_components = 1
+    obs_n1 = MagicMock()
+    obs_n1.rho = np.array([0.8])
+    obs_n1.name_line = ["L1"]
+    obs_n1.n_components = 1
+    obs_after = MagicMock()
+    obs_after.rho = np.array([0.7])
+    obs_after.name_line = ["L1"]
+    obs_after.n_components = 1
+    obs_n1.simulate.return_value = (obs_after, None, None, {"exception": None})
+
+    svc._get_simulation_env = MagicMock(return_value=env)
+    svc._get_base_network = MagicMock(return_value=n)
+    svc._get_n_variant = MagicMock(return_value="n_var")
+    svc._get_n1_variant = MagicMock(return_value="n1_var")
+    svc._get_monitoring_parameters = MagicMock(return_value=(["L1"], ["L1"]))
+
+    # Prime both caches so `_fetch_n_and_n1_observations` takes the
+    # cache-hit branch — it will NOT touch set_working_variant, so we
+    # must verify the explicit pin-to-N-1 kicks in before .simulate().
+    svc._cached_obs_n = obs_n
+    svc._cached_obs_n_id = "n_var"
+    svc._cached_obs_n1 = obs_n1
+    svc._cached_obs_n1_id = "n1_var"
+
+    # Track the order of calls against the shared Network.
+    call_log = []
+    n.set_working_variant.side_effect = lambda vid: call_log.append(("set_working_variant", vid))
+    orig_simulate = obs_n1.simulate
+    def wrapped_simulate(*args, **kwargs):
+        call_log.append(("simulate",))
+        return orig_simulate.return_value
+    obs_n1.simulate = wrapped_simulate
+
+    config.MONITORING_FACTOR_THERMAL_LIMITS = 0.95
+    config.PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02
+    config.PYPOWSYBL_FAST_MODE = False
+
+    svc.simulate_manual_action("act1", "DISCO_A")
+
+    # Find the last set_working_variant call before the simulate call.
+    sim_idx = next((i for i, c in enumerate(call_log) if c[0] == "simulate"), None)
+    assert sim_idx is not None, "simulate was never called"
+    pre_simulate_variants = [c[1] for c in call_log[:sim_idx] if c[0] == "set_working_variant"]
+    assert pre_simulate_variants, "no set_working_variant was called before simulate"
+    assert pre_simulate_variants[-1] == "n1_var", (
+        f"expected variant pinned to N-1 ('n1_var') right before simulate, "
+        f"last set was {pre_simulate_variants[-1]!r}. Full pre-simulate order: {pre_simulate_variants}"
+    )
+
+
 def test_augment_combined_actions_with_target_max_rho_is_noop_without_context():
     """No-op when the analysis context is missing obs_simu_defaut or
     lines_overloaded_ids — nothing to scope the target against."""

--- a/expert_backend/tests/test_superposition_service.py
+++ b/expert_backend/tests/test_superposition_service.py
@@ -277,5 +277,115 @@ def test_dict_action_merge_preserves_original_keys(recommender):
     assert result["action"] is new_data["action"]
 
 
+def test_compute_superposition_reuses_context_obs_simu_defaut(recommender):
+    """Regression: on-demand `compute_superposition` must use the N-1
+    observation captured by step1 (stored on `_analysis_context`) as
+    `obs_start` rather than fetching a fresh `env.get_obs()`.
+
+    Background: step2's `run_analysis_step2_discovery` pre-computes betas
+    using `context["obs_simu_defaut"]`. Grid2Op's
+    `obs.simulate(action, keep_variant=True)` (used by
+    `simulate_manual_action`) can mutate the shared N-1 variant, so a
+    fresh fetch here would see a drifted baseline and produce betas
+    that diverge from the "Computed Pairs" view for the same pair.
+    Reusing the context obs keeps the two paths numerically consistent.
+    """
+    aid1, aid2 = "act1", "act2"
+    obs1 = _make_obs([0.9], [90.0])
+    obs2 = _make_obs([0.9], [85.0])
+    actions = {
+        aid1: {"action": MagicMock(), "observation": obs1},
+        aid2: {"action": MagicMock(), "observation": obs2},
+    }
+    _setup_superposition_env(recommender, actions, {})
+
+    # Simulate what step1 leaves behind: a context carrying the original
+    # N-1 observation. A later fresh `env.get_obs()` would return a
+    # drifted observation (different rho values) — the reuse must pick
+    # the context obs, not the drifted fresh fetch.
+    ctx_obs = _make_obs([1.5], [150.0])
+    recommender._analysis_context = {"obs_simu_defaut": ctx_obs}
+
+    with patch('expert_backend.services.simulation_mixin._identify_action_elements', return_value=([0], [])), \
+         patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_combine:
+        mock_combine.return_value = {"betas": [0.5, 0.5], "p_or_combined": [100.0]}
+
+        recommender.compute_superposition(aid1, aid2, "contingency")
+
+        obs_start_passed = mock_combine.call_args.kwargs["obs_start"]
+        assert obs_start_passed is ctx_obs, (
+            "compute_superposition should pass the context's obs_simu_defaut as "
+            "obs_start so betas match the step2 pre-computed values"
+        )
+
+
+def test_compute_superposition_falls_back_to_fresh_fetch_without_context(recommender):
+    """When no analysis context exists (first-time pair estimation with
+    no prior step1), `compute_superposition` must still work by fetching
+    `obs_start` from `env.get_obs()`. This test pins the fallback so the
+    new context-preferred path does not silently break the no-context
+    case.
+    """
+    aid1, aid2 = "act1", "act2"
+    obs1 = _make_obs([0.9], [90.0])
+    obs2 = _make_obs([0.9], [85.0])
+    actions = {
+        aid1: {"action": MagicMock(), "observation": obs1},
+        aid2: {"action": MagicMock(), "observation": obs2},
+    }
+    env = _setup_superposition_env(recommender, actions, {})
+    recommender._analysis_context = None
+
+    with patch('expert_backend.services.simulation_mixin._identify_action_elements', return_value=([0], [])), \
+         patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_combine:
+        mock_combine.return_value = {"betas": [0.5, 0.5], "p_or_combined": [100.0]}
+
+        recommender.compute_superposition(aid1, aid2, "contingency")
+
+        assert env.get_obs.call_count == 2, "expected fresh fetch for both N-1 and N in fallback path"
+
+
+def test_superposition_lines_overloaded_reads_context_ids_or_names(recommender):
+    """`_superposition_lines_overloaded` must prefer the step1-populated
+    keys (``lines_overloaded_ids`` and ``lines_overloaded_names``) so the
+    on-demand monitoring set matches what step2's discovery used —
+    previously only the session-reload key ``lines_overloaded`` was
+    consulted, causing fresh-analysis on-demand re-estimation to
+    recompute from ``obs_start`` and drift from the pre-computed view.
+    """
+    name_line = ["L0", "L1", "L2", "L3"]
+    obs_start = _make_obs([0.5, 0.8, 0.99, 1.1])
+
+    # Case 1: step1-populated `lines_overloaded_ids` wins.
+    recommender._analysis_context = {"lines_overloaded_ids": [1, 3]}
+    ids = recommender._superposition_lines_overloaded(
+        obs_start, name_line, {n: i for i, n in enumerate(name_line)},
+        pre_existing_rho={}, lines_we_care_about=set(name_line),
+        branches_with_limits=set(name_line),
+        monitoring_factor=0.95, worsening_threshold=0.02,
+    )
+    assert ids == [1, 3]
+
+    # Case 2: only names present — still resolved via name_to_idx_map.
+    recommender._analysis_context = {"lines_overloaded_names": ["L2", "L3"]}
+    ids = recommender._superposition_lines_overloaded(
+        obs_start, name_line, {n: i for i, n in enumerate(name_line)},
+        pre_existing_rho={}, lines_we_care_about=set(name_line),
+        branches_with_limits=set(name_line),
+        monitoring_factor=0.95, worsening_threshold=0.02,
+    )
+    assert ids == [2, 3]
+
+    # Case 3: session-reload key still honoured for backwards compat.
+    recommender._analysis_context = {"lines_overloaded": ["L0"]}
+    ids = recommender._superposition_lines_overloaded(
+        obs_start, name_line, {n: i for i, n in enumerate(name_line)},
+        pre_existing_rho={}, lines_we_care_about=set(name_line),
+        branches_with_limits=set(name_line),
+        monitoring_factor=0.95, worsening_threshold=0.02,
+    )
+    assert ids == [0]
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/frontend/src/components/ActionCard.test.tsx
+++ b/frontend/src/components/ActionCard.test.tsx
@@ -323,4 +323,62 @@ describe('ActionCard', () => {
         render(<ActionCard {...defaultProps} details={details} />);
         expect(screen.getByText('No reduction')).toBeInTheDocument();
     });
+
+    // Regression: for a combined action like
+    // ``load_shedding_BEON3 TR311+reco_GEN.PY762``, the card used to
+    // render ONLY the load-shedding voltage level as a clickable badge
+    // and drop the reco's line because an ``if (isLoadShedding) { …
+    // return } else { topology-based extraction }`` short-circuit
+    // skipped the topology branch whenever load-shedding details were
+    // present. Both sub-actions must now produce a badge. Same
+    // expectation holds for ``curtailment + reco`` and for pairs where
+    // one leg is a disco / coupling.
+    it('renders both load-shedding VL and reco line for combined LS+reco action', () => {
+        const details: ActionDetail = {
+            ...baseDetails,
+            load_shedding_details: [
+                { load_name: 'BEON3 TR311', voltage_level_id: 'BEON3', shedded_mw: 6.4 },
+            ],
+            action_topology: {
+                lines_ex_bus: { 'GEN.PY762': 1 },
+                lines_or_bus: {},
+                gens_bus: {},
+                loads_bus: {},
+            },
+        };
+        render(
+            <ActionCard
+                {...defaultProps}
+                id="load_shedding_BEON3 TR311+reco_GEN.PY762"
+                details={details}
+            />
+        );
+        // Both sub-actions' impacted assets must be clickable.
+        expect(screen.getByRole('button', { name: 'BEON3' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'GEN.PY762' })).toBeInTheDocument();
+    });
+
+    it('renders both curtailment VL and reco line for combined RC+reco action', () => {
+        const details: ActionDetail = {
+            ...baseDetails,
+            curtailment_details: [
+                { gen_name: 'WIND_A', voltage_level_id: 'VL_WIND', curtailed_mw: 42.0 },
+            ],
+            action_topology: {
+                lines_ex_bus: {},
+                lines_or_bus: { 'LINE_R': 1 },
+                gens_bus: {},
+                loads_bus: {},
+            },
+        };
+        render(
+            <ActionCard
+                {...defaultProps}
+                id="curtail_WIND_A+reco_LINE_R"
+                details={details}
+            />
+        );
+        expect(screen.getByRole('button', { name: 'VL_WIND' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'LINE_R' })).toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -107,8 +107,6 @@ const ActionCard: React.FC<ActionCardProps> = ({
 
     const renderBadges = () => {
         const badges: React.ReactNode[] = [];
-        const isLoadShedding = details.load_shedding_details && details.load_shedding_details.length > 0;
-        const isRenewableCurtailment = details.curtailment_details && details.curtailment_details.length > 0;
         const badgeBtn = (name: string, bg: string, color: string, title: string, onDoubleClick?: (e: React.MouseEvent) => void) => (
             <button key={name}
                 style={{ padding: '2px 7px', borderRadius: '4px', border: 'none', cursor: 'pointer', fontSize: '11px', fontWeight: 600, textDecoration: 'underline dotted', flexShrink: 0, backgroundColor: bg, color }}
@@ -119,65 +117,70 @@ const ActionCard: React.FC<ActionCardProps> = ({
             </button>
         );
 
-        if (isLoadShedding) {
-            const vlSet = new Set<string>();
-            details.load_shedding_details!.forEach(ls => {
-                if (ls.voltage_level_id && !vlSet.has(ls.voltage_level_id)) {
-                    vlSet.add(ls.voltage_level_id);
-                    badges.push(badgeBtn(ls.voltage_level_id, '#d1fae5', '#065f46', `Click: zoom to ${ls.voltage_level_id} | Double-click: open SLD`, (e) => {
-                        e.stopPropagation();
-                        onVlDoubleClick?.(id, ls.voltage_level_id!);
-                    }));
-                }
-            });
-        } else if (isRenewableCurtailment) {
-            const vlSet = new Set<string>();
-            details.curtailment_details!.forEach(rc => {
-                if (rc.voltage_level_id && !vlSet.has(rc.voltage_level_id)) {
-                    vlSet.add(rc.voltage_level_id);
-                    badges.push(badgeBtn(rc.voltage_level_id, '#d1fae5', '#065f46', `Click: zoom to ${rc.voltage_level_id} | Double-click: open SLD`, (e) => {
-                        e.stopPropagation();
-                        onVlDoubleClick?.(id, rc.voltage_level_id!);
-                    }));
-                }
-            });
-        } else {
-            if (nodesByEquipmentId) {
-                const vlNames = getActionTargetVoltageLevels(details, id, nodesByEquipmentId);
-                vlNames.forEach(vlName => {
-                    badges.push(badgeBtn(vlName, '#d1fae5', '#065f46', `Click: zoom to ${vlName} | Double-click: open SLD`, (e) => {
-                        e.stopPropagation();
-                        onVlDoubleClick?.(id, vlName);
-                    }));
-                });
+        // Collect badges from every source that applies. A combined
+        // action like ``load_shedding_X+reco_Y`` owes a badge to BOTH
+        // sub-actions — using an if/else-if/else here used to drop the
+        // topology-based sub-action (reco / disco / coupling) whenever
+        // the pair also contained a load-shedding or curtailment leg.
+        const vlSet = new Set<string>();
+
+        details.load_shedding_details?.forEach(ls => {
+            if (ls.voltage_level_id && !vlSet.has(ls.voltage_level_id)) {
+                vlSet.add(ls.voltage_level_id);
+                badges.push(badgeBtn(ls.voltage_level_id, '#d1fae5', '#065f46', `Click: zoom to ${ls.voltage_level_id} | Double-click: open SLD`, (e) => {
+                    e.stopPropagation();
+                    onVlDoubleClick?.(id, ls.voltage_level_id!);
+                }));
             }
+        });
 
-            const isCoupling = isCouplingAction(id, details.description_unitaire);
-            const lineNames = edgesByEquipmentId
-                ? getActionTargetLines(details, id, edgesByEquipmentId)
-                : Array.from(new Set([
-                    ...(isCoupling ? [] : Object.keys(details.action_topology?.lines_ex_bus || {})),
-                    ...(isCoupling ? [] : Object.keys(details.action_topology?.lines_or_bus || {})),
-                    ...Object.keys(details.action_topology?.pst_tap || {}),
-                ]));
+        details.curtailment_details?.forEach(rc => {
+            if (rc.voltage_level_id && !vlSet.has(rc.voltage_level_id)) {
+                vlSet.add(rc.voltage_level_id);
+                badges.push(badgeBtn(rc.voltage_level_id, '#d1fae5', '#065f46', `Click: zoom to ${rc.voltage_level_id} | Double-click: open SLD`, (e) => {
+                    e.stopPropagation();
+                    onVlDoubleClick?.(id, rc.voltage_level_id!);
+                }));
+            }
+        });
 
-            lineNames.forEach(name => {
-                if (badges.some(b => React.isValidElement(b) && b.key === name)) return;
+        if (nodesByEquipmentId) {
+            const vlNames = getActionTargetVoltageLevels(details, id, nodesByEquipmentId);
+            vlNames.forEach(vlName => {
+                if (vlSet.has(vlName)) return;
+                vlSet.add(vlName);
+                badges.push(badgeBtn(vlName, '#d1fae5', '#065f46', `Click: zoom to ${vlName} | Double-click: open SLD`, (e) => {
+                    e.stopPropagation();
+                    onVlDoubleClick?.(id, vlName);
+                }));
+            });
+        }
+
+        const isCoupling = isCouplingAction(id, details.description_unitaire);
+        const lineNames = edgesByEquipmentId
+            ? getActionTargetLines(details, id, edgesByEquipmentId)
+            : Array.from(new Set([
+                ...(isCoupling ? [] : Object.keys(details.action_topology?.lines_ex_bus || {})),
+                ...(isCoupling ? [] : Object.keys(details.action_topology?.lines_or_bus || {})),
+                ...Object.keys(details.action_topology?.pst_tap || {}),
+            ]));
+
+        lineNames.forEach(name => {
+            if (badges.some(b => React.isValidElement(b) && b.key === name)) return;
+            badges.push(badgeBtn(name, '#dbeafe', '#1e40af', `Zoom to ${name}`));
+        });
+
+        if (badges.length === 0) {
+            const topo = details.action_topology;
+            const equipNames = Array.from(new Set([
+                ...Object.keys(topo?.gens_bus || {}),
+                ...Object.keys(topo?.loads_bus || {}),
+                ...Object.keys(topo?.loads_p || {}),
+                ...Object.keys(topo?.gens_p || {}),
+            ]));
+            equipNames.forEach(name => {
                 badges.push(badgeBtn(name, '#dbeafe', '#1e40af', `Zoom to ${name}`));
             });
-
-            if (badges.length === 0) {
-                const topo = details.action_topology;
-                const equipNames = Array.from(new Set([
-                    ...Object.keys(topo?.gens_bus || {}),
-                    ...Object.keys(topo?.loads_bus || {}),
-                    ...Object.keys(topo?.loads_p || {}),
-                    ...Object.keys(topo?.gens_p || {}),
-                ]));
-                equipNames.forEach(name => {
-                    badges.push(badgeBtn(name, '#dbeafe', '#1e40af', `Zoom to ${name}`));
-                });
-            }
         }
 
         return (

--- a/frontend/src/components/CombinedActionsModal.tsx
+++ b/frontend/src/components/CombinedActionsModal.tsx
@@ -247,17 +247,6 @@ const CombinedActionsModal: React.FC<Props> = ({
             interactionLogger.record('combine_pair_toggled', { action_id: id, selected: false });
         } else {
             if (newSet.size >= 2) return; // Only allow 2
-            
-            // Prevent selecting load shedding or curtailment for combination
-            const detail = allActions[id];
-            const isRestricted = (detail?.load_shedding_details && detail.load_shedding_details.length > 0) ||
-                                (detail?.curtailment_details && detail.curtailment_details.length > 0);
-            
-            if (isRestricted) {
-                setError("Load shedding and curtailment actions cannot be combined with other actions.");
-                return;
-            }
-            
             newSet.add(id);
             interactionLogger.record('combine_pair_toggled', { action_id: id, selected: true });
         }

--- a/frontend/src/components/CombinedActionsModal.tsx
+++ b/frontend/src/components/CombinedActionsModal.tsx
@@ -137,6 +137,8 @@ const CombinedActionsModal: React.FC<Props> = ({
                     betas: data.betas,
                     estimated_max_rho: estMaxRho,
                     estimated_max_rho_line: estMaxRhoLine,
+                    target_max_rho: data.target_max_rho ?? null,
+                    target_max_rho_line: data.target_max_rho_line,
                     is_suspect: !!data.is_islanded,
                     isSimulated,
                     simulated_max_rho: simMaxRho,

--- a/frontend/src/components/ComputedPairsTable.test.tsx
+++ b/frontend/src/components/ComputedPairsTable.test.tsx
@@ -120,6 +120,30 @@ describe('ComputedPairsTable', () => {
         expect(screen.getByText('—')).toBeInTheDocument();
     });
 
+    it('shows a "target: X% on LINE" subtitle when the target overload differs from the estimated max line', () => {
+        const focusedPair: ComputedPairEntry = {
+            ...basePair,
+            estimated_max_rho: 0.82,
+            estimated_max_rho_line: 'LOUHAL31PYMON',
+            target_max_rho: 0.20,
+            target_max_rho_line: 'BEON L31CPVAN',
+        };
+        render(<ComputedPairsTable {...defaultProps} computedPairsList={[focusedPair]} />);
+        expect(screen.getByText(/target:.*20\.0%.*BEON L31CPVAN/)).toBeInTheDocument();
+    });
+
+    it('does not render target subtitle when target line equals estimated line', () => {
+        const matchingPair: ComputedPairEntry = {
+            ...basePair,
+            estimated_max_rho: 0.82,
+            estimated_max_rho_line: 'L3',
+            target_max_rho: 0.82,
+            target_max_rho_line: 'L3',
+        };
+        render(<ComputedPairsTable {...defaultProps} computedPairsList={[matchingPair]} />);
+        expect(screen.queryByText(/target:/)).not.toBeInTheDocument();
+    });
+
     it('shows islanding icon for simulated islanded pair', () => {
         const islandedPair: ComputedPairEntry = {
             ...basePair,

--- a/frontend/src/components/ComputedPairsTable.tsx
+++ b/frontend/src/components/ComputedPairsTable.tsx
@@ -24,6 +24,8 @@ export interface ComputedPairEntry {
     betas?: number[];
     estimated_max_rho?: number | null;
     estimated_max_rho_line?: string;
+    target_max_rho?: number | null;
+    target_max_rho_line?: string;
     is_suspect: boolean;
     isSimulated: boolean;
     simulated_max_rho: number | null;
@@ -94,7 +96,14 @@ const ComputedPairsTable: React.FC<ComputedPairsTableProps> = ({
                                         </span>
                                     ) : '—'}
                                 </td>
-                                <td style={{ fontSize: '11px', color: '#666', fontStyle: 'italic' }}>{p.estimated_max_rho_line ? displayName(p.estimated_max_rho_line) : 'N/A'}</td>
+                                <td style={{ fontSize: '11px', color: '#666', fontStyle: 'italic' }}>
+                                    {p.estimated_max_rho_line ? displayName(p.estimated_max_rho_line) : 'N/A'}
+                                    {p.target_max_rho != null && p.target_max_rho_line && p.target_max_rho_line !== 'N/A' && p.target_max_rho_line !== p.estimated_max_rho_line && (
+                                        <div style={{ fontSize: '10px', color: '#888', marginTop: '2px', fontStyle: 'normal' }} title="Max on the lines this pair was selected to resolve">
+                                            target: {(p.target_max_rho * 100).toFixed(1)}% on {displayName(p.target_max_rho_line)}
+                                        </div>
+                                    )}
+                                </td>
 
                                 <td style={{ textAlign: 'center' }}>
                                     {isSimulated && simMaxRho != null ? (

--- a/frontend/src/components/ExplorePairsTab.test.tsx
+++ b/frontend/src/components/ExplorePairsTab.test.tsx
@@ -100,9 +100,32 @@ describe('ExplorePairsTab', () => {
         expect(screen.getByText('Estimate combination effect')).toBeInTheDocument();
     });
 
-    it('shows "Combination not allowed" when hasRestricted is true', () => {
+    it('disables Estimate and surfaces the load-shedding/curtailment caveat when hasRestricted is true', () => {
         render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} hasRestricted={true} />);
-        expect(screen.getByText('Combination not allowed')).toBeInTheDocument();
+        const estimateBtn = screen.getByTestId('estimate-button');
+        expect(estimateBtn).toBeDisabled();
+        expect(estimateBtn).toHaveTextContent(/Estimation not available/i);
+    });
+
+    it('exposes a Simulate Combined button in the no-preview state that stays enabled even when hasRestricted', () => {
+        const onSimulate = vi.fn();
+        render(
+            <ExplorePairsTab
+                {...defaultProps}
+                selectedIds={new Set(['act1', 'act2'])}
+                hasRestricted={true}
+                onSimulate={onSimulate}
+            />,
+        );
+        const simBtn = screen.getByTestId('simulate-combined-button');
+        expect(simBtn).toBeEnabled();
+        fireEvent.click(simBtn);
+        expect(onSimulate).toHaveBeenCalled();
+    });
+
+    it('disables the no-preview Simulate Combined button until 2 actions are selected', () => {
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1'])} />);
+        expect(screen.getByTestId('simulate-combined-button')).toBeDisabled();
     });
 
     it('calls onEstimate when estimate button is clicked', () => {

--- a/frontend/src/components/ExplorePairsTab.test.tsx
+++ b/frontend/src/components/ExplorePairsTab.test.tsx
@@ -6,7 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import ExplorePairsTab from './ExplorePairsTab';
 import type { AnalysisResult, CombinedAction } from '../types';
@@ -171,6 +171,55 @@ describe('ExplorePairsTab', () => {
         render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} simulationFeedback={feedback} />);
         expect(screen.getByTestId('simulation-feedback')).toBeInTheDocument();
         expect(screen.getByText('68.0%')).toBeInTheDocument();
+    });
+
+    it('shows the Simulate Combined button on top of the card while a preview is shown and no simulation has run yet', () => {
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,
+            max_rho_line: 'L3', is_rho_reduction: true, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.72],
+        };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} />);
+        expect(screen.getByTestId('simulate-combined-top-button')).toBeInTheDocument();
+    });
+
+    it('hides the top Simulate Combined button once a simulation result is available', () => {
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,
+            max_rho_line: 'L3', is_rho_reduction: true, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.72],
+        };
+        const feedback = { max_rho: 0.68, max_rho_line: 'L2', is_rho_reduction: true };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} simulationFeedback={feedback} />);
+        expect(screen.queryByTestId('simulate-combined-top-button')).not.toBeInTheDocument();
+    });
+
+    it('renders the card with only the Simulation Result column when simulation ran without an estimate', () => {
+        const feedback = { max_rho: 0.68, max_rho_line: 'L2', is_rho_reduction: true };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} simulationFeedback={feedback} />);
+        expect(screen.getByTestId('comparison-card')).toBeInTheDocument();
+        expect(screen.getByTestId('simulation-feedback')).toBeInTheDocument();
+        expect(screen.queryByText(/Estimated Max Loading/)).not.toBeInTheDocument();
+    });
+
+    it('does not render Estimate / Simulate buttons inside the comparison card header', () => {
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,
+            max_rho_line: 'L3', is_rho_reduction: true, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.72],
+        };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} />);
+        const card = screen.getByTestId('comparison-card');
+        expect(within(card).queryByText('Estimate combination effect')).not.toBeInTheDocument();
+        expect(within(card).queryByText('Estimation unavailable')).not.toBeInTheDocument();
+        expect(within(card).queryByText('Simulate Combined')).not.toBeInTheDocument();
+    });
+
+    it('hides the bottom action bar once a simulation has run (no preview path)', () => {
+        const feedback = { max_rho: 0.68, max_rho_line: 'L2', is_rho_reduction: true };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} simulationFeedback={feedback} />);
+        expect(screen.queryByTestId('estimate-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('simulate-combined-button')).not.toBeInTheDocument();
     });
 
     it('shows error message in comparison card', () => {

--- a/frontend/src/components/ExplorePairsTab.test.tsx
+++ b/frontend/src/components/ExplorePairsTab.test.tsx
@@ -253,6 +253,33 @@ describe('ExplorePairsTab', () => {
         expect(within(card).queryByText('Explore Pairs Comparison')).not.toBeInTheDocument();
     });
 
+    it('surfaces target_max_rho in the comparison card when it differs from the global estimated line', () => {
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.5, 0.5],
+            max_rho: 0.82, max_rho_line: 'LOUHAL31PYMON',
+            estimated_max_rho: 0.82, estimated_max_rho_line: 'LOUHAL31PYMON',
+            target_max_rho: 0.20, target_max_rho_line: 'BEON L31CPVAN',
+            is_rho_reduction: false, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.20],
+        };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} />);
+        const target = screen.getByTestId('target-max-rho');
+        expect(target).toHaveTextContent(/20\.0%.*BEON L31CPVAN/);
+    });
+
+    it('hides target_max_rho when it matches the global estimated line (nothing to add)', () => {
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.0, 0.9],
+            max_rho: 0.72, max_rho_line: 'L3',
+            estimated_max_rho: 0.72, estimated_max_rho_line: 'L3',
+            target_max_rho: 0.72, target_max_rho_line: 'L3',
+            is_rho_reduction: true, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.72],
+        };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} />);
+        expect(screen.queryByTestId('target-max-rho')).not.toBeInTheDocument();
+    });
+
     it('uses the "Explore Pairs Comparison" title when an estimate is present', () => {
         const preview: CombinedAction = {
             action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,

--- a/frontend/src/components/ExplorePairsTab.test.tsx
+++ b/frontend/src/components/ExplorePairsTab.test.tsx
@@ -222,6 +222,48 @@ describe('ExplorePairsTab', () => {
         expect(screen.queryByTestId('simulate-combined-button')).not.toBeInTheDocument();
     });
 
+    it('clicking the top Simulate Combined button calls onSimulate', () => {
+        const onSimulate = vi.fn();
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,
+            max_rho_line: 'L3', is_rho_reduction: true, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.72],
+        };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} onSimulate={onSimulate} />);
+        fireEvent.click(screen.getByTestId('simulate-combined-top-button'));
+        expect(onSimulate).toHaveBeenCalled();
+    });
+
+    it('disables the top Simulate Combined button while simulating', () => {
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,
+            max_rho_line: 'L3', is_rho_reduction: true, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.72],
+        };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} simulating={true} />);
+        expect(screen.getByTestId('simulate-combined-top-button')).toBeDisabled();
+    });
+
+    it('uses the "Simulation Result" title when only simulation ran (no estimate)', () => {
+        const feedback = { max_rho: 0.68, max_rho_line: 'L2', is_rho_reduction: true };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} simulationFeedback={feedback} />);
+        const card = screen.getByTestId('comparison-card');
+        // "Simulation Result" appears as both the card title and the column header — so we expect 2 matches
+        expect(within(card).getAllByText('Simulation Result').length).toBe(2);
+        expect(within(card).queryByText('Explore Pairs Comparison')).not.toBeInTheDocument();
+    });
+
+    it('uses the "Explore Pairs Comparison" title when an estimate is present', () => {
+        const preview: CombinedAction = {
+            action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,
+            max_rho_line: 'L3', is_rho_reduction: true, description: 'Combined',
+            p_or_combined: [], rho_before: [0.8], rho_after: [0.72],
+        };
+        render(<ExplorePairsTab {...defaultProps} selectedIds={new Set(['act1', 'act2'])} preview={preview} />);
+        const card = screen.getByTestId('comparison-card');
+        expect(within(card).getByText('Explore Pairs Comparison')).toBeInTheDocument();
+    });
+
     it('shows error message in comparison card', () => {
         const preview: CombinedAction = {
             action1_id: 'act1', action2_id: 'act2', betas: [1.0], max_rho: 0.72,

--- a/frontend/src/components/ExplorePairsTab.tsx
+++ b/frontend/src/components/ExplorePairsTab.tsx
@@ -236,6 +236,7 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             onClick={onEstimate}
                             disabled={selectedIds.size !== 2 || loading || hasRestricted}
                             data-testid="estimate-button"
+                            title={hasRestricted ? 'Estimation is not available when a load shedding or curtailment action is selected — use Simulate Combined instead.' : undefined}
                             style={{
                                 width: '100%',
                                 padding: '12px',
@@ -250,7 +251,27 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                                 boxShadow: (selectedIds.size === 2 && !loading && !hasRestricted) ? '0 4px 6px rgba(52, 152, 219, 0.2)' : 'none'
                             }}
                         >
-                            {loading ? '⚙️ Estimating Combination...' : (selectedIds.size === 2 ? (hasRestricted ? 'Combination not allowed' : 'Estimate combination effect') : 'Select 2 actions to estimate')}
+                            {loading ? '⚙️ Estimating Combination...' : (selectedIds.size === 2 ? (hasRestricted ? 'Estimation not available for load shedding / curtailment' : 'Estimate combination effect') : 'Select 2 actions to estimate')}
+                        </button>
+                        <button
+                            onClick={onSimulate}
+                            disabled={selectedIds.size !== 2 || simulating}
+                            data-testid="simulate-combined-button"
+                            style={{
+                                width: '100%',
+                                padding: '10px',
+                                background: (selectedIds.size === 2 && !simulating) ? '#27ae60' : '#ecf0f1',
+                                color: (selectedIds.size === 2 && !simulating) ? 'white' : '#bdc3c7',
+                                border: 'none',
+                                borderRadius: '6px',
+                                cursor: (selectedIds.size !== 2 || simulating) ? 'not-allowed' : 'pointer',
+                                fontWeight: 'bold',
+                                fontSize: '13px',
+                                transition: 'all 0.2s',
+                                boxShadow: (selectedIds.size === 2 && !simulating) ? '0 2px 4px rgba(39,174,96,0.2)' : 'none'
+                            }}
+                        >
+                            {simulating ? '⌛ Simulating...' : (selectedIds.size === 2 ? 'Simulate Combined' : 'Select 2 actions to simulate')}
                         </button>
                     </div>
                 ) : (
@@ -275,28 +296,38 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             <div style={{ display: 'flex', gap: '8px' }}>
                                 <button
                                     onClick={onEstimate}
-                                    disabled={loading}
-                                    style={{ padding: '6px 12px', background: 'white', border: '1px solid #3498db', color: '#3498db', borderRadius: '4px', cursor: 'pointer', fontSize: '12px', fontWeight: 'bold' }}
+                                    disabled={loading || hasRestricted}
+                                    title={hasRestricted ? 'Estimation is not available when a load shedding or curtailment action is selected — use Simulate Combined instead.' : undefined}
+                                    style={{
+                                        padding: '6px 12px',
+                                        background: 'white',
+                                        border: '1px solid ' + (hasRestricted ? '#bdc3c7' : '#3498db'),
+                                        color: hasRestricted ? '#bdc3c7' : '#3498db',
+                                        borderRadius: '4px',
+                                        cursor: (loading || hasRestricted) ? 'not-allowed' : 'pointer',
+                                        fontSize: '12px',
+                                        fontWeight: 'bold'
+                                    }}
                                 >
-                                    {loading ? '...' : 'Estimate combination effect'}
+                                    {loading ? '...' : (hasRestricted ? 'Estimation unavailable' : 'Estimate combination effect')}
                                 </button>
                                 <button
                                     onClick={onSimulate}
-                                    disabled={simulating || hasRestricted}
+                                    disabled={simulating}
                                     style={{
                                         padding: '6px 16px',
-                                        background: (simulating || hasRestricted) ? '#6c757d' : '#27ae60',
+                                        background: simulating ? '#6c757d' : '#27ae60',
                                         color: 'white',
                                         border: 'none',
                                         borderRadius: '6px',
-                                        cursor: (simulating || hasRestricted) ? 'not-allowed' : 'pointer',
+                                        cursor: simulating ? 'not-allowed' : 'pointer',
                                         fontWeight: 'bold',
                                         fontSize: '12px',
-                                        boxShadow: (simulating || hasRestricted) ? 'none' : '0 2px 4px rgba(39,174,96,0.2)',
+                                        boxShadow: simulating ? 'none' : '0 2px 4px rgba(39,174,96,0.2)',
                                         minWidth: '140px'
                                     }}
                                 >
-                                    {simulating ? '⌛ Simulating...' : (hasRestricted ? 'Simulation Locked' : 'Simulate Combined')}
+                                    {simulating ? '⌛ Simulating...' : 'Simulate Combined'}
                                 </button>
                             </div>
                         </div>

--- a/frontend/src/components/ExplorePairsTab.tsx
+++ b/frontend/src/components/ExplorePairsTab.tsx
@@ -333,6 +333,11 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                                         <div style={{ fontSize: '12px', color: '#666' }}>
                                             Line: {displayName(preview.estimated_max_rho_line ?? preview.max_rho_line)}
                                         </div>
+                                        {preview.target_max_rho != null && preview.target_max_rho_line && preview.target_max_rho_line !== 'N/A' && preview.target_max_rho_line !== (preview.estimated_max_rho_line ?? preview.max_rho_line) && (
+                                            <div style={{ fontSize: '11px', color: '#555', marginTop: '6px', padding: '4px 8px', background: 'rgba(255,255,255,0.6)', borderRadius: '4px', display: 'inline-block' }} data-testid="target-max-rho">
+                                                Target overload: <strong style={{ color: (preview.target_max_rho ?? 0) <= monitoringFactor ? '#28a745' : '#d35400' }}>{((preview.target_max_rho ?? 0) * 100).toFixed(1)}%</strong> on {displayName(preview.target_max_rho_line)}
+                                            </div>
+                                        )}
                                     </div>
                                 )}
                                 <div style={{ flex: 1 }}>

--- a/frontend/src/components/ExplorePairsTab.tsx
+++ b/frontend/src/components/ExplorePairsTab.tsx
@@ -230,7 +230,7 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
 
             {/* Action Bar / Comparison Card */}
             <div style={{ marginTop: '5px' }}>
-                {!preview ? (
+                {!preview && !simulationFeedback && !simulating && (
                     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
                         <button
                             onClick={onEstimate}
@@ -274,7 +274,33 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             {simulating ? '⌛ Simulating...' : (selectedIds.size === 2 ? 'Simulate Combined' : 'Select 2 actions to simulate')}
                         </button>
                     </div>
-                ) : (
+                )}
+
+                {preview && !simulationFeedback && (
+                    <button
+                        onClick={onSimulate}
+                        disabled={simulating}
+                        data-testid="simulate-combined-top-button"
+                        style={{
+                            width: '100%',
+                            padding: '10px',
+                            marginBottom: '8px',
+                            background: simulating ? '#6c757d' : '#27ae60',
+                            color: 'white',
+                            border: 'none',
+                            borderRadius: '6px',
+                            cursor: simulating ? 'not-allowed' : 'pointer',
+                            fontWeight: 'bold',
+                            fontSize: '13px',
+                            boxShadow: simulating ? 'none' : '0 2px 4px rgba(39,174,96,0.2)',
+                            transition: 'all 0.2s'
+                        }}
+                    >
+                        {simulating ? '⌛ Simulating...' : 'Simulate Combined'}
+                    </button>
+                )}
+
+                {(preview || simulationFeedback || simulating) && (
                     <div style={{
                         padding: '15px',
                         background: error ? '#fff3cd' : '#e1f5fe',
@@ -282,70 +308,33 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                         borderLeft: '5px solid ' + (error ? '#856404' : '#0288d1'),
                         boxShadow: '0 2px 5px rgba(0,0,0,0.05)'
                     }} data-testid="comparison-card">
-                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '10px' }}>
-                            <div style={{ flex: 1 }}>
-                                {preview.betas && (
-                                    <div style={{ marginBottom: '8px', fontSize: '11px', color: '#666', background: 'rgba(255,255,255,0.6)', padding: '2px 8px', borderRadius: '4px', display: 'inline-block', fontWeight: 600 }}>
-                                        Betas: {preview.betas.map(b => b.toFixed(3)).join(', ')}
-                                    </div>
-                                )}
-                                <div style={{ fontWeight: 800, color: error ? '#856404' : '#01579b', fontSize: '15px' }}>
-                                    {error ? '⚠️ Estimation Failed' : 'Explore Pairs Comparison'}
+                        <div style={{ marginBottom: '10px' }}>
+                            {preview?.betas && (
+                                <div style={{ marginBottom: '8px', fontSize: '11px', color: '#666', background: 'rgba(255,255,255,0.6)', padding: '2px 8px', borderRadius: '4px', display: 'inline-block', fontWeight: 600 }}>
+                                    Betas: {preview.betas.map(b => b.toFixed(3)).join(', ')}
                                 </div>
-                            </div>
-                            <div style={{ display: 'flex', gap: '8px' }}>
-                                <button
-                                    onClick={onEstimate}
-                                    disabled={loading || hasRestricted}
-                                    title={hasRestricted ? 'Estimation is not available when a load shedding or curtailment action is selected — use Simulate Combined instead.' : undefined}
-                                    style={{
-                                        padding: '6px 12px',
-                                        background: 'white',
-                                        border: '1px solid ' + (hasRestricted ? '#bdc3c7' : '#3498db'),
-                                        color: hasRestricted ? '#bdc3c7' : '#3498db',
-                                        borderRadius: '4px',
-                                        cursor: (loading || hasRestricted) ? 'not-allowed' : 'pointer',
-                                        fontSize: '12px',
-                                        fontWeight: 'bold'
-                                    }}
-                                >
-                                    {loading ? '...' : (hasRestricted ? 'Estimation unavailable' : 'Estimate combination effect')}
-                                </button>
-                                <button
-                                    onClick={onSimulate}
-                                    disabled={simulating}
-                                    style={{
-                                        padding: '6px 16px',
-                                        background: simulating ? '#6c757d' : '#27ae60',
-                                        color: 'white',
-                                        border: 'none',
-                                        borderRadius: '6px',
-                                        cursor: simulating ? 'not-allowed' : 'pointer',
-                                        fontWeight: 'bold',
-                                        fontSize: '12px',
-                                        boxShadow: simulating ? 'none' : '0 2px 4px rgba(39,174,96,0.2)',
-                                        minWidth: '140px'
-                                    }}
-                                >
-                                    {simulating ? '⌛ Simulating...' : 'Simulate Combined'}
-                                </button>
+                            )}
+                            <div style={{ fontWeight: 800, color: error ? '#856404' : '#01579b', fontSize: '15px' }}>
+                                {error ? '⚠️ Estimation Failed' : (preview ? 'Explore Pairs Comparison' : 'Simulation Result')}
                             </div>
                         </div>
 
                         {!error && (
                             <div style={{ display: 'flex', gap: '30px', borderTop: '1px solid rgba(0,0,0,0.05)', paddingTop: '12px' }}>
-                                <div style={{ flex: 1, borderRight: '1px solid rgba(0,0,0,0.05)', paddingRight: '15px' }}>
-                                    <div style={{ fontSize: '11px', fontWeight: 700, color: '#666', textTransform: 'uppercase', marginBottom: '8px', letterSpacing: '0.5px' }}>Estimated Effect</div>
-                                    <div style={{ fontSize: '13px', marginBottom: '4px' }}>
-                                        Estimated Max Loading: <strong style={{ color: (preview.estimated_max_rho ?? preview.max_rho ?? 0) <= monitoringFactor ? '#28a745' : '#d35400', fontSize: '16px' }}>{((preview.estimated_max_rho ?? preview.max_rho ?? 0) * 100).toFixed(1)}%</strong>
-                                        {preview.is_islanded && (
-                                            <span style={{ marginLeft: '6px' }} title="Estimation suspect due to islanding">⚠️</span>
-                                        )}
+                                {preview && (
+                                    <div style={{ flex: 1, borderRight: '1px solid rgba(0,0,0,0.05)', paddingRight: '15px' }}>
+                                        <div style={{ fontSize: '11px', fontWeight: 700, color: '#666', textTransform: 'uppercase', marginBottom: '8px', letterSpacing: '0.5px' }}>Estimated Effect</div>
+                                        <div style={{ fontSize: '13px', marginBottom: '4px' }}>
+                                            Estimated Max Loading: <strong style={{ color: (preview.estimated_max_rho ?? preview.max_rho ?? 0) <= monitoringFactor ? '#28a745' : '#d35400', fontSize: '16px' }}>{((preview.estimated_max_rho ?? preview.max_rho ?? 0) * 100).toFixed(1)}%</strong>
+                                            {preview.is_islanded && (
+                                                <span style={{ marginLeft: '6px' }} title="Estimation suspect due to islanding">⚠️</span>
+                                            )}
+                                        </div>
+                                        <div style={{ fontSize: '12px', color: '#666' }}>
+                                            Line: {displayName(preview.estimated_max_rho_line ?? preview.max_rho_line)}
+                                        </div>
                                     </div>
-                                    <div style={{ fontSize: '12px', color: '#666' }}>
-                                        Line: {displayName(preview.estimated_max_rho_line ?? preview.max_rho_line)}
-                                    </div>
-                                </div>
+                                )}
                                 <div style={{ flex: 1 }}>
                                     <div style={{ fontSize: '11px', fontWeight: 700, color: '#666', textTransform: 'uppercase', marginBottom: '8px', letterSpacing: '0.5px' }}>Simulation Result</div>
                                     {simulating && (
@@ -374,7 +363,7 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                                         </div>
                                     )}
                                     {!simulating && !simulationFeedback && (
-                                        <div style={{ color: '#aaa', fontSize: '12px', fontStyle: 'italic', marginTop: '5px' }}>Click "Simulate Combined" to run</div>
+                                        <div style={{ color: '#aaa', fontSize: '12px', fontStyle: 'italic', marginTop: '5px' }}>Click "Simulate Combined" above to run</div>
                                     )}
                                 </div>
                             </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -94,6 +94,12 @@ export interface CombinedAction {
     disconnected_mw?: number;
     estimated_max_rho?: number | null;
     estimated_max_rho_line?: string;
+    // Max over the user-selected overloaded lines only — surfaces the
+    // pair's predicted effect on the contingency alongside the global
+    // `max_rho`, which may land on an off-target line because of
+    // linearisation error on lines far from either action.
+    target_max_rho?: number | null;
+    target_max_rho_line?: string;
     error?: string;
 }
 

--- a/scripts/test_estimation_vs_simulation_small_grid.py
+++ b/scripts/test_estimation_vs_simulation_small_grid.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Diagnose the combined-pair estimation vs. simulation discrepancy.
+
+Targets the Co-Study4Grid backend running on the small test grid with
+contingency P.SAOL31RONCI, reproducing the gap observed in the
+"Combine Actions → Computed Pairs" modal between the library's
+superposition estimate (``estimated_max_rho`` / ``target_max_rho``)
+and the backend's post-action simulation (``max_rho`` returned by
+``/api/simulate-manual-action``).
+
+Runs step1 → step2 → per-pair simulate and prints:
+
+    • per-pair breakdown:
+        - library estimate (from step2 `combined_actions`)
+        - library's OWN internal simulation (embedded in step2 payload as
+          ``max_rho_simulated`` when ``VERIFY_SUPERPOSITION_MAX_RHO`` is on
+          — this is the <2% "ground-truth" reference the user's library
+          report was computed from)
+        - backend's simulation (what the UI "Re-Simulate" button calls)
+    • variant-bug flag (simulated line == contingency?)
+    • monitoring-scope mismatch flag (est line absent from sim overloads)
+    • aggregate stats: two gap columns — library_est vs library_sim, and
+      library_sim vs backend_sim (the real discrepancy to explain)
+
+Usage:
+    # 1. Start the backend (from project root):
+    python -m expert_backend.main
+
+    # 2. Run this script:
+    python scripts/test_estimation_vs_simulation_small_grid.py
+
+Env:
+    BACKEND_URL   - backend base URL (default http://127.0.0.1:8000)
+    TOP_N_PAIRS   - how many pairs to diagnose, by estimated_max_rho (default 15)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from statistics import median
+
+import numpy as np
+import requests
+
+
+BACKEND_URL = os.environ.get("BACKEND_URL", "http://127.0.0.1:8000")
+TOP_N_PAIRS = int(os.environ.get("TOP_N_PAIRS", "15"))
+ONLY_PAIR = os.environ.get("DIAGNOSE_ONLY_PAIR", "").strip()  # exact combined_actions key
+
+NETWORK_PATH = "/home/marotant/dev/Expert_op4grid_recommender/data/bare_env_small_grid_test/grid.xiidm"
+ACTION_FILE_PATH = "/home/marotant/dev/Expert_op4grid_recommender/data/action_space/reduced_model_actions_test.json"
+CONTINGENCY = "P.SAOL31RONCI"
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def api_post(path, payload, *, timeout=300):
+    resp = requests.post(f"{BACKEND_URL}{path}", json=payload, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_get(path, *, timeout=60):
+    resp = requests.get(f"{BACKEND_URL}{path}", timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def api_post_ndjson(path, payload, *, timeout=600):
+    resp = requests.post(f"{BACKEND_URL}{path}", json=payload, stream=True, timeout=timeout)
+    resp.raise_for_status()
+    events = []
+    for line in resp.iter_lines():
+        if line:
+            events.append(json.loads(line))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Pipeline steps
+# ---------------------------------------------------------------------------
+
+def load_config():
+    print(f"[CONFIG] network: {NETWORK_PATH}")
+    print(f"[CONFIG] actions: {ACTION_FILE_PATH}")
+    payload = {
+        "network_path": NETWORK_PATH,
+        "action_file_path": ACTION_FILE_PATH,
+        "min_line_reconnections": 2,
+        "min_close_coupling": 3,
+        "min_open_coupling": 2,
+        "min_line_disconnections": 3,
+        "min_pst": 1,
+        "min_load_shedding": 2,
+        "min_renewable_curtailment_actions": 0,
+        "n_prioritized_actions": 15,
+        "monitoring_factor": 0.95,
+        "pre_existing_overload_threshold": 0.02,
+        "ignore_reconnections": False,
+        "pypowsybl_fast_mode": True,
+    }
+    api_post("/api/config", payload)
+    print("[CONFIG] applied\n")
+
+
+def run_step1():
+    print(f"[STEP1] contingency = {CONTINGENCY}")
+    result = api_post("/api/run-analysis-step1", {"disconnected_element": CONTINGENCY})
+    overloads = result.get("lines_overloaded", []) or []
+    print(f"[STEP1] overloads: {overloads}")
+    if not overloads:
+        raise SystemExit("[STEP1] no overloads detected — contingency mislabeled or monitoring path off")
+    print()
+    return overloads
+
+
+def run_step2(overloads):
+    print(f"[STEP2] resolving {len(overloads)} overloads (streaming NDJSON)")
+    events = api_post_ndjson(
+        "/api/run-analysis-step2",
+        {
+            "selected_overloads": overloads,
+            "all_overloads": overloads,
+            "monitor_deselected": False,
+        },
+    )
+    result_event = next((e for e in events if e.get("type") == "result"), None)
+    if not result_event:
+        raise SystemExit("[STEP2] no result event received")
+    combined = result_event.get("combined_actions", {}) or {}
+    prioritized = result_event.get("actions", {}) or {}
+    lwca = result_event.get("lines_we_care_about")
+    print(f"[STEP2] prioritized_actions: {len(prioritized)} | combined_pairs: {len(combined)}")
+    if lwca is not None:
+        print(f"[STEP2] lines_we_care_about: {len(lwca)} lines")
+    print()
+    return prioritized, combined, lwca
+
+
+def simulate_pair(pair_id):
+    return api_post(
+        "/api/simulate-manual-action",
+        {"action_id": pair_id, "disconnected_element": CONTINGENCY},
+    )
+
+
+def recompute_superposition(action1_id, action2_id):
+    try:
+        return api_post(
+            "/api/compute-superposition",
+            {
+                "action1_id": action1_id,
+                "action2_id": action2_id,
+                "disconnected_element": CONTINGENCY,
+            },
+        )
+    except requests.HTTPError as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic
+# ---------------------------------------------------------------------------
+
+def _fmt_rho(v):
+    return f"{v:.4f}" if isinstance(v, (int, float)) and v is not None else str(v)
+
+
+def _betas_close(b1, b2, tol=1e-3):
+    if not b1 or not b2 or len(b1) != len(b2):
+        return False
+    return all(abs(a - b) <= tol for a, b in zip(b1, b2))
+
+
+def diagnose_pair(pair_key, pair_data, sim_result):
+    print("=" * 80)
+    print(f"PAIR: {pair_key}")
+    print("=" * 80)
+
+    est_rho = pair_data.get("max_rho")
+    est_line = pair_data.get("max_rho_line")
+    target_rho = pair_data.get("target_max_rho")
+    target_line = pair_data.get("target_max_rho_line")
+    betas = pair_data.get("betas") or []
+
+    # Library's OWN internal simulation, embedded in step2 payload when
+    # VERIFY_SUPERPOSITION_MAX_RHO is on. This is the "ground-truth"
+    # reference that the user's previous <2% gap report came from.
+    lib_sim_rho = pair_data.get("max_rho_simulated")
+    lib_sim_line = pair_data.get("max_rho_line_simulated")
+    lib_sim_gap = pair_data.get("max_rho_gap")
+    lib_sim_match = pair_data.get("max_rho_line_match")
+
+    sim_rho = sim_result.get("max_rho")
+    sim_line = sim_result.get("max_rho_line")
+    sim_overloaded = sim_result.get("lines_overloaded_after") or []
+    sim_nc = sim_result.get("non_convergence")
+    sim_islanded = sim_result.get("is_islanded")
+
+    print("  [LIBRARY ESTIMATE (step2 superposition formula)]")
+    print(f"    max_rho (global):              {_fmt_rho(est_rho)}  on {est_line}")
+    print(f"    target_max_rho (overload set): {_fmt_rho(target_rho)}  on {target_line}")
+    print(f"    betas:                         {betas}")
+
+    if lib_sim_rho is not None:
+        print("  [LIBRARY INTERNAL SIMULATION (_verify_pair_max_rho_by_simulation)]")
+        print(f"    max_rho_simulated:             {_fmt_rho(lib_sim_rho)}  on {lib_sim_line}")
+        print(f"    max_rho_gap (est - lib_sim):   {_fmt_rho(lib_sim_gap)}  "
+              f"(line_match={lib_sim_match})")
+    else:
+        print("  [LIBRARY INTERNAL SIMULATION] not present in step2 payload "
+              "(VERIFY_SUPERPOSITION_MAX_RHO disabled?)")
+
+    print("  [BACKEND SIMULATION (/api/simulate-manual-action — what the UI calls)]")
+    print(f"    max_rho:                       {_fmt_rho(sim_rho)}  on {sim_line}")
+    print(f"    overloaded_after:              {sim_overloaded}")
+    print(f"    non_convergence:               {sim_nc}")
+    print(f"    is_islanded:                   {sim_islanded}")
+
+    flags = []
+
+    # Variant-bug flag
+    if sim_line == CONTINGENCY:
+        flags.append(
+            f"VARIANT-BUG? backend sim max_rho_line IS the contingency ({CONTINGENCY})"
+        )
+
+    # Estimation vs backend simulation line mismatch
+    line_match_est_bsim = est_line == sim_line
+    if not line_match_est_bsim:
+        note = "est line != backend_sim line"
+        if est_line and sim_overloaded and est_line not in sim_overloaded:
+            note += f" — '{est_line}' absent from backend's overloaded_after"
+        flags.append(note)
+
+    # Library_sim vs backend_sim line mismatch — these should match since
+    # both are AC simulations of the same combined action on N-1.
+    if lib_sim_line is not None and sim_line is not None and lib_sim_line != sim_line:
+        flags.append(
+            f"SIM-PATH DIVERGENCE: library_sim line '{lib_sim_line}' "
+            f"!= backend_sim line '{sim_line}'"
+        )
+
+    # Gaps
+    def _gap(a, b):
+        if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+            return a - b
+        return None
+
+    gap_est_libsim = _gap(est_rho, lib_sim_rho)      # library estimate vs library simulation (expected <2%)
+    gap_est_bsim   = _gap(est_rho, sim_rho)          # library estimate vs backend sim (UI-visible gap)
+    gap_libsim_bsim = _gap(lib_sim_rho, sim_rho)     # library sim vs backend sim (same formula, different path)
+
+    print("  [GAPS]")
+    print(f"    est       - lib_sim          = {_fmt_rho(gap_est_libsim)}  "
+          "(library internal; expected <2%)")
+    print(f"    est       - backend_sim      = {_fmt_rho(gap_est_bsim)}  "
+          "(UI-visible 'Max Loading (Est.)' vs 'Simulated Max Rho')")
+    print(f"    lib_sim   - backend_sim      = {_fmt_rho(gap_libsim_bsim)}  "
+          "(two sims of the same action — should be ~0; non-zero = backend sim-path bug)")
+
+    if flags:
+        print("  [FLAGS]")
+        for f in flags:
+            print(f"    ⚠ {f}")
+
+    print()
+
+    return {
+        "pair_key": pair_key,
+        "est_rho": est_rho,
+        "est_line": est_line,
+        "lib_sim_rho": lib_sim_rho,
+        "lib_sim_line": lib_sim_line,
+        "sim_rho": sim_rho,
+        "sim_line": sim_line,
+        "gap_est_libsim": gap_est_libsim,
+        "gap_est_bsim": gap_est_bsim,
+        "gap_libsim_bsim": gap_libsim_bsim,
+        "line_match_est_bsim": line_match_est_bsim,
+        "line_match_libsim_bsim": (
+            lib_sim_line is not None and sim_line is not None and lib_sim_line == sim_line
+        ),
+        "is_variant_bug": sim_line == CONTINGENCY,
+    }
+
+
+def aggregate(rows):
+    def _clean(vals):
+        return [v for v in vals if isinstance(v, (int, float))]
+
+    gaps_est_libsim = _clean([r["gap_est_libsim"] for r in rows])
+    gaps_est_bsim = _clean([r["gap_est_bsim"] for r in rows])
+    gaps_libsim_bsim = _clean([r["gap_libsim_bsim"] for r in rows])
+    n = len(rows)
+    line_match_est_bsim_n = sum(1 for r in rows if r["line_match_est_bsim"])
+    line_match_libsim_bsim_n = sum(1 for r in rows if r["line_match_libsim_bsim"])
+    variant_n = sum(1 for r in rows if r["is_variant_bug"])
+
+    def _stats(vals, label):
+        if not vals:
+            print(f"  {label}: n=0")
+            return
+        arr = np.asarray(vals, dtype=float)
+        print(
+            f"  {label}: n={len(vals)} "
+            f"mean_signed={arr.mean():+.4f} "
+            f"mean_abs={np.abs(arr).mean():.4f} "
+            f"median_abs={median(np.abs(arr)):.4f} "
+            f"max_abs={np.abs(arr).max():.4f} "
+            f"rmse={float(np.sqrt((arr ** 2).mean())):.4f}"
+        )
+
+    print("=" * 80)
+    print(f"AGGREGATE over {n} pairs")
+    print("=" * 80)
+    _stats(gaps_est_libsim,  "est       - lib_sim     ")
+    _stats(gaps_est_bsim,    "est       - backend_sim ")
+    _stats(gaps_libsim_bsim, "lib_sim   - backend_sim ")
+    print(f"  line match est vs backend_sim:     {line_match_est_bsim_n}/{n}")
+    print(f"  line match lib_sim vs backend_sim: {line_match_libsim_bsim_n}/{n}")
+    print(f"  variant-bug flags:                 {variant_n}/{n}")
+    print()
+    print("INTERPRETATION:")
+    print("  • est - lib_sim  should be <~2% (the user's known-good reference).")
+    print("  • lib_sim - backend_sim is the real discrepancy: both are AC")
+    print("    simulations of the SAME combined action on N-1, so any gap here")
+    print("    points to a divergence in how the backend's simulate_manual_action")
+    print("    constructs the simulation (different obs_start, different rebuilt")
+    print("    action object, or different simulate() parameters).")
+    print("  • est - backend_sim = (est - lib_sim) + (lib_sim - backend_sim),")
+    print("    and the bulk is in the second term.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    load_config()
+    overloads = run_step1()
+    prioritized, combined, _ = run_step2(overloads)
+
+    if not combined:
+        print("[DONE] No combined pairs produced by step2 — nothing to diagnose.")
+        return 0
+
+    # Rank pairs by estimated_max_rho desc; narrow to a single pair if asked.
+    if ONLY_PAIR:
+        if ONLY_PAIR not in combined:
+            print(f"[FATAL] DIAGNOSE_ONLY_PAIR={ONLY_PAIR!r} not in combined_actions")
+            return 1
+        pairs_ranked = [(ONLY_PAIR, combined[ONLY_PAIR])]
+    else:
+        pairs_ranked = sorted(
+            combined.items(),
+            key=lambda kv: (kv[1].get("max_rho") or 0.0),
+            reverse=True,
+        )[:TOP_N_PAIRS]
+
+    print(f"[DIAGNOSE] Top {len(pairs_ranked)} pairs by estimated_max_rho\n")
+
+    rows = []
+    for pair_key, pair_data in pairs_ranked:
+        try:
+            sim_result = simulate_pair(pair_key)
+        except requests.HTTPError as e:
+            print(f"[{pair_key}] simulate failed: {e}")
+            continue
+
+        row = diagnose_pair(pair_key, pair_data, sim_result)
+        rows.append(row)
+
+    if rows:
+        aggregate(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except requests.ConnectionError:
+        print(f"[FATAL] backend not reachable at {BACKEND_URL} — start it first.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"[FATAL] {type(e).__name__}: {e}")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
This PR adds "target max rho" metrics to combined action pair estimation, allowing the UI to surface the pair's effect on the user-selected overloaded lines alongside the global max rho. This addresses a regression where linearisation error could place the global max on an unrelated line, obscuring the pair's actual impact on the contingency being resolved.

## Key Changes

### Backend (expert_backend/)
- **simulation_mixin.py**: 
  - Modified `compute_superposition()` to reuse the N-1 observation from analysis context (`obs_simu_defaut`) instead of fetching a fresh one, ensuring numerical consistency with pre-computed pairs (Grid2Op's `simulate()` can mutate the shared N-1 variant)
  - Added explicit N-1 variant pinning in `simulate_manual_action()` immediately before `obs.simulate()` to prevent simulation against the N state when observation caches hit
  - Updated `_superposition_lines_overloaded()` to prefer step1-populated context keys (`lines_overloaded_ids`, `lines_overloaded_names`) over session-reload keys, keeping on-demand re-estimation aligned with pre-computed discovery

- **analysis_mixin.py**:
  - Added `_augment_combined_actions_with_target_max_rho()` method to enrich pre-computed pairs with target metrics scoped to user-selected overloads
  - Integrated target augmentation into `run_analysis_step2()` after discovery completes

- **simulation_helpers.py**:
  - Added `compute_target_max_rho()` helper to calculate max rho/line over a subset of lines, returning `(0.0, "N/A")` when no overloads are available

### Frontend (frontend/src/)
- **ExplorePairsTab.tsx**:
  - Restructured action bar to show "Simulate Combined" button alongside "Estimate" in no-preview state
  - Added separate "Simulate Combined" button on top of comparison card when preview exists but no simulation has run
  - Updated button text and disabled states to reflect load-shedding/curtailment restrictions
  - Hides action bar once simulation completes

- **ExplorePairsTab.test.tsx**:
  - Added comprehensive test coverage for new button states and visibility logic
  - Tests verify target max rho display, comparison card rendering, and button enable/disable conditions

- **ComputedPairsTable.tsx/test.tsx**:
  - Added `target_max_rho` and `target_max_rho_line` fields to `ComputedPairEntry` interface
  - Renders target subtitle when target line differs from estimated line

- **CombinedActionsModal.tsx**:
  - Passes `target_max_rho` and `target_max_rho_line` from backend response to modal data

- **types.ts**:
  - Extended `CombinedAction` interface with target max rho fields

### Tests
- **test_superposition_service.py**: Added 8 new regression tests covering context reuse, fallback behavior, target max rho emission, and augmentation logic
- **test_combined_actions_scenario.py**: Added integration test verifying on-demand `compute_superposition()` matches pre-computed pair values
- **test_cache_synchronization.py**: Updated to reflect additional `_get_n1_variant` call from explicit pinning

## Notable Implementation Details
- The fix preserves the global `max_rho` scan to catch newly-introduced overloads while adding a scoped "target" metric for the contingency's actual overloads
- Context observation reuse ensures on-demand pair re-estimation produces identical betas to the pre-computed "Computed Pairs" view, preventing drift from Grid2Op's in-place variant mutations
- Explicit N-1 variant pinning before simulate prevents physically impossible states (non-zero rho on disconnected contingency line) when observation caches hit
- Target fields always present in payload with `"N/A"` sentinel when no target info available, simplifying frontend branching logic

https://claude.ai/code/session_01HBuTAKw7NKbfoRREE4XFU2