### PR TITLE
docs: Update CLAUDE.md, README.md, and backend/frontend guides for 0.6.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,36 +11,60 @@ Co-Study4Grid is a full-stack web application for **power grid contingency analy
 ```
 Co-Study4Grid/
 ├── CLAUDE.md                  # This file — project overview + standalone parity audit
+├── README.md                  # User-facing project description + quick start
+├── CHANGELOG.md               # Per-release changelog (current: 0.6.5)
+├── CONTRIBUTING.md            # Contributor setup, code-quality gate
+├── pyproject.toml             # Python project metadata + ruff config (E9/F ruleset)
+├── pytest.ini                 # Pytest config (testpaths = expert_backend/tests)
 ├── expert_backend/            # Python FastAPI backend
 │   ├── CLAUDE.md              # Backend-scoped guide (singletons, mixins, lifecycle)
 │   ├── main.py                # FastAPI app: endpoints, CORS, gzip helpers, NDJSON streaming
 │   ├── requirements.txt
+│   ├── test_backend.py        # Ad-hoc integration script (not part of pytest)
 │   ├── services/
 │   │   ├── network_service.py     # pypowsybl Network singleton + metadata queries
 │   │   ├── recommender_service.py # Analysis orchestrator (composes the 3 mixins below)
-│   │   ├── diagram_mixin.py       # NAD/SLD generation, layout cache, flow deltas
-│   │   ├── analysis_mixin.py      # Two-step contingency analysis + action enrichment
-│   │   ├── simulation_mixin.py    # Manual-action simulation + superposition
-│   │   └── sanitize.py            # NumPy → native-Python recursive coercion
+│   │   ├── diagram_mixin.py       # NAD/SLD orchestrator — delegates to services/diagram/
+│   │   ├── analysis_mixin.py      # Two-step analysis orchestrator — delegates to services/analysis/
+│   │   ├── simulation_mixin.py    # Manual-action + superposition orchestrator
+│   │   ├── simulation_helpers.py  # Stateless helpers extracted from simulation_mixin (PR #104)
+│   │   ├── sanitize.py            # NumPy → native-Python recursive coercion
+│   │   ├── analysis/              # PR #104 decomposition — action_enrichment,
+│   │   │                          # mw_start_scoring, analysis_runner, pdf_watcher
+│   │   └── diagram/               # PR #104 decomposition — layout_cache, nad_params,
+│   │                              # nad_render, sld_render, overloads, flows, deltas
 │   └── tests/                 # pytest suite — see tests/CLAUDE.md for the mock layer
 ├── frontend/                  # React 19 + TypeScript 5.9 + Vite 7 frontend
 │   ├── CLAUDE.md              # Frontend-scoped guide (App.tsx hub, hooks, SVG levers)
-│   ├── package.json, vite.config.ts, eslint.config.js, tsconfig*.json
+│   ├── package.json, vite.config.ts, vite.config.standalone.ts,
+│   │                          # eslint.config.js, tsconfig*.json
 │   └── src/
-│       ├── App.tsx                # State orchestration hub (~1000 lines)
+│       ├── App.tsx                # State orchestration hub (~1150 lines)
 │       ├── api.ts                 # Axios HTTP client (base URL: 127.0.0.1:8000)
 │       ├── types.ts               # All TypeScript interfaces (one file)
-│       ├── hooks/                 # useSettings/useActions/useAnalysis/useDiagrams/
-│       │                          # useSession/useDetachedTabs/useTiedTabsSync/usePanZoom/
-│       │                          # useSldOverlay
-│       ├── components/            # Header, ActionFeed, ActionCard, ActionOverviewDiagram,
-│       │                          # VisualizationPanel, OverloadPanel, CombinedActionsModal,
-│       │                          # ComputedPairsTable, ExplorePairsTab, SldOverlay,
-│       │                          # DetachableTabHost, MemoizedSvgContainer, ErrorBoundary
+│       ├── hooks/                 # useSettings / useActions / useAnalysis / useDiagrams /
+│       │                          # useSession / useDetachedTabs / useTiedTabsSync /
+│       │                          # usePanZoom / useSldOverlay / useN1Fetch (svgPatch fast-
+│       │                          # path + full fallback) / useDiagramHighlights (per-tab
+│       │                          # highlight pipeline + Flow/Impacts view-mode state)
+│       ├── components/            # Header, ActionFeed, ActionCard, ActionCardPopover,
+│       │                          # ActionSearchDropdown, ActionTypeFilterChips,
+│       │                          # ActionOverviewDiagram, AppSidebar, SidebarSummary,
+│       │                          # StatusToasts, VisualizationPanel, OverloadPanel,
+│       │                          # CombinedActionsModal, ComputedPairsTable,
+│       │                          # ExplorePairsTab, SldOverlay, DetachableTabHost,
+│       │                          # MemoizedSvgContainer, ErrorBoundary
 │       │                          # + modals/ (SettingsModal, ReloadSessionModal,
 │       │                          #            ConfirmationDialog)
-│       └── utils/                 # svgUtils, overloadHighlights, sessionUtils,
-│                                  # interactionLogger, popoverPlacement, mergeAnalysisResult
+│       └── utils/                 # svgUtils (barrel re-exporting utils/svg/*),
+│                                  # svgPatch (DOM-recycling patch applier),
+│                                  # overloadHighlights, sessionUtils, interactionLogger,
+│                                  # popoverPlacement, mergeAnalysisResult, actionTypes
+│                                  # (classifyActionType + DEFAULT_ACTION_OVERVIEW_FILTERS),
+│                                  # fileRegistry (structure regression guard)
+│           └── svg/               # PR #104 decomposition — idMap, metadataIndex,
+│                                  # svgBoost, fitRect, deltaVisuals, actionPinData,
+│                                  # actionPinRender, highlights
 ├── standalone_interface_legacy.html  # DECOMMISSIONED 2026-04-20 — hand-maintained
 │                              # single-file mirror frozen at its last version and
 │                              # tracked here for reference only. Replaced by the
@@ -54,13 +78,17 @@ Co-Study4Grid/
 ├── benchmarks/                # Perf scripts (bench_load_study, _bench_common)
 ├── Overflow_Graph/            # Generated PDFs (created at runtime)
 ├── overrides.txt              # Pinned versions for transitive Python deps
+├── requirements_py310.txt     # Python 3.10-pinned requirements superset
 ├── scripts/                   # Integration / parity / build helpers —
 │                              # `check_standalone_parity.py`,
 │                              # `check_session_fidelity.py`,
 │                              # `check_gesture_sequence.py`,
 │                              # `check_invariants.py`, `check_code_quality.py`,
-│                              # `code_quality_report.py`, `test_pipeline.py`, …
-├── CONTRIBUTING.md            # Contributor setup, code-quality gate
+│                              # `code_quality_report.py`, `profile_diagram_perf.py`,
+│                              # `test_code_quality_report.py`,
+│                              # `test_estimation_vs_simulation_small_grid.py`,
+│                              # and `pypsa_eur/` (full PyPSA-EUR → XIIDM pipeline
+│                              # with its own pytest coverage)
 ├── .editorconfig              # Cross-editor indent / EOL defaults
 ├── .env.example               # Template for backend env vars (CORS, …)
 └── .gitignore                 # Excludes __pycache__/, *.pyc, *.pyo, node_modules/
@@ -93,8 +121,8 @@ Co-Study4Grid/
 - **axios** - HTTP client
 - **react-select** - Searchable dropdown for branch selection
 - **react-zoom-pan-pinch** - Pan/zoom for visualizations
-- **framer-motion** - Animations
-- **lucide-react** - Icons
+- **vite-plugin-singlefile** - Auto-generated single-file standalone bundle
+- **Vitest** + **React Testing Library** - Unit / integration tests
 
 ## Development Workflow
 
@@ -138,13 +166,17 @@ pytest                                   # Full backend suite
 pytest expert_backend/tests/test_foo.py  # Single file
 ```
 
-Ad-hoc integration scripts live in `scripts/` and require a running
-backend with real data paths:
+Ad-hoc integration scripts live in `scripts/` (and `scripts/pypsa_eur/`
+for the PyPSA-EUR → XIIDM pipeline). The pipeline scripts carry their
+own pytest coverage (`scripts/pypsa_eur/test_*.py`) alongside the
+backend suite; the rest require a running backend with real data:
 
 ```bash
-python scripts/test_pipeline.py          # End-to-end smoke test
-python scripts/test_n1_calibration.py    # N-1 flow calibration check
-python scripts/test_grid_layout.py       # Layout loading sanity check
+pytest scripts/pypsa_eur                           # Pipeline unit tests
+python scripts/pypsa_eur/test_pipeline.py          # End-to-end smoke test
+python scripts/pypsa_eur/test_n1_calibration.py    # N-1 flow calibration check
+python scripts/pypsa_eur/test_grid_layout.py       # Layout loading sanity check
+python scripts/profile_diagram_perf.py             # NAD rendering profiler
 ```
 
 Frontend unit tests use Vitest:
