### PR TITLE
Add voltage-level names toggle with native tooltip fallback

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -173,6 +173,21 @@ performance levers are applied today:
   whenever the SVG content changes.
 - **`boostSvgForLargeGrid`**: dynamic font/node-radius scaling for
   grids ≥ 500 voltage levels so labels stay readable at high zoom.
+- **VL-names toggle** (`useDiagrams.showVoltageLevelNames`, default
+  on): a `🏷 VL` button next to the bottom-left Inspect field flips
+  the `nad-hide-vl-labels` class on each `MemoizedSvgContainer`. The
+  CSS rule (`App.css`) hides every shape pypowsybl uses for VL
+  labels — `foreignObject.nad-text-nodes`, inline `<text>` under
+  `.nad-vl-nodes` / `.nad-label-nodes`, and root-level
+  `.nad-label-box` divs — with `!important` to beat the inline
+  `<style>` block pypowsybl appends after App.css. When labels are
+  hidden the VL name is still reachable via a native `<title>`
+  tooltip on each bus circle: `applyVlTitles` (`utils/svg/vlTitles.ts`)
+  walks the metadata index after every diagram refresh and injects /
+  updates one `<title data-vl-title>` per node group, idempotently.
+  The toggle emits a `vl_names_toggled { show }` interaction event
+  (declared in both `specConformance.test.ts` SPEC and the Python
+  `SPEC_DETAILS`).
 
 The visualization is rendered inside `react-zoom-pan-pinch`. Zoom
 state is owned by `usePanZoom` per tab (`nPZ`, `n1PZ`, `actionPZ`,

--- a/frontend/src/App.contingency.test.tsx
+++ b/frontend/src/App.contingency.test.tsx
@@ -103,6 +103,7 @@ vi.mock('./utils/svgUtils', () => ({
   getIdMap: () => new Map(),
   invalidateIdMapCache: vi.fn(),
   isCouplingAction: vi.fn(() => false),
+  applyVlTitles: vi.fn(),
 }));
 
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,6 +65,14 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
     display: none;
 }
 
+/* User-toggle: hide every voltage-level label everywhere on the diagram.
+   pypowsybl emits all VL labels inside a single root-level
+   `<foreignObject class="nad-text-nodes">`, so a single rule on that
+   class is enough to cover the entire NAD regardless of zoom tier. */
+.svg-container.nad-hide-vl-labels foreignObject.nad-text-nodes {
+    display: none;
+}
+
 /* ===== Highlight styles ===== */
 
 .nad-highlight {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,12 +65,23 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
     display: none;
 }
 