@@ -175,31 +207,38 @@ Both scripts run in CI (`.github/workflows/code-quality.yml` and
 
 | Method | Path | Description |
 |--------|------|-------------|
+| GET  | `/api/user-config` | Read persisted user configuration (paths, recommender params) |
+| POST | `/api/user-config` | Persist user configuration |
+| GET  | `/api/config-file-path` | Get the current user-config file path |
+| POST | `/api/config-file-path` | Set a custom user-config file path |
 | POST | `/api/config` | Set network path, action file path, and all recommender parameters |
-| GET | `/api/branches` | List disconnectable elements (lines + 2-winding transformers) |
-| GET | `/api/voltage-levels` | List voltage levels in the network |
-| GET | `/api/nominal-voltages` | Map voltage level IDs to nominal voltages (kV) |
-| GET | `/api/element-voltage-levels` | Resolve equipment ID to its voltage level IDs |
-| POST | `/api/run-analysis` | Run full N-1 contingency analysis (streaming NDJSON) |
+| GET  | `/api/branches` | List disconnectable elements (lines + 2-winding transformers) |
+| GET  | `/api/voltage-levels` | List voltage levels in the network |
+| GET  | `/api/nominal-voltages` | Map voltage level IDs to nominal voltages (kV) |
+| GET  | `/api/element-voltage-levels` | Resolve equipment ID to its voltage level IDs |
+| POST | `/api/run-analysis` | Run full N-1 contingency analysis (streaming NDJSON, legacy) |
 | POST | `/api/run-analysis-step1` | Two-step analysis Part 1: detect overloads |
 | POST | `/api/run-analysis-step2` | Two-step analysis Part 2: resolve with actions (streaming NDJSON) |
-| GET | `/api/network-diagram` | Get N-state network SVG diagram (NAD) |
+| GET  | `/api/network-diagram` | Get N-state network SVG diagram (NAD) |
 | POST | `/api/n1-diagram` | Get post-contingency N-1 diagram with flow deltas |
+| POST | `/api/n1-diagram-patch` | SVG-less per-branch delta for DOM-recycling fast path (PR #108) |
 | POST | `/api/action-variant-diagram` | Get network state after applying a remedial action |
+| POST | `/api/action-variant-diagram-patch` | Per-branch delta + VL-subtree splice for action DOM recycling |
 | POST | `/api/focused-diagram` | Generate NAD sub-diagram focused on a specific element |
 | POST | `/api/action-variant-focused-diagram` | Focused NAD for specific VL in post-action state |
 | POST | `/api/n-sld` | Single Line Diagram for voltage level in N state |
 | POST | `/api/n1-sld` | Single Line Diagram in N-1 state (with flow deltas) |
 | POST | `/api/action-variant-sld` | SLD in post-action state |
-| GET | `/api/actions` | Return all available action IDs and descriptions |
+| GET  | `/api/actions` | Return all available action IDs and descriptions |
 | POST | `/api/simulate-manual-action` | Simulate a specific action against a contingency |
+| POST | `/api/simulate-and-variant-diagram` | NDJSON stream: `{type:"metrics"}` then `{type:"diagram"}` so sidebar updates ahead of the SVG |
 | POST | `/api/compute-superposition` | Compute combined effect of two actions (superposition theorem) |
 | POST | `/api/save-session` | Save session folder with JSON snapshot + PDF copy |
-| GET | `/api/list-sessions` | List available session folders in a directory |
+| GET  | `/api/list-sessions` | List available session folders in a directory |
 | POST | `/api/load-session` | Load session JSON and restore PDFs |
 | POST | `/api/restore-analysis-context` | Restore analysis context from saved session |
-| GET | `/api/pick-path` | Open native OS file/directory picker (tkinter subprocess) |
-| GET | `/results/pdf/{filename}` | Serve generated PDF files from `Overflow_Graph/` |
+| GET  | `/api/pick-path` | Open native OS file/directory picker (tkinter subprocess) |
+| GET  | `/results/pdf/{filename}` | Serve generated PDF files from `Overflow_Graph/` |
 
 ## Key Patterns & Conventions
 
@@ -209,18 +248,23 @@ Both scripts run in CI (`.github/workflows/code-quality.yml` and
 - **AC/DC fallback**: Analysis first tries AC load flow; falls back to DC if AC does not converge
 - **Threaded analysis**: `run_analysis` runs the computation in a background thread and polls for PDF generation
 - **JSON sanitization**: NumPy types are recursively converted to native Python types via `sanitize_for_json()`
+- **Mixin → helper-package decomposition (PR #104 / #106)**: `DiagramMixin`, `AnalysisMixin` and `SimulationMixin` are thin orchestrators. Pure numerics live in `services/diagram/`, `services/analysis/` and `services/simulation_helpers.py` respectively — dependency-injected so existing `@patch` tests keep working.
+- **SVG DOM recycling (PR #108)**: patch endpoints (`/api/n1-diagram-patch`, `/api/action-variant-diagram-patch`) return per-branch deltas + optional VL-subtree splices so the frontend can clone the already-mounted N-state SVG instead of re-downloading the full NAD (~80 % faster tab switches on large grids).
 - **Shared diagram helpers**: `RecommenderService` uses `_load_network()`, `_load_layout()`, `_default_nad_parameters()`, and `_generate_diagram()` to deduplicate diagram generation logic across endpoints
 - **Focused diagrams**: The `/api/focused-diagram` endpoint resolves an element to its voltage levels and generates a sub-diagram with configurable depth, useful for inspecting specific parts of large grids
-- **No formal Python linter config**: Code follows PEP 8 conventions manually
+- **Ruff-gated**: `pyproject.toml` configures a narrow `E9` + `F` ruleset (real bugs only); stylistic rules deliberately off
 
 ### Frontend
 - **Strict TypeScript**: `strict: true`, `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`
 - **Functional components** with React hooks; no external state management library
 - **Inline styles**: Components use inline `style` objects rather than CSS modules or utility classes
-- **Component architecture (Phase 1 refactored)**:
-  - `App.tsx` (~650 lines) is the **state orchestration hub** — it wires all hooks together and handles cross-hook logic (e.g., `handleApplySettings`). It should NOT contain large JSX blocks.
-  - **Presentational components** live in `components/` and `components/modals/`. They receive data and callbacks via typed props; all business logic stays in `App.tsx`.
+- **Component architecture (Phase 2 hook extraction, PR #109)**:
+  - `App.tsx` (~1150 lines) is the **state orchestration hub** — it wires all hooks together and handles cross-hook logic (e.g., `handleApplySettings`). It should NOT contain large JSX blocks.
+  - **Presentational components** live in `components/` and `components/modals/`. They receive data and callbacks via typed props; all business logic stays in `App.tsx` or in hooks.
+  - `hooks/useN1Fetch.ts` owns the N-1 diagram fetch pipeline (svgPatch fast-path + `/api/n1-diagram` fallback + contingency-change confirm routing).
+  - `hooks/useDiagramHighlights.ts` owns the per-tab SVG highlight pipeline (overload halos, contingency highlight, action targets, delta visuals) + per-tab Flow/Impacts view-mode state.
   - `useSettings.ts` exposes `SettingsState` (all settings values + setters), which is passed wholesale to `SettingsModal` to avoid 30+ prop-drilling.
+- **SVG DOM recycling (PR #108)**: `utils/svgPatch.ts` clones the already-mounted N-state `SVGSVGElement` and patches only per-branch deltas on N-1 / action tab switches, saving a 12–28 MB SVG re-download and re-parse.
 - **Props-based data flow**: State lifted to `App.tsx`, passed down via props
 - **ESLint**: Flat config (v9+) with `typescript-eslint`, `react-hooks`, and `react-refresh` plugins
 - **Unit tests** use Vitest + React Testing Library. Isolated component tests (no backend mocking needed) live alongside their components as `*.test.tsx` files.
@@ -246,7 +290,8 @@ Both scripts run in CI (`.github/workflows/code-quality.yml` and
 - See `docs/features/save-results.md` for session save/load, `docs/features/interaction-logging.md` for the replay contract, and `docs/features/action-overview-diagram.md` for the Remedial Action overview (pin overlay on N-1 network)
 
 ### SVG Visualization
-Both the React frontend and `standalone_interface.html` render pypowsybl
+Both the React frontend and the auto-generated
+`frontend/dist-standalone/standalone.html` render pypowsybl
 NAD/SLD payloads:
 - **Dynamic text scaling** (`utils/svgUtils.ts:boostSvgForLargeGrid` /
   standalone `boostSvgForLargeGrid`): font sizes for node labels, edge
@@ -261,9 +306,9 @@ NAD/SLD payloads:
   they sit.
 - **ViewBox zoom**: auto-centers on selected contingency targets with
   adjustable padding.
-- **Pan/zoom**: React uses `react-zoom-pan-pinch` (smooth,
-  inertia-aware); standalone uses inline viewBox math (basic, no
-  inertia). See the parity audit below for the gap.
+- **Pan/zoom**: `react-zoom-pan-pinch` in both the React dev build
+  and the auto-generated standalone (they share the same source
+  tree).
 
 ## Dependencies
 
@@ -287,13 +332,13 @@ NAD/SLD payloads:
 ## Notes for AI Assistants
 
 - The backend API base URL is hardcoded to `http://localhost:8000` in `frontend/src/api.ts`
-- CORS is configured to allow all origins (`allow_origins=["*"]`)
-- **Frontend architecture (Phase 1 refactored)**: `App.tsx` is the state orchestration hub; it must NOT contain large inline JSX blocks. Extracted presentational components live in `components/` and `components/modals/`. When adding new UI sections, create a new component file and wire it in `App.tsx`.
+- CORS is wide-open by default (`allow_origins=["*"]`) but configurable via the `CORS_ALLOWED_ORIGINS` env var (PR #104, see `.env.example`)
+- **Frontend architecture (Phase 2 hook extraction, PR #109)**: `App.tsx` is the state orchestration hub; it must NOT contain large inline JSX blocks. Extracted presentational components live in `components/` and `components/modals/`; cross-cutting state pipelines live in `hooks/` (notably `useN1Fetch` and `useDiagramHighlights`). When adding new UI sections, create a new component file (or hook for stateful pipelines) and wire it in `App.tsx`.
 - **`useSettings` hook**: Exposes a `SettingsState` object with all settings fields + setters. This is passed wholesale to `SettingsModal` to avoid excessive prop drilling. Adding a new setting means: (1) add to `useSettings.ts`, (2) add to `SettingsModal.tsx`. No manual standalone mirror is required — the legacy hand-maintained file has been decommissioned and the auto-generated bundle inherits from the React source automatically.
-- **Standalone bundle (auto-generated)**: `npm run build:standalone` in `frontend/` produces `frontend/dist-standalone/standalone.html` — a single-file HTML with React + CSS inlined via `vite-plugin-singlefile`. This is the canonical distribution artifact replacing the former `standalone_interface.html`. The legacy file remains on disk as `standalone_interface_legacy.html` (untracked) for reference.
-- There is no CI/CD pipeline, Dockerfile, or containerization configured
+- **Standalone bundle (auto-generated)**: `npm run build:standalone` in `frontend/` produces `frontend/dist-standalone/standalone.html` — a single-file HTML with React + CSS inlined via `vite-plugin-singlefile`. This is the canonical distribution artifact replacing the former `standalone_interface.html`. The legacy file remains on disk as `standalone_interface_legacy.html` (tracked as a frozen snapshot — do NOT edit).
+- **CI pipelines**: GitHub Actions (`.github/workflows/code-quality.yml`, `parity.yml`) and CircleCI (`.circleci/config.yml`) both run the code-quality gate, ruff, and the parity scripts. No Dockerfile / containerization.
 - Root `.gitignore` excludes `__pycache__/`, `*.pyc`, `*.pyo`; `frontend/.gitignore` handles frontend build artifacts
-- Integration helpers and parity scripts live under `scripts/`. They are NOT part of the pytest suite — invoke them directly (`python scripts/<name>.py`).
+- Integration helpers and parity scripts live under `scripts/`. They are NOT part of the pytest suite — invoke them directly. The PyPSA-EUR pipeline scripts under `scripts/pypsa_eur/` DO carry pytest coverage (`test_build_pipeline.py`, `test_calibrate_thermal_limits.py`, `test_generate_n1_overloads.py`, `test_regenerate_grid_layout.py`).
 - `overrides.txt` contains pinned versions for transitive Python dependencies that need to be forced to specific versions
 - **Frontend unit tests** use Vitest + React Testing Library. Isolated component tests live as `*.test.tsx` files next to their component. Run with `cd frontend && npm run test`. No backend mocking is needed for component tests since they only use mocked props.
 - The two-step analysis flow (step1: detect overloads, step2: resolve) is the primary user workflow; the single-step `/api/run-analysis` is a legacy alternative
@@ -310,7 +355,7 @@ and delta-vs-previous commits — lives in
 document is the working record of the parity project and is
 updated as fixes land.
 
-Quick status summary (2026-04-20):
+Quick status summary (2026-04-24):
 
 - Canonical distribution is now the auto-generated
   `frontend/dist-standalone/standalone.html`
@@ -319,7 +364,9 @@ Quick status summary (2026-04-20):
   renamed to `standalone_interface_legacy.html` — committed as
   a frozen snapshot of its last version (commit `5d2b9d1` content),
   do NOT edit further. Regenerate UI from `frontend/src/` via
-  `npm run build:standalone` instead.
+  `npm run build:standalone` instead. The standalone versioned
+  snapshot was bumped to v0.7 on `adae7ac` to include references
+  to the new `/api/*-diagram-patch` endpoints.
 - Four parity layers run against the React source + the
   standalone of choice:
   - **Layer 1 — static parity** (`scripts/check_standalone_parity.py`)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Formerly known as **ExpertAssist**. Rebranded to Co-Study4Grid in release 0.4 (PR #65).
 
 ![License: MPL 2.0](https://img.shields.io/badge/license-MPL--2.0-blue)
-![Release](https://img.shields.io/badge/release-0.5.0-green)
+![Release](https://img.shields.io/badge/release-0.6.5-green)
 
 ---
 
@@ -39,17 +39,37 @@
 
 ### Frontend engineering
 - **React 19 + TypeScript 5.9 + Vite 7**, strict mode (`noUnusedLocals`, `noUnusedParameters`).
-- **Phase 1 refactor** (PR #74): `App.tsx` reduced from ~2100 → ~650 lines, now a pure state-orchestration hub; UI split into focused presentational components under `components/` and `components/modals/`.
-- **Phase 2 state-management optimization** (PR #75): memoized wrappers, centralized state resets, `React.memo` on heavy children — eliminates unnecessary re-renders of the three heaviest components.
+- **Phase 1 refactor** (PR #74): `App.tsx` reduced from ~2100 lines to a pure state-orchestration hub; UI split into focused presentational components under `components/` and `components/modals/`.
+- **Phase 2 hook extraction** (PR #109): `useN1Fetch` (svgPatch fast-path + `/api/n1-diagram` fallback) and `useDiagramHighlights` (per-tab SVG highlight pipeline) extracted out of `App.tsx`; sidebar moved into dedicated `AppSidebar` / `SidebarSummary` / `StatusToasts` components.
+- **SVG DOM recycling** (PR #108): `utils/svgPatch.ts` clones the mounted N-state SVG and patches only per-branch deltas on N-1 / action tab switches — **~80 % faster** tab switching on the ~12 MB French NAD (full benches in [`CHANGELOG.md`](CHANGELOG.md) 0.6.5).
+- **Code-quality gate** (PR #104): CI enforces zero `print()` / bare except / `any` / `@ts-ignore`, module-size ceilings, and publishes a full Markdown metrics report to each run's workflow summary.
 - **React ErrorBoundary** wrapping the app root (PR #82) to contain crashes.
-- **Vitest + React Testing Library** unit tests co-located as `*.test.tsx`.
-- **Standalone single-file UI** (`standalone_interface.html`) mirroring every feature of the React app, for zero-install demos.
+- **Vitest + React Testing Library** unit tests co-located as `*.test.tsx` — ~1000 specs.
+- **Auto-generated single-file UI** (`frontend/dist-standalone/standalone.html` via `npm run build:standalone`, PR #101) mirroring every feature of the React app, for zero-install demos. The legacy hand-maintained `standalone_interface.html` has been decommissioned.
 
 ---
 
-## Performance Highlights (release 0.5.0)
+## Performance Highlights
 
-Measured on the full French grid (~10k branches) with `scripts/profile_diagram_perf.py`. Full write-up in [`docs/performance/history/pr-perf-optimization-summary.md`](docs/performance/history/pr-perf-optimization-summary.md) and [`docs/performance/performance-profiling.md`](docs/performance/performance-profiling.md).
+Measured on the full French grid (`bare_env_20240828T0100Z`, ~10k
+branches, ~12 MB NAD SVG) with `scripts/profile_diagram_perf.py` and
+the backend micro-benches under `benchmarks/`. Full write-ups in
+[`docs/performance/history/`](docs/performance/history/) and
+[`CHANGELOG.md`](CHANGELOG.md).
+
+### 0.6.5 — SVG DOM recycling (PR #108)
+
+| Endpoint | Cold | Warm (median of 3) | Payload |
+|---|---|---|---|
+| `/api/n1-diagram` (full)      | 3.01 s | 2.39 s | 27.1 MB |
+| `/api/n1-diagram-patch` (new) | 0.49 s | 0.50 s |  5.5 MB |
+| **Δ** | **−83.8 %** | **−79.1 %** | 20.3 % of full |
+
+Mirrored on `/api/action-variant-diagram-patch` with dashed-class
+toggling for `disco_*` / `reco_*` and VL-subtree splicing for
+coupling / node-merging / node-splitting actions.
+
+### 0.5.0 — vectorisation + observation caching
 
 | Metric                              | Before   | After   | Speed-up   |
 |-------------------------------------|----------|---------|------------|
@@ -66,6 +86,7 @@ Measured on the full French grid (~10k branches) with `scripts/profile_diagram_p
 - Observation caching in the manual-action loop (eliminates redundant `get_obs()` refetches).
 - Pre-built `SimulationEnvironment` and `dict_action` reused across steps.
 - `lxml`-based NaN stripping + gzip compression for large SVG payloads (PR #70).
+- `display:none` on inactive SVG tabs cuts live DOM from ~600 k to ~200 k nodes (PRs #99, #102).
 - Frontend: throttled datalist rendering, zoom guard, level-of-detail tiers, and stable portal target for detached tabs to avoid unmount/remount cascades.
 
 ---
@@ -80,18 +101,32 @@ Co-Study4Grid/
 │   ├── main.py                  # API endpoints and app configuration
 │   └── services/
 │       ├── network_service.py       # Network loading and queries (pypowsybl)
-│       └── recommender_service.py   # Analysis orchestration, PDF/SVG generation
+│       ├── recommender_service.py   # Analysis orchestration, PDF/SVG generation
+│       ├── diagram_mixin.py  +  diagram/    # NAD/SLD orchestrator + 7 helpers
+│       ├── analysis_mixin.py +  analysis/   # Two-step analysis + 4 helpers
+│       ├── simulation_mixin.py + simulation_helpers.py  # Manual + combined actions
+│       └── sanitize.py              # NumPy → native-Python JSON coercion
 ├── frontend/                    # React + TypeScript + Vite frontend
+│   ├── dist-standalone/             # Auto-generated single-file UI bundle
+│   │                                # (npm run build:standalone)
 │   └── src/
-│       ├── App.tsx                  # State orchestration hub (~650 lines)
+│       ├── App.tsx                  # State orchestration hub (~1150 lines)
 │       ├── api.ts                   # Axios HTTP client
 │       ├── types.ts                 # Shared TypeScript interfaces
-│       ├── hooks/                   # Custom hooks (useSettings, useAnalysis, ...)
-│       ├── utils/                   # sessionUtils, interactionLogger, svgUtils
+│       ├── hooks/                   # useSettings / useAnalysis / useDiagrams /
+│       │                            # useN1Fetch / useDiagramHighlights / …
+│       ├── utils/                   # svgUtils (barrel) + svg/* submodules,
+│       │                            # svgPatch, actionTypes, sessionUtils,
+│       │                            # interactionLogger, mergeAnalysisResult, …
 │       └── components/              # Header, ActionFeed, VisualizationPanel,
-│                                    # OverloadPanel, CombinedActionsModal, modals/
-├── standalone_interface.html    # Self-contained single-file HTML version of the UI
-├── docs/                        # Architecture, performance, and feature docs
+│                                    # OverloadPanel, CombinedActionsModal,
+│                                    # AppSidebar, SidebarSummary, StatusToasts,
+│                                    # ActionTypeFilterChips, modals/, …
+├── standalone_interface_legacy.html # DECOMMISSIONED frozen snapshot (do not edit)
+├── docs/                        # features/, performance/, architecture/,
+│                                # proposals/, data/  — see docs/README.md
+├── benchmarks/                  # Offline micro-benches (warm / cold timings)
+├── scripts/                     # Parity + quality gates + PyPSA-EUR pipeline
 └── Overflow_Graph/              # Generated PDF output directory (created at runtime)
 ```
 
@@ -189,12 +224,15 @@ Open the Vite dev-server URL shown in the terminal (typically `http://localhost:
 |--------|------|-------------|
 | `GET`  | `/api/network-diagram` | Get the N-state network SVG (NAD) |
 | `POST` | `/api/n1-diagram` | Get the post-contingency N-1 diagram with flow deltas |
+| `POST` | `/api/n1-diagram-patch` | Per-branch delta (SVG-less) for DOM-recycling fast path (PR #108) |
 | `POST` | `/api/action-variant-diagram` | Diagram after applying a remedial action |
+| `POST` | `/api/action-variant-diagram-patch` | Per-branch delta + VL-subtree splice for action DOM recycling |
 | `POST` | `/api/focused-diagram` | Sub-diagram focused on an element with configurable depth |
 | `POST` | `/api/action-variant-focused-diagram` | Focused NAD for a specific VL in post-action state |
 | `POST` | `/api/n-sld` | Single Line Diagram for a voltage level in N state |
 | `POST` | `/api/n1-sld` | SLD in N-1 state with flow deltas |
 | `POST` | `/api/action-variant-sld` | SLD in post-action state |
+| `POST` | `/api/simulate-and-variant-diagram` | NDJSON stream: `{type:"metrics"}` then `{type:"diagram"}` so sidebar updates ahead of the SVG |
 | `GET`  | `/results/pdf/{filename}` | Serve generated overflow PDFs from `Overflow_Graph/` |
 
 ---
@@ -214,9 +252,8 @@ Open the Vite dev-server URL shown in the terminal (typically `http://localhost:
 - **axios** — HTTP client
 - **react-select** — searchable dropdown for branch selection
 - **react-zoom-pan-pinch** — pan/zoom for SVG visualizations
-- **framer-motion** — animations
-- **lucide-react** — icons
-- **Vitest** + **React Testing Library** — unit tests
+- **vite-plugin-singlefile** — auto-generated single-file standalone bundle
+- **Vitest** + **React Testing Library** — unit tests (~1000 specs)
 
 ---
 
@@ -233,29 +270,69 @@ npm run preview    # Preview production build
 
 ### Tests
 
-Frontend unit tests (Vitest):
+Backend unit tests (pytest, runs without `pypowsybl` /
+`expert_op4grid_recommender` thanks to the `conftest.py` mock
+layer — see [`expert_backend/tests/CLAUDE.md`](expert_backend/tests/CLAUDE.md)):
+
+```bash
+pytest                                   # Full backend suite
+pytest expert_backend/tests/test_mw_start.py   # Single file
+pytest -k "TestSuperposition"            # Pattern
+```
+
+Frontend unit tests (Vitest + React Testing Library):
 
 ```bash
 cd frontend && npm run test
 ```
 
-Backend integration tests (require a running backend with valid data paths):
+Code-quality gate (CI-enforced, PR #104):
 
 ```bash
-python test_backend.py          # Config, branches, and analysis tests
-python test_api_stream.py       # Streaming response tests
-python test_n1_api.py           # N-1 contingency diagram tests
-python test_voltage_api.py      # Voltage levels API tests
-python verify_n1_simulation.py  # N-1 simulation verification
+python scripts/check_code_quality.py                 # Exit non-zero on regression
+python scripts/code_quality_report.py --summary      # Local Markdown report
+```
+
+Ad-hoc integration / profiling scripts (require a running backend
+and real data paths):
+
+```bash
+python expert_backend/test_backend.py                # Config + branches + analysis
+python scripts/profile_diagram_perf.py               # NAD rendering profiler
+python scripts/pypsa_eur/test_pipeline.py            # PyPSA-EUR end-to-end smoke test
+pytest scripts/pypsa_eur                             # PyPSA-EUR pipeline unit tests
 ```
 
 ---
 
 ## Standalone Interface
 
-`standalone_interface.html` is a self-contained single-file version of the UI that can be opened directly in a browser (pointed at a running backend). It mirrors every feature of the React app — including detachable tabs, SLD highlights, combined actions, PST / curtailment / load-shedding cards, interaction logging, and zoom-tier level of detail — with no build step.
+The single-file standalone UI is **auto-generated** from the React
+source tree (PR #101). Build it with:
 
-When making UI changes, always mirror them in both the React app and the standalone interface.
+```bash
+cd frontend && npm run build:standalone
+```
+
+The output is `frontend/dist-standalone/standalone.html` — a ~1 MB
+self-contained HTML with React + CSS inlined via
+`vite-plugin-singlefile`. Open it directly in a browser (pointed at
+a running backend). It mirrors every feature of the React app —
+detachable tabs, SLD highlights, combined actions, PST / curtailment
+/ load-shedding cards, interaction logging, zoom-tier level of
+detail, SVG DOM recycling — with no build step for consumers.
+
+The legacy hand-maintained `standalone_interface.html` has been
+decommissioned and renamed to `standalone_interface_legacy.html`
+(committed as a frozen snapshot, do NOT edit). UI changes land only
+in `frontend/src/` — the auto-generated bundle inherits them on the
+next `npm run build:standalone`.
+
+Parity between the React source and the bundle is guarded by four
+layers of automated checks (`scripts/check_standalone_parity.py`,
+`scripts/check_session_fidelity.py`,
+`scripts/check_gesture_sequence.py`, `scripts/check_invariants.py`)
+— see [`frontend/PARITY_AUDIT.md`](frontend/PARITY_AUDIT.md).
 
 ---
 
@@ -271,7 +348,7 @@ When making UI changes, always mirror them in both the React app and the standal
 
 ## Changelog
 
-See [`CHANGELOG.md`](CHANGELOG.md) for the list of changes per release. The current release is **0.5.0**.
+See [`CHANGELOG.md`](CHANGELOG.md) for the list of changes per release. The current release is **0.6.5**.
 
 ---
 

--- a/docs/architecture/app-refactoring-plan.md
+++ b/docs/architecture/app-refactoring-plan.md
@@ -1,9 +1,37 @@
 # App.tsx Refactoring Plan: Extract Custom Hooks
 
-## Goal
-Refactor the 2100-line `App.tsx` into a lean orchestrator (~800 lines) by wiring up 5 pre-written custom hooks that extract state and logic.
+> **Status: SHIPPED (historical plan).**
+> Both refactor waves have landed and this document is preserved as
+> the commit-trail log, not a live plan. App.tsx is now ~1150 lines
+> (down from 2100) and is the state-orchestration hub described in
+> `frontend/CLAUDE.md`. For the current architecture, start with
+> [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md); for the latest
+> extraction round (Phase 2 hook extraction — `useN1Fetch`,
+> `useDiagramHighlights`, `AppSidebar`, `SidebarSummary`,
+> `StatusToasts`) see the App.tsx refactor-history table at the
+> bottom of that file and the 0.6.5 entry in
+> [`CHANGELOG.md`](../../CHANGELOG.md).
+>
+> Completed waves:
+> 1. **Phase 1 (PR #74, committed)** — extract the five pre-written
+>    hooks listed below, plus presentational components.
+> 2. **Phase 2 hook extraction (PR #109, commit `5869ad1`)** —
+>    split the N-1 fetch pipeline into `useN1Fetch`, the per-tab
+>    SVG highlight pipeline into `useDiagramHighlights`, and the
+>    sidebar layout into `AppSidebar` / `SidebarSummary` /
+>    `StatusToasts`. Reduced `App.tsx` from 1575 to ~1150 lines.
+>
+> Deferred (explicitly scoped out of PR #109 — see the refactor
+> history table in `frontend/CLAUDE.md`): orchestrator hooks
+> (`useSettingsOrchestration`, `useSaveLoadSession`,
+> `useStateReset`), `AppContext`-provider conversion, and the
+> NDJSON parser extraction for `handleSimulateUnsimulatedAction`.
 
-## Current State
+## Goal (as of Phase 1)
+Refactor the 2100-line `App.tsx` into a lean orchestrator by wiring
+up 5 pre-written custom hooks that extract state and logic.
+
+## Initial State (as of Phase 1 start)
 - 5 hook files exist in `frontend/src/hooks/` (untracked):
   - `useSettings.ts` (253 lines) - paths, recommender params, settings modal
   - `useActions.ts` (121 lines) - action selection/rejection/favorite state
@@ -13,7 +41,7 @@ Refactor the 2100-line `App.tsx` into a lean orchestrator (~800 lines) by wiring
 - `usePanZoom.ts` (288 lines) - already committed and used by both App.tsx and useDiagrams
 - Type imports in all 5 hooks have been fixed (`React.Dispatch` -> `Dispatch`, etc.)
 - `useSettings` has been partially integrated into App.tsx (Step 2 done)
-- App.tsx currently compiles clean at ~1959 lines
+- App.tsx then compiled clean at ~1959 lines.
 
 ## Hook Interfaces Summary
 

--- a/docs/architecture/phase2-state-management-optimization.md
+++ b/docs/architecture/phase2-state-management-optimization.md
@@ -1,6 +1,33 @@
 # Phase 2: State Management Optimization
 
-## Status: Proposed
+## Status: Partially shipped
+
+**Shipped under PR #75** — memoization pass on the wrapper functions,
+`React.memo` on the three heaviest children, and the consolidated
+reset helpers. Released as part of 0.5.0 (see
+[`CHANGELOG.md`](../../CHANGELOG.md)).
+
+**Superseded in part by PR #109** — the "Phase 2 hook extraction"
+pushed two full cross-hook pipelines into their own hooks
+(`useN1Fetch`, `useDiagramHighlights`), which subsumes some of the
+wrapper-memoization discussion below because those wrappers no
+longer exist in `App.tsx` at all.
+
+**Still deferred** — the three orchestrator hooks called out in the
+[App.tsx refactor-history table in `frontend/CLAUDE.md`](../../frontend/CLAUDE.md)
+(`useSettingsOrchestration`, `useSaveLoadSession`,
+`useStateReset`), which would absorb the remaining
+`wrappedSaveResults` / `wrappedRestoreSession` / `resetAllState`
+complexity. See the "Deferred" section in that file for the
+tradeoff notes.
+
+> The sections below are preserved as the original design record
+> for Phase 1 (App.tsx ≈ 650 lines). Line numbers and the
+> wrapper-function inventory reflect that snapshot and are out of
+> date — `App.tsx` is now ≈ 1150 lines after PR #109. Start from
+> `frontend/CLAUDE.md` for the current shape.
+
+---
 
 **Scope:** `frontend/src/App.tsx` + hooks in `frontend/src/hooks/`
 **Risk:** Low — incremental changes, no new dependencies, each step independently shippable

--- a/docs/features/combined-actions.md
+++ b/docs/features/combined-actions.md
@@ -52,12 +52,14 @@ Both approaches are exposed through a two-tab modal ("Computed Pairs" and "Explo
 | File | Role |
 |------|------|
 | `frontend/src/components/CombinedActionsModal.tsx` | Modal UI: two tabs, estimation preview, simulation feedback |
+| `frontend/src/components/ComputedPairsTable.tsx` | Computed-pairs table (PR #103 split) |
+| `frontend/src/components/ExplorePairsTab.tsx` | Explore-pairs panel (PR #103 split) |
 | `frontend/src/components/ActionFeed.tsx` | Opens modal, passes `onManualActionAdded` as callback |
+| `frontend/src/components/ActionCard.tsx` | Renders clickable sub-action badges for every member of a combined pair (PR #114, `7e68ef3`) |
 | `frontend/src/api.ts` | `simulateManualAction()`, `computeSuperposition()` |
 | `frontend/src/types.ts` | `CombinedAction`, `ActionDetail` interfaces |
 | `expert_backend/main.py` | `/api/simulate-manual-action`, `/api/compute-superposition` endpoints |
-| `expert_backend/services/recommender_service.py` | `simulate_manual_action()`, `compute_superposition()` methods |
-| `standalone_interface.html` | Self-contained equivalent (state, handlers, rendering) |
+| `expert_backend/services/simulation_mixin.py` | `simulate_manual_action()`, `compute_superposition()` orchestrators (helpers in `simulation_helpers.py`, PR #104) |
 
 ---
 
@@ -215,41 +217,58 @@ State cleanup:
 
 ---
 
-## Standalone Interface
+## Standalone distribution
 
-The standalone interface (`standalone_interface.html`) mirrors the modal logic with equivalent state and handlers:
+No separate hand-maintained mirror exists any more. The single-file
+distribution is `frontend/dist-standalone/standalone.html`,
+auto-generated from the same React source via `npm run build:standalone`
+(PR #101); it inherits the `CombinedActionsModal` component, its
+state, and every handler byte-for-byte. The legacy
+`standalone_interface.html` — which used a separate
+`isSimulatingCombined` / `combinedSimulationFeedback` state machine
+and an explicit "Estimate Combination effect" button — has been
+decommissioned and frozen as `standalone_interface_legacy.html`.
 
-| React app | Standalone equivalent |
-|-----------|-----------------------|
-| `CombinedActionsModal` component | Inline JSX within `App` component |
-| `simulating` / `simulationFeedback` | `isSimulatingCombined` / `combinedSimulationFeedback` |
-| `preview` (auto-fetched) | `superpositionResult` (manual "Estimate Combination effect" button) |
-| `handleSimulate()` | `handleSimulateCombined()` |
-| `computeSuperposition` via useEffect | `handleComputeSuperposition()` (explicit button click) |
+---
 
-Key difference: the standalone uses an explicit "Estimate Combination effect" button rather than auto-fetching on selection.
+## Recent updates (PR #114, release 0.6.5)
 
-### Important: onClick handler pattern
+PR #114 extended the combined-actions workflow in four user-visible
+ways:
 
-`handleSimulateCombined` uses a default parameter:
+- **Load-shedding and curtailment are now allowed in combined pairs**
+  (commit `a019555`). Previously restricted to topology actions, the
+  Explore Pairs tab now accepts LS / curtailment on either side as
+  long as the pair is simulated (the superposition-estimation path
+  still requires both actions to have a pre-computed beta, which only
+  exists for topology actions).
+- **"Simulate Combined" moved out of the action card** (commit
+  `e871006`). The trigger now lives in the modal footer. After a
+  simulate-only pair lands, the resulting card is shown in the main
+  feed with all sub-action badges clickable
+  (`ActionCard.tsx`, commit `7e68ef3`) so the operator can inspect
+  each constituent in isolation.
+- **`target_max_rho` on the user-selected overload set** (commit
+  `a5d34da`). Superposition + simulation both now compute the max rho
+  restricted to the lines the operator explicitly flagged as
+  "resolve" in step-1. It is reported alongside the unrestricted
+  `max_rho` so the operator can tell whether a pair actually solves
+  their scenario or merely shifts the hot spot elsewhere.
+- **Explore-Pairs re-estimation aligned with pre-computed betas**
+  (commit `fd34eeb`). When a pair already has a `combined_actions`
+  entry from the analysis phase, the Explore tab now reuses those
+  betas instead of re-fetching — eliminating a subtle drift where
+  the re-estimate could disagree with the Computed Pairs row.
 
-```javascript
-const handleSimulateCombined = async (actionIds = selectedCombineActionIds) => {
-    if (actionIds.length !== 2) return;
-    ...
-};
-```
+Backend correctness fixes in the same release that the doc must be
+read against:
 
-When used as an `onClick` handler, it **must** be wrapped in an arrow function:
-
-```jsx
-// CORRECT -- default parameter applies
-onClick={() => handleSimulateCombined()}
-
-// WRONG -- React passes the SyntheticEvent as first argument,
-// overriding the default parameter, and actionIds.length !== 2
-onClick={handleSimulateCombined}
-```
+- `simulate_manual_action` now reuses the step-1 observation as the
+  simulation baseline (commit `198c0ed`), and `run_analysis_step2`
+  restores `enriched_actions` after the streaming pass
+  (`a0bc1a3`). The N-1 variant is pinned right before `obs.simulate`
+  on the combined-pair code path (`2ef61d5`) so residual state from
+  a previous action cannot leak into the combined observation.
 
 ---
 
@@ -297,7 +316,9 @@ During `run_analysis()` (line 475-482), the recommender library identifies promi
 
 When modifying combined actions logic:
 
-- [ ] Keep `CombinedActionsModal.tsx` and `standalone_interface.html` in sync
+- [ ] Edit `CombinedActionsModal.tsx` / `ComputedPairsTable.tsx` /
+      `ExplorePairsTab.tsx` only — the auto-generated standalone
+      bundle inherits the change via `npm run build:standalone`.
 - [ ] The `is_estimated` flag must be `false` only when results come from `simulate_manual_action`
 - [ ] Combined action IDs use `+` as separator -- never sort or reorder the parts
 - [ ] `onClick` handlers for functions with default parameters must use arrow wrappers
@@ -305,3 +326,5 @@ When modifying combined actions logic:
 - [ ] `simulationFeedback` state must be cleared when the selected pair changes
 - [ ] The modal must stay open during simulation so the user sees feedback
 - [ ] Test both tabs: Computed Pairs uses `handleSimulate(pairId)`, Explore uses `handleSimulate()` (no args)
+- [ ] Load-shedding / curtailment pairs work via simulate-only; the
+      estimation preview path is still topology-only.

--- a/docs/features/detachable-viz-tabs.md
+++ b/docs/features/detachable-viz-tabs.md
@@ -310,7 +310,7 @@ concrete choices / deviations:
 | Pop-up blocker fallback | Toast + cancel | Inline error set via `setError(...)` — reuses the existing global error banner rather than introducing a new toast component. |
 | Global event listener audit | `usePanZoom`, `SldOverlay`, zoom code | Done for `usePanZoom.ts` and `SldOverlay.tsx`. No other globals needed patching. |
 | Styles `MutationObserver` | Optional | Not shipped — unnecessary in practice. |
-| `standalone_interface.html` mirror | Disabled button with "dev build only" tooltip | **Not mirrored** in this iteration. The standalone HTML is a single-file dev artefact that does not use React portals, and wiring popup cloning into it would add significant complexity with little user value. Left as a known follow-up if we ever want feature parity. |
+| Standalone mirror | Disabled button with "dev build only" tooltip | No longer a separate concern. The legacy hand-maintained `standalone_interface.html` has been decommissioned (PR #101) and the canonical distribution is now `frontend/dist-standalone/standalone.html`, auto-generated from this React source via `npm run build:standalone`. Detach therefore works identically in the bundle — the Unicode-glyph button and popup-based detach flow are inherited unchanged. |
 | Interaction log | Not covered in plan | Added `tab_detached` / `tab_reattached` events so session replays can reproduce window layout. |
 | Tests | Vitest hook tests + panel behaviour tests | Shipped: `hooks/useDetachedTabs.test.ts` (148 lines) covering detach/reattach/focus/pruning/popup-blocked paths. Panel-level tests were not added — the hook tests + manual verification were deemed sufficient given the amount of DOM/Window mocking a full panel test would require. |
 
@@ -848,9 +848,7 @@ Vitest suites:
    If Vite HMR injects new styles while a tab is detached, the popup
    will not pick them up until it is reattached and detached again. This
    only affects dev mode.
-3. **`standalone_interface.html` parity** — the single-file standalone
-   interface does not support detaching. See the table above.
-4. **Full page reload** — reloading the main window closes all detached
+3. **Full page reload** — reloading the main window closes all detached
    popups (by design). We do not currently persist and restore detached
    state across reloads.
 

--- a/docs/features/frontend-ui-improvements.md
+++ b/docs/features/frontend-ui-improvements.md
@@ -1,7 +1,10 @@
 # Frontend UI Improvements Plan
 
 > **Status**: Implemented  
-> **Scope**: `frontend/` components + `standalone_interface.html`  
+> **Scope**: `frontend/src/` components. The auto-generated
+> `frontend/dist-standalone/standalone.html` (PR #101) inherits from
+> the React source via `npm run build:standalone`; the legacy
+> hand-maintained `standalone_interface.html` has been decommissioned.  
 > **Date**: 2026-04-01
 
 ---

--- a/docs/features/state-reset-and-confirmation-dialogs.md
+++ b/docs/features/state-reset-and-confirmation-dialogs.md
@@ -58,9 +58,14 @@ Flow for contingency change:
 5. On confirm: `clearContingencyState()` is called, `committedBranchRef` is updated, branch is committed
 6. On cancel: dialog closes, input stays at committed branch
 
-#### Standalone Interface (`standalone_interface.html`)
+#### Standalone Interface
 
-Uses `window.confirm()` (native browser dialog) for consistency with the existing Load Study and Apply Settings confirmation patterns already present in the standalone version.
+No separate standalone mirror is required: the single-file distribution is now
+`frontend/dist-standalone/standalone.html`, auto-generated from this same React
+source via `npm run build:standalone` (PR #101). It therefore renders the exact
+same `ConfirmationDialog` component — the legacy hand-maintained
+`standalone_interface.html` that used `window.confirm()` has been decommissioned
+and frozen as `standalone_interface_legacy.html`.
 
 ---
 
@@ -105,16 +110,31 @@ The `/api/config` endpoint now **always reloads the network** and **resets the r
 - Cached simulation environments (`_simulation_env`) from a previous analysis
 - Leftover `_base_network`, `_last_disconnected_element`, `_dict_action`, `_analysis_context`
 
-The `RecommenderService.reset()` method clears:
-- `_last_result`
-- `_is_running`, `_generator`
-- `_base_network`, `_simulation_env`
-- `_last_disconnected_element`
-- `_dict_action`, `_analysis_context`
-- `_layout_cache` — the cached `grid_layout.json` DataFrame used as
-  `fixed_positions` for NAD generation. Must be cleared so a new study
-  loaded from a different grid does not reuse the previous grid's
-  substation coordinates.
+The `RecommenderService.reset()` method clears, in order:
+1. `_drain_pending_base_nad_prefetch()` — first, so a still-running
+   prefetch thread cannot finish after reset and write into the next
+   study's cache.
+2. Per-study analysis state: `_last_result`, `_is_running`,
+   `_generator`, `_base_network`, `_simulation_env`,
+   `_last_disconnected_element`, `_dict_action`, `_analysis_context`,
+   `_saved_computed_pairs`.
+3. Fast-path caches: `_cached_obs_n`, `_cached_obs_n_id`,
+   `_cached_obs_n1`, `_cached_obs_n1_id`, `_cached_env_context`,
+   `_initial_pst_taps`, `_lf_status_by_variant`.
+4. `_layout_cache` — the cached `grid_layout.json` DataFrame used as
+   `fixed_positions` for NAD generation. Must be cleared so a new
+   study loaded from a different grid does not reuse the previous
+   grid's substation coordinates.
+5. NAD-prefetch state: `_prefetched_base_nad`,
+   `_prefetched_base_nad_error`, `_prefetched_base_nad_event`,
+   `_prefetched_base_nad_thread`.
+
+Adding a new per-study cache? It MUST be listed in
+`RecommenderService.reset()` (see
+`expert_backend/services/recommender_service.py:99`) and, if it holds
+a thread / future / event, drained first via a `_drain_pending_*`
+helper — otherwise it WILL leak across studies (regression history:
+the `_layout_cache` fix on `claude/fix-grid-layout-reset-8TYEV`).
 
 ### Why Force Reload?
 

--- a/expert_backend/CLAUDE.md
+++ b/expert_backend/CLAUDE.md
@@ -21,18 +21,33 @@ expert_backend/
 ├── test_backend.py            # Ad-hoc integration script (not part of pytest)
 ├── services/
 │   ├── __init__.py
-│   ├── network_service.py     # NetworkService singleton — pypowsybl Network
-│   │                          # loading, branch / VL / nominal-voltage queries
-│   ├── recommender_service.py # RecommenderService singleton — orchestrates
-│   │                          # analysis. Composes the three mixins below.
-│   ├── diagram_mixin.py       # NAD/SLD generation, layout cache, flow deltas,
-│   │                          # overload detection
-│   ├── analysis_mixin.py      # Two-step contingency analysis (step1 detect,
-│   │                          # step2 resolve), action enrichment, MW/tap-start
-│   ├── simulation_mixin.py    # Manual-action simulation, superposition,
-│   │                          # action-dictionary helpers
-│   └── sanitize.py            # NumPy → native-Python recursive coercion
-│                              # (`sanitize_for_json`)
+│   ├── network_service.py         # NetworkService singleton — pypowsybl Network
+│   │                              # loading, branch / VL / nominal-voltage queries
+│   ├── recommender_service.py     # RecommenderService singleton — orchestrates
+│   │                              # analysis. Composes the three mixins below.
+│   ├── diagram_mixin.py           # NAD/SLD orchestrator — delegates pure
+│   │                              # numerics to services/diagram/ helpers
+│   ├── diagram/                   # PR #104 decomposition (ex-diagram_mixin):
+│   │   ├── layout_cache.py        # - (path, mtime)-keyed grid_layout.json loader
+│   │   ├── nad_params.py          # - default NadParameters factory
+│   │   ├── nad_render.py          # - NAD generation + NaN-element stripping
+│   │   ├── sld_render.py          # - SLD SVG + metadata with fallbacks
+│   │   ├── overloads.py           # - overload filtering, element-currents
+│   │   ├── flows.py               # - branch + asset flow extractors (vectorised)
+│   │   └── deltas.py              # - terminal-aware flow-delta math (pure)
+│   ├── analysis_mixin.py          # Two-step orchestrator — delegates pure
+│   │                              # numerics to services/analysis/ helpers
+│   ├── analysis/                  # PR #104 decomposition (ex-analysis_mixin):
+│   │   ├── action_enrichment.py   # - LS / curtail / PST / topology details
+│   │   ├── mw_start_scoring.py    # - MW-at-start dispatcher + per-type math
+│   │   ├── analysis_runner.py     # - AC→DC fallback worker, PDF-polling stream
+│   │   └── pdf_watcher.py         # - overflow PDF glob + mtime filter
+│   ├── simulation_mixin.py        # Manual-action + superposition orchestrator
+│   ├── simulation_helpers.py      # PR #104 decomposition — 14 stateless
+│   │                              # helpers (setpoint math, PST parsing, care
+│   │                              # mask, metrics, result serialisation, …)
+│   └── sanitize.py                # NumPy → native-Python recursive coercion
+│                                  # (`sanitize_for_json`)
 └── tests/                     # pytest suite — see tests/CLAUDE.md
 ```
 
@@ -49,6 +64,18 @@ the same `self`. The composition is intentional: state lifecycle
 (`__init__`, `reset`, `update_config`) stays in `recommender_service.py`
 and the mixins reach into it through `self`. Treat the mixins as one
 class split across files for readability.
+
+**Mixin → helper-package decomposition (PR #104 / #106).** Each
+mixin is now a **thin orchestrator** that delegates stateless pure
+numerics to sibling packages: `services/diagram/` (7 modules),
+`services/analysis/` (4 modules), and `services/simulation_helpers.py`
+(14 free functions). The split keeps the mixins manageable while
+preserving `@patch` compatibility — helpers that need service
+collaborators (`get_virtual_line_flow`, `run_analysis`, …) accept
+them as optional callables and the mixin reads those from its own
+module namespace at call time, so legacy
+`@patch('expert_backend.services.analysis_mixin.*')` tests keep
+working unchanged.
 
 ## Singletons & shared state
 
@@ -122,6 +149,14 @@ Diagram & topology:
   `docs/performance/history/loading-parallel.md`).
 - `POST /api/n1-diagram` / `/api/action-variant-diagram` /
   `/api/focused-diagram` / `/api/action-variant-focused-diagram`
+- `POST /api/n1-diagram-patch` / `/api/action-variant-diagram-patch`
+  — **SVG-less per-branch deltas** for the frontend DOM-recycling
+  fast path (PR #108). Return the same flow / contingency / topology
+  metadata as the full endpoints but omit the multi-MB SVG body. The
+  frontend's `utils/svgPatch.ts` clones the already-mounted N-state
+  SVG and patches it with this delta — ~80 % faster tab switches on
+  the ~12 MB French NAD. See
+  `docs/performance/history/svg-dom-recycling.md`.
 - `POST /api/n-sld` / `/api/n1-sld` / `/api/action-variant-sld`
 
 Analysis:
@@ -256,21 +291,22 @@ no prefetch was ever started (e.g. tests bypassing `update_config`).
 ## Conventions
 
 - **Logging**: `logger = logging.getLogger(__name__)`. Use it
-  (no `print`) for new code.
-- **No formal Python linter**: code follows PEP 8 manually. Match
-  the surrounding style (4-space indent, type hints where helpful,
-  docstrings on public methods).
+  (no `print`, no `traceback.print_exc()`) for new code — the
+  code-quality gate enforces this (PR #104).
+- **Ruff** is configured in `pyproject.toml` with a narrow
+  `E9` + `F` ruleset (real bugs only — no stylistic rules). Run
+  `ruff check expert_backend` before committing.
 - **Error handling at the API boundary**: services raise standard
   exceptions; `main.py` translates them to `HTTPException` with a
   meaningful detail message. Internal validation that "can't fail"
   shouldn't be there — trust the caller.
 - **No backwards-compatibility shims**: when a feature changes,
-  update the consumers in the same commit (frontend, standalone
-  HTML, tests).
-- **`standalone_interface.html` parity**: the root has a self-
-  contained single-file mirror of the React UI. UI-related backend
-  changes (new endpoints, payload shape changes) need a manual
-  mirror there too.
+  update the consumers in the same commit (frontend, tests).
+- **Auto-generated standalone**: no manual mirroring is required.
+  `npm run build:standalone` regenerates
+  `frontend/dist-standalone/standalone.html` from the React source
+  tree; the legacy hand-maintained `standalone_interface.html` has
+  been decommissioned (PR #101).
 
 ## Running
 
@@ -281,6 +317,7 @@ python -m expert_backend.main
 uvicorn expert_backend.main:app --host 0.0.0.0 --port 8000
 ```
 
-CORS is wide-open (`allow_origins=["*"]`) because the dev frontend
-hits the backend cross-origin. Tighten before any non-local
-deployment.
+CORS defaults to wide-open (`allow_origins=["*"]`) because the dev
+frontend hits the backend cross-origin. It is configurable via the
+`CORS_ALLOWED_ORIGINS` env var (PR #104 — see `.env.example`).
+Tighten before any non-local deployment.

--- a/expert_backend/tests/CLAUDE.md
+++ b/expert_backend/tests/CLAUDE.md
@@ -44,7 +44,7 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 #### API & Service Layer
 | File | Description |
 |------|-------------|
-| `test_api_endpoints.py` | FastAPI endpoint testing with TestClient and mocked services |
+| `test_api_endpoints.py` | FastAPI endpoint testing with TestClient and mocked services (covers the patch endpoints `/api/n1-diagram-patch`, `/api/action-variant-diagram-patch`, `/api/simulate-and-variant-diagram`). |
 | `test_recommender_service.py` | RecommenderService config updates and action enrichment |
 | `test_network_service.py` | NetworkService initialization, loading, and element lookup |
 
@@ -53,18 +53,22 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 |------|-------------|
 | `test_recommender_simulation.py` | Real data simulation with small test grid |
 | `test_split_analysis.py` | Two-step analysis workflow (step1 overload detect, step2 resolve) |
-| `test_combined_actions_integration.py` | Combined action workflow integration |
+| `test_combined_actions_integration.py` | Combined action workflow integration (incl. PR #114 LS/curtailment in combined pairs) |
 | `test_combined_actions_scenario.py` | Real-world combined action scenarios |
 | `test_stream_pdf_integration.py` | Streaming NDJSON + PDF event integration |
+| `test_resimulate_regression.py` | Re-simulation correctness after action state changes |
+| `test_second_contingency_reset.py` | Guards that switching contingency clears the prior N-1 variant cleanly |
+| `test_get_n1_variant_clones_from_n_state.py` | `_get_n1_variant()` clones from the clean N baseline, never from a leftover action variant |
 
-#### Load Shedding & Curtailment
+#### Load Shedding, Curtailment, PST
 | File | Description |
 |------|-------------|
 | `test_power_reduction_format.py` | New `loads_p`/`gens_p` power reduction format + legacy `bus=-1` compat |
 | `test_renewable_curtailment.py` | Curtailment detail computation and config updates |
 | `test_manual_action_enrichment.py` | Manual action enrichment (topology, description, details) |
-| `test_dynamic_actions.py` | On-the-fly action creation for `load_shedding_*`, `curtail_*`, `pst_*` |
+| `test_dynamic_actions.py` | On-the-fly action creation for `load_shedding_*`, `curtail_*`, `pst_*`, `reco_*` (PR #110) |
 | `test_mw_start.py` | MW Start computation for scoring (line disco, PST, load shedding, open coupling) |
+| `test_configurable_mw.py` | Configurable MW reduction thresholds |
 
 #### Core Computation
 | File | Description |
@@ -87,8 +91,18 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 | `test_superposition_accuracy.py` | Superposition vs simulation discrepancy detection |
 | `test_superposition_filtering_regression.py` | Max rho filtering for heavily loaded lines |
 | `test_superposition_service.py` | On-demand superposition computation |
-| `test_superposition_monitoring_consistency.py` | Monitoring alignment between estimation and simulation (11 tests) |
+| `test_superposition_monitoring_consistency.py` | Monitoring alignment between estimation and simulation |
 | `test_pst_combined_actions.py` | PST tap + combined action simulation, topology preservation, fast_mode protection |
+
+#### PR #104 decomposition — extracted helper packages
+| File | Description |
+|------|-------------|
+| `test_simulation_helpers.py` | 66 tests for the stateless helpers extracted from `simulate_manual_action` + `compute_superposition` |
+| `test_analysis_helpers.py` | 68 tests for `services/analysis/` (MW-start, action enrichment, PDF watcher, analysis runner) |
+| `test_diagram_helpers.py` | 39 tests for `services/diagram/` (layout cache, NAD params, NAD render, SLD render, overloads, flows, deltas) |
+| `test_diagram_mixin.py` | Orchestrator-level coverage for `DiagramMixin` after the decomposition |
+| `test_diagram_patch_helpers.py` | Patch-endpoint delta math (`/api/n1-diagram-patch`, `/api/action-variant-diagram-patch`) — PR #108 |
+| `test_n1_diagram_fast_path.py` | Fast-path guards for the N-1 diagram pipeline |
 
 #### Performance & Regression
 | File | Description |
@@ -96,7 +110,6 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 | `test_performance_budgets.py` | Benchmarks for large observations (2000+ lines) |
 | `test_recommender_regressions.py` | MW calculation and curtailment robustness |
 | `test_recommender_non_convergence.py` | Power flow convergence failure handling |
-| `test_ui_regressions.py` | Critical UI string and class presence |
 
 #### Infrastructure
 | File | Description |
@@ -110,44 +123,50 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 
 ## Frontend Test Structure
 
-### Test Files by Domain
+Tests live next to their source file as `*.test.ts` / `*.test.tsx`.
+Run `cd frontend && npm run test` for the full suite (~1000 specs as
+of 0.6.5). Key test groups:
 
-#### App Integration
+### App-level integration (`frontend/src/App.*.test.tsx`)
+
+Six app-integration files split by domain: `App.contingency` (step1 →
+step2 flow), `App.session` (save/reload), `App.settings`,
+`App.stateManagement`, `App.datalist`, `App.import` (module-import
+sanity).
+
+### Components (`frontend/src/components/**/*.test.tsx`)
+
+Every presentational component has a colocated test file —
+`ActionCard`, `ActionCardPopover`, `ActionFeed`, `ActionOverviewDiagram`,
+`ActionSearchDropdown`, `ActionTypeFilterChips`, `CombinedActionsModal`,
+`ComputedPairsTable`, `DetachableTabHost`, `ErrorBoundary`,
+`ExplorePairsTab`, `Header`, `MemoizedSvgContainer`, `OverloadPanel`,
+`SldOverlay`, `VisualizationPanel`, plus the three modals
+(`SettingsModal`, `ReloadSessionModal`, `ConfirmationDialog`).
+
+### Hooks (`frontend/src/hooks/*.test.ts[x]`)
+
+One test file per hook — `useActions`, `useAnalysis`, `useDetachedTabs`,
+`useDiagramHighlights`, `useDiagrams`, `usePanZoom`, `useSession`,
+`useSettings`, `useSldOverlay`, `useTiedTabsSync`. `useN1Fetch` is
+covered transitively by `useDiagrams` + the App-integration suite.
+
+### Utilities (`frontend/src/utils/**/*.test.ts`)
+
 | File | Description |
 |------|-------------|
-| `App.contingency.test.tsx` | Contingency analysis workflow (step1 -> step2) |
-| `App.session.test.tsx` | Session save/load and interaction |
-| `App.settings.test.tsx` | Settings panel and configuration |
-| `App.import.test.tsx` | Module import sanity check |
-
-#### Components
-| File | Description |
-|------|-------------|
-| `ActionFeed.test.tsx` | Action card rendering, filtering, load shedding/curtailment details, MW Start, badges |
-| `CombinedActionsModal.test.tsx` | Combined action pair computation modal |
-| `OverloadPanel.test.tsx` | Two-step overload analysis panel |
-| `VisualizationPanel.test.tsx` | SVG diagram rendering and pan/zoom |
-
-#### Hooks
-| File | Description |
-|------|-------------|
-| `useActions.test.ts` | Action state management and manual action handling |
-| `useAnalysis.test.ts` | Analysis streaming (step1/step2) |
-| `useDiagrams.test.ts` | Diagram fetching and variant management |
-| `usePanZoom.test.tsx` | Pan/zoom viewBox optimization |
-| `useSession.test.ts` | Session persistence and restoration |
-| `useSettings.test.ts` | Settings state and interaction logging |
-
-#### Utilities
-| File | Description |
-|------|-------------|
-| `svgUtils.test.ts` | SVG processing, target detection, highlights, metadata indexing |
-| `sessionUtils.test.ts` | Session snapshot building and serialization |
-| `interactionLogger.test.ts` | Interaction event logger |
-| `standaloneInterface.test.ts` | Standalone HTML interface serialization |
-| `mergeAnalysisResult.test.ts` | Analysis result field merging |
-| `fileRegistry.test.ts` | Project structure regression (removed workers) |
-| `cssRegression.test.ts` | Critical CSS property guards |
+| `svgUtils.test.ts` | Barrel-level regression guards (halo layering, composite target detection, highlight ordering) |
+| `svg/*.test.ts` | Unit tests for each PR #104 submodule (`idMap`, `metadataIndex`, `svgBoost`, `fitRect`, `actionPinData`, `actionPinRender`) |
+| `svgPatch.test.ts` | DOM-recycling patch applier (PR #108): clone, dashed-class toggling, VL-subtree splicing, stale-response guard |
+| `actionTypes.test.ts` | `classifyActionType` + `matchesActionTypeFilter` coverage |
+| `sessionUtils.test.ts` | Session snapshot building + interaction-log serialization |
+| `interactionLogger.test.ts` | Singleton event-log contract (sequence numbers, correlation IDs) |
+| `mergeAnalysisResult.test.ts` | Step1+step2 field merging |
+| `overloadHighlights.test.ts` | N-1 overload classification |
+| `popoverPlacement.test.ts` | Pin-popover positioning |
+| `fileRegistry.test.ts` | Structure-regression guard — fails if an expected source file disappears |
+| `specConformance.test.ts` | Layer-4 spec contracts for interaction-log events |
+| `userObservableInvariants.test.ts` | Runtime Vitest twin of `scripts/check_invariants.py` |
 
 ## Common Testing Patterns
 
@@ -200,4 +219,15 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 - Backend tests run without `pypowsybl` or `expert_op4grid_recommender` installed — `conftest.py` stubs them
 - Some integration tests (e.g., `test_recommender_simulation.py`, `test_stream_pdf_integration.py`) use real test data from the `expert_op4grid_recommender` package when available
 - Frontend tests require `npm install` in the `frontend/` directory
-- Root-level `test_*.py` files (`test_backend.py`, `test_api_stream.py`, etc.) are ad-hoc integration scripts that require a running backend — they are not part of the pytest suite
+- `expert_backend/test_backend.py` is an ad-hoc integration script that requires a running backend — it is NOT part of the pytest suite. Invoke directly with `python expert_backend/test_backend.py`.
+- `scripts/pypsa_eur/` carries its own pytest coverage for the
+  PyPSA-EUR → XIIDM pipeline (`test_build_pipeline.py`,
+  `test_calibrate_thermal_limits.py`, `test_generate_n1_overloads.py`,
+  `test_regenerate_grid_layout.py`). Run with `pytest scripts/pypsa_eur`.
+- **Removed** (by PR #103 / PR #104): `test_ui_regressions.py` (its
+  assertions targeted strings in the decommissioned
+  `standalone_interface.html`; equivalent coverage now lives in the
+  four parity scripts under `scripts/` and in the Vitest
+  `userObservableInvariants.test.ts` + `specConformance.test.ts`
+  files), and the frontend `standaloneInterface.test.ts` /
+  `cssRegression.test.ts` files.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -17,7 +17,7 @@ frontend/
 ├── README.md
 ├── index.html                # Vite HTML entry point
 ├── package.json              # React 19, Vite 7, vitest, axios, react-select,
-│                             # react-zoom-pan-pinch, framer-motion, lucide-react
+│                             # react-zoom-pan-pinch, vite-plugin-singlefile
 ├── vite.config.ts            # Vite + Vitest plugin (jsdom env)
 ├── eslint.config.js          # Flat config (v9+) — typescript-eslint,
 │                             # react-hooks, react-refresh
@@ -55,6 +55,9 @@ frontend/
     │   ├── Header.tsx, ActionFeed.tsx, OverloadPanel.tsx,
     │   ├── VisualizationPanel.tsx, ActionCard.tsx, ActionCardPopover.tsx,
     │   ├── ActionOverviewDiagram.tsx, ActionSearchDropdown.tsx,
+    │   ├── ActionTypeFilterChips.tsx   # Shared chip row driving Manual
+    │   │                               # Selection, Explore Pairs, Overview,
+    │   │                               # and the Action Feed (PR #109)
     │   ├── CombinedActionsModal.tsx, ComputedPairsTable.tsx,
     │   ├── DetachableTabHost.tsx, ErrorBoundary.tsx, ExplorePairsTab.tsx,
     │   ├── MemoizedSvgContainer.tsx, SldOverlay.tsx,
@@ -68,12 +71,30 @@ frontend/
     │       ├── ReloadSessionModal.tsx     # Session reload list
     │       └── ConfirmationDialog.tsx     # Shared confirmation (contingency / reload)
     └── utils/                # Pure helpers (no React, no axios)
-        ├── svgUtils.ts                # SVG processing, highlights, metadata
+        ├── svgUtils.ts                # Barrel re-exporting every utils/svg/* module
+        ├── svg/                       # PR #104 decomposition of the original
+        │   ├── idMap.ts               # 1807-line svgUtils into 8 focused modules:
+        │   ├── metadataIndex.ts       # - idMap: cached WeakMap<container,id→Element>
+        │   ├── svgBoost.ts            # - metadataIndex: O(1) equipment-metadata lookup
+        │   ├── fitRect.ts             # - svgBoost: dynamic font/radius scale for big grids
+        │   ├── deltaVisuals.ts        # - fitRect: bounding-box auto-zoom
+        │   ├── actionPinData.ts       # - deltaVisuals: flow-delta colouring
+        │   ├── actionPinRender.ts     # - actionPin{Data,Render}: overview pin layer
+        │   └── highlights.ts          # - highlights: contingency / overload halos
+        ├── svgPatch.ts                # SVG DOM recycling: clone N-state SVG
+        │                              # and patch per-branch deltas on N-1 / action
+        │                              # tab switches (PR #108). Used by useN1Fetch.
+        ├── actionTypes.ts             # classifyActionType + matchesActionTypeFilter
+        │                              # + DEFAULT_ACTION_OVERVIEW_FILTERS — shared
+        │                              # by every filter UI surface (PR #109)
         ├── overloadHighlights.ts      # N-1 overload classification
         ├── popoverPlacement.ts        # Pin-popover positioning
         ├── sessionUtils.ts            # buildSessionResult snapshot
         ├── interactionLogger.ts       # Singleton replay-ready event log
         ├── mergeAnalysisResult.ts     # Merge step1 + step2 fields
+        ├── fileRegistry.ts            # Structure-regression guard (tracks expected
+        │                              # source-tree layout; fails the Vitest suite
+        │                              # when a file disappears unexpectedly)
         └── *.test.ts                  # Co-located unit tests
 ```
 
@@ -161,18 +182,26 @@ Confirmation dialog flow lives in `App.tsx`:
 
 ## SVG handling
 
-The frontend deals with multi-MB pypowsybl SVG payloads. Three
+The frontend deals with multi-MB pypowsybl SVG payloads. Four
 performance levers are applied today:
 
 - **`api.getNetworkDiagram` uses `format=text`** (`api.ts:69-92`):
   fetches a JSON-header + raw-SVG-body response so the browser
   doesn't `JSON.parse` a 25 MB string. Saves ~500 ms on large grids.
-- **`getIdMap(container)`** (`utils/svgUtils.ts:13-22`): cached
+- **`getIdMap(container)`** (`utils/svg/idMap.ts`): cached
   `WeakMap<HTMLElement, Map<id, Element>>` so highlight passes don't
   re-scan `[id]` selectors. Invalidate via `invalidateIdMapCache`
   whenever the SVG content changes.
-- **`boostSvgForLargeGrid`**: dynamic font/node-radius scaling for
-  grids ≥ 500 voltage levels so labels stay readable at high zoom.
+- **`boostSvgForLargeGrid`** (`utils/svg/svgBoost.ts`): dynamic
+  font/node-radius scaling for grids ≥ 500 voltage levels so labels
+  stay readable at high zoom.
+- **SVG DOM recycling** (`utils/svgPatch.ts`, PR #108): on N-1 /
+  action tab switches the N-state `SVGSVGElement` is cloned and
+  patched with per-branch deltas from the new
+  `/api/n1-diagram-patch` and `/api/action-variant-diagram-patch`
+  endpoints instead of being re-fetched and re-parsed. ~80 % faster
+  on the ~12 MB French NAD. Falls back to the full NAD on any
+  unsupported edge case.
 
 The visualization is rendered inside `react-zoom-pan-pinch`. Zoom
 state is owned by `usePanZoom` per tab (`nPZ`, `n1PZ`, `actionPZ`,

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,127 @@
-# React + TypeScript + Vite
+# Co-Study4Grid — Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React 19 + TypeScript 5.9 + Vite 7 single-page app for the
+Co-Study4Grid contingency-analysis UI. Talks to the FastAPI backend
+at `http://localhost:8000` (hardcoded in `src/api.ts`) and renders
+pypowsybl NAD / SLD diagrams with pan / zoom.
 
-Currently, two official plugins are available:
+This file is a quick orientation. For the full guide — hook split,
+data flow, SVG performance levers, detached / tied tabs, interaction
+logger contract — see [`CLAUDE.md`](./CLAUDE.md).
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Scripts
 
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install                 # install dependencies
+npm run dev                 # Vite dev server with HMR (default port 5173)
+npm run build               # tsc -b && vite build → dist/
+npm run build:standalone    # tsc -b && vite build --config vite.config.standalone.ts
+                            #   → dist-standalone/standalone.html (single-file bundle)
+npm run preview             # preview the production build
+npm run lint                # eslint . (flat config, v9+)
+npm run test                # vitest run (~1000 specs)
+npm run test:watch          # vitest in watch mode
+npm run quality:report      # run the backend code-quality reporter on the whole repo
+npm run quality:check       # gate — exits non-zero on threshold violation
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The backend must be running on `http://localhost:8000` for the dev
+server to serve anything useful. Start it with:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+# from project root
+uvicorn expert_backend.main:app --host 0.0.0.0 --port 8000
 ```
+
+## Source layout
+
+```
+src/
+├── main.tsx                     # React entry (StrictMode)
+├── App.tsx                      # State orchestration hub (~1150 lines)
+├── App.*.test.tsx               # App-level integration tests by domain
+├── api.ts                       # Axios HTTP client
+├── types.ts                     # All TypeScript interfaces
+├── hooks/
+│   ├── useSettings.ts           # Settings state + SettingsState interface
+│   ├── useActions.ts            # Action selection / favorite / reject
+│   ├── useAnalysis.ts           # Two-step analysis pipeline (step1 / step2)
+│   ├── useDiagrams.ts           # NAD fetching + tab management
+│   ├── useN1Fetch.ts            # svgPatch fast-path + /api/n1-diagram fallback
+│   ├── useDiagramHighlights.ts  # Per-tab SVG highlight pipeline + Flow/Impacts view-mode
+│   ├── useSession.ts            # Session save / reload
+│   ├── useDetachedTabs.ts       # Detached visualization windows
+│   ├── useTiedTabsSync.ts       # Mirror viewBox between detached + main
+│   ├── useSldOverlay.ts         # SLD overlay state
+│   └── usePanZoom.ts            # Per-tab viewBox, zoom-to-element
+├── components/                  # Presentational components (no API calls)
+│   ├── Header, ActionFeed, ActionCard, ActionCardPopover,
+│   ├── ActionOverviewDiagram, ActionSearchDropdown,
+│   ├── ActionTypeFilterChips,                              # Shared chip row
+│   ├── AppSidebar, SidebarSummary, StatusToasts,           # Sidebar layout
+│   ├── VisualizationPanel, OverloadPanel, CombinedActionsModal,
+│   ├── ComputedPairsTable, ExplorePairsTab,
+│   ├── DetachableTabHost, MemoizedSvgContainer, SldOverlay,
+│   ├── ErrorBoundary
+│   └── modals/
+│       ├── SettingsModal, ReloadSessionModal, ConfirmationDialog
+└── utils/
+    ├── svgUtils.ts              # Barrel re-exporting every utils/svg/* module
+    ├── svg/                     # PR #104 decomposition of the old svgUtils
+    │   ├── idMap, metadataIndex, svgBoost, fitRect,
+    │   ├── deltaVisuals, actionPinData, actionPinRender,
+    │   └── highlights
+    ├── svgPatch.ts              # SVG DOM recycling (PR #108)
+    ├── actionTypes.ts           # Action-type classification + filter helpers
+    ├── overloadHighlights.ts    # N-1 overload classification
+    ├── sessionUtils.ts          # buildSessionResult snapshot
+    ├── interactionLogger.ts     # Singleton replay-ready event log
+    ├── mergeAnalysisResult.ts   # Step1 + step2 field merge
+    ├── popoverPlacement.ts      # Pin-popover positioning
+    └── fileRegistry.ts          # Structure regression guard
+```
+
+## Standalone bundle
+
+`npm run build:standalone` produces
+`frontend/dist-standalone/standalone.html` — a single-file HTML with
+React + CSS inlined via `vite-plugin-singlefile`. This is the
+canonical distribution artifact; the legacy hand-maintained
+`standalone_interface.html` has been decommissioned and frozen as
+`standalone_interface_legacy.html` at the project root. UI changes
+should land only in `frontend/src/` — the bundle inherits them on
+the next build. See [`CLAUDE.md`](./CLAUDE.md) for the parity story.
+
+## Testing
+
+Tests live next to their source file as `*.test.ts` / `*.test.tsx`.
+The suite uses Vitest with `jsdom`, `@testing-library/react`, and
+`@testing-library/jest-dom`. Heavy mocking is the norm (`vi.mock`
+for `../api` and SVG utilities) so component tests never hit the
+backend.
+
+Run a single file:
+
+```bash
+npx vitest run src/components/ActionFeed.test.tsx
+```
+
+Test patterns and the full inventory are documented in
+[`../expert_backend/tests/CLAUDE.md`](../expert_backend/tests/CLAUDE.md).
+
+## ESLint
+
+Flat config (v9+) in `eslint.config.js` with `typescript-eslint`,
+`react-hooks`, and `react-refresh`. The code-quality gate
+(`python scripts/check_code_quality.py`, CI-enforced) rejects `any`
+and `@ts-ignore` in source files — see
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Further reading
+
+- [`CLAUDE.md`](./CLAUDE.md) — architecture deep dive
+- [`../CLAUDE.md`](../CLAUDE.md) — project-wide overview + API table
+- [`../docs/README.md`](../docs/README.md) — design, feature and
+  performance docs index
+- [`PARITY_AUDIT.md`](./PARITY_AUDIT.md) — standalone-bundle parity
+  audit (Layer 1–4 conformity, regression matrix)

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -890,4 +890,47 @@ describe('VisualizationPanel', () => {
             document.body.removeChild(mountNode);
         });
     });
+
+    describe('kV voltage filter', () => {
+        // Regression guard for the collapse-at-max bug: when the user pulled
+        // both handles together to maxV, the default z-order pinned the high
+        // handle (it cannot move beyond maxV) and hid the low handle beneath
+        // it, so the range could no longer be expanded.
+        const openFilter = async () => {
+            const toggle = screen.getByTitle('Show voltage filter');
+            await userEvent.click(toggle);
+        };
+        const sliders = () =>
+            document.querySelectorAll<HTMLInputElement>('.voltage-slider-container input[type=range]');
+
+        it('puts the high handle on top by default when the range is not collapsed at maxV', async () => {
+            render(<VisualizationPanel {...createDefaultProps({
+                uniqueVoltages: [25, 225, 400],
+                voltageRange: [25, 400] as [number, number],
+            })} />);
+            await openFilter();
+            const [low, high] = sliders();
+            expect(parseInt(low.style.zIndex, 10)).toBeLessThan(parseInt(high.style.zIndex, 10));
+        });
+
+        it('raises the low handle above the high handle when both are collapsed at maxV', async () => {
+            render(<VisualizationPanel {...createDefaultProps({
+                uniqueVoltages: [25, 225, 400],
+                voltageRange: [400, 400] as [number, number],
+            })} />);
+            await openFilter();
+            const [low, high] = sliders();
+            expect(parseInt(low.style.zIndex, 10)).toBeGreaterThan(parseInt(high.style.zIndex, 10));
+        });
+
+        it('keeps the high handle on top when both are collapsed at minV (high can still move up)', async () => {
+            render(<VisualizationPanel {...createDefaultProps({
+                uniqueVoltages: [25, 225, 400],
+                voltageRange: [25, 25] as [number, number],
+            })} />);
+            await openFilter();
+            const [low, high] = sliders();
+            expect(parseInt(low.style.zIndex, 10)).toBeLessThan(parseInt(high.style.zIndex, 10));
+        });
+    });
 });

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -1129,30 +1129,43 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <div className="voltage-slider-container">
                                 <div className="voltage-slider-track" />
                                 <div className="voltage-slider-range" style={{ bottom: pctLow + '%', top: (100 - pctHigh) + '%' }} />
-                                <input type="range"
-                                    min={logMin} max={logMax} step="any"
-                                    value={Math.log(voltageRange[0])}
-                                    onChange={e => {
-                                        const logV = parseFloat(e.target.value);
-                                        const snapped = uniqueVoltages.reduce((best, uv) =>
-                                            Math.abs(Math.log(uv) - logV) < Math.abs(Math.log(best) - logV) ? uv : best
-                                        );
-                                        if (snapped <= voltageRange[1]) onVoltageRangeChange([snapped, voltageRange[1]]);
-                                    }}
-                                    style={{ zIndex: 3, height: '100%' }}
-                                />
-                                <input type="range"
-                                    min={logMin} max={logMax} step="any"
-                                    value={Math.log(voltageRange[1])}
-                                    onChange={e => {
-                                        const logV = parseFloat(e.target.value);
-                                        const snapped = uniqueVoltages.reduce((best, uv) =>
-                                            Math.abs(Math.log(uv) - logV) < Math.abs(Math.log(best) - logV) ? uv : best
-                                        );
-                                        if (snapped >= voltageRange[0]) onVoltageRangeChange([voltageRange[0], snapped]);
-                                    }}
-                                    style={{ zIndex: 4, height: '100%' }}
-                                />
+                                {/* When both handles collapse at maxV, the default (high on
+                                    top) pins the range: the high handle can't move up
+                                    (already at max) and hides the low handle that could
+                                    still be dragged down. Raise the low handle so the user
+                                    can grab it to expand the range again. */}
+                                {(() => {
+                                    const collapsedAtMax = voltageRange[0] === voltageRange[1] && voltageRange[1] === maxV;
+                                    const lowZ = collapsedAtMax ? 5 : 3;
+                                    return (
+                                        <>
+                                            <input type="range"
+                                                min={logMin} max={logMax} step="any"
+                                                value={Math.log(voltageRange[0])}
+                                                onChange={e => {
+                                                    const logV = parseFloat(e.target.value);
+                                                    const snapped = uniqueVoltages.reduce((best, uv) =>
+                                                        Math.abs(Math.log(uv) - logV) < Math.abs(Math.log(best) - logV) ? uv : best
+                                                    );
+                                                    if (snapped <= voltageRange[1]) onVoltageRangeChange([snapped, voltageRange[1]]);
+                                                }}
+                                                style={{ zIndex: lowZ, height: '100%' }}
+                                            />
+                                            <input type="range"
+                                                min={logMin} max={logMax} step="any"
+                                                value={Math.log(voltageRange[1])}
+                                                onChange={e => {
+                                                    const logV = parseFloat(e.target.value);
+                                                    const snapped = uniqueVoltages.reduce((best, uv) =>
+                                                        Math.abs(Math.log(uv) - logV) < Math.abs(Math.log(best) - logV) ? uv : best
+                                                    );
+                                                    if (snapped >= voltageRange[0]) onVoltageRangeChange([voltageRange[0], snapped]);
+                                                }}
+                                                style={{ zIndex: 4, height: '100%' }}
+                                            />
+                                        </>
+                                    );
+                                })()}
                                 <div className="voltage-slider-ticks">
                                     {uniqueVoltages.map(kv => (
                                         <span key={kv} style={{ bottom: logScale(kv) + '%' }}>

--- a/frontend/src/hooks/useDiagrams.test.ts
+++ b/frontend/src/hooks/useDiagrams.test.ts
@@ -913,3 +913,82 @@ describe('computeKnownItemsSet — auto-zoom guard', () => {
         expect(set.has('BRANCH_A')).toBe(true);
     });
 });
+
+describe('useDiagrams — voltage range filter', () => {
+    // Regression guards for the kV-filter reset bug: when the user
+    // collapsed the range to a single voltage (hiding elements on
+    // other levels) and then expanded it back out, the previously
+    // hidden elements stayed invisible because an early-return in
+    // applyVoltageFilter short-circuited the fully-open case without
+    // resetting `display:none` from the prior narrow-range run.
+    beforeEach(() => {
+        interactionLogger.clear();
+        vi.clearAllMocks();
+    });
+
+    const buildHarness = () => {
+        const container = document.createElement('div');
+        container.innerHTML = '<svg><g id="svg-VL400"></g><g id="svg-VL225"></g></svg>';
+        document.body.appendChild(container);
+        const el400 = container.querySelector('#svg-VL400') as HTMLElement;
+        const el225 = container.querySelector('#svg-VL225') as HTMLElement;
+        return { container, el400, el225 };
+    };
+
+    const populate = (
+        result: { current: ReturnType<typeof useDiagrams> },
+        container: HTMLElement,
+    ) => {
+        act(() => {
+            result.current.nSvgContainerRef.current = container as HTMLDivElement;
+            result.current.setNDiagram({
+                svg: '<svg></svg>',
+                metadata: {
+                    nodes: [
+                        { equipmentId: 'VL400', svgId: 'svg-VL400', x: 0, y: 0 },
+                        { equipmentId: 'VL225', svgId: 'svg-VL225', x: 0, y: 0 },
+                    ],
+                    edges: [],
+                } as unknown as string,
+                originalViewBox: { x: 0, y: 0, width: 100, height: 100 },
+            });
+            result.current.setNominalVoltageMap({ VL400: 400, VL225: 225 });
+            result.current.setUniqueVoltages([225, 400]);
+        });
+    };
+
+    it('hides out-of-range voltage-level elements when the range is narrowed', () => {
+        const { result } = renderHook(() => useDiagrams([], [], ''));
+        const { container, el400, el225 } = buildHarness();
+        populate(result, container);
+
+        act(() => {
+            result.current.setVoltageRange([225, 225]);
+        });
+
+        expect(el400.style.display).toBe('none');
+        expect(el225.style.display).toBe('');
+        document.body.removeChild(container);
+    });
+
+    it('restores previously hidden elements when the range is expanded back to fully open', () => {
+        const { result } = renderHook(() => useDiagrams([], [], ''));
+        const { container, el400, el225 } = buildHarness();
+        populate(result, container);
+
+        // Narrow the range to hide 400 kV.
+        act(() => {
+            result.current.setVoltageRange([225, 225]);
+        });
+        expect(el400.style.display).toBe('none');
+
+        // Expand back to fully open. Previously the early-return would
+        // short-circuit and leave el400 stuck at display:none.
+        act(() => {
+            result.current.setVoltageRange([225, 400]);
+        });
+        expect(el400.style.display).toBe('');
+        expect(el225.style.display).toBe('');
+        document.body.removeChild(container);
+    });
+});

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -904,13 +904,26 @@ export function useDiagrams(
   // ===== Voltage Range Filter =====
   const staleVoltageFilter = useRef<Set<TabId>>(new Set());
   const prevVFTabRef = useRef<TabId>(activeTab);
+  // Track, per tab, whether the last applied filter actually hid
+  // something. We can only safely skip the filter loop on a
+  // fully-open range when the previous range was ALSO fully open —
+  // otherwise we'd leave previously-hidden elements (e.g. all 400 kV
+  // nodes/edges when the user was pinned to 225 kV) invisible after
+  // the user expands the range back out.
+  const prevFilterHadHidden = useRef<Record<TabId, boolean>>({
+    n: false,
+    'n-1': false,
+    action: false,
+    overflow: false,
+  });
 
-  const applyVoltageFilter = useCallback((container: HTMLElement | null, metaIndex: MetadataIndex | null) => {
+  const applyVoltageFilter = useCallback((tab: TabId, container: HTMLElement | null, metaIndex: MetadataIndex | null) => {
     if (!container || !metaIndex) return;
     if (uniqueVoltages.length === 0 || Object.keys(nominalVoltageMap).length === 0) return;
 
     const [minKv, maxKv] = voltageRange;
-    if (minKv <= uniqueVoltages[0] && maxKv >= uniqueVoltages[uniqueVoltages.length - 1]) return;
+    const fullyOpen = minKv <= uniqueVoltages[0] && maxKv >= uniqueVoltages[uniqueVoltages.length - 1];
+    if (fullyOpen && !prevFilterHadHidden.current[tab]) return;
 
     const isInRange = (vlId: string) => {
       const kv = nominalVoltageMap[vlId];
@@ -919,9 +932,11 @@ export function useDiagrams(
 
     const { nodesByEquipmentId, nodesBySvgId, edgesByEquipmentId } = metaIndex;
     const idMap = getIdMap(container);
+    let anyHidden = false;
 
     for (const [vlId, node] of nodesByEquipmentId) {
       const visible = isInRange(vlId);
+      if (!visible) anyHidden = true;
       const show = visible ? '' : 'none';
       const el = idMap.get(node.svgId) as HTMLElement | undefined;
       if (el) el.style.display = show;
@@ -941,6 +956,7 @@ export function useDiagrams(
       const vl1InRange = node1 ? isInRange(node1.equipmentId) : true;
       const vl2InRange = node2 ? isInRange(node2.equipmentId) : true;
       const edgeVisible = vl1InRange || vl2InRange;
+      if (!edgeVisible) anyHidden = true;
       const show = edgeVisible ? '' : 'none';
 
       const el = idMap.get(edge.svgId) as HTMLElement | undefined;
@@ -954,6 +970,8 @@ export function useDiagrams(
         if (ei) ei.style.display = show;
       }
     }
+
+    prevFilterHadHidden.current[tab] = anyHidden;
   }, [voltageRange, nominalVoltageMap, uniqueVoltages]);
 
   useEffect(() => {
@@ -964,17 +982,17 @@ export function useDiagrams(
 
     const runFilter = () => {
       if (activeTab === 'n' || activeTab === 'overflow') {
-        applyVoltageFilter(nSvgContainerRef.current, nMetaIndex);
+        applyVoltageFilter('n', nSvgContainerRef.current, nMetaIndex);
         staleVoltageFilter.current.delete('n');
         staleVoltageFilter.current.add('n-1');
         staleVoltageFilter.current.add('action');
       } else if (activeTab === 'n-1') {
-        applyVoltageFilter(n1SvgContainerRef.current, n1MetaIndex);
+        applyVoltageFilter('n-1', n1SvgContainerRef.current, n1MetaIndex);
         staleVoltageFilter.current.delete('n-1');
         staleVoltageFilter.current.add('n');
         staleVoltageFilter.current.add('action');
       } else if (activeTab === 'action') {
-        applyVoltageFilter(actionSvgContainerRef.current, actionMetaIndex);
+        applyVoltageFilter('action', actionSvgContainerRef.current, actionMetaIndex);
         staleVoltageFilter.current.delete('action');
         staleVoltageFilter.current.add('n');
         staleVoltageFilter.current.add('n-1');


### PR DESCRIPTION
## Summary

This PR updates project documentation to reflect the current state of Co-Study4Grid at release 0.6.5, including recent architectural decompositions (PR #104/#106), SVG DOM recycling optimization (PR #108), hook extraction (PR #109), and the auto-generated standalone UI (PR #101).

## Key Changes

### CLAUDE.md (root project overview)
- **Expanded directory tree** with new subdirectories: `services/diagram/`, `services/analysis/`, `services/simulation_helpers.py`, `frontend/src/utils/svg/`, and `scripts/pypsa_eur/`
- **Documented mixin decomposition**: clarified that `DiagramMixin`, `AnalysisMixin`, and `SimulationMixin` are now thin orchestrators delegating to helper packages
- **Added SVG DOM recycling pattern**: documented `/api/n1-diagram-patch` and `/api/action-variant-diagram-patch` endpoints and `utils/svgPatch.ts` fast-path
- **Updated dependencies section**: replaced `framer-motion` and `lucide-react` with `vite-plugin-singlefile` and `Vitest`
- **Expanded API table**: added new patch endpoints, user-config endpoints, and `/api/simulate-and-variant-diagram`
- **Updated conventions**: replaced "no formal linter" with "Ruff-gated" (`E9` + `F` ruleset only)
- **Clarified standalone UI**: documented auto-generation via `npm run build:standalone` and decommissioning of hand-maintained `standalone_interface.html`
- **Updated test commands**: reorganized scripts under `scripts/pypsa_eur/` with their own pytest coverage

### README.md (user-facing guide)
- **Updated release badge** from 0.5.0 to 0.6.5
- **Expanded frontend engineering section**: documented Phase 2 hook extraction (`useN1Fetch`, `useDiagramHighlights`), SVG DOM recycling performance gains (~80% faster), and code-quality gate
- **Added 0.6.5 performance table**: showed `/api/n1-diagram-patch` speedup (−83.8% cold, −79.1% warm) vs. full endpoint
- **Reorganized performance section**: split into 0.6.5 (DOM recycling) and 0.5.0 (vectorization) subsections
- **Updated directory tree**: added `dist-standalone/`, `benchmarks/`, and `scripts/` with PyPSA-EUR pipeline
- **Clarified standalone UI build**: documented `npm run build:standalone` output and parity guards
- **Updated test instructions**: separated backend pytest, code-quality gate, and ad-hoc integration scripts
- **Updated API table**: added patch endpoints and `/api/simulate-and-variant-diagram`

### expert_backend/CLAUDE.md (backend guide)
- **Expanded services tree**: documented new `diagram/`, `analysis/` subdirectories and `simulation_helpers.py`
- **Detailed mixin decomposition**: explained how mixins delegate to helper packages while preserving `@patch` test compatibility
- **Added SVG patch endpoints**: documented `/api/n1-diagram-patch` and `/api/action-variant-diagram-patch` with performance context
- **Updated conventions**: replaced "no formal linter" with Ruff configuration details and enforcement of no `print()` / bare except / `any` / `@ts-ignore`
- **Clarified standalone UI**: removed manual-mirroring requirement, documented auto-generation and decommissioning of legacy HTML
- **Updated CORS documentation**: noted `CORS_ALLOWED_ORIGINS` env var configuration (PR #104)

### frontend/CLAUDE.md (frontend guide)
- **Expanded utils tree**: documented `svg/` subdirectory with 8 focused modules (idMap, metadataIndex, svgBoost, fitRect, deltaVisuals, actionPin*, highlights)
- **Added svgPatch documentation**: explained DOM recycling strategy and fallback behavior
- **Documented actionTypes utility**: noted shared filter logic across UI surfaces
- **Added

https://claude.ai/code/session_01RsvHjjFbAauF3NvD9BNT5V