-/* User-toggle: hide every voltage-level label everywhere on the diagram.
-   pypowsybl emits all VL labels inside a single root-level
-   `<foreignObject class="nad-text-nodes">`, so a single rule on that
-   class is enough to cover the entire NAD regardless of zoom tier. */
-.svg-container.nad-hide-vl-labels foreignObject.nad-text-nodes {
-    display: none;
+/* User-toggle: hide every voltage-level label on the diagram. pypowsybl
+   emits VL labels in two interchangeable shapes depending on the diagram
+   configuration: a root-level `<foreignObject class="nad-text-nodes">`
+   carrying HTML `<div>` labels, and inline `<text>` siblings under
+   `.nad-vl-nodes` / `.nad-label-nodes`. Cover both shapes (and the
+   inline `nad-label-box` divs that some pypowsybl builds emit at the
+   SVG root without a foreignObject wrapper) so the toggle works across
+   all networks. `!important` overrides pypowsybl's own inline `<style>`
+   block, which is appended to the document AFTER App.css when the SVG
+   is injected by `replaceChildren(svg)`. */
+.svg-container.nad-hide-vl-labels .nad-text-nodes,
+.svg-container.nad-hide-vl-labels foreignObject.nad-text-nodes,
+.svg-container.nad-hide-vl-labels .nad-vl-nodes foreignObject,
+.svg-container.nad-hide-vl-labels .nad-label-nodes foreignObject,
+.svg-container.nad-hide-vl-labels .nad-label-nodes,
+.svg-container.nad-hide-vl-labels .nad-label-box {
+    display: none !important;
 }
 
 /* ===== Highlight styles ===== */

--- a/frontend/src/App.session.test.tsx
+++ b/frontend/src/App.session.test.tsx
@@ -93,6 +93,7 @@ vi.mock('./utils/svgUtils', () => ({
   getIdMap: () => new Map(),
   invalidateIdMapCache: vi.fn(),
   isCouplingAction: vi.fn(() => false),
+  applyVlTitles: vi.fn(),
 }));
 
 

--- a/frontend/src/App.settings.test.tsx
+++ b/frontend/src/App.settings.test.tsx
@@ -93,6 +93,7 @@ vi.mock('./utils/svgUtils', () => ({
   getIdMap: () => new Map(),
   invalidateIdMapCache: vi.fn(),
   isCouplingAction: vi.fn(() => false),
+  applyVlTitles: vi.fn(),
 }));
 
 

--- a/frontend/src/App.stateManagement.test.tsx
+++ b/frontend/src/App.stateManagement.test.tsx
@@ -86,6 +86,7 @@ vi.mock('./utils/svgUtils', () => ({
   getIdMap: () => new Map(),
   invalidateIdMapCache: vi.fn(),
   isCouplingAction: vi.fn(() => false),
+  applyVlTitles: vi.fn(),
 }));
 
 // Mock API

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import { useN1Fetch } from './hooks/useN1Fetch';
 import { useDiagramHighlights } from './hooks/useDiagramHighlights';
 import { interactionLogger } from './utils/interactionLogger';
 import { DEFAULT_ACTION_OVERVIEW_FILTERS } from './utils/actionTypes';
+import { applyVlTitles } from './utils/svgUtils';
 
 function App() {
   // ===== Settings Hook =====
@@ -152,7 +153,8 @@ function App() {
     vlOverlay, handleViewModeChange, handleManualZoomIn, handleManualZoomOut,
     handleManualReset, handleVlDoubleClick, handleOverlaySldTabChange, handleOverlayClose,
     inspectableItems,
-    nSvgContainerRef, n1SvgContainerRef, actionSvgContainerRef
+    nSvgContainerRef, n1SvgContainerRef, actionSvgContainerRef,
+    showVoltageLevelNames, setShowVoltageLevelNames,
   } = diagrams;
 
   // When a pin on the overview is single-clicked we want the sidebar
@@ -369,6 +371,7 @@ function App() {
     diagrams.setN1Diagram(null);
     diagrams.setOriginalViewBox(null);
     diagrams.setActionViewMode('network');
+    diagrams.setShowVoltageLevelNames(true);
     diagrams.setN1Loading(false);
     diagrams.setActionDiagramLoading(false);
     diagrams.committedBranchRef.current = '';
@@ -873,6 +876,23 @@ function App() {
     diagrams.selectedBranchForSld.current = selectedBranch;
   }, [selectedBranch, diagrams.selectedBranchForSld]);
 
+  // Inject `<title>` elements into each voltage-level node group on every
+  // diagram refresh so the browser surfaces the VL name as a native
+  // tooltip when the user hovers a bus circle. This is the fallback path
+  // when the on-diagram label is hidden via the VL-names toggle (see
+  // `nad-hide-vl-labels`), but the titles are kept attached
+  // unconditionally — they're invisible until hover and cost effectively
+  // nothing.
+  useEffect(() => {
+    applyVlTitles(nSvgContainerRef.current, diagrams.nMetaIndex, displayName);
+  }, [nDiagram, diagrams.nMetaIndex, displayName, nSvgContainerRef]);
+  useEffect(() => {
+    applyVlTitles(n1SvgContainerRef.current, diagrams.n1MetaIndex, displayName);
+  }, [n1Diagram, diagrams.n1MetaIndex, displayName, n1SvgContainerRef]);
+  useEffect(() => {
+    applyVlTitles(actionSvgContainerRef.current, diagrams.actionMetaIndex, displayName);
+  }, [actionDiagram, diagrams.actionMetaIndex, displayName, actionSvgContainerRef]);
+
 
 
   useN1Fetch({
@@ -943,6 +963,11 @@ function App() {
     interactionLogger.record('inspect_query_changed', { query: q });
     diagrams.setInspectQuery(q);
   }, [diagrams]);
+
+  const handleToggleVoltageLevelNames = useCallback((show: boolean) => {
+    interactionLogger.record('vl_names_toggled', { show });
+    setShowVoltageLevelNames(show);
+  }, [setShowVoltageLevelNames]);
 
   // Per-tab inspect variant. Lets a detached tab's overlay zoom its
   // own tab rather than the main-window activeTab — see
@@ -1138,6 +1163,8 @@ function App() {
             unsimulatedActionIds={unsimulatedActionIds}
             unsimulatedActionInfo={unsimulatedActionInfo}
             onSimulateUnsimulatedAction={handleSimulateUnsimulatedAction}
+            showVoltageLevelNames={showVoltageLevelNames}
+            onToggleVoltageLevelNames={handleToggleVoltageLevelNames}
           />
         </div>
       </div>

--- a/frontend/src/components/MemoizedSvgContainer.tsx
+++ b/frontend/src/components/MemoizedSvgContainer.tsx
@@ -17,9 +17,11 @@ interface SvgContainerProps {
     containerRef: RefObject<HTMLDivElement | null>;
     display: string;
     tabId: TabId;
+    /** When false, the NAD voltage-level label foreignObject is hidden via CSS. */
+    hideVlLabels?: boolean;
 }
 
-const MemoizedSvgContainer = React.memo(({ svg, containerRef, display, tabId }: SvgContainerProps) => {
+const MemoizedSvgContainer = React.memo(({ svg, containerRef, display, tabId, hideVlLabels = false }: SvgContainerProps) => {
     React.useLayoutEffect(() => {
         const container = containerRef.current;
         if (!container || !svg) return;
@@ -38,7 +40,7 @@ const MemoizedSvgContainer = React.memo(({ svg, containerRef, display, tabId }: 
     return (
         <div
             ref={containerRef}
-            className="svg-container"
+            className={hideVlLabels ? 'svg-container nad-hide-vl-labels' : 'svg-container'}
             id={`${tabId}-svg-container`}
             style={{ display, width: '100%', height: '100%', overflow: 'hidden' }}
         />

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -586,7 +586,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                             boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
                                         }}
                                     >
-                                        {showVoltageLevelNames ? '\u{1F3F7} VL names' : '\u{1F3F7} VL names off'}
+                                        {'\u{1F3F7} VL'}
                                     </button>
                                 )}
                                 {inspectQuery && voltageLevels.includes(inspectQuery) && (

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -251,6 +251,14 @@ interface VisualizationPanelProps {
     unsimulatedActionInfo?: Readonly<Record<string, UnsimulatedActionScoreInfo>>;
     /** Kick off a manual simulation when an un-simulated pin is double-clicked. */
     onSimulateUnsimulatedAction?: (actionId: string) => void;
+    /**
+     * When false, voltage-level labels rendered by pypowsybl inside the
+     * NAD's `<foreignObject class="nad-text-nodes">` are hidden via CSS.
+     * The VL name remains accessible as a native `<title>` tooltip on
+     * hover over each bus-node group. Default is true.
+     */
+    showVoltageLevelNames?: boolean;
+    onToggleVoltageLevelNames?: (show: boolean) => void;
 }
 
 
@@ -314,6 +322,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     unsimulatedActionIds,
     unsimulatedActionInfo,
     onSimulateUnsimulatedAction,
+    showVoltageLevelNames = true,
+    onToggleVoltageLevelNames,
 }) => {
     // No-op fallbacks so conditional branches don't need to guard.
     const detachTabCb = onDetachTab ?? (() => {});
@@ -556,6 +566,29 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     onChangeQuery={inspectQueryChangeForCb}
                                     filteredInspectables={filteredInspectables}
                                 />
+                                {onToggleVoltageLevelNames && (
+                                    <button
+                                        onClick={() => onToggleVoltageLevelNames(!showVoltageLevelNames)}
+                                        title={showVoltageLevelNames
+                                            ? 'Hide voltage-level names on the diagram (hover bus circles to see them as tooltips)'
+                                            : 'Show voltage-level names on the diagram'}
+                                        aria-pressed={showVoltageLevelNames}
+                                        data-testid="toggle-vl-names"
+                                        style={{
+                                            background: showVoltageLevelNames ? '#e8f0fe' : '#fff',
+                                            color: showVoltageLevelNames ? '#2c7be5' : '#555',
+                                            border: `1px solid ${showVoltageLevelNames ? '#2c7be5' : '#ccc'}`,
+                                            borderRadius: '4px',
+                                            padding: '4px 8px',
+                                            cursor: 'pointer',
+                                            fontSize: '12px',
+                                            fontWeight: 600,
+                                            boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
+                                        }}
+                                    >
+                                        {showVoltageLevelNames ? '\u{1F3F7} VL names' : '\u{1F3F7} VL names off'}
+                                    </button>
+                                )}
                                 {inspectQuery && voltageLevels.includes(inspectQuery) && (
                                     <button
                                         onClick={() => onVlOpen(inspectQuery)}
@@ -934,7 +967,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                     }}>
                         {detachedTabs['n'] && renderDetachedHeader('n', 'Network (N)', '#3498db')}
                         {/* Always mounted — see comment on N-1 container below. */}
-                        <MemoizedSvgContainer svg={nDiagram?.svg || ''} containerRef={nSvgContainerRef} display="block" tabId="n" />
+                        <MemoizedSvgContainer svg={nDiagram?.svg || ''} containerRef={nSvgContainerRef} display="block" tabId="n" hideVlLabels={!showVoltageLevelNames} />
                         {configLoading && (
                             <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Loading configuration...
@@ -984,7 +1017,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             would cause StrictMode to double-invoke its layout effect,
                             and the second DOM injection would overwrite the auto-zoom
                             viewBox that was applied between the two invocations. */}
-                        <MemoizedSvgContainer svg={n1Diagram?.svg || ''} containerRef={n1SvgContainerRef} display="block" tabId="n-1" />
+                        <MemoizedSvgContainer svg={n1Diagram?.svg || ''} containerRef={n1SvgContainerRef} display="block" tabId="n-1" hideVlLabels={!showVoltageLevelNames} />
                         {n1Loading && (
                             <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Generating N-1 Diagram...
@@ -1035,7 +1068,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             </div>
                         )}
                         {/* Always mounted — see comment on N-1 container. */}
-                        <MemoizedSvgContainer svg={actionDiagram?.svg || ''} containerRef={actionSvgContainerRef} display="block" tabId="action" />
+                        <MemoizedSvgContainer svg={actionDiagram?.svg || ''} containerRef={actionSvgContainerRef} display="block" tabId="action" hideVlLabels={!showVoltageLevelNames} />
                         {/*
                           Action-overview layer: rendered on top of the
                           (hidden) action-diagram container when no card

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -79,6 +79,13 @@ export interface DiagramsState {
   setActionViewMode: (v: 'network' | 'delta') => void;
   handleViewModeChange: (mode: 'network' | 'delta') => void;
 
+  // Voltage-level name labels: when false, the per-node labels rendered
+  // by pypowsybl inside the NAD's `<foreignObject class="nad-text-nodes">`
+  // are hidden via CSS, and the equipment id is exposed as a native
+  // `<title>` tooltip on hover instead. Defaults to true.
+  showVoltageLevelNames: boolean;
+  setShowVoltageLevelNames: (v: boolean) => void;
+
   // ViewBox
   originalViewBox: ViewBox | null;
   setOriginalViewBox: (v: ViewBox | null) => void;
@@ -219,6 +226,8 @@ export function useDiagrams(
   const handleViewModeChange = useCallback((mode: 'network' | 'delta') => {
     setActionViewMode(mode);
   }, []);
+
+  const [showVoltageLevelNames, setShowVoltageLevelNames] = useState<boolean>(true);
 
   // ViewBox
   const [originalViewBox, setOriginalViewBox] = useState<ViewBox | null>(null);
@@ -1051,6 +1060,7 @@ export function useDiagrams(
     actionDiagramLoading, setActionDiagramLoading,
     actionViewMode, setActionViewMode,
     handleViewModeChange,
+    showVoltageLevelNames, setShowVoltageLevelNames,
     originalViewBox, setOriginalViewBox,
     inspectQuery, setInspectQuery,
     setInspectQueryForTab,
@@ -1081,6 +1091,7 @@ export function useDiagrams(
   }), [
     activeTab, nDiagram, n1Diagram, n1Loading,
     selectedActionId, actionDiagram, actionDiagramLoading, actionViewMode, handleViewModeChange,
+    showVoltageLevelNames,
     originalViewBox, inspectQuery,
     nPZ, n1PZ, actionPZ,
     nMetaIndex, n1MetaIndex, actionMetaIndex,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -526,6 +526,7 @@ export type InteractionType =
     | 'zoom_out'
     | 'zoom_reset'
     | 'inspect_query_changed'
+    | 'vl_names_toggled'
     // SLD Overlay
     | 'sld_overlay_opened'
     | 'sld_overlay_tab_changed'

--- a/frontend/src/utils/specConformance.test.ts
+++ b/frontend/src/utils/specConformance.test.ts
@@ -87,6 +87,7 @@ const SPEC: Record<string, SpecRow> = {
   zoom_out:                       { required: new Set(['tab']) },
   zoom_reset:                     { required: new Set(['tab']) },
   inspect_query_changed:          { required: new Set(['query']), optional: new Set(['target_tab']) },
+  vl_names_toggled:               { required: new Set(['show']) },
   // --- Action Overview Diagram ---
   overview_shown:                 { required: new Set(['has_pins', 'pin_count']) },
   overview_hidden:                { required: new Set() },

--- a/frontend/src/utils/svg/vlTitles.ts
+++ b/frontend/src/utils/svg/vlTitles.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import type { MetadataIndex } from '../../types';
+import { getIdMap } from './idMap';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const VL_TITLE_MARKER = 'data-vl-title';
+
+/**
+ * Inject a `<title>` SVG element into each voltage-level node group so
+ * the browser shows a native tooltip with the VL name when the user
+ * hovers the bus circle and surrounding coordinates. Used in tandem
+ * with the `nad-hide-vl-labels` class (toggled by the user from the
+ * diagram bottom-left controls): when the on-diagram labels are
+ * hidden the tooltip is the only way to recover the VL name.
+ *
+ * Idempotent — re-running on the same container updates each title's
+ * text content rather than duplicating elements.
+ */
+export const applyVlTitles = (
+    container: HTMLElement | null,
+    metaIndex: MetadataIndex | null,
+    displayName?: (id: string) => string,
+): void => {
+    if (!container || !metaIndex) return;
+    const idMap = getIdMap(container);
+    metaIndex.nodesBySvgId.forEach((node, svgId) => {
+        const el = idMap.get(svgId);
+        if (!el) return;
+        const equipmentId = node.equipmentId;
+        const friendly = displayName ? displayName(equipmentId) : equipmentId;
+        const text = friendly && friendly !== equipmentId
+            ? `${friendly} (${equipmentId})`
+            : equipmentId;
+        let title = el.querySelector(`:scope > title[${VL_TITLE_MARKER}]`);
+        if (!title) {
+            title = document.createElementNS(SVG_NS, 'title');
+            title.setAttribute(VL_TITLE_MARKER, '');
+            el.insertBefore(title, el.firstChild);
+        }
+        if (title.textContent !== text) title.textContent = text;
+    });
+};

--- a/frontend/src/utils/svgUtils.ts
+++ b/frontend/src/utils/svgUtils.ts
@@ -27,6 +27,7 @@ export {
     applyContingencyHighlight,
 } from './svg/highlights';
 export { applyDeltaVisuals } from './svg/deltaVisuals';
+export { applyVlTitles } from './svg/vlTitles';
 export {
     severityFill,
     severityFillDimmed,

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -177,6 +177,7 @@ SPEC_DETAILS: dict[str, dict] = {
     "zoom_out":                 _spec_row({"tab"}),
     "zoom_reset":               _spec_row({"tab"}),
     "inspect_query_changed":    _spec_row({"query"}, optional={"target_tab"}),
+    "vl_names_toggled":         _spec_row({"show"}),
     # --- Action Overview Diagram ---
     "overview_shown":           _spec_row({"has_pins", "pin_count"}),
     "overview_hidden":          _spec_row(set()),


### PR DESCRIPTION
## Summary
Adds a user-facing toggle to hide/show voltage-level (VL) labels on network diagrams, with a native browser tooltip fallback when labels are hidden. This improves diagram readability for large networks while keeping VL names accessible via hover.

## Key Changes

- **New VL-names toggle button** (`🏷 VL`) in the bottom-left diagram controls that flips the `nad-hide-vl-labels` CSS class on each diagram container
- **CSS rule** (`App.css`) hides all pypowsybl VL label shapes (foreignObject, inline text, root-level divs) with `!important` to override pypowsybl's inline styles
- **Native tooltip injection** via new `applyVlTitles()` utility (`utils/svg/vlTitles.ts`) that walks the metadata index after each diagram refresh and injects/updates `<title>` elements into voltage-level node groups, providing hover tooltips when labels are hidden
- **State management** in `useDiagrams` hook with `showVoltageLevelNames` boolean (defaults to true) and setter
- **Props threading** through `VisualizationPanel` and `MemoizedSvgContainer` to control the CSS class application
- **Interaction logging** for the toggle action (`vl_names_toggled` event with `show` parameter)
- **Reset behavior** when switching networks (VL names toggle resets to true)
- **Test mocks** updated to include the new `applyVlTitles` function

## Implementation Details

- The `applyVlTitles()` function is idempotent — re-running updates existing titles rather than duplicating elements, making it safe to call on every diagram refresh
- Titles are injected unconditionally (not just when hidden) as they're invisible until hover and have negligible performance cost
- The CSS rule covers multiple pypowsybl label emission patterns to work across different network configurations
- The toggle state is preserved per-session but resets when loading a new network

https://claude.ai/code/session_01UfZ6CDCozVrMSNzYXeYK6V