### PR TITLE
feat(frontend): design-token migration (recommendation #1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ The gate enforces:
 - Backend modules stay under **1200 lines** (the "god-object" ceiling)
 - Frontend components stay under **1500 lines**
 - No `any` type annotations or `@ts-ignore` in frontend sources
+- **No new hex color literals** in frontend source. The current ceiling
+  (518) ratchets down as files migrate to design tokens. Define new
+  colors in [`frontend/src/styles/tokens.css`](./frontend/src/styles/tokens.css)
+  and consume them via `var(--…)` (CSS) or the `colors` / `space` /
+  `text` / `radius` exports from `frontend/src/styles/tokens.ts`
+  (inline styles).
 
 Lower the thresholds — don't raise them. Tightening the gate
 is how we protect the hard-won reductions documented in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,14 @@ The gate enforces:
 - Backend modules stay under **1200 lines** (the "god-object" ceiling)
 - Frontend components stay under **1500 lines**
 - No `any` type annotations or `@ts-ignore` in frontend sources
-- **No new hex color literals** in frontend source. The current ceiling
-  (56) covers a small queue of SVG-emitting files awaiting a Phase C
-  pin-palette extension. Define new colors in
+- **No hex color literals** in frontend source. The ceiling is zero —
+  every colour must come from a named token. Define new colours in
   [`frontend/src/styles/tokens.css`](./frontend/src/styles/tokens.css)
-  and consume them via `var(--…)` (CSS) or the `colors` / `space` /
-  `text` / `radius` exports from `frontend/src/styles/tokens.ts`
-  (inline styles).
+  (the canonical CSS variables) and re-export them from
+  [`frontend/src/styles/tokens.ts`](./frontend/src/styles/tokens.ts)
+  for inline-style consumers (`colors` / `space` / `text` / `radius`,
+  plus `pinColors` / `pinChrome` for SVG-attribute use cases). Both
+  token files are exempt from the gate; nothing else is.
 
 Lower the thresholds — don't raise them. Tightening the gate
 is how we protect the hard-won reductions documented in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,9 @@ The gate enforces:
 - Frontend components stay under **1500 lines**
 - No `any` type annotations or `@ts-ignore` in frontend sources
 - **No new hex color literals** in frontend source. The current ceiling
-  (518) ratchets down as files migrate to design tokens. Define new
-  colors in [`frontend/src/styles/tokens.css`](./frontend/src/styles/tokens.css)
+  (56) covers a small queue of SVG-emitting files awaiting a Phase C
+  pin-palette extension. Define new colors in
+  [`frontend/src/styles/tokens.css`](./frontend/src/styles/tokens.css)
   and consume them via `var(--…)` (CSS) or the `colors` / `space` /
   `text` / `radius` exports from `frontend/src/styles/tokens.ts`
   (inline styles).

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ Unimplemented ideas and rejected designs kept for reference.
 |------|-------|
 | [`rendering-lod-strategies.md`](proposals/rendering-lod-strategies.md) | **Consolidated** LoD rendering history + current plan. Supersedes `nad_optimization.md`, `network_rendering_profiling_recommendations.md`, and `spatial_lod_architecture_proposal.md`. |
 | [`new-features-brainstorm-mars26.md`](proposals/new-features-brainstorm-mars26.md) | Brainstorm of 12 candidate features (batch N-1, heatmap, Cmd+K, shortcuts, …). French text. |
+| [`ui-design-critique.md`](proposals/ui-design-critique.md) | UI critique (2026-05-01, code + screenshot review): consistency, hierarchy, NAD halo sizing, a11y, ActionCard density. Prioritizes design tokens + ActionCard redesign + halo cap + warning-tier + diagram legend. |
 
 ## Data (`data/`)
 

--- a/docs/proposals/ui-design-critique.md
+++ b/docs/proposals/ui-design-critique.md
@@ -1,17 +1,45 @@
 # UI design critique — Co-Study4Grid frontend
 
 **Status**: Proposal / review. **Recommendation #1 (design-token layer)
-Phase A landed 2026-05-01** — `frontend/src/styles/tokens.{css,ts}`
-defines ~24 semantic colors (Tailwind blue-ramp brand), 4/8 spacing
-scale, 6 type sizes, 3 radii, plus diagram-signal colors. App.css /
-index.css and four representative components (Header, StatusToasts,
-SidebarSummary, OverloadPanel) are migrated. The
-`scripts/check_code_quality.py` gate ratchets hex-literal count
-(currently 518) and refuses to let it grow. **Phase B** — migrate
-the remaining components (ActionCard, ActionFeed, ActionCardPopover,
-VisualizationPanel, ExplorePairsTab, ActionSearchDropdown,
-ActionOverviewDiagram, SettingsModal, ComputedPairsTable, others)
-in focused PRs that lower the ceiling each time.
+Phase A + Phase B landed 2026-05-01** — `frontend/src/styles/tokens.{css,ts}`
+defines the semantic palette: ~24 colors (Tailwind blue-ramp brand,
+Bootstrap warning/danger/success, info-cyan family for curtailment,
+accent-purple family for PST tap edits), 4/8 spacing scale, 6 type
+sizes, 3 radii, plus diagram-signal colors (overload, contingency,
+action-target soft/strong/darker, breaker, deltas). All 18
+inline-style components are migrated; ActionFeed and VisualizationPanel
+test assertions now read the `var(--…)` strings instead of resolved
+RGB. The `scripts/check_code_quality.py` gate ratchets the
+hex-literal count (currently **56**, down from ~654 pre-Phase A,
+518 after Phase A) and refuses to let it grow.
+
+**Phase C — remaining 56 hex literals** are concentrated in three
+SVG-emitting files that need a different migration treatment because
+they use `setAttribute('fill', '#…')` to set raw SVG attribute values
+(which don't reliably resolve `var(--…)` across browsers):
+- `frontend/src/utils/svg/actionPinData.ts` (12) — severity palette
+  for the Remedial Action overview pins (green/orange/red/grey
+  triplets: base, faded for unsimulated, highlighted on hover).
+- `frontend/src/utils/svg/actionPinRender.ts` (8) — pin glyph
+  fills (white inner, dark text, gold star, red cross).
+- `frontend/src/components/ActionOverviewDiagram.tsx` (35) — legend
+  swatches that pass `color="#…"` props into pin children, plus
+  inspect-input chrome.
+
+The clean migration is to (a) extend `tokens.css` with a
+`--pin-{severity}-{base,faded,highlighted}` family, (b) switch the
+SVG attribute setters to inline `style.fill = 'var(--…)'`, and
+(c) update the `'#28a745'` / `'#dc3545'` / `'#eab308'` test
+assertions in `ActionOverviewDiagram.test.tsx` to read the resolved
+attribute string. Worth a dedicated follow-up so the pin-palette
+extension can be reviewed on its own.
+
+`frontend/src/index.css` carries one remaining literal — the
+`#242424` dark-mode placeholder background that the Vite template
+sets before the `prefers-color-scheme: light` override kicks in. It
+stays because the app does not yet support dark mode and adding a
+single `--color-surface-dark` token for one use site is overkill;
+re-evaluate if/when dark mode lands.
 **Date**: 2026-05-01 (updated same day with screenshot review)
 **Method**: Initial pass was a code-only review of `frontend/src/`.
 A second pass cross-checked the findings against a screenshot of the

--- a/docs/proposals/ui-design-critique.md
+++ b/docs/proposals/ui-design-critique.md
@@ -1,0 +1,448 @@
+# UI design critique — Co-Study4Grid frontend
+
+**Status**: Proposal / review. **Recommendation #1 (design-token layer)
+Phase A landed 2026-05-01** — `frontend/src/styles/tokens.{css,ts}`
+defines ~24 semantic colors (Tailwind blue-ramp brand), 4/8 spacing
+scale, 6 type sizes, 3 radii, plus diagram-signal colors. App.css /
+index.css and four representative components (Header, StatusToasts,
+SidebarSummary, OverloadPanel) are migrated. The
+`scripts/check_code_quality.py` gate ratchets hex-literal count
+(currently 518) and refuses to let it grow. **Phase B** — migrate
+the remaining components (ActionCard, ActionFeed, ActionCardPopover,
+VisualizationPanel, ExplorePairsTab, ActionSearchDropdown,
+ActionOverviewDiagram, SettingsModal, ComputedPairsTable, others)
+in focused PRs that lower the ceiling each time.
+**Date**: 2026-05-01 (updated same day with screenshot review)
+**Method**: Initial pass was a code-only review of `frontend/src/`.
+A second pass cross-checked the findings against a screenshot of the
+running app on `bare_env_small_grid_test` with one contingency
+(`ARGIAL71CANTE`) and a combined remedial action selected
+(`disco_BERG9L61CANTE+pst_tap_ARKA_TD_661_inc2`), with the SLD
+overlay open on `CANTEP6` and the Overflow Analysis PDF detached to
+a side window. Corrections from that pass are folded inline; a
+running list lives at the end of the doc under "Screenshot review —
+confirmations and corrections". File-path + line-number citations
+are included throughout so each finding can be sanity-checked
+against the real surface.
+
+This doc supersedes the ad-hoc `frontend-ui-improvements.md` log for
+*new* visual-design work; that file remains the record of the changes
+already shipped (voltage filter, run-button placement, etc.). When any
+finding here lands, migrate the relevant section into a `features/`
+doc and remove it from this critique.
+
+---
+
+## TL;DR
+
+The interaction design is thoughtful — sticky sidebar summary,
+severity-coded action cards, "Make a first guess" empty state, tied
+detached tabs. The visual layer has not kept pace. Three competing
+color systems (Flat UI, Bootstrap, Tailwind), 273 hex literals, 464
+inline `style={{}}` blocks, no design tokens, and ~20 distinct
+emoji acting as primary navigation glyphs.
+
+The headline opportunities (re-ranked after screenshot review):
+
+1. **Design-token layer** — replace 273 hex literals + 202 numeric
+   font sizes with a small semantic token set.
+2. **Progressive-disclosure pass on `ActionCard`** — at-rest cards
+   show 5 fields, not 15.
+3. **Cap NAD overload halo size** — small CSS change, large
+   legibility win. *Promoted from "Moderate" after screenshot
+   confirmed the halos dwarf network detail at typical zoom.*
+4. Warning-tier consolidation, then diagram legend. See
+   "Priority recommendations" below.
+
+Most other findings fall out of these.
+
+---
+
+## Scope
+
+What was read:
+
+- `frontend/src/App.tsx` (state hub)
+- `frontend/src/App.css` and `frontend/src/index.css`
+- `frontend/src/components/Header.tsx`
+- `frontend/src/components/AppSidebar.tsx` and `SidebarSummary.tsx`
+- `frontend/src/components/OverloadPanel.tsx`
+- `frontend/src/components/ActionFeed.tsx`
+- `frontend/src/components/ActionCard.tsx`
+- `frontend/src/components/StatusToasts.tsx`
+- `frontend/src/components/modals/SettingsModal.tsx` (head)
+- `frontend/src/components/VisualizationPanel.tsx` (head)
+
+What was *not* read in depth (and is therefore not covered here):
+
+- `CombinedActionsModal`, `ComputedPairsTable`, `ExplorePairsTab`,
+  `ActionSearchDropdown`, `ActionCardPopover`, `SldOverlay`,
+  `ActionOverviewDiagram`, `DetachableTabHost`,
+  `ReloadSessionModal`, `ConfirmationDialog`.
+
+When the recommendations below are scheduled, those surfaces should
+get a follow-up pass.
+
+---
+
+## First impression (2-second read)
+
+*Updated from screenshot.* The eye actually lands first on the NAD
+view's halo highlights — a large yellow halo (the contingency line)
+and a large pink halo (the action target) dominate the centre panel.
+This is **the right hierarchy** for a contingency tool: the operator's
+job is to look at the network, and the network leads. The original
+code-only critique that "buttons in the Header outweigh the title"
+was overstated — at rendered scale the dark-slate Header reads as
+neutral chrome, the brand is legible, and the four primary buttons
+(Load Study, Save Results, Reload Session, Settings) sit right-aligned
+without competing with the diagram below.
+
+Two real first-impression problems remain:
+
+- **The halos are too large at typical zoom.** Both the yellow
+  contingency halo and the pink action-target halo are sized in grid
+  units, so at this zoom level they are roughly 8-10× the visual
+  weight of the line they highlight. They identify *which area* to
+  look at but obscure the network detail underneath. See
+  "Diagram visualization" below.
+- **No legend or color key anywhere on screen.** The NAD shows lines
+  in purple, red, orange, green, and dashed variants; the detached
+  Overflow PDF uses red / orange / green coloured ovals; the SLD
+  overlay introduces yet another palette. None of it is explained on
+  the surface. A new operator has to learn the conventions
+  out-of-band. This is a meaningful onboarding gap.
+
+---
+
+## Usability
+
+| Finding | Severity | Recommendation |
+|---|---|---|
+| **Warning fatigue.** Five different yellow `#fff3cd` banners can stack in the sidebar simultaneously: action-dictionary info (`ActionFeed.tsx:761`), recommender-settings hint (`ActionFeed.tsx:917`), selected-action overlap (`ActionFeed.tsx:794`), rejected-action overlap (`ActionFeed.tsx:969`), monitoring-coverage warning (`OverloadPanel.tsx:140`). Each has a Dismiss × button, so users will reflexively close them — losing genuinely useful info. | Moderate | Tier them. Errors stay in the toast (`StatusToasts.tsx`). Persistent constraints (recommender thresholds, monitoring scope) belong as a small "context" line under the relevant section, not a yellow banner. Reserve the banner pattern for one warning at a time. |
+| **`ActionCard` is doing the work of three components.** A single card carries: severity badge, description, optional load-shedding edit row, optional curtailment edit row, optional PST tap edit row, islanding warning, voltage-level badges, line badges, "Loading after" line list, max-loading link, ⭐ / ❌ buttons, plus a vertical "VIEWING" ribbon when active (`ActionCard.tsx:193-413`). At 12px font on a 25%-width sidebar, this is dense to the point of being hard to scan. | Critical | Collapse the editable detail rows into an "Edit parameters" disclosure that expands only on the *viewing* card. Move the inline ⭐ / ❌ to a hover-revealed action group. The card should at-rest show: rank, ID, severity, max ρ, primary target — five fields, not fifteen. |
+| **Two-step analysis flow is not signposted.** The user has to (a) pick a contingency, (b) optionally toggle which N-1 overloads to monitor (double-click in `OverloadPanel.tsx:99-106`, undocumented in the UI itself except via a hover tooltip on a `?` glyph), (c) click "Analyze & Suggest", (d) click "Display N prioritized actions". The double-click toggle is invisible — the `?` help bubble (`OverloadPanel.tsx:194`) is the only affordance. | Moderate | Make the toggle explicit (a checkbox in front of each N-1 overload, or "Include in analysis" on hover). The "Display N prioritized actions" step looks redundant with "Analyze & Suggest" — consider auto-displaying once analysis completes, with a "Re-run" button instead. |
+| **Emoji as primary affordance.** ⚡ 📄 🔄 💾 ⚙️ 🎯 🔍 ⚠️ 💡 📊 ⛔ 📐 🔓 🔒 🏝️ ⭐ ❌ across the chrome. Emoji rendering is OS-dependent (Apple's ⚠️ is yellow, Microsoft's is orange, some Linux fontconfig setups render as monochrome boxes). On a workstation that may run Windows or Linux in a control room, this is a brand-consistency risk. | Moderate | Replace navigation/action emoji with `lucide-react` icons (already in `package.json`). Keep emoji only where they are user data (e.g. severity legends), not as button glyphs. |
+| **Network path lives in two places.** Header has a path input (`Header.tsx:60-91`); Settings → Paths has the same field (`SettingsModal.tsx:91-97`) — the modal carries a "Synchronized with the banner field" hint (line 92). Two-source-of-truth UIs always confuse some operators. | Minor | Pick one. The header field is faster for the common case (load → study → switch); the modal could show the path read-only with an "Edit in header" affordance. |
+| **Keyboard navigation through the action feed.** No visible tabindex management — pressing Tab cycles through every nested button, edit input, and underlined link inside each `ActionCard`. With 20+ cards visible after analysis, that's hundreds of stops. | Moderate | Wrap each card in a single keyboard-focusable shell with `role="article"`; expose card-level commands (select, reject, view) via keyboard shortcuts and a screen-reader-friendly menu. |
+
+---
+
+## Visual hierarchy
+
+**What draws the eye first** *(corrected from screenshot)*: the NAD
+halos in the centre panel — yellow (contingency) and pink (action
+target). This is the correct lead. The Header reads as supporting
+chrome, not as a competing focal point.
+
+**Reading flow**: top-to-bottom in the sidebar (Sticky summary →
+Select Contingency → Overloads → Action feed) is correct, and the
+section weights actually work better at rendered scale than the
+source suggested. The 11px sticky summary (`SidebarSummary.tsx:48`)
+*is* small, but it sits against a darker grey and reads as
+"persistent state" rather than primary content — appropriate for a
+status strip. The bigger consistency miss is that **each section
+still uses different conventions**: the Overloads panel mixes
+`⚠️ N-1 Overloads:` (left-aligned, 14px) with a tiny `?` help bubble
+and an inline checkbox; the Action feed jumps to 14-15px headers with
+pill counters; the sticky summary uses dotted-underline links.
+A unified treatment of "section header + counter + inline actions"
+would tighten the rhythm noticeably.
+
+**Specific emphasis problems**:
+
+- Card heading `#1 — load_shedding_X` at 12px (`ActionCard.tsx:248-256`)
+  is *smaller* than the severity badge next to it (11px bold,
+  color-filled). Confirmed in screenshot — the "Still overloaded"
+  pill consistently reads louder than the action ID.
+- The "VIEWING" vertical ribbon (`ActionCard.tsx:224-244`).
+  *Corrected from screenshot.* At rendered scale it is less dominant
+  than the source suggested — it reads as a quiet vertical accent
+  rather than shouting. The heavier signals on the viewing card are
+  actually the light-blue card background and the inline editable
+  PST tap row. The ribbon itself is fine; it is the surrounding
+  weight (background change + extra controls) that combines into a
+  visually heavy state.
+- The "Analyze & Suggest" CTA uses a gradient
+  `linear-gradient(135deg, #27ae60, #2ecc71)` with a colored
+  drop-shadow (`ActionFeed.tsx:878-882`) — the only gradient in the
+  app. Not visible in the captured screenshot (the analysis has
+  already run), but worth flagging because it breaks the otherwise-
+  flat aesthetic.
+
+**Whitespace**: tight throughout. Cards have 10px padding, sidebar has
+15px padding, Overloads panel has 8px. There is no breathing room
+between dense elements — the sidebar feels packed even when it has
+only three cards in it.
+
+---
+
+## Diagram visualization
+
+*Section added after screenshot review.* This was not visible from the
+source alone — the rendered NAD, SLD overlay, and detached Overflow
+PDF together raise their own design issues.
+
+| Finding | Severity | Recommendation |
+|---|---|---|
+| **Overload halo size dwarfs the network it highlights.** The yellow contingency halo and pink action-target halo are sized in grid units, so at typical operator zoom they cover roughly 8-10× the area of the line they identify. Useful for "where do I look", actively unhelpful for "what is happening on this line". The halos in the screenshot occlude several substations and a half-dozen connecting lines. See `App.css:140-167` (stroke-width 150px in grid units). | Critical | Cap the halo's *visual* width. Either (a) switch to a screen-space stroke (`vector-effect: non-scaling-stroke` is already used elsewhere — apply it here too) capped at e.g. 24px, or (b) keep the grid-unit stroke for zoomed-out overview but fade to a thinner outline + glow at zoom-tier `region` and `detail`. The existing `data-zoom-tier` infrastructure (`App.css:44-66`) is the right hook. |
+| **No legend / color key on screen.** Lines render in purple (most), red, orange, green, with solid and dashed variants. The detached Overflow PDF uses a totally different palette (red / orange / green colored ovals). The SLD overlay introduces a third. None of it is explained on the surface. | Moderate | Add a small collapsible legend in the bottom-right of each diagram tab. At minimum: contingency (yellow halo), action target (pink halo), overloaded line (orange halo), disconnected branch (dashed), nominal voltage colors (the existing voltage-range slider already has the data — extend it with color swatches). |
+| **Tab title truncation hides important context.** The Remedial Action tab reads `Remedial Action: disco_BERG9L61CANTE+pst_tap_ARKA…` — the action ID is truncated mid-token. For combined actions this loses the second leg entirely. | Moderate | Use a two-line tab label (small grey "Remedial Action" line + larger truncated ID line with a `title` attribute holding the full ID), or move the action ID into a separate breadcrumb-style strip below the tab row. |
+| **The detached PDF graph is more legible than the live NAD.** The Overflow Analysis panel on the right shows a node-graph visualization (substations as labeled colored ovals, flow arrows between them, percentages on edges) that reads dramatically clearer than the geographically-laid-out NAD next to it. It is doing less — fewer lines, no geographic constraint, larger node labels — but the operator can absorb the post-action flow picture in seconds from the PDF and only minutes from the NAD. | Insight, not action | Worth understanding *why* the PDF reads better and whether any of those choices (larger node labels at zoom-tier `overview`, cleaner edge routing on overload paths) can be borrowed into the NAD. Possible follow-up doc, not an immediate change. |
+| **SLD overlay floats over the NAD rather than docking.** The `CANTEP6 Flows` overlay in the screenshot occludes a sizable portion of the network it was opened from. The user can drag-resize but cannot dock it to a side panel. | Minor | Offer a "dock left" / "dock right" affordance in the overlay header, or auto-position it on the side opposite the selected voltage level. The existing detached-tabs infrastructure (`useDetachedTabs`) is most of the plumbing already. |
+
+---
+
+## Consistency
+
+This is the single largest gap. Numbers from the codebase:
+
+- **464 inline `style={{}}` declarations** across 21 component files
+- **273 hardcoded hex colors** across 24 files
+- **202 numeric `fontSize:` declarations** across 19 files
+- **0 design tokens, CSS variables, or utility classes** for color /
+  spacing / typography
+
+The hex values reveal three competing color systems living together:
+
+| System | Where | Sample colors |
+|---|---|---|
+| Flat UI | Header, StatusToasts, sliders | `#2c3e50`, `#3498db`, `#e74c3c`, `#27ae60`, `#7f8c8d` |
+| Bootstrap | ActionFeed CTAs, modals, tooltips | `#007bff`, `#dc3545`, `#28a745`, `#856404`, `#fff3cd` |
+| Tailwind | ActionCard sub-rows, SidebarSummary | `#1e40af`, `#dbeafe`, `#fef3c7`, `#92400e`, `#d1fae5` |
+
+A single `ActionCard` renders blue links from Tailwind (`#1e40af`), a
+yellow shedding box from Tailwind (`#fef3c7` / `#92400e`), a cyan
+curtailment box from Tailwind (`#e0f2fe` / `#075985`), a purple PST
+box from Tailwind (`#f3e8ff` / `#6b21a8`), and a Bootstrap-blue
+"VIEWING" ribbon (`#007bff`) — five sub-systems on one card.
+
+Other consistency issues:
+
+- Type sizes range from 10px to 22px without a clear scale. Common:
+  10, 11, 12, 13, 14 (minor steps), then jumps to 1.1rem (~17.6px)
+  and back. No `--font-size-md` etc.
+- Spacing values: 2, 3, 4, 5, 6, 7, 8, 10, 12, 15, 20, 25 — every
+  multiple of 1px is in play. No 4 / 8 grid.
+- Border radii: 3, 4, 6, 8, 10, 12 — same fragmentation.
+- The "underlined-dotted clickable link" pattern is reimplemented in
+  `OverloadPanel`, `SidebarSummary`, and `ActionCard` with subtly
+  different colors and weights. This is the most obvious component
+  that has not yet been extracted.
+
+---
+
+## Accessibility
+
+Best-effort review from source — no live contrast measurement.
+
+- **Body text below 12px is common.** SidebarSummary is 11px
+  (`SidebarSummary.tsx:48`), Overloads list is 12px
+  (`OverloadPanel.tsx:170`), tooltips are 10px (`ActionFeed.tsx:995`),
+  the VIEWING ribbon is 10px. WCAG does not set a hard size minimum,
+  but human-factors literature flags <12px as fatiguing for sustained
+  reading — and grid operators *will* read this for hours.
+- **Color-only state encoding.** Selected vs. deselected overloads
+  differ by hex (`#1e40af` vs `#bdc3c7`) plus font weight
+  (`OverloadPanel.tsx:91-95`). For deuteranomaly (~5% of men) the
+  blue-vs-grey distinction at 11-12px will be subtle. Pair with an
+  icon (✓ vs ✗) or add underline / strikethrough.
+- **Low-contrast pair to verify.** `#bdc3c7` on `#ffffff` (deselected
+  overloads on white) — approximately 1.7:1, well below WCAG AA's
+  4.5:1. The intent is "barely visible" but the same style is used in
+  clickable text. Run a contrast checker on this pair.
+- **Severity badges rely on color + text.** The text labels
+  ("Solves overload", "Solved — low margin", "Still overloaded") help,
+  but they sit inside same-color-as-border pills at 11px — so the
+  *first* read is color-only. Pair with a small icon (`CheckCircle` /
+  `AlertTriangle` / `XCircle` from `lucide-react`).
+- **Touch targets.** Underlined dotted "links" in `OverloadPanel` and
+  `SidebarSummary` are 11px with 0 padding (`OverloadPanel.tsx:65-76`).
+  About 12-14×16px. Fine for mouse; below 44×44 for touch. Likely not
+  a use case here, but worth noting if control-room touchscreens are
+  in scope.
+- **Focus styles** rely on browser defaults — none of the inline
+  styles override `:focus`. With background-colored buttons everywhere,
+  the default outline may be invisible on the colored fills. Add
+  explicit `:focus-visible` rings via a CSS class.
+
+---
+
+## What works well
+
+- **The "Make a first guess" empty state** (`ActionFeed.tsx:819-842`)
+  is genuinely good guided onboarding — dashed border, soft hover,
+  clear CTA, and it disappears once analysis starts (line 815-818).
+  Exactly the right pattern for a tool with a non-obvious entry path.
+- **The sticky `SidebarSummary`** (`AppSidebar.tsx:58-66`) keeps the
+  contingency and N-1 overloads visible while the rest of the sidebar
+  scrolls. Real operational thinking — the operator never loses the
+  "what am I working on" anchor.
+- **Severity logic on `ActionCard`** (`ActionCard.tsx:75-88`) handles
+  the surprising states (`non_convergence`, `is_islanded`) by
+  *replacing* the severity verdict, not stacking on top of it. That is
+  the right call — divergence and islanding are not shades of severity,
+  they are different verdicts entirely.
+- **Branch search via `<datalist>`** (`AppSidebar.tsx:71-86`) gives
+  operators native autocomplete with name + ID display labels
+  (`App.tsx:241`). For a tool with thousands of branches this is the
+  right primitive.
+- **Detachable + tied tabs** (`useDetachedTabs`, `useTiedTabsSync`).
+  The side-by-side comparison workflow they enable is core to this
+  domain and surprisingly rare in network-analysis tools. Keep it.
+- **Comments preserve a lot of design rationale** (e.g. why "Loading
+  before" was removed from cards, `ActionCard.tsx:374-378`). That is a
+  sign of considered design even where the visual layer is rough.
+- **Detached panel reattach affordance** (visible in the screenshot's
+  right-hand Overflow Analysis pane). The "Reattach" button is
+  clearly labeled, in the panel header, with an arrow-back icon —
+  the user is never stuck in detached mode. Good.
+- **The right hierarchy at first glance.** The NAD with its halos
+  carries the focal weight, the sidebar provides context, the Header
+  recedes. This is correct for a contingency tool and is the kind of
+  outcome that is easy to get wrong by overdesigning the chrome.
+
+---
+
+## Priority recommendations
+
+### 1. Stand up a design-token layer first
+
+Before any visual work, replace the 273 hex literals and 202 numeric
+font sizes with a small token set:
+
+- ~12 semantic colors: surface, border, text-primary / secondary /
+  tertiary, brand, success, warning, danger, accent.
+- A 4 / 8 spacing scale.
+- 6 type sizes (e.g. xs 11, sm 12, md 14, lg 16, xl 20, xxl 24).
+- 3 radii (sm 4, md 6, lg 8).
+
+Pick one of the three palettes (Tailwind's blue-50…900 ramp is the
+closest fit for what is already there) and migrate. This single change
+probably resolves half the consistency issues mechanically and gives
+you a place to enforce dark-mode if it ever becomes a requirement.
+
+The CONTRIBUTING.md gate already enforces "no `any`" — add "no inline
+hex" once the token layer exists. The `check_code_quality.py` script
+is the right place to land that rule.
+
+### 2. Redesign `ActionCard` around progressive disclosure
+
+At rest: rank, ID, severity badge with icon, max ρ%, primary target.
+On hover: ⭐ / ❌ slide in from the right edge. On viewing-state: the
+parameter editors (load shedding / curtailment / PST tap) expand
+inline; everything else stays terse. Drop the vertical "VIEWING"
+ribbon — a left-edge accent stripe at higher saturation does the same
+job at lower visual cost. This is the single largest scannability win
+available.
+
+Open question: the editable MW / tap inputs are currently always
+visible. Hiding them behind a disclosure changes the muscle-memory of
+operators who already know the workflow. Likely worth a quick check
+with two or three operators before committing.
+
+### 3. Cap NAD overload halo size
+
+*Promoted from "Moderate" finding to top-three after screenshot
+review.* At the current zoom level the halos cover so much of the
+network that they hurt more than they help. Either switch to a
+screen-space stroke capped at ~24px or leverage the existing
+`data-zoom-tier` infrastructure (`App.css:44-66`) to shrink the halo
+at `region` and `detail` zoom tiers. This is a small CSS change with
+a disproportionately large legibility win — it is the cheapest of the
+top three to land.
+
+### 4. Tier the warning system
+
+Replace the five concurrent yellow banners with:
+
+- One toast for transient errors (already in place via
+  `StatusToasts.tsx`).
+- A single "Notices" pill in the sidebar header that opens a panel
+  listing active warnings (action-dict info, recommender thresholds,
+  monitoring coverage).
+- Inline contextual hints (small grey text under the relevant control)
+  for things like "5 actions filtered out by the overview filter".
+
+The cumulative warning load is currently teaching users to ignore
+yellow. *Note: the captured screenshot has analysis already complete
+and only one non-zero overload condition active, so none of the five
+banners are visible — this finding remains a code-only inference. It
+should be re-validated by replicating the multi-warning state.*
+
+### 5. Add a diagram legend
+
+Smallest standalone improvement on the list. A collapsible legend in
+the bottom-right of each diagram tab — covering halo colors,
+disconnection styling, and voltage-level color mapping — would close
+the largest onboarding gap visible in the screenshot.
+
+---
+
+## Screenshot review — confirmations and corrections
+
+A second pass against a real screenshot (analysis run on
+`bare_env_small_grid_test`, contingency `ARGIAL71CANTE`, combined
+remedial action selected, SLD overlay open on `CANTEP6`, Overflow
+Analysis PDF detached) shifted several findings. Recorded here so the
+provenance of each claim stays clear.
+
+**Corrected (claim was overstated in the code-only pass):**
+
+- *"Header buttons outweigh the brand."* Not really — at rendered
+  scale the Header reads as neutral chrome. Brand is legible. Removed
+  from First Impression and Visual Hierarchy.
+- *"The VIEWING ribbon out-shouts the card content."* The ribbon
+  itself is quiet; what reads as heavy on a viewing card is the
+  combination of light-blue background + inline editable controls.
+  Updated.
+- *"Three near-identical sidebar greys with no clear edge."* The
+  edges are clearer at rendered scale than the source suggested.
+  Removed.
+
+**Confirmed (visible in screenshot, finding stands):**
+
+- ActionCard density. The selected combined action carries header +
+  description + two badge links + editable PST tap row + re-simulate
+  button + Loading after + Max loading + viewing ribbon — ~7 vertical
+  rows in a card on a ~350px-wide sidebar. Critical-severity finding
+  unchanged.
+- Severity badges read louder than action IDs. "Still overloaded"
+  pills are the loudest text on each suggested card.
+- Emoji-as-affordance throughout (yellow stars, red ✕s, ⚠️s, 🎯s,
+  🔍s). All visible.
+- Sticky `SidebarSummary` works as designed — the operator can see
+  the current contingency and N-1 overload while scrolling the
+  action feed.
+
+**New (only visible at render time):**
+
+- NAD overload halos dwarf network detail at typical zoom. Promoted
+  to a top-three priority recommendation.
+- No on-screen legend or color key. New "Add a diagram legend"
+  recommendation.
+- Tab title truncation on long action IDs (e.g.
+  `disco_BERG9L61CANTE+pst_tap_ARKA…`).
+- The detached Overflow PDF reads dramatically clearer than the live
+  NAD next to it. Worth a separate investigation; flagged as insight
+  rather than action.
+- SLD overlay floats over the NAD rather than docking — minor.
+
+**Still unverified:**
+
+- Multi-warning state (all five `#fff3cd` banners stacked). The
+  captured run only triggers one or two conditions, so the cumulative
+  warning load remains a code-only inference.
+- Behaviour with realistic data volume. The captured run shows ~10
+  suggested actions; the density problem may scale non-linearly with
+  ~50+ actions on `pypsa_eur_fr400`.
+- Emoji rendering on non-macOS workstations.
+
+---
+
+## Related docs
+
+- [`features/frontend-ui-improvements.md`](../features/frontend-ui-improvements.md) — record of UI changes already shipped.
+- [`features/action-overview-diagram.md`](../features/action-overview-diagram.md) — the pin-overlay surface, not yet covered here.
+- [`architecture/code-quality-analysis.md`](../architecture/code-quality-analysis.md) — broader quality audit; the design-token gap is a natural follow-up to its frontend findings.
+- [`proposals/new-features-brainstorm-mars26.md`](new-features-brainstorm-mars26.md) — feature ideas; some (Cmd+K, shortcuts) intersect with the keyboard-nav finding above.

--- a/docs/proposals/ui-design-critique.md
+++ b/docs/proposals/ui-design-critique.md
@@ -1,45 +1,55 @@
 # UI design critique — Co-Study4Grid frontend
 
 **Status**: Proposal / review. **Recommendation #1 (design-token layer)
-Phase A + Phase B landed 2026-05-01** — `frontend/src/styles/tokens.{css,ts}`
-defines the semantic palette: ~24 colors (Tailwind blue-ramp brand,
-Bootstrap warning/danger/success, info-cyan family for curtailment,
-accent-purple family for PST tap edits), 4/8 spacing scale, 6 type
-sizes, 3 radii, plus diagram-signal colors (overload, contingency,
-action-target soft/strong/darker, breaker, deltas). All 18
-inline-style components are migrated; ActionFeed and VisualizationPanel
-test assertions now read the `var(--…)` strings instead of resolved
-RGB. The `scripts/check_code_quality.py` gate ratchets the
-hex-literal count (currently **56**, down from ~654 pre-Phase A,
-518 after Phase A) and refuses to let it grow.
+landed in full 2026-05-01 → 2026-05-02** across three commits.
+`frontend/src/styles/tokens.{css,ts}` defines the semantic palette:
+~24 colors (Tailwind blue-ramp brand, Bootstrap warning/danger/success,
+info-cyan family for curtailment, accent-purple family for PST tap
+edits), 4/8 spacing scale, 6 type sizes, 3 radii, diagram-signal
+colors (overload, contingency, action-target soft/strong/darker,
+breaker, deltas), and the action-overview pin palette
+(severity green/orange/red/grey × base/dimmed/highlighted, plus pin
+chrome — glyph background, label text, gold star, rejected cross,
+neutral stroke). All inline-style components AND the SVG-emitting
+pin renderer are migrated; ActionFeed / VisualizationPanel test
+assertions read the `var(--…)` strings. The
+`scripts/check_code_quality.py` gate now requires **zero** hex
+literals outside the token files (down from ~654 pre-migration,
+518 after Phase A, 56 after Phase B).
 
-**Phase C — remaining 56 hex literals** are concentrated in three
-SVG-emitting files that need a different migration treatment because
-they use `setAttribute('fill', '#…')` to set raw SVG attribute values
-(which don't reliably resolve `var(--…)` across browsers):
-- `frontend/src/utils/svg/actionPinData.ts` (12) — severity palette
-  for the Remedial Action overview pins (green/orange/red/grey
-  triplets: base, faded for unsimulated, highlighted on hover).
-- `frontend/src/utils/svg/actionPinRender.ts` (8) — pin glyph
-  fills (white inner, dark text, gold star, red cross).
-- `frontend/src/components/ActionOverviewDiagram.tsx` (35) — legend
-  swatches that pass `color="#…"` props into pin children, plus
-  inspect-input chrome.
+**Phase A** (commit 47a2700, 2026-05-01) — token scaffold + global
+CSS + 4 representative components (Header, StatusToasts,
+SidebarSummary, OverloadPanel) + ratcheting gate.
 
-The clean migration is to (a) extend `tokens.css` with a
-`--pin-{severity}-{base,faded,highlighted}` family, (b) switch the
-SVG attribute setters to inline `style.fill = 'var(--…)'`, and
-(c) update the `'#28a745'` / `'#dc3545'` / `'#eab308'` test
-assertions in `ActionOverviewDiagram.test.tsx` to read the resolved
-attribute string. Worth a dedicated follow-up so the pin-palette
-extension can be reviewed on its own.
+**Phase B** (commit 0e60059, 2026-05-01) — 14 inline-style
+components (ActionTypeFilterChips, ConfirmationDialog, AppSidebar,
+ActionCardPopover, ErrorBoundary, ReloadSessionModal,
+CombinedActionsModal, SldOverlay, ComputedPairsTable, SettingsModal,
+ActionSearchDropdown, ActionCard, ExplorePairsTab, ActionFeed,
+VisualizationPanel) + test-assertion updates.
 
-`frontend/src/index.css` carries one remaining literal — the
-`#242424` dark-mode placeholder background that the Vite template
-sets before the `prefers-color-scheme: light` override kicks in. It
-stays because the app does not yet support dark mode and adding a
-single `--color-surface-dark` token for one use site is overkill;
-re-evaluate if/when dark mode lands.
+**Phase C** (2026-05-02) — the three SVG-emitting files that use
+`setAttribute('fill', …)` for raw SVG presentation attributes:
+- `frontend/src/utils/svg/actionPinData.ts` — severity triplets
+  (green/orange/red/grey × base/dimmed/highlighted) now alias the
+  `pinColors` / `pinColorsDimmed` / `pinColorsHighlighted` exports
+  from `tokens.ts`.
+- `frontend/src/utils/svg/actionPinRender.ts` — pin glyph fills
+  (white inner, dark text, gold star, red cross, neutral stroke)
+  now read from `pinChrome`.
+- `frontend/src/components/ActionOverviewDiagram.tsx` — legend
+  swatch `color={pinColors.green}` etc., plus all the inline-style
+  chrome migrated to `colors.*` var() refs.
+- `frontend/src/index.css` — the `#242424` dark-mode placeholder
+  now uses `var(--color-surface-dark)`.
+
+The Phase C compromise: `tokens.ts` is the runtime source of truth
+for pin colours (raw hex strings) because browsers don't reliably
+resolve `var(--…)` inside SVG presentation attributes set via
+`setAttribute`, and unit tests assert on the resolved hex via
+`getAttribute('fill')`. `tokens.css` mirrors the same values for
+future CSS-only consumers. Both `tokens.css` and `tokens.ts` are
+exempt from the hex-literal gate. Nothing else is.
 **Date**: 2026-05-01 (updated same day with screenshot review)
 **Method**: Initial pass was a code-only review of `frontend/src/`.
 A second pass cross-checked the findings against a screenshot of the

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -298,11 +298,15 @@ npm run test:watch   # watch mode
   or utility-class framework). Match the surrounding component.
 - **Design tokens** — use `colors` / `space` / `text` / `radius` from
   `src/styles/tokens.ts` for inline styles, and `var(--…)` from
-  `src/styles/tokens.css` for stylesheet rules. Do not introduce new
-  hex literals; add a token instead. The code-quality gate
-  (`scripts/check_code_quality.py`) ratchets the hex-literal count
-  down as files migrate. See `docs/proposals/ui-design-critique.md`
-  recommendation #1 for the migration plan.
+  `src/styles/tokens.css` for stylesheet rules. For raw SVG attribute
+  values (`element.setAttribute('fill', …)`), import the hex-valued
+  `pinColors` / `pinColorsDimmed` / `pinColorsHighlighted` /
+  `pinChrome` constants from `tokens.ts` — browsers don't reliably
+  resolve `var(--…)` inside SVG presentation attributes, and a few
+  unit tests assert on the resolved hex via `getAttribute('fill')`.
+  Do not introduce hex literals anywhere outside the token files; the
+  code-quality gate enforces zero. See
+  `docs/proposals/ui-design-critique.md` recommendation #1.
 - **Memoize at the right level**: `useCallback` for handlers passed
   as props, `useMemo` for derived data passed to large children.
   Don't memoize cheap inline objects on small leaf components.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -296,6 +296,13 @@ npm run test:watch   # watch mode
   unbearable.
 - **Inline `style` objects** are the convention here (no CSS modules
   or utility-class framework). Match the surrounding component.
+- **Design tokens** — use `colors` / `space` / `text` / `radius` from
+  `src/styles/tokens.ts` for inline styles, and `var(--…)` from
+  `src/styles/tokens.css` for stylesheet rules. Do not introduce new
+  hex literals; add a token instead. The code-quality gate
+  (`scripts/check_code_quality.py`) ratchets the hex-literal count
+  down as files migrate. See `docs/proposals/ui-design-critique.md`
+  recommendation #1 for the migration plan.
 - **Memoize at the right level**: `useCallback` for handlers passed
   as props, `useMemo` for derived data passed to large children.
   Don't memoize cheap inline objects on small leaf components.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -87,13 +87,13 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 /* ===== Highlight styles ===== */
 
 .nad-highlight {
-    stroke: #e74c3c !important;
+    stroke: var(--color-danger) !important;
     stroke-width: 4px !important;
     opacity: 1;
 }
 
 circle.nad-highlight {
-    fill: #e74c3c !important;
+    fill: var(--color-danger) !important;
 }
 
 /* Highlight overloaded lines in orange (clone-based halo) */
@@ -106,7 +106,7 @@ circle.nad-highlight {
 .nad-overloaded polyline,
 .nad-overloaded rect,
 .nad-overloaded polygon {
-    stroke: #ff8c00 !important;
+    stroke: var(--signal-overload) !important;
     stroke-width: 120px !important;
     stroke-opacity: 1 !important;
     stroke-dasharray: none !important;
@@ -161,7 +161,7 @@ circle.nad-highlight {
 .nad-action-target polyline,
 .nad-action-target rect,
 .nad-action-target polygon {
-    stroke: #ff4081 !important;
+    stroke: var(--signal-action-target) !important;
     stroke-width: 150px !important;
     stroke-opacity: 1 !important;
     stroke-dasharray: none !important;
@@ -176,7 +176,7 @@ circle.nad-highlight {
 .nad-contingency-highlight polyline,
 .nad-contingency-highlight rect,
 .nad-contingency-highlight polygon {
-    stroke: #ffe033 !important;
+    stroke: var(--signal-contingency) !important;
     stroke-width: 150px !important;
     stroke-opacity: 1 !important;
     stroke-dasharray: none !important;
@@ -189,20 +189,20 @@ circle.nad-highlight {
    background halo that doesn't shrink into invisibility on large grids. */
 .nad-action-target circle,
 .nad-action-target rect {
-    stroke: #ff4081 !important;
+    stroke: var(--signal-action-target) !important;
     stroke-width: 45px !important;
     stroke-opacity: 1 !important;
-    fill: #ff4081 !important;
+    fill: var(--signal-action-target) !important;
     fill-opacity: 1 !important;
     vector-effect: non-scaling-stroke !important;
 }
 
 .nad-contingency-highlight circle,
 .nad-contingency-highlight rect {
-    stroke: #ffe033 !important;
+    stroke: var(--signal-contingency) !important;
     stroke-width: 45px !important;
     stroke-opacity: 1 !important;
-    fill: #ffe033 !important;
+    fill: var(--signal-contingency) !important;
     fill-opacity: 1 !important;
     opacity: 1 !important;
     vector-effect: non-scaling-stroke !important;
@@ -249,7 +249,7 @@ circle.nad-highlight {
 .nad-delta-positive path,
 .nad-delta-positive line,
 .nad-delta-positive polyline {
-    stroke: #ff9800 !important;
+    stroke: var(--signal-delta-positive) !important;
     stroke-width: 3px !important;
 }
 
@@ -257,7 +257,7 @@ circle.nad-highlight {
 .nad-delta-negative path,
 .nad-delta-negative line,
 .nad-delta-negative polyline {
-    stroke: #2196F3 !important;
+    stroke: var(--signal-delta-negative) !important;
     stroke-width: 3px !important;
 }
 
@@ -265,7 +265,7 @@ circle.nad-highlight {
 .nad-delta-grey path,
 .nad-delta-grey line,
 .nad-delta-grey polyline {
-    stroke: #999 !important;
+    stroke: var(--signal-delta-neutral) !important;
     stroke-opacity: 0.4 !important;
 }
 
@@ -279,7 +279,7 @@ circle.nad-highlight {
 .sld-delta-positive polyline,
 .sld-delta-positive rect,
 .sld-delta-positive circle {
-    stroke: #ff8c00 !important;
+    stroke: var(--signal-overload) !important;
     stroke-width: 2px !important;
 }
 
@@ -288,7 +288,7 @@ circle.nad-highlight {
 .sld-delta-negative polyline,
 .sld-delta-negative rect,
 .sld-delta-negative circle {
-    stroke: #2196F3 !important;
+    stroke: var(--signal-delta-negative) !important;
     stroke-width: 2px !important;
 }
 
@@ -297,21 +297,21 @@ circle.nad-highlight {
 .sld-delta-grey polyline,
 .sld-delta-grey rect,
 .sld-delta-grey circle {
-    stroke: #999 !important;
+    stroke: var(--signal-delta-neutral) !important;
     stroke-opacity: 0.5 !important;
 }
 
 /* Delta text label styling */
 .sld-delta-text-positive {
-    fill: #ff8c00 !important;
+    fill: var(--signal-overload) !important;
 }
 
 .sld-delta-text-negative {
-    fill: #2196F3 !important;
+    fill: var(--signal-delta-negative) !important;
 }
 
 .sld-delta-text-grey {
-    fill: #999 !important;
+    fill: var(--signal-delta-neutral) !important;
     fill-opacity: 0.5 !important;
 }
 
@@ -321,7 +321,7 @@ circle.nad-highlight {
 
 /* Contingency element on N-1 SLD (yellow glow behind) */
 .sld-highlight-clone.sld-highlight-contingency {
-    filter: drop-shadow(0 0 4px #ffe033) drop-shadow(0 0 8px #ffe033);
+    filter: drop-shadow(0 0 4px var(--signal-contingency)) drop-shadow(0 0 8px var(--signal-contingency));
 }
 
 .sld-highlight-clone.sld-highlight-contingency path,
@@ -329,7 +329,7 @@ circle.nad-highlight {
 .sld-highlight-clone.sld-highlight-contingency polyline,
 .sld-highlight-clone.sld-highlight-contingency rect,
 .sld-highlight-clone.sld-highlight-contingency circle {
-    stroke: #ffe033 !important;
+    stroke: var(--signal-contingency) !important;
     stroke-width: 6px !important;
     stroke-opacity: 1 !important;
     stroke-dasharray: none !important;
@@ -338,7 +338,7 @@ circle.nad-highlight {
 
 /* Action target on action SLD (purple-pink halo behind) */
 .sld-highlight-clone.sld-highlight-action {
-    filter: drop-shadow(0 0 4px #ff4081) drop-shadow(0 0 8px #ff4081);
+    filter: drop-shadow(0 0 4px var(--signal-action-target)) drop-shadow(0 0 8px var(--signal-action-target));
 }
 
 .sld-highlight-clone.sld-highlight-action path,
@@ -346,7 +346,7 @@ circle.nad-highlight {
 .sld-highlight-clone.sld-highlight-action polyline,
 .sld-highlight-clone.sld-highlight-action rect,
 .sld-highlight-clone.sld-highlight-action circle {
-    stroke: #ff4081 !important;
+    stroke: var(--signal-action-target) !important;
     stroke-width: 6px !important;
     stroke-opacity: 1 !important;
     fill: none !important;
@@ -354,7 +354,7 @@ circle.nad-highlight {
 
 /* Overloaded lines on SLD (orange halo, consistent with contingency style) */
 .sld-highlight-clone.sld-highlight-overloaded {
-    filter: drop-shadow(0 0 4px #ff8c00) drop-shadow(0 0 8px #ff8c00);
+    filter: drop-shadow(0 0 4px var(--signal-overload)) drop-shadow(0 0 8px var(--signal-overload));
 }
 
 .sld-highlight-clone.sld-highlight-overloaded path,
@@ -362,7 +362,7 @@ circle.nad-highlight {
 .sld-highlight-clone.sld-highlight-overloaded polyline,
 .sld-highlight-clone.sld-highlight-overloaded rect,
 .sld-highlight-clone.sld-highlight-overloaded circle {
-    stroke: #ff8c00 !important;
+    stroke: var(--signal-overload) !important;
     stroke-width: 6px !important;
     stroke-opacity: 1 !important;
     stroke-dasharray: none !important;
@@ -371,14 +371,14 @@ circle.nad-highlight {
 
 /* Affected breakers/switches on SLD (light purple halo behind) */
 .sld-highlight-clone.sld-highlight-breaker {
-    filter: drop-shadow(0 0 3px #ce93d8) drop-shadow(0 0 6px #ce93d8);
+    filter: drop-shadow(0 0 3px var(--signal-breaker)) drop-shadow(0 0 6px var(--signal-breaker));
 }
 
 .sld-highlight-clone.sld-highlight-breaker path,
 .sld-highlight-clone.sld-highlight-breaker line,
 .sld-highlight-clone.sld-highlight-breaker rect,
 .sld-highlight-clone.sld-highlight-breaker circle {
-    stroke: #ce93d8 !important;
+    stroke: var(--signal-breaker) !important;
     stroke-width: 6px !important;
     stroke-opacity: 1 !important;
     fill: none !important;
@@ -399,33 +399,33 @@ circle.nad-highlight {
     bottom: 0;
     width: 62px;
     background: rgba(244, 244, 244, 0.92);
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--color-border);
     display: flex;
     flex-direction: column;
     align-items: center;
     z-index: 15;
-    padding: 8px 0;
+    padding: var(--space-2) 0;
     box-sizing: border-box;
 }
 
 .voltage-sidebar .vs-label {
     font-size: 0.65rem;
     font-weight: bold;
-    color: #2c3e50;
+    color: var(--color-chrome);
     writing-mode: vertical-rl;
     text-orientation: mixed;
     letter-spacing: 0.5px;
-    margin-bottom: 4px;
+    margin-bottom: var(--space-1);
 }
 
 .voltage-sidebar .vs-range-label {
     font-size: 0.6rem;
     font-weight: bold;
-    color: #2c3e50;
-    background: #e8f0fe;
+    color: var(--color-chrome);
+    background: var(--color-brand-soft);
     border-radius: 3px;
-    padding: 2px 4px;
-    margin-bottom: 6px;
+    padding: var(--space-half) var(--space-1);
+    margin-bottom: var(--space-2);
     text-align: center;
     line-height: 1.2;
 }
@@ -443,7 +443,7 @@ circle.nad-highlight {
     top: 0;
     bottom: 0;
     width: 4px;
-    background: #ddd;
+    background: var(--color-border);
     border-radius: 2px;
 }
 
@@ -451,7 +451,7 @@ circle.nad-highlight {
     position: absolute;
     left: 12px;
     width: 4px;
-    background: #3498db;
+    background: var(--color-brand-mid);
     border-radius: 2px;
 }
 
@@ -473,7 +473,7 @@ circle.nad-highlight {
     height: 18px;
     width: 18px;
     border-radius: 50%;
-    background: #3498db;
+    background: var(--color-brand-mid);
     border: 2px solid white;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     cursor: pointer;
@@ -484,7 +484,7 @@ circle.nad-highlight {
     height: 18px;
     width: 18px;
     border-radius: 50%;
-    background: #3498db;
+    background: var(--color-brand-mid);
     border: 2px solid white;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     cursor: pointer;
@@ -502,7 +502,7 @@ circle.nad-highlight {
 .voltage-slider-ticks span {
     position: absolute;
     font-size: 0.58rem;
-    color: #666;
+    color: var(--color-text-tertiary);
     white-space: nowrap;
     transform: translateY(-50%);
     left: 2px;
@@ -517,20 +517,20 @@ circle.nad-highlight {
     width: 24px;
     background: rgba(244, 244, 244, 0.85);
     border: none;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--color-border);
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 15;
-    color: #666;
-    font-size: 11px;
+    color: var(--color-text-tertiary);
+    font-size: var(--text-xs);
     padding: 0;
 }
 
 .voltage-sidebar-toggle:hover {
     background: rgba(220, 220, 220, 0.95);
-    color: #333;
+    color: var(--color-text-primary);
 }
 /* ============================================================
    Action-overview pins (Remedial Action tab, no card selected)

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import type { ActionDetail, NodeMeta, EdgeMeta } from '../types';
 import { getActionTargetVoltageLevels, getActionTargetLines, isCouplingAction } from '../utils/svgUtils';
+import { colors } from '../styles/tokens';
 
 interface ActionCardProps {
     id: string;
@@ -42,7 +43,7 @@ const clickableLinkStyle: React.CSSProperties = {
     cursor: 'pointer',
     padding: 0,
     fontSize: 'inherit',
-    color: '#1e40af',
+    color: colors.brand,
     fontWeight: 600,
     textDecoration: 'underline dotted',
 };
@@ -77,14 +78,14 @@ const ActionCard: React.FC<ActionCardProps> = ({
         ? (details.max_rho > monitoringFactor ? 'red' as const : details.max_rho > (monitoringFactor - 0.05) ? 'orange' as const : 'green' as const)
         : (details.is_rho_reduction ? 'green' as const : 'red' as const);
     const severityColors = {
-        green: { border: '#28a745', badgeBg: '#d4edda', badgeText: '#155724', label: 'Solves overload' },
-        orange: { border: '#f0ad4e', badgeBg: '#fff3cd', badgeText: '#856404', label: 'Solved \u2014 low margin' },
-        red: { border: '#dc3545', badgeBg: '#f8d7da', badgeText: '#721c24', label: details.is_rho_reduction ? 'Still overloaded' : 'No reduction' },
+        green: { border: colors.success, badgeBg: colors.successSoft, badgeText: colors.successText, label: 'Solves overload' },
+        orange: { border: colors.warningStrong, badgeBg: colors.warningSoft, badgeText: colors.warningText, label: 'Solved \u2014 low margin' },
+        red: { border: colors.danger, badgeBg: colors.dangerSoft, badgeText: colors.dangerText, label: details.is_rho_reduction ? 'Still overloaded' : 'No reduction' },
     };
     const sc = details.non_convergence
-        ? { border: '#dc3545', badgeBg: '#dc3545', badgeText: '#fff', label: 'divergent' }
+        ? { border: colors.danger, badgeBg: colors.danger, badgeText: colors.textOnBrand, label: 'divergent' }
         : details.is_islanded
-            ? { border: '#dc3545', badgeBg: '#dc3545', badgeText: '#fff', label: 'islanded' }
+            ? { border: colors.danger, badgeBg: colors.danger, badgeText: colors.textOnBrand, label: 'islanded' }
             : severityColors[severity];
 
     const renderRho = (arr: number[] | null, actionId: string, tab: 'action' | 'n-1' = 'action'): React.ReactNode => {
@@ -127,7 +128,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
         details.load_shedding_details?.forEach(ls => {
             if (ls.voltage_level_id && !vlSet.has(ls.voltage_level_id)) {
                 vlSet.add(ls.voltage_level_id);
-                badges.push(badgeBtn(ls.voltage_level_id, '#d1fae5', '#065f46', `Click: zoom to ${ls.voltage_level_id} | Double-click: open SLD`, (e) => {
+                badges.push(badgeBtn(ls.voltage_level_id, colors.successSoft, colors.successText, `Click: zoom to ${ls.voltage_level_id} | Double-click: open SLD`, (e) => {
                     e.stopPropagation();
                     onVlDoubleClick?.(id, ls.voltage_level_id!);
                 }));
@@ -137,7 +138,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
         details.curtailment_details?.forEach(rc => {
             if (rc.voltage_level_id && !vlSet.has(rc.voltage_level_id)) {
                 vlSet.add(rc.voltage_level_id);
-                badges.push(badgeBtn(rc.voltage_level_id, '#d1fae5', '#065f46', `Click: zoom to ${rc.voltage_level_id} | Double-click: open SLD`, (e) => {
+                badges.push(badgeBtn(rc.voltage_level_id, colors.successSoft, colors.successText, `Click: zoom to ${rc.voltage_level_id} | Double-click: open SLD`, (e) => {
                     e.stopPropagation();
                     onVlDoubleClick?.(id, rc.voltage_level_id!);
                 }));
@@ -149,7 +150,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
             vlNames.forEach(vlName => {
                 if (vlSet.has(vlName)) return;
                 vlSet.add(vlName);
-                badges.push(badgeBtn(vlName, '#d1fae5', '#065f46', `Click: zoom to ${vlName} | Double-click: open SLD`, (e) => {
+                badges.push(badgeBtn(vlName, colors.successSoft, colors.successText, `Click: zoom to ${vlName} | Double-click: open SLD`, (e) => {
                     e.stopPropagation();
                     onVlDoubleClick?.(id, vlName);
                 }));
@@ -167,7 +168,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
 
         lineNames.forEach(name => {
             if (badges.some(b => React.isValidElement(b) && b.key === name)) return;
-            badges.push(badgeBtn(name, '#dbeafe', '#1e40af', `Zoom to ${name}`));
+            badges.push(badgeBtn(name, colors.brandSoft, colors.brand, `Zoom to ${name}`));
         });
 
         if (badges.length === 0) {
@@ -179,7 +180,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                 ...Object.keys(topo?.gens_p || {}),
             ]));
             equipNames.forEach(name => {
-                badges.push(badgeBtn(name, '#dbeafe', '#1e40af', `Zoom to ${name}`));
+                badges.push(badgeBtn(name, colors.brandSoft, colors.brand, `Zoom to ${name}`));
             });
         }
 
@@ -194,12 +195,12 @@ const ActionCard: React.FC<ActionCardProps> = ({
         <div
             data-testid={`action-card-${id}`}
             style={{
-                background: (details.non_convergence || details.is_islanded) ? '#fff5f5' : (isViewing ? '#e7f1ff' : 'white'),
-                border: (details.non_convergence || details.is_islanded) ? '1px solid #dc3545' : '1px solid #ddd',
+                background: (details.non_convergence || details.is_islanded) ? colors.dangerSoft : (isViewing ? colors.brandSoft : colors.surface),
+                border: (details.non_convergence || details.is_islanded) ? `1px solid ${colors.danger}` : `1px solid ${colors.border}`,
                 borderRadius: '8px',
                 marginBottom: '10px',
                 boxShadow: isViewing ? '0 0 0 2px rgba(0,123,255,0.3), 0 2px 8px rgba(0,0,0,0.15)' : '0 2px 4px rgba(0,0,0,0.1)',
-                borderLeft: `5px solid ${isViewing ? '#007bff' : sc.border}`,
+                borderLeft: `5px solid ${isViewing ? colors.brand : sc.border}`,
                 cursor: 'pointer',
                 transition: 'all 0.15s ease',
                 display: 'flex',
@@ -227,8 +228,8 @@ const ActionCard: React.FC<ActionCardProps> = ({
                     style={{
                         writingMode: 'vertical-rl',
                         transform: 'rotate(180deg)',
-                        background: '#007bff',
-                        color: 'white',
+                        background: colors.brand,
+                        color: colors.textOnBrand,
                         fontSize: '10px',
                         fontWeight: 700,
                         letterSpacing: '1.5px',
@@ -247,7 +248,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                 <h4 style={{
                     margin: 0,
                     fontSize: '12px',
-                    color: isViewing ? '#0056b3' : undefined,
+                    color: isViewing ? colors.brandStrong : undefined,
                     flex: 1,
                     minWidth: 0,
                     overflowWrap: 'anywhere'
@@ -264,7 +265,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                 <div style={{ flex: 1 }}>
                     <p style={{ fontSize: '12px', margin: 0 }}>{details.description_unitaire}</p>
                     {details.load_shedding_details && details.load_shedding_details.length > 0 && (
-                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: '#fef3c7', color: '#92400e', padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: '1px solid #fcd34d', fontWeight: 500 }}>
+                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: colors.warningSoft, color: colors.warningText, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.warningBorder}`, fontWeight: 500 }}>
                             {details.load_shedding_details.map((ls, i) => (
                                 <div key={ls.load_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
                                     <span>Shedding on <strong>{ls.load_name}</strong> in MW:</span>
@@ -275,7 +276,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                                         step={0.1}
                                         value={cardEditMw[id] ?? ls.shedded_mw.toFixed(1)}
                                         onChange={(e) => onCardEditMwChange(id, e.target.value)}
-                                        style={{ width: '65px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: '1px solid #d97706', borderRadius: '3px', textAlign: 'right' }}
+                                        style={{ width: '65px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: `1px solid ${colors.warningStrong}`, borderRadius: '3px', textAlign: 'right' }}
                                     />
                                     <button
                                         data-testid={`resimulate-${id}`}
@@ -284,7 +285,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                                             if (!isNaN(mwVal) && mwVal >= 0) onResimulate(id, mwVal);
                                         }}
                                         disabled={resimulating === id}
-                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: '1px solid #d97706', background: '#fbbf24', color: '#78350f', cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
+                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: `1px solid ${colors.warningStrong}`, background: colors.warning, color: colors.warningText, cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
                                     >
                                         {resimulating === id ? 'Simulating...' : 'Re-simulate'}
                                     </button>
@@ -293,7 +294,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                         </div>
                     )}
                     {details.curtailment_details && details.curtailment_details.length > 0 && (
-                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: '#e0f2fe', color: '#075985', padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: '1px solid #7dd3fc', fontWeight: 500 }}>
+                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: colors.infoSoft, color: colors.infoText, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.infoBorder}`, fontWeight: 500 }}>
                             {details.curtailment_details.map((rc, i) => (
                                 <div key={rc.gen_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
                                     <span>Curtailment on <strong>{rc.gen_name}</strong> in MW:</span>
@@ -304,7 +305,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                                         step={0.1}
                                         value={cardEditMw[id] ?? rc.curtailed_mw.toFixed(1)}
                                         onChange={(e) => onCardEditMwChange(id, e.target.value)}
-                                        style={{ width: '65px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: '1px solid #0284c7', borderRadius: '3px', textAlign: 'right' }}
+                                        style={{ width: '65px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: `1px solid ${colors.info}`, borderRadius: '3px', textAlign: 'right' }}
                                     />
                                     <button
                                         data-testid={`resimulate-${id}`}
@@ -313,7 +314,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                                             if (!isNaN(mwVal) && mwVal >= 0) onResimulate(id, mwVal);
                                         }}
                                         disabled={resimulating === id}
-                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: '1px solid #0284c7', background: '#38bdf8', color: '#0c4a6e', cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
+                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: `1px solid ${colors.info}`, background: colors.infoBorder, color: colors.infoText, cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
                                     >
                                         {resimulating === id ? 'Simulating...' : 'Re-simulate'}
                                     </button>
@@ -322,7 +323,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                         </div>
                     )}
                     {details.pst_details && details.pst_details.length > 0 && (
-                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: '#f3e8ff', color: '#6b21a8', padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: '1px solid #c084fc', fontWeight: 500 }}>
+                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: colors.accentSoft, color: colors.accentText, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.accentBorder}`, fontWeight: 500 }}>
                             {details.pst_details.map((pst, i) => (
                                 <div key={pst.pst_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
                                     <span>PST <strong>{pst.pst_name}</strong> tap:</span>
@@ -334,10 +335,10 @@ const ActionCard: React.FC<ActionCardProps> = ({
                                         step={1}
                                         value={cardEditTap[id] ?? pst.tap_position}
                                         onChange={(e) => onCardEditTapChange(id, e.target.value)}
-                                        style={{ width: '55px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: '1px solid #9333ea', borderRadius: '3px', textAlign: 'right' }}
+                                        style={{ width: '55px', fontSize: '11px', fontFamily: 'monospace', padding: '2px 4px', border: `1px solid ${colors.accent}`, borderRadius: '3px', textAlign: 'right' }}
                                     />
                                     {pst.low_tap != null && pst.high_tap != null && (
-                                        <span style={{ fontSize: '10px', color: '#7c3aed' }}>
+                                        <span style={{ fontSize: '10px', color: colors.accent }}>
                                             [{pst.low_tap}..{pst.high_tap}]
                                         </span>
                                     )}
@@ -348,7 +349,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                                             if (!isNaN(tapVal)) onResimulateTap(id, tapVal);
                                         }}
                                         disabled={resimulating === id}
-                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: '1px solid #9333ea', background: '#c084fc', color: '#3b0764', cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
+                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: `1px solid ${colors.accent}`, background: colors.accentBorder, color: colors.accentText, cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
                                     >
                                         {resimulating === id ? 'Simulating...' : 'Re-simulate'}
                                     </button>
@@ -357,19 +358,19 @@ const ActionCard: React.FC<ActionCardProps> = ({
                         </div>
                     )}
                     {details.non_convergence && (
-                        <div style={{ fontSize: '11px', color: '#9a3412', backgroundColor: '#fff8f1', padding: '2px 6px', borderRadius: '4px', marginTop: '4px', border: '1px solid #ffedd5', display: 'inline-block' }}>
+                        <div style={{ fontSize: '11px', color: colors.warningText, backgroundColor: colors.warningSoft, padding: '2px 6px', borderRadius: '4px', marginTop: '4px', border: `1px solid ${colors.warningBorder}`, display: 'inline-block' }}>
                             ⚠️ LoadFlow failure: {details.non_convergence}
                         </div>
                     )}
                     {details.is_islanded && (
-                        <div style={{ fontSize: '12px', background: '#fff5f5', color: '#dc3545', padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: '1px solid #dc3545', fontWeight: 500 }}>
+                        <div style={{ fontSize: '12px', background: colors.dangerSoft, color: colors.danger, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.danger}`, fontWeight: 500 }}>
                             🏝️ Islanding detected ({details.disconnected_mw?.toFixed(1)} MW disconnected)
                         </div>
                     )}
                 </div>
                 {renderBadges()}
             </div>
-            <div style={{ fontSize: '12px', background: isViewing ? '#dce8f7' : '#f8f9fa', padding: '5px', marginTop: '5px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+            <div style={{ fontSize: '12px', background: isViewing ? colors.brandSoft : colors.surfaceMuted, padding: '5px', marginTop: '5px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
                 <div>
                     {/*
                       "Loading before" removed — the N-1 pre-action loading
@@ -382,8 +383,8 @@ const ActionCard: React.FC<ActionCardProps> = ({
                         <div style={{ marginTop: '3px' }}>
                             Max loading: <strong style={{ color: sc.border }}>{maxRhoPct}%</strong>
                             {details.max_rho_line && (
-                                <span style={{ color: '#888' }}> on <button
-                                    style={{ ...clickableLinkStyle, color: '#888' }}
+                                <span style={{ color: colors.textTertiary }}> on <button
+                                    style={{ ...clickableLinkStyle, color: colors.textTertiary }}
                                     title={`Zoom to ${details.max_rho_line}`}
                                     onClick={(e) => { e.stopPropagation(); onAssetClick(id, details.max_rho_line, 'action'); }}
                                 >{displayName(details.max_rho_line)}</button></span>
@@ -395,14 +396,14 @@ const ActionCard: React.FC<ActionCardProps> = ({
                     {!isSelected && (
                         <button
                             onClick={(e) => { e.stopPropagation(); onActionFavorite(id); }}
-                            style={{ background: 'white', border: '1px solid #ddd', borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                             title="Select this action"
                         ><span style={{ fontSize: '14px' }}>⭐</span></button>
                     )}
                     {!isRejected && (
                         <button
                             onClick={(e) => { e.stopPropagation(); onActionReject(id); }}
-                            style={{ background: 'white', border: '1px solid #ddd', borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                             title={isSelected ? "Remove from selected" : "Reject this action"}
                         ><span style={{ fontSize: '14px' }}>❌</span></button>
                     )}

--- a/frontend/src/components/ActionCardPopover.tsx
+++ b/frontend/src/components/ActionCardPopover.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, type CSSProperties, type Ref } from 'react';
 import type { ActionDetail, MetadataIndex } from '../types';
 import ActionCard from './ActionCard';
+import { colors } from '../styles/tokens';
 
 /**
  * Floating ActionCard popover — shared between the action
@@ -121,8 +122,8 @@ const ActionCardPopover: React.FC<ActionCardPopoverProps> = ({
             {...(extraDataAttributes ?? {})}
             style={{
                 ...style,
-                background: 'white',
-                border: '1px solid #cbd5e1',
+                background: colors.surface,
+                border: `1px solid ${colors.border}`,
                 borderRadius: 8,
                 boxShadow: '0 10px 24px rgba(0, 0, 0, 0.25)',
                 zIndex: 300,
@@ -138,14 +139,14 @@ const ActionCardPopover: React.FC<ActionCardPopoverProps> = ({
                     top: 6,
                     right: 8,
                     zIndex: 2,
-                    background: 'white',
-                    border: '1px solid #cbd5e1',
+                    background: colors.surface,
+                    border: `1px solid ${colors.border}`,
                     borderRadius: '50%',
                     width: 22,
                     height: 22,
                     cursor: 'pointer',
                     fontSize: 12,
-                    color: '#475569',
+                    color: colors.textSecondary,
                     boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
                     lineHeight: 1,
                 }}

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -436,17 +436,17 @@ describe('ActionFeed', () => {
 
         const card = screen.getByTestId(`action-card-${actionId}`);
 
-        // 1. Check Divergent Badge (red)
+        // 1. Check Divergent Badge (danger token)
         const badge = screen.getByText('divergent');
-        expect(badge.style.background).toContain('rgb(220, 53, 69)'); // #dc3545
+        expect(badge.style.background).toContain('var(--color-danger)');
 
-        // 2. Check Warning Box (orange)
+        // 2. Check Warning Box (warning tokens)
         const warningBox = screen.getByText(/LoadFlow failure: Critical Error/);
-        expect(warningBox.style.color).toContain('rgb(154, 52, 18)'); // #9a3412
-        expect(warningBox.style.backgroundColor).toContain('rgb(255, 248, 241)'); // #fff8f1
+        expect(warningBox.style.color).toContain('var(--color-warning-text)');
+        expect(warningBox.style.backgroundColor).toContain('var(--color-warning-soft)');
 
-        // 3. Check Card Background (reddish)
-        expect(card.style.background).toContain('rgb(255, 245, 245)');
+        // 3. Check Card Background (danger-soft token)
+        expect(card.style.background).toContain('var(--color-danger-soft)');
     });
 
     it('ranks non-convergent actions at the bottom', () => {
@@ -652,12 +652,12 @@ describe('ActionFeed', () => {
         // Timing fix: it should appear at the same time as other user warnings (even during analysis)
         const warning = screen.getByText(/Action dictionary/);
         expect(warning).toBeInTheDocument();
-        // Check yellow theme
+        // Check warning theme via design tokens (jsdom returns the var() string for inline styles)
         const parent = warning.closest('div[style*="background"]') as HTMLDivElement;
         if (parent) {
-            expect(parent.style.background).toContain('rgb(255, 243, 205)'); // #fff3cd
-            expect(parent.style.border).toContain('rgb(255, 238, 186)'); // #ffeeba
-            expect(parent.style.color).toContain('rgb(133, 100, 4)'); // #856404
+            expect(parent.style.background).toContain('var(--color-warning-soft)');
+            expect(parent.style.border).toContain('var(--color-warning-border)');
+            expect(parent.style.color).toContain('var(--color-warning-text)');
         }
     });
 
@@ -670,8 +670,8 @@ describe('ActionFeed', () => {
 
         const banner = screen.getByText('⚙️ Analyzing…');
         expect(banner).toBeInTheDocument();
-        expect(banner.style.background).toContain('rgb(255, 243, 205)'); // #fff3cd
-        expect(banner.style.color).toContain('rgb(133, 100, 4)'); // #856404
+        expect(banner.style.background).toContain('var(--color-warning-soft)');
+        expect(banner.style.color).toContain('var(--color-warning-text)');
     });
 
     it('includes minPst in the recommender settings warning', () => {

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -14,6 +14,7 @@ import { interactionLogger } from '../utils/interactionLogger';
 import CombinedActionsModal from './CombinedActionsModal';
 import ActionCard from './ActionCard';
 import ActionSearchDropdown from './ActionSearchDropdown';
+import { colors } from '../styles/tokens';
 
 interface ActionFeedProps {
     actions: Record<string, ActionDetail>;
@@ -699,8 +700,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 <button
                     onClick={handleOpenSearch}
                     style={{
-                        background: searchOpen ? '#007bff' : '#e9ecef',
-                        color: searchOpen ? 'white' : '#333',
+                        background: searchOpen ? colors.brand : colors.surfaceMuted,
+                        color: searchOpen ? colors.textOnBrand : colors.textPrimary,
                         border: 'none',
                         borderRadius: '6px',
                         padding: '4px 10px',
@@ -715,8 +716,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 <button
                     onClick={() => setCombineModalOpen(true)}
                     style={{
-                        background: combineModalOpen ? '#007bff' : '#e9ecef',
-                        color: combineModalOpen ? 'white' : '#333',
+                        background: combineModalOpen ? colors.brand : colors.surfaceMuted,
+                        color: combineModalOpen ? colors.textOnBrand : colors.textPrimary,
                         border: 'none',
                         borderRadius: '6px',
                         padding: '4px 10px',
@@ -762,11 +763,11 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 <div style={{
                     display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
                     gap: '8px', padding: '8px 10px',
-                    background: '#fff3cd', border: '1px solid #ffeeba',
-                    borderRadius: '6px', marginBottom: '10px', fontSize: '12px', color: '#856404'
+                    background: colors.warningSoft, border: `1px solid ${colors.warningBorder}`,
+                    borderRadius: '6px', marginBottom: '10px', fontSize: '12px', color: colors.warningText
                 }}>
                     <div style={{ flex: 1 }}>
-                        <div style={{ fontWeight: 600, marginBottom: '4px' }}>ℹ️ Action dictionary: <code style={{ fontFamily: 'monospace', background: '#fcf3cf', padding: '1px 4px', borderRadius: '3px', border: '1px solid #f9e79f' }}>{actionDictFileName}</code></div>
+                        <div style={{ fontWeight: 600, marginBottom: '4px' }}>ℹ️ Action dictionary: <code style={{ fontFamily: 'monospace', background: colors.warningSoft, padding: '1px 4px', borderRadius: '3px', border: `1px solid ${colors.warningBorder}` }}>{actionDictFileName}</code></div>
                         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '4px' }}>
                             <span>🔄 Reco: <strong>{actionDictStats.reco}</strong></span>
                             <span>⛔ Disco: <strong>{actionDictStats.disco}</strong></span>
@@ -775,25 +776,25 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                             <span>🔒 Close coupling: <strong>{actionDictStats.close_coupling}</strong></span>
                         </div>
                         {onOpenSettings && (
-                            <button onClick={() => onOpenSettings('paths')} style={{ background: 'none', border: 'none', color: '#0056b3', textDecoration: 'underline', cursor: 'pointer', padding: 0, fontSize: '12px' }}>Change in settings</button>
+                            <button onClick={() => onOpenSettings('paths')} style={{ background: 'none', border: 'none', color: colors.brandStrong, textDecoration: 'underline', cursor: 'pointer', padding: 0, fontSize: '12px' }}>Change in settings</button>
                         )}
                     </div>
-                    <button onClick={() => setShowActionDictWarning(false)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', lineHeight: 1, color: '#856404' }} title="Dismiss">✕</button>
+                    <button onClick={() => setShowActionDictWarning(false)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', lineHeight: 1, color: colors.warningText }} title="Dismiss">✕</button>
                 </div>
             )}
             <div style={{ marginBottom: '15px' }}>
-                <h4 style={{ margin: '0 0 10px 0', fontSize: '14px', color: '#333', borderBottom: '1px solid #eee', paddingBottom: '4px', display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '8px' }}>
+                <h4 style={{ margin: '0 0 10px 0', fontSize: '14px', color: colors.textPrimary, borderBottom: `1px solid ${colors.borderSubtle}`, paddingBottom: '4px', display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '8px' }}>
                     Selected Actions
-                    {selectedEntries.length > 0 && <span style={{ background: '#e9ecef', color: '#495057', fontSize: '11px', padding: '2px 6px', borderRadius: '10px' }}>{selectedEntries.length}</span>}
+                    {selectedEntries.length > 0 && <span style={{ background: colors.surfaceMuted, color: colors.textSecondary, fontSize: '11px', padding: '2px 6px', borderRadius: '10px' }}>{selectedEntries.length}</span>}
                 </h4>
                 {selectedEntries.length > 0 ? (
                     <>
                         {!dismissedSelectedWarning && selectedEntries.some(([id]) => manuallyAddedIds.has(id) && analysisActionIds.has(id)) && (() => {
                             const overlapIds = selectedEntries.filter(([id]) => manuallyAddedIds.has(id) && analysisActionIds.has(id)).map(([id]) => id).join(', ');
                             return (
-                                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', padding: '8px 10px', background: '#fff3cd', border: '1px solid #ffeeba', borderRadius: '6px', marginBottom: '10px', fontSize: '13px', color: '#856404' }}>
+                                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', padding: '8px 10px', background: colors.warningSoft, border: `1px solid ${colors.warningBorder}`, borderRadius: '6px', marginBottom: '10px', fontSize: '13px', color: colors.warningText }}>
                                     <div>⚠️ User warning: The following manually selected actions are also recommended by the recent analysis run: {overlapIds}</div>
-                                    <button onClick={() => setDismissedSelectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '16px', lineHeight: 1, color: '#856404' }} title="Dismiss">&times;</button>
+                                    <button onClick={() => setDismissedSelectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '16px', lineHeight: 1, color: colors.warningText }} title="Dismiss">&times;</button>
                                 </div>
                             );
                         })()}
@@ -801,7 +802,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     </>
                 ) : (
                     <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', margin: '5px 0 15px 0' }}>
-                        <p style={{ color: '#666', fontStyle: 'italic', fontSize: '13px', margin: 0 }}>Select an action manually or from suggested ones.</p>
+                        <p style={{ color: colors.textTertiary, fontStyle: 'italic', fontSize: '13px', margin: 0 }}>Select an action manually or from suggested ones.</p>
                         {/* "Make a first guess" is a pre-analysis shortcut.
                             Once the operator has launched "Analyze & Suggest"
                             (or the analysis has completed / is pending
@@ -821,9 +822,9 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                 data-testid="make-first-guess-button"
                                 style={{
                                     padding: '10px',
-                                    backgroundColor: '#f8f9fa',
-                                    border: '1px dashed #007bff',
-                                    color: '#007bff',
+                                    backgroundColor: colors.surfaceMuted,
+                                    border: `1px dashed ${colors.brand}`,
+                                    color: colors.brand,
                                     borderRadius: '8px',
                                     cursor: 'pointer',
                                     fontWeight: 600,
@@ -834,8 +835,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                     justifyContent: 'center',
                                     gap: '8px',
                                 }}
-                                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#e7f1ff'; }}
-                                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = '#f8f9fa'; }}
+                                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = colors.brandSoft; }}
+                                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.backgroundColor = colors.surfaceMuted; }}
                             >
                                 <span style={{ fontSize: '16px' }}>💡</span> Make a first guess
                             </button>
@@ -845,15 +846,15 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
             </div>
 
             <div style={{ marginBottom: '15px' }}>
-                <div style={{ display: 'flex', borderBottom: '1px solid #eee', marginBottom: '10px' }}>
+                <div style={{ display: 'flex', borderBottom: `1px solid ${colors.borderSubtle}`, marginBottom: '10px' }}>
                     <button
                         onClick={() => setSuggestedTab('prioritized')}
-                        style={{ flex: 1, padding: '8px', cursor: 'pointer', border: 'none', background: 'none', borderBottom: suggestedTab === 'prioritized' ? '2px solid #007bff' : 'none', fontWeight: suggestedTab === 'prioritized' ? 'bold' : 'normal', color: suggestedTab === 'prioritized' ? '#007bff' : '#666', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '6px' }}
-                    >Suggested Actions {prioritizedEntries.length > 0 && <span style={{ background: suggestedTab === 'prioritized' ? '#e7f1ff' : '#f8f9fa', color: suggestedTab === 'prioritized' ? '#007bff' : '#6c757d', fontSize: '11px', padding: '2px 6px', borderRadius: '10px', fontWeight: 'bold' }}>{prioritizedEntries.length}</span>}</button>
+                        style={{ flex: 1, padding: '8px', cursor: 'pointer', border: 'none', background: 'none', borderBottom: suggestedTab === 'prioritized' ? `2px solid ${colors.brand}` : 'none', fontWeight: suggestedTab === 'prioritized' ? 'bold' : 'normal', color: suggestedTab === 'prioritized' ? colors.brand : colors.textTertiary, display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '6px' }}
+                    >Suggested Actions {prioritizedEntries.length > 0 && <span style={{ background: suggestedTab === 'prioritized' ? colors.brandSoft : colors.surfaceMuted, color: suggestedTab === 'prioritized' ? colors.brand : colors.textSecondary, fontSize: '11px', padding: '2px 6px', borderRadius: '10px', fontWeight: 'bold' }}>{prioritizedEntries.length}</span>}</button>
                     <button
                         onClick={() => setSuggestedTab('rejected')}
-                        style={{ flex: 1, padding: '8px', cursor: 'pointer', border: 'none', background: 'none', borderBottom: suggestedTab === 'rejected' ? '2px solid #e74c3c' : 'none', fontWeight: suggestedTab === 'rejected' ? 'bold' : 'normal', color: suggestedTab === 'rejected' ? '#e74c3c' : '#666', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '6px' }}
-                    >Rejected Actions {rejectedEntries.length > 0 && <span style={{ background: suggestedTab === 'rejected' ? '#fdecea' : '#f8f9fa', color: suggestedTab === 'rejected' ? '#e74c3c' : '#6c757d', fontSize: '11px', padding: '2px 6px', borderRadius: '10px', fontWeight: 'bold' }}>{rejectedEntries.length}</span>}</button>
+                        style={{ flex: 1, padding: '8px', cursor: 'pointer', border: 'none', background: 'none', borderBottom: suggestedTab === 'rejected' ? `2px solid ${colors.danger}` : 'none', fontWeight: suggestedTab === 'rejected' ? 'bold' : 'normal', color: suggestedTab === 'rejected' ? colors.danger : colors.textTertiary, display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '6px' }}
+                    >Rejected Actions {rejectedEntries.length > 0 && <span style={{ background: suggestedTab === 'rejected' ? colors.dangerSoft : colors.surfaceMuted, color: suggestedTab === 'rejected' ? colors.danger : colors.textSecondary, fontSize: '11px', padding: '2px 6px', borderRadius: '10px', fontWeight: 'bold' }}>{rejectedEntries.length}</span>}</button>
                 </div>
 
 
@@ -863,8 +864,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                         {analysisLoading ? (
                             <button disabled style={{
                                 width: '100%', padding: '10px 16px',
-                                background: '#fff3cd', color: '#856404',
-                                border: '1px solid #ffeeba', borderRadius: '8px',
+                                background: colors.warningSoft, color: colors.warningText,
+                                border: `1px solid ${colors.warningBorder}`, borderRadius: '8px',
                                 cursor: 'not-allowed', fontSize: '14px', fontWeight: 700,
                                 boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
                             }}>
@@ -875,8 +876,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                 onClick={onDisplayPrioritizedActions}
                                 style={{
                                     width: '100%', padding: '10px 16px',
-                                    background: 'linear-gradient(135deg, #27ae60, #2ecc71)',
-                                    color: 'white', border: 'none', borderRadius: '8px',
+                                    background: colors.success,
+                                    color: colors.textOnBrand, border: 'none', borderRadius: '8px',
                                     cursor: 'pointer', fontSize: '14px', fontWeight: 700,
                                     boxShadow: '0 2px 8px rgba(39,174,96,0.3)', transition: 'transform 0.1s',
                                 }}
@@ -891,8 +892,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                 disabled={!canRunAnalysis}
                                 style={{
                                     width: '100%', padding: '10px 16px',
-                                    background: canRunAnalysis ? '#27ae60' : '#95a5a6',
-                                    color: 'white', border: 'none', borderRadius: '8px',
+                                    background: canRunAnalysis ? colors.success : colors.disabled,
+                                    color: colors.textOnBrand, border: 'none', borderRadius: '8px',
                                     cursor: canRunAnalysis ? 'pointer' : 'not-allowed',
                                     fontSize: '14px', fontWeight: 700,
                                     boxShadow: canRunAnalysis ? '0 2px 8px rgba(39,174,96,0.3)' : 'none',
@@ -911,18 +912,18 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     prioritizedEntries.length > 0 ? renderActionList(prioritizedEntries) : (
                         !analysisLoading ? (
                             <div style={{ textAlign: 'center' }}>
-                                <p style={{ color: '#666', fontStyle: 'italic', fontSize: '13px', margin: '5px 0' }}>
+                                <p style={{ color: colors.textTertiary, fontStyle: 'italic', fontSize: '13px', margin: '5px 0' }}>
                                     {!pendingAnalysisResult ? 'Click \u201cAnalyze & Suggest\u201d above to get action suggestions.' : 'No suggested actions available.'}
                                 </p>
                                 {!pendingAnalysisResult && showRecommenderWarning && (
                                     <div style={{
                                         marginTop: '10px',
                                         padding: '10px',
-                                        background: '#fff3cd',
-                                        border: '1px solid #ffeeba',
+                                        background: colors.warningSoft,
+                                        border: `1px solid ${colors.warningBorder}`,
                                         borderRadius: '6px',
                                         fontSize: '12px',
-                                        color: '#856404',
+                                        color: colors.warningText,
                                         textAlign: 'left'
                                     }}>
                                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '6px' }}>
@@ -934,7 +935,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                         style={{
                                                             background: 'none',
                                                             border: 'none',
-                                                            color: '#0056b3',
+                                                            color: colors.brandStrong,
                                                             textDecoration: 'underline',
                                                             cursor: 'pointer',
                                                             padding: '0',
@@ -946,7 +947,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                                 )}
                                                 <button
                                                     onClick={() => setShowRecommenderWarning(false)}
-                                                    style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', lineHeight: 1, color: '#856404' }}
+                                                    style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', lineHeight: 1, color: colors.warningText }}
                                                     title="Dismiss"
                                                 >&times;</button>
                                             </div>
@@ -966,16 +967,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                             {!dismissedRejectedWarning && rejectedEntries.some(([id]) => analysisActionIds.has(id)) && (() => {
                                 const overlapIds = rejectedEntries.filter(([id]) => analysisActionIds.has(id)).map(([id]) => id).join(', ');
                                 return (
-                                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', padding: '8px 10px', background: '#fff3cd', border: '1px solid #ffeeba', borderRadius: '6px', marginBottom: '10px', fontSize: '13px', color: '#856404' }}>
+                                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', padding: '8px 10px', background: colors.warningSoft, border: `1px solid ${colors.warningBorder}`, borderRadius: '6px', marginBottom: '10px', fontSize: '13px', color: colors.warningText }}>
                                         <div>⚠️ User warning: The following manually rejected actions were recommended by the recent analysis run: {overlapIds}</div>
-                                        <button onClick={() => setDismissedRejectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '16px', lineHeight: 1, color: '#856404' }} title="Dismiss">&times;</button>
+                                        <button onClick={() => setDismissedRejectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '16px', lineHeight: 1, color: colors.warningText }} title="Dismiss">&times;</button>
                                     </div>
                                 );
                             })()}
                             {renderActionList(rejectedEntries)}
                         </>
                     ) : (
-                        <p style={{ color: '#666', fontStyle: 'italic', fontSize: '13px', margin: '5px 0', textAlign: 'center' }}>No rejected actions.</p>
+                        <p style={{ color: colors.textTertiary, fontStyle: 'italic', fontSize: '13px', margin: '5px 0', textAlign: 'center' }}>No rejected actions.</p>
                     )
                 )}
             </div>
@@ -987,8 +988,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     top: tooltip.y,
                     left: tooltip.x,
                     zIndex: 99999,
-                    backgroundColor: '#343a40',
-                    color: '#fff',
+                    backgroundColor: colors.chrome,
+                    color: colors.textOnBrand,
                     textAlign: 'left',
                     borderRadius: '4px',
                     padding: '6px 8px',

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ActionDetail, ActionOverviewFilters, ActionSeverityCategory, ActionTypeFilterToken, DiagramData, MetadataIndex, UnsimulatedActionScoreInfo, ViewBox } from '../types';
 import { DEFAULT_ACTION_OVERVIEW_FILTERS, matchesActionTypeFilter } from '../utils/actionTypes';
+import { colors, pinColors } from '../styles/tokens';
 import ActionTypeFilterChips from './ActionTypeFilterChips';
 import {
     actionPassesOverviewFilter,
@@ -863,9 +864,9 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     flexWrap: 'nowrap',
                     gap: '6px',
                     fontSize: '12px',
-                    background: '#f8fafc',
-                    borderBottom: '1px solid #e2e8f0',
-                    color: '#334155',
+                    background: colors.surfaceMuted,
+                    borderBottom: `1px solid ${colors.borderSubtle}`,
+                    color: colors.textPrimary,
                     overflowX: 'auto',
                     whiteSpace: 'nowrap',
                 }}
@@ -874,7 +875,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     <span
                         data-testid="overview-pin-counter"
                         title={`${pins.length} pin${pins.length === 1 ? '' : 's'} on the N-1 network${unsimulatedPins.length > 0 ? ` (+ ${unsimulatedPins.length} un-simulated)` : ''}`}
-                        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontWeight: 600, color: '#1f2937', flexShrink: 0 }}
+                        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, fontWeight: 600, color: colors.textPrimary, flexShrink: 0 }}
                     >
                         <span aria-hidden>{'\uD83D\uDCCD'}</span>
                         <span style={{ fontVariantNumeric: 'tabular-nums' }}>
@@ -885,25 +886,25 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                 )}
                 <CategoryToggle
                     testId="filter-category-green"
-                    color="#28a745" label="Solves overload"
+                    color={pinColors.green} label="Solves overload"
                     enabled={activeFilters.categories.green}
                     onToggle={() => toggleCategory('green')}
                 />
                 <CategoryToggle
                     testId="filter-category-orange"
-                    color="#f0ad4e" label="Low margin"
+                    color={pinColors.orange} label="Low margin"
                     enabled={activeFilters.categories.orange}
                     onToggle={() => toggleCategory('orange')}
                 />
                 <CategoryToggle
                     testId="filter-category-red"
-                    color="#dc3545" label="Still overloaded"
+                    color={pinColors.red} label="Still overloaded"
                     enabled={activeFilters.categories.red}
                     onToggle={() => toggleCategory('red')}
                 />
                 <CategoryToggle
                     testId="filter-category-grey"
-                    color="#9ca3af" label="Divergent / islanded"
+                    color={pinColors.grey} label="Divergent / islanded"
                     enabled={activeFilters.categories.grey}
                     onToggle={() => toggleCategory('grey')}
                 />
@@ -930,7 +931,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                     style={{ display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0 }}
                     title="Hide actions whose max loading rate (%) exceeds this threshold"
                 >
-                    <span style={{ color: '#475569' }}>Max loading</span>
+                    <span style={{ color: colors.textSecondary }}>Max loading</span>
                     <input
                         data-testid="filter-threshold-input"
                         type="number"
@@ -949,12 +950,12 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                             padding: '2px 4px',
                             fontSize: 12,
                             fontVariantNumeric: 'tabular-nums',
-                            border: '1px solid #cbd5e1',
+                            border: `1px solid ${colors.border}`,
                             borderRadius: 4,
                             textAlign: 'right',
                         }}
                     />
-                    <span style={{ color: '#475569' }}>%</span>
+                    <span style={{ color: colors.textSecondary }}>%</span>
                 </label>
                 <label
                     data-testid="filter-show-unsimulated"
@@ -966,7 +967,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                         checked={activeFilters.showUnsimulated}
                         onChange={toggleUnsimulated}
                     />
-                    <span style={{ color: '#475569' }}>Show unsimulated</span>
+                    <span style={{ color: colors.textSecondary }}>Show unsimulated</span>
                 </label>
                 <span
                     aria-hidden
@@ -974,7 +975,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                         display: 'inline-block',
                         width: 1,
                         height: 18,
-                        background: '#cbd5e1',
+                        background: colors.border,
                         margin: '0 2px',
                         flexShrink: 0,
                     }}
@@ -1029,9 +1030,9 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                                     ...controlButtonStyle,
                                     padding: '4px 10px',
                                     fontSize: 12,
-                                    border: `1px solid ${isTied ? '#2c7be5' : '#ccc'}`,
-                                    backgroundColor: isTied ? '#e8f0fe' : '#fff',
-                                    color: isTied ? '#2c7be5' : '#555',
+                                    border: `1px solid ${isTied ? colors.brand : colors.border}`,
+                                    backgroundColor: isTied ? colors.brandSoft : colors.surface,
+                                    color: isTied ? colors.brand : colors.textSecondary,
                                 }}
                             >
                                 {isTied ? '\u{1F517} Tied' : '\u{26D3} Tie'}
@@ -1083,7 +1084,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                                 placeholder="🔍 Focus asset..."
                                 style={{
                                     padding: '5px 10px',
-                                    border: inspectQuery ? '2px solid #3498db' : '1px solid #ccc',
+                                    border: inspectQuery ? `2px solid ${colors.brand}` : `1px solid ${colors.border}`,
                                     borderRadius: 4,
                                     fontSize: 12,
                                     width: 180,
@@ -1102,7 +1103,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                                         maxHeight: 220,
                                         overflowY: 'auto',
                                         background: 'white',
-                                        border: '1px solid #3498db',
+                                        border: `1px solid ${colors.brand}`,
                                         borderRadius: 4,
                                         boxShadow: '0 4px 12px rgba(0,0,0,0.18)',
                                         zIndex: 200,
@@ -1120,13 +1121,13 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                                             style={{
                                                 padding: '5px 10px',
                                                 cursor: 'pointer',
-                                                borderBottom: '1px solid #eee',
+                                                borderBottom: `1px solid ${colors.borderSubtle}`,
                                                 whiteSpace: 'nowrap',
                                                 overflow: 'hidden',
                                                 textOverflow: 'ellipsis',
                                             }}
-                                            onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = '#f0f8ff'; }}
-                                            onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'white'; }}
+                                            onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.brandSoft; }}
+                                            onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.surface; }}
                                         >
                                             {item}
                                         </div>
@@ -1138,7 +1139,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                             <button
                                 onClick={() => setInspectQuery('')}
                                 style={{
-                                    background: '#e74c3c', color: 'white', border: 'none',
+                                    background: colors.danger, color: colors.textOnBrand, border: 'none',
                                     borderRadius: 4, padding: '4px 8px', cursor: 'pointer',
                                     fontSize: 12, boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
                                 }}
@@ -1155,7 +1156,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                 <div style={{
                     position: 'absolute', inset: 0, top: 40,
                     display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    color: '#999', fontStyle: 'italic', textAlign: 'center', padding: '40px',
+                    color: colors.textTertiary, fontStyle: 'italic', textAlign: 'center', padding: '40px',
                     pointerEvents: 'none',
                 }}>
                     Load a contingency first, then run the analysis to populate this overview.
@@ -1165,7 +1166,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                 <div style={{
                     position: 'absolute', inset: 0, top: 40,
                     display: 'flex', alignItems: 'center', justifyContent: 'center',
-                    color: '#999', fontStyle: 'italic', textAlign: 'center', padding: '40px',
+                    color: colors.textTertiary, fontStyle: 'italic', textAlign: 'center', padding: '40px',
                     pointerEvents: 'none',
                 }}>
                     Run &ldquo;Analyze &amp; Suggest&rdquo; to see prioritised remedial actions as pins on the network.
@@ -1232,9 +1233,9 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
 };
 
 const controlButtonStyle: React.CSSProperties = {
-    background: 'white',
-    color: '#333',
-    border: '1px solid #ccc',
+    background: colors.surface,
+    color: colors.textPrimary,
+    border: `1px solid ${colors.border}`,
     borderRadius: 4,
     padding: '5px 12px',
     cursor: 'pointer',
@@ -1244,9 +1245,9 @@ const controlButtonStyle: React.CSSProperties = {
 };
 
 const filterChipButtonStyle: React.CSSProperties = {
-    background: 'white',
-    color: '#334155',
-    border: '1px solid #cbd5e1',
+    background: colors.surface,
+    color: colors.textPrimary,
+    border: `1px solid ${colors.border}`,
     borderRadius: 4,
     padding: '3px 8px',
     cursor: 'pointer',
@@ -1279,12 +1280,12 @@ const CategoryToggle: React.FC<{
             alignItems: 'center',
             gap: 4,
             cursor: 'pointer',
-            background: enabled ? 'white' : '#eef2f7',
-            border: `1px solid ${enabled ? color : '#cbd5e1'}`,
+            background: enabled ? colors.surface : colors.surfaceMuted,
+            border: `1px solid ${enabled ? color : colors.border}`,
             borderRadius: 12,
             padding: '2px 8px',
             fontSize: 12,
-            color: enabled ? '#1f2937' : '#94a3b8',
+            color: enabled ? colors.textPrimary : colors.textTertiary,
             opacity: enabled ? 1 : 0.65,
             flexShrink: 0,
         }}

--- a/frontend/src/components/ActionSearchDropdown.tsx
+++ b/frontend/src/components/ActionSearchDropdown.tsx
@@ -8,6 +8,7 @@
 import React, { type RefObject } from 'react';
 import type { ActionDetail, ActionTypeFilterToken, AvailableAction } from '../types';
 import ActionTypeFilterChips from './ActionTypeFilterChips';
+import { colors } from '../styles/tokens';
 
 export interface ScoredActionItem {
     type: string;
@@ -76,8 +77,8 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                 right: 0,
                 left: 0,
                 zIndex: 100,
-                backgroundColor: 'white',
-                border: '1px solid #ccc',
+                backgroundColor: colors.surface,
+                border: `1px solid ${colors.border}`,
                 borderRadius: '8px',
                 boxShadow: '0 4px 16px rgba(0,0,0,0.15)',
                 marginTop: '4px',
@@ -94,14 +95,14 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                     style={{
                         width: '100%',
                         padding: '6px 10px',
-                        border: '1px solid #ccc',
+                        border: `1px solid ${colors.border}`,
                         borderRadius: '4px',
                         fontSize: '13px',
                         boxSizing: 'border-box',
                     }}
                 />
             </div>
-            <div style={{ padding: '4px 8px', borderTop: '1px solid #eee' }}>
+            <div style={{ padding: '4px 8px', borderTop: `1px solid ${colors.borderSubtle}` }}>
                 <ActionTypeFilterChips
                     testIdPrefix="search-dropdown-filter"
                     value={actionTypeFilter}
@@ -112,15 +113,15 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                 <div style={{
                     padding: '6px 8px',
                     fontSize: '12px',
-                    color: '#dc3545',
-                    borderTop: '1px solid #eee',
+                    color: colors.danger,
+                    borderTop: `1px solid ${colors.borderSubtle}`,
                 }}>
                     {error}
                 </div>
             )}
             <div style={{ maxHeight: '250px', overflowY: 'auto' }}>
                 {loadingActions ? (
-                    <div style={{ padding: '10px', textAlign: 'center', color: '#888', fontSize: '13px' }}>
+                    <div style={{ padding: '10px', textAlign: 'center', color: colors.textTertiary, fontSize: '13px' }}>
                         Loading actions...
                     </div>
                 ) : (
@@ -164,10 +165,10 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                                 style={{
                                     margin: '6px 8px',
                                     padding: '6px 8px',
-                                    background: '#fff3cd',
-                                    border: '1px solid #ffeeba',
+                                    background: colors.warningSoft,
+                                    border: `1px solid ${colors.warningBorder}`,
                                     borderRadius: 4,
-                                    color: '#856404',
+                                    color: colors.warningText,
                                     fontSize: 12,
                                     lineHeight: 1.35,
                                 }}
@@ -178,7 +179,7 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
 
                         {/* Search Results */}
                         {(!searchQuery && scoredActionsList.length === 0 && filteredActions.length === 0) && (
-                            <div style={{ padding: '10px', textAlign: 'center', color: '#888', fontSize: '13px' }}>
+                            <div style={{ padding: '10px', textAlign: 'center', color: colors.textTertiary, fontSize: '13px' }}>
                                 All actions already added
                             </div>
                         )}
@@ -189,20 +190,20 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                                 style={{
                                     padding: '8px 10px',
                                     cursor: simulating ? 'wait' : 'pointer',
-                                    borderTop: '1px solid #eee',
-                                    backgroundColor: '#f8f9fa',
-                                    color: '#007bff',
+                                    borderTop: `1px solid ${colors.borderSubtle}`,
+                                    backgroundColor: colors.surfaceMuted,
+                                    color: colors.brand,
                                     fontSize: '12px',
                                     fontWeight: 600,
                                 }}
-                                onMouseEnter={(e) => (e.currentTarget as HTMLDivElement).style.backgroundColor = '#eef6ff'}
-                                onMouseLeave={(e) => (e.currentTarget as HTMLDivElement).style.backgroundColor = '#f8f9fa'}
+                                onMouseEnter={(e) => (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.brandSoft}
+                                onMouseLeave={(e) => (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.surfaceMuted}
                             >
                                 ✨ Simulate manual ID: <strong>{searchQuery}</strong>
                             </div>
                         )}
                         {(searchQuery && filteredActions.length === 0 && searchQuery !== (filteredActions[0]?.id)) && (
-                            <div style={{ padding: '10px', textAlign: 'center', color: '#888', fontSize: '13px' }}>
+                            <div style={{ padding: '10px', textAlign: 'center', color: colors.textTertiary, fontSize: '13px' }}>
                                 No other matching actions
                             </div>
                         )}
@@ -214,18 +215,18 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                                 style={{
                                     padding: '6px 10px',
                                     cursor: simulating ? 'wait' : 'pointer',
-                                    borderTop: '1px solid #eee',
-                                    backgroundColor: simulating === a.id ? '#e7f1ff' : 'transparent',
+                                    borderTop: `1px solid ${colors.borderSubtle}`,
+                                    backgroundColor: simulating === a.id ? colors.brandSoft : 'transparent',
                                     opacity: simulating && simulating !== a.id ? 0.5 : 1,
                                 }}
-                                onMouseEnter={(e) => { if (!simulating) (e.currentTarget as HTMLDivElement).style.backgroundColor = '#f0f0f0'; }}
+                                onMouseEnter={(e) => { if (!simulating) (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.surfaceMuted; }}
                                 onMouseLeave={(e) => { if (simulating !== a.id) (e.currentTarget as HTMLDivElement).style.backgroundColor = 'transparent'; }}
                             >
-                                <div style={{ fontWeight: 600, fontSize: '12px', color: '#333' }}>
+                                <div style={{ fontWeight: 600, fontSize: '12px', color: colors.textPrimary }}>
                                     {simulating === a.id ? 'Simulating...' : a.id}
                                 </div>
                                 {a.description && (
-                                    <div style={{ fontSize: '11px', color: '#777', marginTop: '2px' }}>
+                                    <div style={{ fontSize: '11px', color: colors.textTertiary, marginTop: '2px' }}>
                                         {a.description}
                                     </div>
                                 )}
@@ -275,7 +276,7 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
 }) => {
     return (
         <div style={{ padding: '0 8px', marginBottom: '8px' }}>
-            <div style={{ fontSize: '12px', fontWeight: 600, color: '#555', marginBottom: '4px' }}>
+            <div style={{ fontSize: '12px', fontWeight: 600, color: colors.textSecondary, marginBottom: '4px' }}>
                 Scored Actions
             </div>
             {Array.from(new Set(scoredActionsList.map(item => item.type))).map(type => {
@@ -295,17 +296,17 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                 const tapStartMap = isPstType ? (typeData as { tap_start?: Record<string, { pst_name: string; tap: number; low_tap: number | null; high_tap: number | null } | null> }).tap_start : undefined;
                 return (
                     <div key={type} style={{ marginBottom: '8px' }}>
-                        <div style={{ fontSize: '11px', fontWeight: 600, color: '#0056b3', backgroundColor: '#e9ecef', padding: '2px 6px', borderRadius: '4px 4px 0 0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <div style={{ fontSize: '11px', fontWeight: 600, color: colors.brandStrong, backgroundColor: colors.surfaceMuted, padding: '2px 6px', borderRadius: '4px 4px 0 0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                             <span>{type.replace('_', ' ').toUpperCase()}</span>
                             {globalParams && (
                                 <span
-                                    style={{ color: '#6c757d', fontSize: '12px', cursor: 'help', marginLeft: '6px' }}
+                                    style={{ color: colors.textSecondary, fontSize: '12px', cursor: 'help', marginLeft: '6px' }}
                                     onMouseEnter={(e) => onShowTooltip(e, (
                                         <>
-                                            <div style={{ fontWeight: 700, marginBottom: '2px', borderBottom: '1px solid #555', paddingBottom: '2px' }}>Scoring Parameters</div>
+                                            <div style={{ fontWeight: 700, marginBottom: '2px', borderBottom: `1px solid ${colors.textSecondary}`, paddingBottom: '2px' }}>Scoring Parameters</div>
                                             {Object.entries(globalParams).map(([k, v]) => (
                                                 <div key={k}>
-                                                    <span style={{ color: '#adb5bd' }}>{k}:</span> {typeof v === 'object' ? JSON.stringify(v) : String(v)}
+                                                    <span style={{ color: colors.textTertiary }}>{k}:</span> {typeof v === 'object' ? JSON.stringify(v) : String(v)}
                                                 </div>
                                             ))}
                                         </>
@@ -314,9 +315,9 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                 >i</span>
                             )}
                         </div>
-                        <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', border: '1px solid #e9ecef', borderTop: 'none' }}>
+                        <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', border: `1px solid ${colors.border}`, borderTop: 'none' }}>
                             <thead>
-                                <tr style={{ background: '#f8f9fa', borderBottom: '1px solid #ddd' }}>
+                                <tr style={{ background: colors.surfaceMuted, borderBottom: `1px solid ${colors.border}` }}>
                                     <th style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '40%' : '55%' }}>Action</th>
                                     <th style={{ textAlign: 'right', padding: '4px 6px', width: '15%' }}>{isPstType ? 'Tap Start' : 'MW Start'}</th>
                                     {isLsOrRcType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}>Target MW</th>}
@@ -389,37 +390,37 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                 onAddAction(item.actionId, mw, tap);
                                             }}
                                             style={{
-                                                borderBottom: '1px solid #eee',
+                                                borderBottom: `1px solid ${colors.borderSubtle}`,
                                                 cursor: (simulating || resimulating) ? 'wait' : (isComputed && !canResimulate && !canResimTap) ? 'not-allowed' : 'pointer',
-                                                color: (isComputed && !canResimulate && !canResimTap) ? '#888' : 'inherit',
+                                                color: (isComputed && !canResimulate && !canResimTap) ? colors.textTertiary : 'inherit',
                                                 opacity: (simulating === item.actionId || resimulating === item.actionId) ? 0.7 : 1,
-                                                background: (simulating === item.actionId || resimulating === item.actionId) ? '#e7f1ff' : 'transparent',
+                                                background: (simulating === item.actionId || resimulating === item.actionId) ? colors.brandSoft : 'transparent',
                                             }}>
                                             <td style={{ padding: '4px 6px', fontWeight: 600, display: 'flex', alignItems: 'center' }}>
                                                 {item.actionId}
                                                 {isComputed && (
                                                     actions[item.actionId]?.non_convergence ? (
-                                                        <span data-testid={`badge-divergent-${item.actionId}`} style={{ marginLeft: '4px', background: '#dc3545', color: '#fff', padding: '2px 4px', borderRadius: '4px', fontSize: '9px', fontWeight: 'bold' }} title={actions[item.actionId].non_convergence || undefined}>divergent</span>
+                                                        <span data-testid={`badge-divergent-${item.actionId}`} style={{ marginLeft: '4px', background: colors.danger, color: colors.textOnBrand, padding: '2px 4px', borderRadius: '4px', fontSize: '9px', fontWeight: 'bold' }} title={actions[item.actionId].non_convergence || undefined}>divergent</span>
                                                     ) : actions[item.actionId]?.is_islanded ? (
-                                                        <span data-testid={`badge-islanded-${item.actionId}`} style={{ marginLeft: '4px', background: '#dc3545', color: '#fff', padding: '2px 4px', borderRadius: '4px', fontSize: '9px', fontWeight: 'bold' }} title={`Islanding detected: ${actions[item.actionId].disconnected_mw?.toFixed(1)} MW disconnected`}>islanded</span>
+                                                        <span data-testid={`badge-islanded-${item.actionId}`} style={{ marginLeft: '4px', background: colors.danger, color: colors.textOnBrand, padding: '2px 4px', borderRadius: '4px', fontSize: '9px', fontWeight: 'bold' }} title={`Islanding detected: ${actions[item.actionId].disconnected_mw?.toFixed(1)} MW disconnected`}>islanded</span>
                                                     ) : (
-                                                        <span data-testid={`badge-computed-${item.actionId}`} style={{ marginLeft: '4px', background: '#28a745', color: '#fff', padding: '2px 4px', borderRadius: '4px', fontSize: '9px', opacity: 0.8 }}>computed</span>
+                                                        <span data-testid={`badge-computed-${item.actionId}`} style={{ marginLeft: '4px', background: colors.success, color: colors.textOnBrand, padding: '2px 4px', borderRadius: '4px', fontSize: '9px', opacity: 0.8 }}>computed</span>
                                                     )
                                                 )}
                                                 {isPerActionParams && typeData.params?.[item.actionId] && (
                                                     <span
-                                                        style={{ color: '#6c757d', fontSize: '12px', cursor: 'help', marginLeft: '6px' }}
+                                                        style={{ color: colors.textSecondary, fontSize: '12px', cursor: 'help', marginLeft: '6px' }}
                                                         onClick={(e) => e.stopPropagation()}
                                                         onMouseEnter={(e) => onShowTooltip(e, (
                                                             <>
-                                                                <div style={{ fontWeight: 700, marginBottom: '2px', borderBottom: '1px solid #555', paddingBottom: '2px' }}>Parameters</div>
+                                                                <div style={{ fontWeight: 700, marginBottom: '2px', borderBottom: `1px solid ${colors.textSecondary}`, paddingBottom: '2px' }}>Parameters</div>
                                                                 {typeData.non_convergence?.[item.actionId] && (
-                                                                    <div style={{ fontSize: '10px', color: '#dc3545' }}>
+                                                                    <div style={{ fontSize: '10px', color: colors.danger }}>
                                                                         Non-convergence: {typeData.non_convergence[item.actionId]}
                                                                     </div>
                                                                 )}
                                                                 {(actions[item.actionId]?.is_islanded) && (
-                                                                    <div style={{ fontSize: '10px', color: '#c2410c' }}>
+                                                                    <div style={{ fontSize: '10px', color: colors.warningText }}>
                                                                         Islanding: {actions[item.actionId].n_components} components
                                                                     </div>
                                                                 )}
@@ -428,7 +429,7 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                                     const displayVal = isTargetTapKey && effectiveTap !== undefined ? effectiveTap : (typeof v === 'object' ? JSON.stringify(v) : String(v));
                                                                     return (
                                                                         <div key={k}>
-                                                                            <span style={{ color: '#adb5bd' }}>{k}:</span> {displayVal}
+                                                                            <span style={{ color: colors.textTertiary }}>{k}:</span> {displayVal}
                                                                         </div>
                                                                     );
                                                                 })}
@@ -438,13 +439,13 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                     >i</span>
                                                 )}
                                             </td>
-                                            <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: (isPstType ? tapInfo == null : item.mwStart == null) ? '#aaa' : '#333' }}>
+                                            <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: (isPstType ? tapInfo == null : item.mwStart == null) ? colors.textTertiary : colors.textPrimary }}>
                                                 {isPstType
                                                     ? (tapInfo != null ? `${tapInfo.tap}` : 'N/A')
                                                     : (item.mwStart != null ? item.mwStart.toFixed(1) : 'N/A')
                                                 }
                                                 {isPstType && tapInfo?.low_tap != null && tapInfo?.high_tap != null && (
-                                                    <span style={{ fontSize: '9px', color: '#7c3aed', marginLeft: '2px' }}>
+                                                    <span style={{ fontSize: '9px', color: colors.accent, marginLeft: '2px' }}>
                                                         [{tapInfo.low_tap}..{tapInfo.high_tap}]
                                                     </span>
                                                 )}
@@ -465,7 +466,7 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                             fontSize: '11px',
                                                             fontFamily: 'monospace',
                                                             padding: '2px 4px',
-                                                            border: '1px solid #ccc',
+                                                            border: `1px solid ${colors.border}`,
                                                             borderRadius: '3px',
                                                             textAlign: 'right',
                                                         }}
@@ -487,7 +488,7 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                             fontSize: '11px',
                                                             fontFamily: 'monospace',
                                                             padding: '2px 4px',
-                                                            border: '1px solid #9333ea',
+                                                            border: `1px solid ${colors.accent}`,
                                                             borderRadius: '3px',
                                                             textAlign: 'right',
                                                         }}

--- a/frontend/src/components/ActionTypeFilterChips.tsx
+++ b/frontend/src/components/ActionTypeFilterChips.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { ACTION_TYPE_FILTER_TOKENS, type ActionTypeFilterToken } from '../utils/actionTypes';
+import { colors, text } from '../styles/tokens';
 
 /**
  * Single-select action-type chip row shared by ExplorePairsTab,
@@ -52,10 +53,10 @@ const ActionTypeFilterChips: React.FC<ActionTypeFilterChipsProps> = ({
                         padding: '4px 12px',
                         borderRadius: '15px',
                         border: '1px solid',
-                        borderColor: active ? '#007bff' : '#ddd',
-                        background: active ? '#007bff' : 'white',
-                        color: active ? 'white' : '#666',
-                        fontSize: '11px',
+                        borderColor: active ? colors.brand : colors.border,
+                        background: active ? colors.brand : colors.surface,
+                        color: active ? colors.textOnBrand : colors.textTertiary,
+                        fontSize: text.xs,
                         cursor: 'pointer',
                         fontWeight: active ? 'bold' : 'normal',
                         transition: 'all 0.2s',

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import SidebarSummary from './SidebarSummary';
+import { colors, radius, space } from '../styles/tokens';
 
 interface AppSidebarProps {
   selectedBranch: string;
@@ -54,7 +55,7 @@ export default function AppSidebar({
   children,
 }: AppSidebarProps) {
   return (
-    <div data-testid="sidebar" style={{ width: '25%', background: '#eee', borderRight: '1px solid #ccc', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <div data-testid="sidebar" style={{ width: '25%', background: colors.borderSubtle, borderRight: `1px solid ${colors.border}`, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       <SidebarSummary
         selectedBranch={selectedBranch}
         n1LinesOverloaded={n1LinesOverloaded}
@@ -64,19 +65,19 @@ export default function AppSidebar({
         onContingencyZoom={onContingencyZoom}
         onOverloadClick={onOverloadClick}
       />
-      <div style={{ flex: 1, overflowY: 'auto', padding: '15px', minHeight: 0, display: 'flex', flexDirection: 'column', gap: '15px' }}>
+      <div style={{ flex: 1, overflowY: 'auto', padding: space[4], minHeight: 0, display: 'flex', flexDirection: 'column', gap: space[4] }}>
         {branches.length > 0 && (
-          <div style={{ flexShrink: 0, padding: '10px 15px', background: 'white', borderRadius: '8px', border: '1px solid #dee2e6', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
+          <div style={{ flexShrink: 0, padding: `${space[3]} ${space[4]}`, background: colors.surface, borderRadius: radius.lg, border: `1px solid ${colors.border}`, boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
             <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>🎯 Select Contingency</label>
             <input
               list="contingencies"
               value={selectedBranch}
               onChange={onContingencyChange}
               placeholder="Search line/bus..."
-              style={{ width: '100%', padding: '7px 10px', border: '1px solid #ccc', borderRadius: '4px', boxSizing: 'border-box', fontSize: '0.85rem' }}
+              style={{ width: '100%', padding: '7px 10px', border: `1px solid ${colors.border}`, borderRadius: radius.sm, boxSizing: 'border-box', fontSize: '0.85rem' }}
             />
             {selectedBranch && nameMap[selectedBranch] && (
-              <div style={{ fontSize: '0.78rem', color: '#4b5563', marginTop: '3px', fontStyle: 'italic', lineHeight: 1.3 }}>
+              <div style={{ fontSize: '0.78rem', color: colors.textSecondary, marginTop: '3px', fontStyle: 'italic', lineHeight: 1.3 }}>
                 {nameMap[selectedBranch]}
               </div>
             )}

--- a/frontend/src/components/CombinedActionsModal.tsx
+++ b/frontend/src/components/CombinedActionsModal.tsx
@@ -11,6 +11,7 @@ import type { AnalysisResult, CombinedAction, ActionDetail } from '../types';
 import { interactionLogger } from '../utils/interactionLogger';
 import ComputedPairsTable, { type ComputedPairEntry } from './ComputedPairsTable';
 import ExplorePairsTab from './ExplorePairsTab';
+import { colors } from '../styles/tokens';
 
 interface SimulationFeedback {
     max_rho: number | null;
@@ -369,7 +370,7 @@ const CombinedActionsModal: React.FC<Props> = ({
             <div
                 data-testid="combine-modal-card"
                 style={{
-                    background: 'white',
+                    background: colors.surface,
                     borderRadius: '12px',
                     // Use (almost) the full viewport width instead of a
                     // fixed 950px so wide tables in the Computed / Explore
@@ -384,12 +385,12 @@ const CombinedActionsModal: React.FC<Props> = ({
                     overflow: 'hidden'
                 }}
             >
-                <div style={{ padding: '15px 24px', borderBottom: '1px solid #eee', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: '#fcfcfc' }}>
+                <div style={{ padding: '15px 24px', borderBottom: `1px solid ${colors.borderSubtle}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: colors.surfaceRaised }}>
                     <h2 style={{ margin: 0, fontSize: '1.25rem' }}>Combine Actions</h2>
-                    <button onClick={onClose} style={{ border: 'none', background: 'none', fontSize: '24px', cursor: 'pointer', color: '#999' }}>&times;</button>
+                    <button onClick={onClose} style={{ border: 'none', background: 'none', fontSize: '24px', cursor: 'pointer', color: colors.textTertiary }}>&times;</button>
                 </div>
 
-                <div style={{ display: 'flex', borderBottom: '1px solid #ddd', background: '#fcfcfc', padding: '0 24px' }}>
+                <div style={{ display: 'flex', borderBottom: `1px solid ${colors.border}`, background: colors.surfaceRaised, padding: '0 24px' }}>
                     <div className={`modal-tab ${activeTab === 'computed' ? 'active' : ''}`} onClick={() => setActiveTab('computed')} data-testid="tab-computed">Computed Pairs</div>
                     <div className={`modal-tab ${activeTab === 'explore' ? 'active' : ''}`} onClick={() => setActiveTab('explore')} data-testid="tab-explore">Explore Pairs</div>
                 </div>
@@ -440,8 +441,8 @@ const CombinedActionsModal: React.FC<Props> = ({
                     )}
                 </div>
 
-                <div style={{ padding: '16px 24px', borderTop: '1px solid #eee', display: 'flex', justifyContent: 'flex-end', gap: '12px', background: '#fcfcfc' }}>
-                    <button onClick={onClose} style={{ padding: '10px 20px', background: 'white', border: '1px solid #ccc', borderRadius: '6px', cursor: 'pointer', fontWeight: 500, color: '#666' }}>Close</button>
+                <div style={{ padding: '16px 24px', borderTop: `1px solid ${colors.borderSubtle}`, display: 'flex', justifyContent: 'flex-end', gap: '12px', background: colors.surfaceRaised }}>
+                    <button onClick={onClose} style={{ padding: '10px 20px', background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '6px', cursor: 'pointer', fontWeight: 500, color: colors.textTertiary }}>Close</button>
                 </div>
 
             </div>

--- a/frontend/src/components/ComputedPairsTable.tsx
+++ b/frontend/src/components/ComputedPairsTable.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import type { ActionDetail } from '../types';
+import { colors } from '../styles/tokens';
 
 interface SimulationFeedback {
     max_rho: number | null;
@@ -66,7 +67,7 @@ const ComputedPairsTable: React.FC<ComputedPairsTableProps> = ({
                 <tbody>
                     {computedPairsList.length === 0 ? (
                         <tr>
-                            <td colSpan={8} style={{ padding: '40px', textAlign: 'center', color: '#888', fontStyle: 'italic' }}>
+                            <td colSpan={8} style={{ padding: '40px', textAlign: 'center', color: colors.textTertiary, fontStyle: 'italic' }}>
                                 No computed combinations found.<br />Go to <strong>Explore Pairs</strong> to create new ones.
                             </td>
                         </tr>
@@ -79,15 +80,15 @@ const ComputedPairsTable: React.FC<ComputedPairsTableProps> = ({
                             <tr key={p.id}>
                                 <td style={{ fontWeight: 'bold', fontSize: '12px' }}>{p.action1}</td>
                                 <td style={{ fontWeight: 'bold', fontSize: '12px' }}>{p.action2}</td>
-                                <td style={{ fontSize: '11px', fontFamily: 'monospace', color: '#666' }}>
+                                <td style={{ fontSize: '11px', fontFamily: 'monospace', color: colors.textTertiary }}>
                                     {p.betas ? p.betas.map(b => b.toFixed(2)).join(', ') : '-'}
                                 </td>
                                 <td>
                                     {estMaxRho != null && !isNaN(estMaxRho) ? (
                                         <span className="metric-badge metric-rho" style={{
-                                            background: estMaxRho > monitoringFactor ? '#ffebee' : estMaxRho > (monitoringFactor - 0.05) ? '#fff3cd' : '#e8f5e9',
-                                            color: estMaxRho > monitoringFactor ? '#c62828' : estMaxRho > (monitoringFactor - 0.05) ? '#856404' : '#2e7d32',
-                                            border: estMaxRho > monitoringFactor ? '1px solid #c62828' : estMaxRho > (monitoringFactor - 0.05) ? '1px solid #856404' : '1px dashed #2e7d32'
+                                            background: estMaxRho > monitoringFactor ? colors.dangerSoft : estMaxRho > (monitoringFactor - 0.05) ? colors.warningSoft : colors.successSoft,
+                                            color: estMaxRho > monitoringFactor ? colors.dangerText : estMaxRho > (monitoringFactor - 0.05) ? colors.warningText : colors.successStrong,
+                                            border: estMaxRho > monitoringFactor ? `1px solid ${colors.dangerText}` : estMaxRho > (monitoringFactor - 0.05) ? `1px solid ${colors.warningText}` : `1px dashed ${colors.successStrong}`
                                         }}>
                                             {(estMaxRho * 100).toFixed(1)}%
                                             {p.is_suspect && (
@@ -96,10 +97,10 @@ const ComputedPairsTable: React.FC<ComputedPairsTableProps> = ({
                                         </span>
                                     ) : '—'}
                                 </td>
-                                <td style={{ fontSize: '11px', color: '#666', fontStyle: 'italic' }}>
+                                <td style={{ fontSize: '11px', color: colors.textTertiary, fontStyle: 'italic' }}>
                                     {p.estimated_max_rho_line ? displayName(p.estimated_max_rho_line) : 'N/A'}
                                     {p.target_max_rho != null && p.target_max_rho_line && p.target_max_rho_line !== 'N/A' && p.target_max_rho_line !== p.estimated_max_rho_line && (
-                                        <div style={{ fontSize: '10px', color: '#888', marginTop: '2px', fontStyle: 'normal' }} title="Max on the lines this pair was selected to resolve">
+                                        <div style={{ fontSize: '10px', color: colors.textTertiary, marginTop: '2px', fontStyle: 'normal' }} title="Max on the lines this pair was selected to resolve">
                                             target: {(p.target_max_rho * 100).toFixed(1)}% on {displayName(p.target_max_rho_line)}
                                         </div>
                                     )}
@@ -108,8 +109,8 @@ const ComputedPairsTable: React.FC<ComputedPairsTableProps> = ({
                                 <td style={{ textAlign: 'center' }}>
                                     {isSimulated && simMaxRho != null ? (
                                         <span className="metric-badge metric-rho" style={{
-                                            background: simMaxRho > monitoringFactor ? '#ffebee' : simMaxRho > (monitoringFactor - 0.05) ? '#fff3cd' : '#e8f5e9',
-                                            color: simMaxRho > monitoringFactor ? '#c62828' : simMaxRho > (monitoringFactor - 0.05) ? '#856404' : '#2e7d32'
+                                            background: simMaxRho > monitoringFactor ? colors.dangerSoft : simMaxRho > (monitoringFactor - 0.05) ? colors.warningSoft : colors.successSoft,
+                                            color: simMaxRho > monitoringFactor ? colors.dangerText : simMaxRho > (monitoringFactor - 0.05) ? colors.warningText : colors.successStrong
                                         }}>
                                             {(simMaxRho * 100).toFixed(1)}%
                                             {(p.simData as ActionDetail | SimulationFeedback)?.is_islanded && (
@@ -117,10 +118,10 @@ const ComputedPairsTable: React.FC<ComputedPairsTableProps> = ({
                                             )}
                                         </span>
                                     ) : (
-                                        <span style={{ color: '#aaa', fontSize: '11px' }}>Not simulated</span>
+                                        <span style={{ color: colors.textTertiary, fontSize: '11px' }}>Not simulated</span>
                                     )}
                                 </td>
-                                <td style={{ fontSize: '11px', color: '#333', fontWeight: isSimulated ? 'bold' : 'normal' }}>
+                                <td style={{ fontSize: '11px', color: colors.textPrimary, fontWeight: isSimulated ? 'bold' : 'normal' }}>
                                     {isSimulated && p.simulated_max_rho_line ? displayName(p.simulated_max_rho_line) : '-'}
                                 </td>
 
@@ -130,8 +131,8 @@ const ComputedPairsTable: React.FC<ComputedPairsTableProps> = ({
                                         disabled={simulating}
                                         style={{
                                             padding: '6px 14px',
-                                            background: isSimulated ? '#007bff' : '#28a745',
-                                            color: 'white',
+                                            background: isSimulated ? colors.brand : colors.success,
+                                            color: colors.textOnBrand,
                                             border: 'none',
                                             borderRadius: '4px',
                                             cursor: simulating ? 'not-allowed' : 'pointer',

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -6,6 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { colors } from '../styles/tokens';
 
 interface ErrorBoundaryProps {
     children: ReactNode;
@@ -69,10 +70,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                         margin: '2rem auto',
                         maxWidth: '720px',
                         fontFamily: 'system-ui, -apple-system, sans-serif',
-                        background: '#fff5f5',
-                        border: '1px solid #feb2b2',
+                        background: colors.dangerSoft,
+                        border: `1px solid ${colors.danger}`,
                         borderRadius: '8px',
-                        color: '#742a2a',
+                        color: colors.dangerText,
                     }}
                 >
                     <h1 style={{ marginTop: 0, fontSize: '1.5rem' }}>
@@ -88,8 +89,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                             style={{
                                 marginTop: '1rem',
                                 padding: '0.75rem',
-                                background: '#fff',
-                                border: '1px solid #fed7d7',
+                                background: colors.surface,
+                                border: `1px solid ${colors.dangerSoft}`,
                                 borderRadius: '4px',
                                 whiteSpace: 'pre-wrap',
                                 fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
@@ -120,8 +121,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                             onClick={this.handleReset}
                             style={{
                                 padding: '0.5rem 1rem',
-                                background: '#3182ce',
-                                color: '#fff',
+                                background: colors.brand,
+                                color: colors.textOnBrand,
                                 border: 'none',
                                 borderRadius: '4px',
                                 cursor: 'pointer',
@@ -135,9 +136,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                             onClick={this.handleReload}
                             style={{
                                 padding: '0.5rem 1rem',
-                                background: '#fff',
-                                color: '#3182ce',
-                                border: '1px solid #3182ce',
+                                background: colors.surface,
+                                color: colors.brand,
+                                border: `1px solid ${colors.brand}`,
                                 borderRadius: '4px',
                                 cursor: 'pointer',
                                 fontWeight: 600,

--- a/frontend/src/components/ExplorePairsTab.tsx
+++ b/frontend/src/components/ExplorePairsTab.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react';
 import type { CombinedAction, AnalysisResult, ActionTypeFilterToken } from '../types';
 import ActionTypeFilterChips from './ActionTypeFilterChips';
 import { matchesActionTypeFilter } from '../utils/actionTypes';
+import { colors } from '../styles/tokens';
 
 interface SimulationFeedback {
     max_rho: number | null;
@@ -70,21 +71,21 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
     return (
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
             {/* Selection Chips Header */}
-            <div style={{ background: '#f8f9fa', padding: '10px 15px', borderRadius: '6px', marginBottom: '15px', border: '1px solid #e9ecef' }}>
+            <div style={{ background: colors.surfaceMuted, padding: '10px 15px', borderRadius: '6px', marginBottom: '15px', border: `1px solid ${colors.border}` }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
-                    <div style={{ fontSize: '12px', fontWeight: 'bold', color: '#444' }}>Selected Actions ({selectedIds.size}/2)</div>
+                    <div style={{ fontSize: '12px', fontWeight: 'bold', color: colors.textSecondary }}>Selected Actions ({selectedIds.size}/2)</div>
                     <button
                         onClick={onClearSelection}
                         disabled={selectedIds.size === 0}
-                        style={{ background: 'none', border: 'none', color: '#007bff', fontSize: '11px', cursor: 'pointer', padding: 0 }}
+                        style={{ background: 'none', border: 'none', color: colors.brand, fontSize: '11px', cursor: 'pointer', padding: 0 }}
                     >Clear All</button>
                 </div>
                 <div style={{ display: 'flex', gap: '8px', minHeight: '30px', flexWrap: 'wrap' }} data-testid="selection-chips">
                     {selectedIds.size === 0 ? (
-                        <div style={{ color: '#999', fontSize: '12px', fontStyle: 'italic', display: 'flex', alignItems: 'center' }}>Click rows in the table below to select...</div>
+                        <div style={{ color: colors.textTertiary, fontSize: '12px', fontStyle: 'italic', display: 'flex', alignItems: 'center' }}>Click rows in the table below to select...</div>
                     ) : (
                         Array.from(selectedIds).map(id => (
-                            <div key={id} data-testid={`chip-${id}`} style={{ background: '#e7f1ff', color: '#007bff', padding: '4px 10px', borderRadius: '20px', fontSize: '11px', fontWeight: 'bold', border: '1px solid #b3d7ff', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                            <div key={id} data-testid={`chip-${id}`} style={{ background: colors.brandSoft, color: colors.brand, padding: '4px 10px', borderRadius: '20px', fontSize: '11px', fontWeight: 'bold', border: `1px solid ${colors.brand}`, display: 'flex', alignItems: 'center', gap: '6px' }}>
                                 {id}
                                 <span onClick={(e) => { e.stopPropagation(); onToggle(id); }} style={{ cursor: 'pointer', fontSize: '14px', lineHeight: '10px' }}>&times;</span>
                             </div>
@@ -104,7 +105,7 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
             </div>
 
             {/* Grouped Table */}
-            <div style={{ flex: 1, maxHeight: '350px', overflowY: 'auto', border: '1px solid #eee', borderRadius: '4px', marginBottom: '15px' }}>
+            <div style={{ flex: 1, maxHeight: '350px', overflowY: 'auto', border: `1px solid ${colors.borderSubtle}`, borderRadius: '4px', marginBottom: '15px' }}>
                 {(() => {
                     const filteredList = scoredActionsList.filter(item =>
                         matchesActionTypeFilter(actionTypeFilter, item.actionId, null, item.type),
@@ -114,7 +115,7 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
 
                     if (filteredList.length === 0) {
                         return (
-                            <div style={{ textAlign: 'center', color: '#888', fontStyle: 'italic', padding: '40px 20px' }}>
+                            <div style={{ textAlign: 'center', color: colors.textTertiary, fontStyle: 'italic', padding: '40px 20px' }}>
                                 No scored actions available for this filter.
                             </div>
                         );
@@ -122,16 +123,16 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
 
                     return types.map(type => (
                         <div key={type} style={{ marginBottom: '1px' }}>
-                            <div style={{ fontSize: '11px', fontWeight: 600, color: '#444', backgroundColor: '#f0f2f5', padding: '4px 10px', borderBottom: '1px solid #e1e4e8', display: 'flex', justifyContent: 'space-between' }}>
+                            <div style={{ fontSize: '11px', fontWeight: 600, color: colors.textSecondary, backgroundColor: colors.surfaceMuted, padding: '4px 10px', borderBottom: `1px solid ${colors.border}`, display: 'flex', justifyContent: 'space-between' }}>
                                 <span>{type.replace(/_/g, ' ').toUpperCase()}</span>
                                 <span>{filteredList.filter(item => item.type === type).length} actions</span>
                             </div>
                             {(type === 'load_shedding' || type === 'ls') && (
                                 <div style={{
                                     padding: '6px 10px',
-                                    background: '#fff3cd',
-                                    color: '#856404',
-                                    borderBottom: '1px solid #ffeeba',
+                                    background: colors.warningSoft,
+                                    color: colors.warningText,
+                                    borderBottom: `1px solid ${colors.warningBorder}`,
                                     fontSize: '11px',
                                     fontWeight: 600,
                                     display: 'flex',
@@ -144,9 +145,9 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             {(type === 'renewable_curtailment' || type === 'rc') && (
                                 <div style={{
                                     padding: '6px 10px',
-                                    background: '#e3f2fd',
-                                    color: '#0d47a1',
-                                    borderBottom: '1px solid #bbdefb',
+                                    background: colors.infoSoft,
+                                    color: colors.infoText,
+                                    borderBottom: `1px solid ${colors.infoBorder}`,
                                     fontSize: '11px',
                                     fontWeight: 600,
                                     display: 'flex',
@@ -169,13 +170,13 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                                                     key={actionId}
                                                     className={isSelected ? 'selected' : ''}
                                                     onClick={() => onToggle(actionId)}
-                                                    style={{ cursor: 'pointer', background: isSelected ? '#fff9db' : '#fdfdfd' }}
+                                                    style={{ cursor: 'pointer', background: isSelected ? colors.warningSoft : colors.surfaceRaised }}
                                                 >
                                                     <td style={{ width: '30px', padding: '8px 0 8px 12px' }}>
                                                         <input type="checkbox" checked={isSelected} readOnly style={{ cursor: 'pointer' }} />
                                                     </td>
                                                     <td style={{ fontWeight: 'bold', fontSize: '12px' }}>{actionId}</td>
-                                                    <td style={{ width: '65px', textAlign: 'right', fontFamily: 'monospace', fontSize: '11px', color: mwStart == null ? '#aaa' : '#333' }}>
+                                                    <td style={{ width: '65px', textAlign: 'right', fontFamily: 'monospace', fontSize: '11px', color: mwStart == null ? colors.textTertiary : colors.textPrimary }}>
                                                         {mwStart != null ? `${mwStart.toFixed(1)}` : 'N/A'}
                                                     </td>
                                                     <td style={{ width: '60px', textAlign: 'right' }}>
@@ -188,14 +189,14 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                                                             <span className="metric-badge metric-rho" style={{
                                                                 transform: 'scale(0.9)',
                                                                 display: 'inline-block',
-                                                                background: (simResult.max_rho ?? 0) > monitoringFactor ? '#ffebee' : '#e8f5e9',
-                                                                color: (simResult.max_rho ?? 0) > monitoringFactor ? '#c62828' : '#2e7d32',
+                                                                background: (simResult.max_rho ?? 0) > monitoringFactor ? colors.dangerSoft : colors.successSoft,
+                                                                color: (simResult.max_rho ?? 0) > monitoringFactor ? colors.dangerText : colors.successStrong,
                                                                 border: '1px solid currentColor'
                                                             }}>
                                                                 {((simResult.max_rho ?? 0) * 100).toFixed(1)}%
                                                             </span>
                                                         ) : (
-                                                            <span style={{ color: '#aaa', fontStyle: 'italic', fontSize: '10px' }}>Untested</span>
+                                                            <span style={{ color: colors.textTertiary, fontStyle: 'italic', fontSize: '10px' }}>Untested</span>
                                                         )}
                                                     </td>
                                                     <td onClick={(e) => e.stopPropagation()} style={{ width: '100px', textAlign: 'right', paddingRight: '12px' }}>
@@ -204,8 +205,8 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                                                             disabled={simulating}
                                                             style={{
                                                                 padding: '3px 10px',
-                                                                background: simResult ? '#95a5a6' : '#2980b9',
-                                                                color: 'white',
+                                                                background: simResult ? colors.disabled : colors.brandStrong,
+                                                                color: colors.textOnBrand,
                                                                 border: 'none',
                                                                 borderRadius: '4px',
                                                                 cursor: simulating ? 'not-allowed' : 'pointer',
@@ -240,8 +241,8 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             style={{
                                 width: '100%',
                                 padding: '12px',
-                                background: (selectedIds.size === 2 && !loading && !hasRestricted) ? '#3498db' : '#ecf0f1',
-                                color: (selectedIds.size === 2 && !loading && !hasRestricted) ? 'white' : '#bdc3c7',
+                                background: (selectedIds.size === 2 && !loading && !hasRestricted) ? colors.brand : colors.surfaceMuted,
+                                color: (selectedIds.size === 2 && !loading && !hasRestricted) ? colors.textOnBrand : colors.textTertiary,
                                 border: 'none',
                                 borderRadius: '6px',
                                 cursor: (selectedIds.size !== 2 || loading || hasRestricted) ? 'not-allowed' : 'pointer',
@@ -260,8 +261,8 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             style={{
                                 width: '100%',
                                 padding: '10px',
-                                background: (selectedIds.size === 2 && !simulating) ? '#27ae60' : '#ecf0f1',
-                                color: (selectedIds.size === 2 && !simulating) ? 'white' : '#bdc3c7',
+                                background: (selectedIds.size === 2 && !simulating) ? colors.success : colors.surfaceMuted,
+                                color: (selectedIds.size === 2 && !simulating) ? colors.textOnBrand : colors.textTertiary,
                                 border: 'none',
                                 borderRadius: '6px',
                                 cursor: (selectedIds.size !== 2 || simulating) ? 'not-allowed' : 'pointer',
@@ -285,8 +286,8 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             width: '100%',
                             padding: '10px',
                             marginBottom: '8px',
-                            background: simulating ? '#6c757d' : '#27ae60',
-                            color: 'white',
+                            background: simulating ? colors.textSecondary : colors.success,
+                            color: colors.textOnBrand,
                             border: 'none',
                             borderRadius: '6px',
                             cursor: simulating ? 'not-allowed' : 'pointer',
@@ -303,18 +304,18 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                 {(preview || simulationFeedback || simulating) && (
                     <div style={{
                         padding: '15px',
-                        background: error ? '#fff3cd' : '#e1f5fe',
+                        background: error ? colors.warningSoft : colors.infoSoft,
                         borderRadius: '8px',
-                        borderLeft: '5px solid ' + (error ? '#856404' : '#0288d1'),
+                        borderLeft: '5px solid ' + (error ? colors.warningText : colors.info),
                         boxShadow: '0 2px 5px rgba(0,0,0,0.05)'
                     }} data-testid="comparison-card">
                         <div style={{ marginBottom: '10px' }}>
                             {preview?.betas && (
-                                <div style={{ marginBottom: '8px', fontSize: '11px', color: '#666', background: 'rgba(255,255,255,0.6)', padding: '2px 8px', borderRadius: '4px', display: 'inline-block', fontWeight: 600 }}>
+                                <div style={{ marginBottom: '8px', fontSize: '11px', color: colors.textTertiary, background: 'rgba(255,255,255,0.6)', padding: '2px 8px', borderRadius: '4px', display: 'inline-block', fontWeight: 600 }}>
                                     Betas: {preview.betas.map(b => b.toFixed(3)).join(', ')}
                                 </div>
                             )}
-                            <div style={{ fontWeight: 800, color: error ? '#856404' : '#01579b', fontSize: '15px' }}>
+                            <div style={{ fontWeight: 800, color: error ? colors.warningText : colors.infoText, fontSize: '15px' }}>
                                 {error ? '⚠️ Estimation Failed' : (preview ? 'Explore Pairs Comparison' : 'Simulation Result')}
                             </div>
                         </div>
@@ -323,58 +324,58 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                             <div style={{ display: 'flex', gap: '30px', borderTop: '1px solid rgba(0,0,0,0.05)', paddingTop: '12px' }}>
                                 {preview && (
                                     <div style={{ flex: 1, borderRight: '1px solid rgba(0,0,0,0.05)', paddingRight: '15px' }}>
-                                        <div style={{ fontSize: '11px', fontWeight: 700, color: '#666', textTransform: 'uppercase', marginBottom: '8px', letterSpacing: '0.5px' }}>Estimated Effect</div>
+                                        <div style={{ fontSize: '11px', fontWeight: 700, color: colors.textTertiary, textTransform: 'uppercase', marginBottom: '8px', letterSpacing: '0.5px' }}>Estimated Effect</div>
                                         <div style={{ fontSize: '13px', marginBottom: '4px' }}>
-                                            Estimated Max Loading: <strong style={{ color: (preview.estimated_max_rho ?? preview.max_rho ?? 0) <= monitoringFactor ? '#28a745' : '#d35400', fontSize: '16px' }}>{((preview.estimated_max_rho ?? preview.max_rho ?? 0) * 100).toFixed(1)}%</strong>
+                                            Estimated Max Loading: <strong style={{ color: (preview.estimated_max_rho ?? preview.max_rho ?? 0) <= monitoringFactor ? colors.success : colors.warningStrong, fontSize: '16px' }}>{((preview.estimated_max_rho ?? preview.max_rho ?? 0) * 100).toFixed(1)}%</strong>
                                             {preview.is_islanded && (
                                                 <span style={{ marginLeft: '6px' }} title="Estimation suspect due to islanding">⚠️</span>
                                             )}
                                         </div>
-                                        <div style={{ fontSize: '12px', color: '#666' }}>
+                                        <div style={{ fontSize: '12px', color: colors.textTertiary }}>
                                             Line: {displayName(preview.estimated_max_rho_line ?? preview.max_rho_line)}
                                         </div>
                                         {preview.target_max_rho != null && preview.target_max_rho_line && preview.target_max_rho_line !== 'N/A' && preview.target_max_rho_line !== (preview.estimated_max_rho_line ?? preview.max_rho_line) && (
-                                            <div style={{ fontSize: '11px', color: '#555', marginTop: '6px', padding: '4px 8px', background: 'rgba(255,255,255,0.6)', borderRadius: '4px', display: 'inline-block' }} data-testid="target-max-rho">
-                                                Target overload: <strong style={{ color: (preview.target_max_rho ?? 0) <= monitoringFactor ? '#28a745' : '#d35400' }}>{((preview.target_max_rho ?? 0) * 100).toFixed(1)}%</strong> on {displayName(preview.target_max_rho_line)}
+                                            <div style={{ fontSize: '11px', color: colors.textSecondary, marginTop: '6px', padding: '4px 8px', background: 'rgba(255,255,255,0.6)', borderRadius: '4px', display: 'inline-block' }} data-testid="target-max-rho">
+                                                Target overload: <strong style={{ color: (preview.target_max_rho ?? 0) <= monitoringFactor ? colors.success : colors.warningStrong }}>{((preview.target_max_rho ?? 0) * 100).toFixed(1)}%</strong> on {displayName(preview.target_max_rho_line)}
                                             </div>
                                         )}
                                     </div>
                                 )}
                                 <div style={{ flex: 1 }}>
-                                    <div style={{ fontSize: '11px', fontWeight: 700, color: '#666', textTransform: 'uppercase', marginBottom: '8px', letterSpacing: '0.5px' }}>Simulation Result</div>
+                                    <div style={{ fontSize: '11px', fontWeight: 700, color: colors.textTertiary, textTransform: 'uppercase', marginBottom: '8px', letterSpacing: '0.5px' }}>Simulation Result</div>
                                     {simulating && (
-                                        <div style={{ color: '#0056b3', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                                        <div style={{ color: colors.brandStrong, fontSize: '13px', display: 'flex', alignItems: 'center', gap: '6px' }}>
                                             <span>⌛</span> Simulating combined action...
                                         </div>
                                     )}
                                     {!simulating && simulationFeedback && (
                                         <div data-testid="simulation-feedback">
                                             <div style={{ fontSize: '13px', marginBottom: '4px' }}>
-                                                Actual Max Loading: <strong style={{ color: (simulationFeedback.max_rho ?? 1) <= monitoringFactor ? '#28a745' : '#d35400', fontSize: '16px' }}>{simulationFeedback.max_rho != null ? `${(simulationFeedback.max_rho * 100).toFixed(1)}%` : 'N/A'}</strong>
+                                                Actual Max Loading: <strong style={{ color: (simulationFeedback.max_rho ?? 1) <= monitoringFactor ? colors.success : colors.warningStrong, fontSize: '16px' }}>{simulationFeedback.max_rho != null ? `${(simulationFeedback.max_rho * 100).toFixed(1)}%` : 'N/A'}</strong>
                                             </div>
-                                            <div style={{ fontSize: '12px', color: '#666' }}>
+                                            <div style={{ fontSize: '12px', color: colors.textTertiary }}>
                                                 Line: {displayName(simulationFeedback.max_rho_line)}
                                             </div>
                                             {simulationFeedback.is_islanded && (
-                                                <div style={{ fontSize: '11px', color: '#dc3545', marginTop: '6px', fontWeight: 600, background: '#fff5f5', padding: '2px 8px', borderRadius: '4px', display: 'inline-block' }}>
+                                                <div style={{ fontSize: '11px', color: colors.danger, marginTop: '6px', fontWeight: 600, background: colors.dangerSoft, padding: '2px 8px', borderRadius: '4px', display: 'inline-block' }}>
                                                     Islanding detected ({simulationFeedback.disconnected_mw?.toFixed(1)} MW disconnected)
                                                 </div>
                                             )}
                                             {simulationFeedback.non_convergence && (
-                                                <div style={{ fontSize: '11px', color: '#dc3545', marginTop: '6px', fontWeight: 600, background: '#fff5f5', padding: '2px 8px', borderRadius: '4px', display: 'inline-block' }}>
+                                                <div style={{ fontSize: '11px', color: colors.danger, marginTop: '6px', fontWeight: 600, background: colors.dangerSoft, padding: '2px 8px', borderRadius: '4px', display: 'inline-block' }}>
                                                     Non-convergence: {simulationFeedback.non_convergence}
                                                 </div>
                                             )}
                                         </div>
                                     )}
                                     {!simulating && !simulationFeedback && (
-                                        <div style={{ color: '#aaa', fontSize: '12px', fontStyle: 'italic', marginTop: '5px' }}>Click "Simulate Combined" above to run</div>
+                                        <div style={{ color: colors.textTertiary, fontSize: '12px', fontStyle: 'italic', marginTop: '5px' }}>Click "Simulate Combined" above to run</div>
                                     )}
                                 </div>
                             </div>
                         )}
                         {error && (
-                            <div style={{ fontSize: '13px', color: '#856404' }}>{error}</div>
+                            <div style={{ fontSize: '13px', color: colors.warningText }}>{error}</div>
                         )}
                     </div>
                 )}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,6 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import type { AnalysisResult } from '../types';
+import { colors, radius, space } from '../styles/tokens';
 
 type SettingsTab = 'paths' | 'recommender' | 'configurations';
 
@@ -48,15 +49,15 @@ const Header: React.FC<HeaderProps> = ({
 
   return (
     <header style={{
-      background: '#2c3e50', color: 'white', padding: '8px 20px',
+      background: colors.chrome, color: colors.textOnBrand, padding: `${space[2]} ${space[5]}`,
       display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-      gap: '15px', flexWrap: 'wrap'
+      gap: space[4], flexWrap: 'wrap'
     }}>
       <h2 style={{ margin: 0, fontSize: '1.1rem', whiteSpace: 'nowrap' }}>⚡ Co-Study4Grid</h2>
 
-      <div style={{ flex: '1 1 200px', display: 'flex', flexDirection: 'column', gap: '2px' }}>
+      <div style={{ flex: '1 1 200px', display: 'flex', flexDirection: 'column', gap: space.half }}>
         <label style={{ fontSize: '0.7rem', opacity: 0.8, whiteSpace: 'nowrap' }}>Network Path</label>
-        <div style={{ display: 'flex', gap: '4px' }}>
+        <div style={{ display: 'flex', gap: space[1] }}>
           <input
             data-testid="header-network-path-input"
             type="text"
@@ -69,9 +70,9 @@ const Header: React.FC<HeaderProps> = ({
             onBlur={e => onCommitNetworkPath(e.target.value)}
             placeholder="load your grid xiidm file path"
             style={{
-              flex: 1, minWidth: 0, padding: '5px 8px',
-              border: '1px solid rgba(255,255,255,0.3)', borderRadius: '4px',
-              background: 'rgba(255,255,255,0.1)', color: 'white', fontSize: '0.8rem'
+              flex: 1, minWidth: 0, padding: `5px ${space[2]}`,
+              border: '1px solid rgba(255,255,255,0.3)', borderRadius: radius.sm,
+              background: 'rgba(255,255,255,0.1)', color: colors.textOnBrand, fontSize: '0.8rem'
             }}
           />
           <button
@@ -81,9 +82,9 @@ const Header: React.FC<HeaderProps> = ({
             // overwrite an active study.
             onClick={() => onPickSettingsPath('file', onCommitNetworkPath)}
             style={{
-              padding: '4px 8px', background: 'rgba(255,255,255,0.15)',
-              border: '1px solid rgba(255,255,255,0.25)', borderRadius: '4px',
-              color: 'white', cursor: 'pointer', fontSize: '0.8rem'
+              padding: `${space[1]} ${space[2]}`, background: 'rgba(255,255,255,0.15)',
+              border: '1px solid rgba(255,255,255,0.25)', borderRadius: radius.sm,
+              color: colors.textOnBrand, cursor: 'pointer', fontSize: '0.8rem'
             }}
           >
             📄
@@ -95,9 +96,9 @@ const Header: React.FC<HeaderProps> = ({
         onClick={onLoadStudy}
         disabled={configLoading}
         style={{
-          padding: '6px 14px',
-          background: configLoading ? '#95a5a6' : '#3498db',
-          color: 'white', border: 'none', borderRadius: '4px',
+          padding: `${space[2]} 14px`,
+          background: configLoading ? colors.disabled : colors.brand,
+          color: colors.textOnBrand, border: 'none', borderRadius: radius.sm,
           cursor: configLoading ? 'not-allowed' : 'pointer',
           fontWeight: 'bold', fontSize: '0.8rem', whiteSpace: 'nowrap'
         }}
@@ -109,9 +110,9 @@ const Header: React.FC<HeaderProps> = ({
         onClick={onSaveResults}
         disabled={saveDisabled}
         style={{
-          padding: '6px 14px',
-          background: saveDisabled ? '#95a5a6' : '#8e44ad',
-          color: 'white', border: 'none', borderRadius: '4px',
+          padding: `${space[2]} 14px`,
+          background: saveDisabled ? colors.disabled : colors.accent,
+          color: colors.textOnBrand, border: 'none', borderRadius: radius.sm,
           cursor: saveDisabled ? 'not-allowed' : 'pointer',
           fontWeight: 'bold', fontSize: '0.8rem', whiteSpace: 'nowrap'
         }}
@@ -124,9 +125,9 @@ const Header: React.FC<HeaderProps> = ({
         onClick={onOpenReloadModal}
         disabled={sessionRestoring}
         style={{
-          padding: '6px 14px',
-          background: sessionRestoring ? '#95a5a6' : '#2980b9',
-          color: 'white', border: 'none', borderRadius: '4px',
+          padding: `${space[2]} 14px`,
+          background: sessionRestoring ? colors.disabled : colors.brandStrong,
+          color: colors.textOnBrand, border: 'none', borderRadius: radius.sm,
           cursor: sessionRestoring ? 'not-allowed' : 'pointer',
           fontWeight: 'bold', fontSize: '0.8rem', whiteSpace: 'nowrap'
         }}
@@ -138,9 +139,9 @@ const Header: React.FC<HeaderProps> = ({
       <button
         onClick={() => onOpenSettings('paths')}
         style={{
-          background: '#7f8c8d', display: 'flex', alignItems: 'center',
-          justifyContent: 'center', padding: '6px 8px', fontSize: '1rem',
-          color: 'white', border: 'none', borderRadius: '4px',
+          background: colors.chromeSoft, display: 'flex', alignItems: 'center',
+          justifyContent: 'center', padding: `${space[2]} ${space[2]}`, fontSize: '1rem',
+          color: colors.textOnBrand, border: 'none', borderRadius: radius.sm,
           cursor: 'pointer', fontWeight: 'bold'
         }}
         title="Settings"

--- a/frontend/src/components/OverloadPanel.tsx
+++ b/frontend/src/components/OverloadPanel.tsx
@@ -3,9 +3,10 @@
 // If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 // SPDX-License-Identifier: MPL-2.0
-// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import React from 'react';
+import { colors, radius, space, text } from '../styles/tokens';
 
 interface OverloadPanelProps {
     nOverloads: string[];
@@ -68,7 +69,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
         cursor: 'pointer',
         padding: 0,
         fontSize: 'inherit',
-        color: '#1e40af',
+        color: colors.brand,
         fontWeight: 600,
         textDecoration: 'underline dotted',
         textAlign: 'left',
@@ -79,7 +80,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
         v == null || Number.isNaN(v) ? null : `${(v * 100).toFixed(1)}%`;
 
     const renderLinks = (lines: string[], rhos: number[] | undefined, tab: 'n' | 'n-1') => {
-        if (!lines || lines.length === 0) return <span style={{ color: '#888', fontStyle: 'italic' }}>None</span>;
+        if (!lines || lines.length === 0) return <span style={{ color: colors.textTertiary, fontStyle: 'italic' }}>None</span>;
         return lines.map((lineName, i) => {
             const isSelected = tab === 'n-1' ? (selectedOverloads?.has(lineName) ?? true) : true;
             const rhoPct = formatRho(rhos?.[i]);
@@ -89,7 +90,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                     <button
                         style={{
                             ...clickableLinkStyle,
-                            color: isSelected ? '#1e40af' : '#bdc3c7',
+                            color: isSelected ? colors.brand : colors.borderStrong,
                             fontWeight: isSelected ? 600 : 400,
                             textDecoration: isSelected ? 'underline dotted' : 'none'
                         }}
@@ -109,9 +110,9 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                     {rhoPct && (
                         <span
                             style={{
-                                color: isSelected ? '#374151' : '#bdc3c7',
+                                color: isSelected ? colors.textPrimary : colors.borderStrong,
                                 fontWeight: 500,
-                                marginLeft: '2px',
+                                marginLeft: space.half,
                             }}
                         >
                             ({rhoPct})
@@ -127,38 +128,38 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
 
     return (
         <div style={{
-            background: 'white',
-            borderBottom: '1px solid #ccc',
-            padding: '8px 12px',
+            background: colors.surface,
+            borderBottom: `1px solid ${colors.border}`,
+            padding: `${space[2]} ${space[3]}`,
             boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
             zIndex: 10
         }}>
-            <h3 style={{ margin: '0 0 6px 0', fontSize: '14px', display: 'flex', alignItems: 'center', gap: '6px' }}>
-                <span style={{ color: '#e74c3c' }}>⚠️</span> Overloads
+            <h3 style={{ margin: `0 0 6px 0`, fontSize: text.md, display: 'flex', alignItems: 'center', gap: '6px' }}>
+                <span style={{ color: colors.danger }}>⚠️</span> Overloads
             </h3>
 
             {showMonitoringWarning && totalLinesCount && totalLinesCount > 0 && (
                 <div style={{
-                    marginBottom: '8px',
-                    padding: '8px 12px',
-                    background: '#fff3cd',
-                    border: '1px solid #ffeeba',
-                    borderRadius: '4px',
-                    color: '#856404',
+                    marginBottom: space[2],
+                    padding: `${space[2]} ${space[3]}`,
+                    background: colors.warningSoft,
+                    border: `1px solid ${colors.warningBorder}`,
+                    borderRadius: radius.sm,
+                    color: colors.warningText,
                     fontSize: '0.8rem',
                     position: 'relative'
                 }}>
                     ⚠️ <strong>{monitorDeselected ? (monitoredLinesCount || 0) : (monitoredLinesCount || 0) - (hasDeselected ? deselectedCount : 0)}</strong> out of <strong>{totalLinesCount}</strong> lines monitored ({totalLinesCount - (monitoredLinesCount || 0)} without permanent limits{hasDeselected && !monitorDeselected ? `, and ${deselectedCount} deselected` : ''}). Monitoring factor: {Math.round((monitoringFactor || 0.95) * 100)}%. {Math.round((preExistingOverloadThreshold || 0.02) * 100)}% loading increase threshold for considering worsened overload in N.
                     <button
                         onClick={onOpenSettings}
-                        style={{ background: 'none', border: 'none', color: '#0056b3', textDecoration: 'underline', cursor: 'pointer', padding: '0 0 0 5px', fontSize: 'inherit' }}
+                        style={{ background: 'none', border: 'none', color: colors.brandStrong, textDecoration: 'underline', cursor: 'pointer', padding: `0 0 0 5px`, fontSize: 'inherit' }}
                     >
                         Change in settings
                     </button>
                     {onDismissWarning && (
                         <button
                             onClick={onDismissWarning}
-                            style={{ float: 'right', background: 'none', border: 'none', fontSize: '16px', lineHeight: 1, color: '#856404', cursor: 'pointer' }}
+                            style={{ float: 'right', background: 'none', border: 'none', fontSize: text.lg, lineHeight: 1, color: colors.warningText, cursor: 'pointer' }}
                             title="Dismiss"
                         >
                             &times;
@@ -167,15 +168,15 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                 </div>
             )}
 
-            <div style={{ fontSize: '12px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <div style={{ fontSize: text.sm, display: 'flex', flexDirection: 'column', gap: space[1] }}>
                 <div style={{
                     display: 'flex',
                     alignItems: 'baseline',
-                    gap: '8px',
-                    padding: '4px 6px',
-                    background: nOverloads.length > 0 ? '#fff3cd' : 'transparent',
-                    borderLeft: nOverloads.length > 0 ? '3px solid #ffc107' : '3px solid transparent',
-                    borderBottom: '1px solid #eee'
+                    gap: space[2],
+                    padding: `${space[1]} 6px`,
+                    background: nOverloads.length > 0 ? colors.warningSoft : 'transparent',
+                    borderLeft: `3px solid ${nOverloads.length > 0 ? 'var(--color-warning)' : 'transparent'}`,
+                    borderBottom: `1px solid ${colors.borderSubtle}`
                 }}>
                     <strong style={{ whiteSpace: 'nowrap' }}>N Overloads:</strong>
                     <div style={{ display: 'inline', wordBreak: 'break-word' }}>
@@ -184,28 +185,28 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                 </div>
 
                 <div style={{
-                    padding: '4px 6px',
-                    background: n1Overloads.length > 0 ? '#f8d7da' : 'transparent',
-                    borderLeft: n1Overloads.length > 0 ? '3px solid #dc3545' : '3px solid transparent',
-                    borderBottom: '1px solid #eee',
+                    padding: `${space[1]} 6px`,
+                    background: n1Overloads.length > 0 ? colors.dangerSoft : 'transparent',
+                    borderLeft: `3px solid ${n1Overloads.length > 0 ? 'var(--color-danger)' : 'transparent'}`,
+                    borderBottom: `1px solid ${colors.borderSubtle}`,
                     lineHeight: '1.6',
                 }}>
-                    <strong style={{ whiteSpace: 'nowrap', marginRight: '4px' }}>N-1 Overloads:</strong>
-                    <span 
-                        title="Double-click on an overload name to toggle its inclusion in the analysis. Selected overloads are blue; unselected are light grey." 
-                        style={{ 
-                            display: 'inline-flex', 
-                            alignItems: 'center', 
-                            justifyContent: 'center', 
-                            width: '14px', 
-                            height: '14px', 
-                            borderRadius: '50%', 
-                            background: '#6c757d', 
-                            color: 'white', 
-                            fontSize: '10px', 
+                    <strong style={{ whiteSpace: 'nowrap', marginRight: space[1] }}>N-1 Overloads:</strong>
+                    <span
+                        title="Double-click on an overload name to toggle its inclusion in the analysis. Selected overloads are blue; unselected are light grey."
+                        style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            width: '14px',
+                            height: '14px',
+                            borderRadius: '50%',
+                            background: colors.chromeSoft,
+                            color: colors.textOnBrand,
+                            fontSize: '10px',
                             cursor: 'help',
                             verticalAlign: 'middle',
-                            marginRight: '4px',
+                            marginRight: space[1],
                         }}
                     >
                         ?
@@ -218,7 +219,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                                 gap: '3px',
                                 cursor: 'pointer',
                                 fontSize: '10px',
-                                color: monitorDeselected ? '#0056b3' : '#6c757d',
+                                color: monitorDeselected ? colors.brandStrong : colors.chromeSoft,
                                 fontWeight: monitorDeselected ? 600 : 400,
                                 whiteSpace: 'nowrap',
                                 marginRight: '6px',

--- a/frontend/src/components/SidebarSummary.tsx
+++ b/frontend/src/components/SidebarSummary.tsx
@@ -6,6 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import React from 'react';
+import { colors, space, text } from '../styles/tokens';
 
 interface SidebarSummaryProps {
   selectedBranch: string;
@@ -42,17 +43,17 @@ export default function SidebarSummary({
       data-testid="sticky-feed-summary"
       style={{
         flexShrink: 0,
-        padding: '6px 12px',
-        background: '#f8f9fa',
-        borderBottom: '1px solid #ccc',
-        fontSize: '11px',
+        padding: `6px ${space[3]}`,
+        background: colors.surfaceMuted,
+        borderBottom: `1px solid ${colors.border}`,
+        fontSize: text.xs,
         lineHeight: 1.5,
         boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
       }}
     >
       {selectedBranch && (
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
-          <span style={{ color: '#555', fontWeight: 600, whiteSpace: 'nowrap' }}>🎯 Contingency:</span>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: space[1] }}>
+          <span style={{ color: colors.textSecondary, fontWeight: 600, whiteSpace: 'nowrap' }}>🎯 Contingency:</span>
           <button
             onClick={(e) => { e.stopPropagation(); onContingencyZoom(selectedBranch); }}
             title={`Zoom to ${selectedBranch} in the current diagram`}
@@ -61,8 +62,8 @@ export default function SidebarSummary({
               border: 'none',
               cursor: 'pointer',
               padding: 0,
-              fontSize: '11px',
-              color: '#1e40af',
+              fontSize: text.xs,
+              color: colors.brand,
               fontWeight: 600,
               textDecoration: 'underline dotted',
               wordBreak: 'break-word',
@@ -74,8 +75,8 @@ export default function SidebarSummary({
         </div>
       )}
       {hasOverloads && (
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
-          <span style={{ color: '#b91c1c', fontWeight: 600, whiteSpace: 'nowrap' }}>⚠️ N-1:</span>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: space[1] }}>
+          <span style={{ color: colors.dangerStrong, fontWeight: 600, whiteSpace: 'nowrap' }}>⚠️ N-1:</span>
           <span style={{ wordBreak: 'break-word' }}>
             {n1LinesOverloaded!.map((name, i) => {
               const rho = n1LinesOverloadedRho?.[i];
@@ -92,8 +93,8 @@ export default function SidebarSummary({
                       border: 'none',
                       cursor: 'pointer',
                       padding: 0,
-                      fontSize: '11px',
-                      color: isSelected ? '#1e40af' : '#bdc3c7',
+                      fontSize: text.xs,
+                      color: isSelected ? colors.brand : colors.borderStrong,
                       fontWeight: isSelected ? 600 : 400,
                       textDecoration: isSelected ? 'underline dotted' : 'none',
                     }}
@@ -101,7 +102,7 @@ export default function SidebarSummary({
                     {displayName(name)}
                   </button>
                   {rhoPct && (
-                    <span style={{ color: isSelected ? '#374151' : '#bdc3c7', marginLeft: '2px' }}>
+                    <span style={{ color: isSelected ? colors.textPrimary : colors.borderStrong, marginLeft: space.half }}>
                       ({rhoPct})
                     </span>
                   )}

--- a/frontend/src/components/SldOverlay.tsx
+++ b/frontend/src/components/SldOverlay.tsx
@@ -8,6 +8,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import type { DiagramData, AnalysisResult, ActionDetail, VlOverlay, SldTab, SldFeederNode } from '../types';
 import { isCouplingAction } from '../utils/svgUtils';
+import { colors } from '../styles/tokens';
 
 export interface SldOverlayProps {
     vlOverlay: VlOverlay;
@@ -799,7 +800,7 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
         <div style={{
             position: 'absolute', top: overlayPos.y + 'px', left: overlayPos.x + 'px',
             width: '440px', height: '420px', minWidth: '220px', minHeight: '150px',
-            background: 'white', border: '1px solid #ccc', borderRadius: '8px',
+            background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '8px',
             boxShadow: '0 4px 24px rgba(0,0,0,0.22)', zIndex: 45,
             display: 'flex', flexDirection: 'column', overflow: 'hidden',
             resize: 'both', boxSizing: 'border-box',
@@ -807,16 +808,16 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
             {/* Header — drag handle */}
             <div
                 onMouseDown={startOverlayDrag}
-                style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 10px', background: '#f0faf4', borderBottom: '1px solid #d1fae5', flexShrink: 0, cursor: 'move', userSelect: 'none' }}
+                style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '6px 10px', background: colors.successSoft, borderBottom: `1px solid ${colors.successSoft}`, flexShrink: 0, cursor: 'move', userSelect: 'none' }}
             >
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <span style={{ fontSize: '13px', fontWeight: 600, color: '#065f46' }}>{vlOverlay.vlName}</span>
+                        <span style={{ fontSize: '13px', fontWeight: 600, color: colors.successText }}>{vlOverlay.vlName}</span>
                         {/* Mode indicator — shows which Flow vs Impact mode was active when overlay opened */}
                         <span style={{
                             fontSize: '10px', fontWeight: 700, padding: '1px 6px', borderRadius: '10px',
-                            background: actionViewMode === 'delta' ? '#dbeafe' : '#f3f4f6',
-                            color: actionViewMode === 'delta' ? '#1d4ed8' : '#374151',
+                            background: actionViewMode === 'delta' ? colors.brandSoft : colors.surfaceMuted,
+                            color: actionViewMode === 'delta' ? colors.brandStrong : colors.textPrimary,
                         }}>
                             {actionViewMode === 'delta' ? 'Impacts' : 'Flows'}
                         </span>
@@ -832,8 +833,8 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                                 onMouseDown={e => e.stopPropagation()}
                                 onClick={(e) => { e.stopPropagation(); onOverlaySldTabChange(tabMode); }}
                                 style={{
-                                    background: vlOverlay.tab === tabMode ? '#059669' : '#e5e7eb',
-                                    color: vlOverlay.tab === tabMode ? 'white' : '#374151',
+                                    background: vlOverlay.tab === tabMode ? colors.successStrong : colors.surfaceMuted,
+                                    color: vlOverlay.tab === tabMode ? colors.textOnBrand : colors.textPrimary,
                                     border: 'none', borderRadius: '4px', padding: '2px 8px',
                                     fontSize: '11px', fontWeight: vlOverlay.tab === tabMode ? 'bold' : 'normal',
                                     cursor: vlOverlay.loading ? 'wait' : 'pointer',
@@ -847,7 +848,7 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                 <button
                     onMouseDown={e => e.stopPropagation()}
                     onClick={(e) => { e.stopPropagation(); onOverlayClose(); }}
-                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '16px', color: '#666', lineHeight: 1, padding: '0 2px' }}
+                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '16px', color: colors.textTertiary, lineHeight: 1, padding: '0 2px' }}
                     title="Close"
                 >✕</button>
             </div>
@@ -858,12 +859,12 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                 onMouseDown={startOverlayPan}
             >
                 {vlOverlay.loading && (
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#999', fontSize: '13px' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: colors.textTertiary, fontSize: '13px' }}>
                         Generating diagram…
                     </div>
                 )}
                 {vlOverlay.error && (
-                    <div style={{ padding: '12px', color: '#dc3545', fontSize: '12px' }}>{vlOverlay.error}</div>
+                    <div style={{ padding: '12px', color: colors.danger, fontSize: '12px' }}>{vlOverlay.error}</div>
                 )}
                 {vlOverlay.svg && (
                     <div style={{

--- a/frontend/src/components/StatusToasts.tsx
+++ b/frontend/src/components/StatusToasts.tsx
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
+import { colors, radius, space } from '../styles/tokens';
+
 interface StatusToastsProps {
   error: string;
   infoMessage: string;
@@ -22,8 +24,8 @@ export default function StatusToasts({ error, infoMessage }: StatusToastsProps) 
       {error && (
         <div style={{
           position: 'fixed', bottom: 20, right: 20,
-          background: '#e74c3c', color: 'white',
-          padding: '10px 20px', borderRadius: '4px',
+          background: colors.danger, color: colors.textOnBrand,
+          padding: `${space[3]} ${space[5]}`, borderRadius: radius.sm,
           boxShadow: '0 2px 10px rgba(0,0,0,0.2)', zIndex: 1000,
         }}>
           {error}
@@ -32,9 +34,9 @@ export default function StatusToasts({ error, infoMessage }: StatusToastsProps) 
       {infoMessage && (
         <div style={{
           position: 'fixed', bottom: 20, left: 20,
-          background: infoMessage.startsWith('SUCCESS') ? '#27ae60' : '#3498db',
-          color: 'white',
-          padding: '12px 24px', borderRadius: '4px',
+          background: infoMessage.startsWith('SUCCESS') ? colors.success : colors.brand,
+          color: colors.textOnBrand,
+          padding: `${space[3]} ${space[6]}`, borderRadius: radius.sm,
           boxShadow: '0 4px 15px rgba(0,0,0,0.3)', zIndex: 1000,
           fontWeight: 'bold',
           border: '1px solid rgba(255,255,255,0.2)'

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -477,8 +477,11 @@ describe('VisualizationPanel', () => {
         expect(screen.getByText('Processing Analysis...')).toBeInTheDocument();
         const placeholder = screen.getByText('Processing Analysis...').parentElement;
         if (placeholder) {
-            expect(placeholder.style.backgroundColor).toBe('rgb(255, 243, 205)'); // #fff3cd
-            expect(placeholder.style.color).toBe('rgb(133, 100, 4)'); // #856404
+            // jsdom doesn't expand the `background:` shorthand into
+            // `backgroundColor` longhand for var(--…) values, so read
+            // the shorthand directly.
+            expect(placeholder.style.background).toContain('var(--color-warning-soft)');
+            expect(placeholder.style.color).toContain('var(--color-warning-text)');
         }
     });
 

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -13,6 +13,7 @@ import DetachableTabHost from './DetachableTabHost';
 import ActionOverviewDiagram from './ActionOverviewDiagram';
 import type { DetachedTabsMap } from '../hooks/useDetachedTabs';
 import type { PZInstance } from '../hooks/useTiedTabsSync';
+import { colors } from '../styles/tokens';
 
 /**
  * Inspect text field + custom suggestions dropdown.
@@ -73,7 +74,7 @@ const InspectSearchField: React.FC<{
                 placeholder="🔍 Inspect..."
                 style={{
                     padding: '5px 10px',
-                    border: inspectQuery ? '2px solid #3498db' : '1px solid #ccc',
+                    border: inspectQuery ? `2px solid ${colors.brand}` : `1px solid ${colors.border}`,
                     borderRadius: '4px',
                     fontSize: '12px',
                     width: '180px',
@@ -92,7 +93,7 @@ const InspectSearchField: React.FC<{
                         maxHeight: '220px',
                         overflowY: 'auto',
                         background: 'white',
-                        border: '1px solid #3498db',
+                        border: `1px solid ${colors.brand}`,
                         borderRadius: '4px',
                         boxShadow: '0 4px 12px rgba(0,0,0,0.18)',
                         zIndex: 200,
@@ -113,12 +114,12 @@ const InspectSearchField: React.FC<{
                             style={{
                                 padding: '5px 10px',
                                 cursor: 'pointer',
-                                borderBottom: '1px solid #eee',
+                                borderBottom: `1px solid ${colors.borderSubtle}`,
                                 whiteSpace: 'nowrap',
                                 overflow: 'hidden',
                                 textOverflow: 'ellipsis',
                             }}
-                            onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = '#f0f8ff'; }}
+                            onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.brandSoft; }}
                             onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'white'; }}
                         >
                             {item}
@@ -383,7 +384,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
             padding: '4px 10px', background: 'rgba(255,255,255,0.95)',
             border: `1px solid ${accentColor}`, borderRadius: '14px',
             boxShadow: '0 2px 8px rgba(0,0,0,0.15)', fontSize: '12px', fontWeight: 600,
-            color: '#2c3e50', pointerEvents: 'auto',
+            color: colors.chrome, pointerEvents: 'auto',
         }}>
             <span style={{ color: accentColor }}>●</span>
             <span>{label}</span>
@@ -397,8 +398,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                     title="Return to the action overview"
                     style={{
                         display: 'inline-flex', alignItems: 'center', gap: 4,
-                        border: '1.5px solid #ec407a', background: '#fce4ec',
-                        color: '#ad1457', borderRadius: '10px',
+                        border: '1.5px solid var(--signal-action-target-strong)', background: 'var(--signal-action-target-soft)',
+                        color: 'var(--signal-action-target-darker)', borderRadius: '10px',
                         padding: '2px 10px', fontSize: '11px', fontWeight: 700, cursor: 'pointer',
                     }}
                 >
@@ -461,18 +462,18 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             display: 'flex',
                             borderRadius: '6px',
                             overflow: 'hidden',
-                            border: '1px solid #ccc',
+                            border: `1px solid ${colors.border}`,
                             boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
                             fontSize: '12px',
                             fontWeight: 600,
-                            backgroundColor: '#fff',
+                            backgroundColor: colors.surface,
                         }}>
                             <button
                                 onClick={() => viewModeChangeForTabCb(tabId, 'network')}
                                 style={{
                                     padding: '4px 12px', border: 'none', cursor: 'pointer',
-                                    backgroundColor: tabViewMode === 'network' ? '#007bff' : '#fff',
-                                    color: tabViewMode === 'network' ? '#fff' : '#555',
+                                    backgroundColor: tabViewMode === 'network' ? colors.brand : colors.surface,
+                                    color: tabViewMode === 'network' ? colors.surface : colors.textSecondary,
                                     transition: 'all 0.15s ease'
                                 }}
                             >
@@ -481,9 +482,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <button
                                 onClick={() => viewModeChangeForTabCb(tabId, 'delta')}
                                 style={{
-                                    padding: '4px 12px', border: 'none', borderLeft: '1px solid #ccc', cursor: 'pointer',
-                                    backgroundColor: tabViewMode === 'delta' ? '#007bff' : '#fff',
-                                    color: tabViewMode === 'delta' ? '#fff' : '#555',
+                                    padding: '4px 12px', border: 'none', borderLeft: `1px solid ${colors.border}`, cursor: 'pointer',
+                                    backgroundColor: tabViewMode === 'delta' ? colors.brand : colors.surface,
+                                    color: tabViewMode === 'delta' ? colors.surface : colors.textSecondary,
                                     transition: 'all 0.15s ease'
                                 }}
                             >
@@ -519,10 +520,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     ? 'Untie: pan/zoom and asset focus no longer mirror between this window and the main window'
                                     : 'Tie: pan/zoom and asset focus will be mirrored between this window and the main window\'s active tab'}
                                 style={{
-                                    padding: '4px 10px', border: `1px solid ${tied ? '#2c7be5' : '#ccc'}`,
+                                    padding: '4px 10px', border: `1px solid ${tied ? colors.brand : colors.border}`,
                                     borderRadius: '6px', cursor: 'pointer',
-                                    backgroundColor: tied ? '#e8f0fe' : '#fff',
-                                    color: tied ? '#2c7be5' : '#555',
+                                    backgroundColor: tied ? colors.brandSoft : colors.surface,
+                                    color: tied ? colors.brand : colors.textSecondary,
                                     fontSize: '12px', fontWeight: 600,
                                     boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
                                 }}
@@ -534,8 +535,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <button
                                 onClick={() => onZoomIn(tabId)}
                                 style={{
-                                    background: 'white', color: '#333',
-                                    border: '1px solid #ccc', borderRadius: '4px',
+                                    background: 'white', color: colors.textPrimary,
+                                    border: `1px solid ${colors.border}`, borderRadius: '4px',
                                     padding: '5px 12px', cursor: 'pointer',
                                     fontSize: '14px', fontWeight: 600,
                                     boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
@@ -547,8 +548,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <button
                                 onClick={() => onResetView(tabId)}
                                 style={{
-                                    background: 'white', color: '#333',
-                                    border: '1px solid #ccc', borderRadius: '4px',
+                                    background: 'white', color: colors.textPrimary,
+                                    border: `1px solid ${colors.border}`, borderRadius: '4px',
                                     padding: '5px 14px', cursor: 'pointer',
                                     fontSize: '12px', fontWeight: 600,
                                     boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
@@ -559,8 +560,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <button
                                 onClick={() => onZoomOut(tabId)}
                                 style={{
-                                    background: 'white', color: '#333',
-                                    border: '1px solid #ccc', borderRadius: '4px',
+                                    background: 'white', color: colors.textPrimary,
+                                    border: `1px solid ${colors.border}`, borderRadius: '4px',
                                     padding: '5px 12px', cursor: 'pointer',
                                     fontSize: '14px', fontWeight: 600,
                                     boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
@@ -587,9 +588,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                         aria-pressed={showVoltageLevelNames}
                                         data-testid="toggle-vl-names"
                                         style={{
-                                            background: showVoltageLevelNames ? '#e8f0fe' : '#fff',
-                                            color: showVoltageLevelNames ? '#2c7be5' : '#555',
-                                            border: `1px solid ${showVoltageLevelNames ? '#2c7be5' : '#ccc'}`,
+                                            background: showVoltageLevelNames ? colors.brandSoft : colors.surface,
+                                            color: showVoltageLevelNames ? colors.brand : colors.textSecondary,
+                                            border: `1px solid ${showVoltageLevelNames ? colors.brand : colors.border}`,
                                             borderRadius: '4px',
                                             padding: '4px 8px',
                                             cursor: 'pointer',
@@ -605,7 +606,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     <button
                                         onClick={() => onVlOpen(inspectQuery)}
                                         style={{
-                                            background: '#d1fae5', color: '#065f46', border: 'none',
+                                            background: colors.successSoft, color: colors.successText, border: 'none',
                                             borderRadius: '4px', padding: '4px 8px', cursor: 'pointer',
                                             fontSize: '12px', boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
                                             fontWeight: 600
@@ -619,7 +620,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     <button
                                         onClick={() => inspectQueryChangeForCb(tabId, '')}
                                         style={{
-                                            background: '#e74c3c', color: 'white', border: 'none',
+                                            background: colors.danger, color: 'white', border: 'none',
                                             borderRadius: '4px', padding: '4px 8px', cursor: 'pointer',
                                             fontSize: '12px', boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
                                         }}
@@ -643,7 +644,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
         <div style={{
             position: 'absolute', inset: 0,
             display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
-            gap: '12px', background: '#f8fafc', color: '#475569', fontSize: '13px',
+            gap: '12px', background: colors.surfaceMuted, color: colors.textSecondary, fontSize: '13px',
         }}>
             <div style={{ fontSize: '32px', color: accentColor }}>{'\u21D7'}</div>
             <div style={{ fontWeight: 600 }}>"{label}" is open in a separate window</div>
@@ -661,7 +662,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                 <button
                     onClick={() => reattachTabCb(tabId)}
                     style={{
-                        border: '1px solid #cbd5e1', background: '#f1f5f9', color: '#475569',
+                        border: `1px solid ${colors.border}`, background: colors.surfaceMuted, color: colors.textSecondary,
                         borderRadius: '4px', padding: '6px 14px', fontSize: '12px',
                         fontWeight: 600, cursor: 'pointer',
                     }}
@@ -677,11 +678,11 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
             {/* Tab bar — all 4 tabs always visible; unavailable ones show placeholder.
                 Each tab exposes a small detach/reattach button so the user can move
                 its content into a secondary browser window and back. */}
-            <div style={{ display: 'flex', borderBottom: '1px solid #ccc', flexShrink: 0 }}>
+            <div style={{ display: 'flex', borderBottom: `1px solid ${colors.border}`, flexShrink: 0 }}>
                 {(
                     [
-                        { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: '#3498db', dimColor: '#7f8c8d', placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
-                        { id: 'n-1' as TabId, label: 'Contingency (N-1)' as React.ReactNode, available: !!n1Diagram?.svg, accentColor: '#e74c3c', dimColor: '#aab', placeholder: 'Select a contingency element from the dropdown to view the N-1 state.' },
+                        { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: colors.brand, dimColor: colors.chromeSoft, placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
+                        { id: 'n-1' as TabId, label: 'Contingency (N-1)' as React.ReactNode, available: !!n1Diagram?.svg, accentColor: colors.danger, dimColor: colors.borderStrong, placeholder: 'Select a contingency element from the dropdown to view the N-1 state.' },
                         // When no card is selected, the Remedial Action tab hosts the
                         // action-overview view (pins over the N-1 network). It is considered
                         // "available" as soon as the N-1 diagram has loaded, so the tab is no
@@ -734,9 +735,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                             gap: 6,
                                             padding: '2px 10px',
                                             borderRadius: 12,
-                                            background: '#fce4ec',
-                                            color: '#ad1457',
-                                            border: '1.5px solid #ec407a',
+                                            background: 'var(--signal-action-target-soft)',
+                                            color: 'var(--signal-action-target-darker)',
+                                            border: '1.5px solid var(--signal-action-target-strong)',
                                             cursor: 'pointer',
                                             fontWeight: 700,
                                             // Let the chip shrink before the "Remedial Action:" label does
@@ -766,7 +767,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                                 width: 14,
                                                 height: 14,
                                                 borderRadius: '50%',
-                                                background: '#ec407a',
+                                                background: 'var(--signal-action-target-strong)',
                                                 color: 'white',
                                                 fontSize: 10,
                                                 lineHeight: 1,
@@ -778,11 +779,11 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                 </span>
                             ) as React.ReactNode : 'Remedial action: overview' as React.ReactNode,
                             available: !!actionDiagram?.svg || !!n1Diagram?.svg,
-                            accentColor: '#ff4081',
-                            dimColor: '#aab',
+                            accentColor: 'var(--signal-action-target)',
+                            dimColor: colors.borderStrong,
                             placeholder: 'Select a contingency and run the analysis to see remedial actions.',
                         },
-                        { id: 'overflow' as TabId, label: 'Overflow Analysis' as React.ReactNode, available: !!result?.pdf_url, accentColor: '#27ae60', dimColor: '#aab', placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
+                        { id: 'overflow' as TabId, label: 'Overflow Analysis' as React.ReactNode, available: !!result?.pdf_url, accentColor: colors.success, dimColor: colors.borderStrong, placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
                     ] as const
                 ).map(tab => {
                     const isActive = activeTab === tab.id;
@@ -792,7 +793,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             key={tab.id}
                             style={{
                                 flex: 1, display: 'flex', alignItems: 'stretch',
-                                background: isActive && !isDetached ? 'white' : '#ecf0f1',
+                                background: isActive && !isDetached ? 'white' : colors.surfaceMuted,
                                 borderBottom: isActive && tab.available && !isDetached ? `3px solid ${tab.accentColor}` : 'none',
                                 minWidth: 0,
                             }}
@@ -812,7 +813,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     fontWeight: isActive && tab.available && !isDetached ? 'bold' : 400,
                                     fontStyle: !tab.available || isDetached ? 'italic' : 'normal',
                                     background: 'transparent',
-                                    color: isDetached ? '#7c8894' : (tab.available ? (isActive ? '#2c3e50' : tab.dimColor) : '#bbb'),
+                                    color: isDetached ? colors.textTertiary : (tab.available ? (isActive ? colors.chrome : tab.dimColor) : colors.borderStrong),
                                     fontSize: tab.id === 'action' && selectedActionId ? '0.75rem' : '0.85rem',
                                     // The action tab with a selected card carries its
                                     // own flex label with internal ellipsis on the chip.
@@ -842,7 +843,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     title={isDetached ? 'Reattach this tab to the main window' : 'Detach this tab into a separate window'}
                                     style={{
                                         border: 'none', background: 'transparent', cursor: 'pointer',
-                                        padding: '0 8px', color: isDetached ? tab.accentColor : '#7c8894',
+                                        padding: '0 8px', color: isDetached ? tab.accentColor : colors.textTertiary,
                                         fontSize: '13px', fontWeight: 700,
                                     }}
                                 >
@@ -869,11 +870,11 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         left: '50%',
                         transform: 'translateX(-50%)',
                         zIndex: 150,
-                        backgroundColor: '#fff3cd',
-                        color: '#856404',
+                        backgroundColor: colors.warningSoft,
+                        color: colors.warningText,
                         padding: '12px 20px',
                         borderRadius: '8px',
-                        border: '1px solid #ffeeba',
+                        border: `1px solid ${colors.warningBorder}`,
                         boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
                         display: 'flex',
                         flexDirection: 'column',
@@ -887,7 +888,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             </div>
                             <button
                                 onClick={() => setWarningDismissed(true)}
-                                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', color: '#856404' }}
+                                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', color: colors.warningText }}
                             >✕</button>
                         </div>
                         <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -900,7 +901,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <a
                                 href="#"
                                 onClick={(e) => { e.preventDefault(); onOpenSettings('paths'); }}
-                                style={{ color: '#0056b3', textDecoration: 'underline', fontWeight: 500 }}
+                                style={{ color: colors.brandStrong, textDecoration: 'underline', fontWeight: 500 }}
                             >
                                 Change in settings
                             </a>
@@ -926,7 +927,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         position: 'absolute', top: 0, left: 0,
                         backgroundColor: 'white',
                     }}>
-                        {detachedTabs['overflow'] && renderDetachedHeader('overflow', 'Overflow Analysis', '#27ae60')}
+                        {detachedTabs['overflow'] && renderDetachedHeader('overflow', 'Overflow Analysis', colors.success)}
                         {/* Hierarchical / Geo layout toggle — mirrors the
                             Flows/Impacts segmented pill used on the N, N-1
                             and Remedial Action tabs. Only visible when an
@@ -947,11 +948,11 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                         display: 'flex',
                                         borderRadius: '6px',
                                         overflow: 'hidden',
-                                        border: '1px solid #ccc',
+                                        border: `1px solid ${colors.border}`,
                                         boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
                                         fontSize: '12px',
                                         fontWeight: 600,
-                                        backgroundColor: '#fff',
+                                        backgroundColor: colors.surface,
                                         opacity: loading ? 0.7 : 1,
                                     }}>
                                         <button
@@ -962,8 +963,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                             style={{
                                                 padding: '4px 12px', border: 'none',
                                                 cursor: loading ? 'wait' : 'pointer',
-                                                backgroundColor: mode === 'hierarchical' ? '#007bff' : '#fff',
-                                                color: mode === 'hierarchical' ? '#fff' : '#555',
+                                                backgroundColor: mode === 'hierarchical' ? colors.brand : colors.surface,
+                                                color: mode === 'hierarchical' ? colors.surface : colors.textSecondary,
                                                 transition: 'all 0.15s ease',
                                             }}
                                         >
@@ -976,10 +977,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                             aria-pressed={mode === 'geo'}
                                             title={hasLayout ? '' : 'No grid_layout.json configured — set the Layout Path in Settings'}
                                             style={{
-                                                padding: '4px 12px', border: 'none', borderLeft: '1px solid #ccc',
+                                                padding: '4px 12px', border: 'none', borderLeft: `1px solid ${colors.border}`,
                                                 cursor: (loading || !hasLayout) ? 'not-allowed' : 'pointer',
-                                                backgroundColor: mode === 'geo' ? '#007bff' : '#fff',
-                                                color: mode === 'geo' ? '#fff' : (hasLayout ? '#555' : '#bbb'),
+                                                backgroundColor: mode === 'geo' ? colors.brand : colors.surface,
+                                                color: mode === 'geo' ? colors.surface : (hasLayout ? colors.textSecondary : colors.borderStrong),
                                                 transition: 'all 0.15s ease',
                                             }}
                                         >
@@ -999,8 +1000,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         ) : (
                             <div style={{
                                 display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%',
-                                color: analysisLoading ? '#856404' : '#999',
-                                background: analysisLoading ? '#fff3cd' : 'white',
+                                color: analysisLoading ? colors.warningText : colors.textTertiary,
+                                background: analysisLoading ? colors.warningSoft : 'white',
                                 fontWeight: analysisLoading ? 600 : 'normal',
                                 gap: '10px'
                             }}>
@@ -1009,12 +1010,12 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                         <span style={{ fontSize: '24px' }}>⚙️</span>
                                         <span>Processing Analysis...</span>
                                     </>
-                                ) : <span style={{ fontStyle: 'italic', color: '#999' }}>Run &ldquo;Analyze &amp; Suggest&rdquo; to see the overflow graph.</span>}
+                                ) : <span style={{ fontStyle: 'italic', color: colors.textTertiary }}>Run &ldquo;Analyze &amp; Suggest&rdquo; to see the overflow graph.</span>}
                             </div>
                         )}
                     </div>
                 </DetachableTabHost>
-                {activeTab === 'overflow' && detachedTabs['overflow'] && renderDetachedPlaceholder('overflow', 'Overflow Analysis', '#27ae60')}
+                {activeTab === 'overflow' && detachedTabs['overflow'] && renderDetachedPlaceholder('overflow', 'Overflow Analysis', colors.success)}
 
                 {/* Inactive, non-detached SVG tabs use `display: none` (not
                     `visibility: hidden`) so their tens-of-thousands-of-node
@@ -1039,23 +1040,23 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         width: '100%', height: '100%',
                         position: 'absolute', top: 0, left: 0,
                     }}>
-                        {detachedTabs['n'] && renderDetachedHeader('n', 'Network (N)', '#3498db')}
+                        {detachedTabs['n'] && renderDetachedHeader('n', 'Network (N)', colors.brand)}
                         {/* Always mounted — see comment on N-1 container below. */}
                         <MemoizedSvgContainer svg={nDiagram?.svg || ''} containerRef={nSvgContainerRef} display="block" tabId="n" hideVlLabels={!showVoltageLevelNames} />
                         {configLoading && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Loading configuration...
                             </div>
                         )}
                         {!configLoading && !nDiagram?.svg && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'white' }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'white' }}>
                                 Load configuration to see diagram
                             </div>
                         )}
                         {renderTabOverlay('n', true)}
                     </div>
                 </DetachableTabHost>
-                {activeTab === 'n' && detachedTabs['n'] && renderDetachedPlaceholder('n', 'Network (N)', '#3498db')}
+                {activeTab === 'n' && detachedTabs['n'] && renderDetachedPlaceholder('n', 'Network (N)', colors.brand)}
 
                 {/* N-1 Container — always mounted, but `display: none` when
                     inactive so its SVG does not enter Blink's layout tree.
@@ -1074,13 +1075,13 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         width: '100%', height: '100%',
                         position: 'absolute', top: 0, left: 0,
                     }}>
-                        {detachedTabs['n-1'] && renderDetachedHeader('n-1', 'Contingency (N-1)', '#e74c3c')}
+                        {detachedTabs['n-1'] && renderDetachedHeader('n-1', 'Contingency (N-1)', colors.danger)}
                         {/* Convergence warning banner */}
                         {n1Diagram && n1Diagram.lf_converged === false && (
                             <div style={{
                                 position: 'absolute', top: 0, left: 0, right: 0, zIndex: 30,
-                                background: '#fff3cd', color: '#856404', padding: '6px 12px',
-                                fontSize: '0.8rem', borderBottom: '1px solid #ffc107',
+                                background: colors.warningSoft, color: colors.warningText, padding: '6px 12px',
+                                fontSize: '0.8rem', borderBottom: `1px solid ${colors.warning}`,
                                 textAlign: 'center', pointerEvents: 'none',
                             }}>
                                 AC load flow: {n1Diagram.lf_status || 'did not converge'} — voltage values may be missing or approximate
@@ -1093,19 +1094,19 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             viewBox that was applied between the two invocations. */}
                         <MemoizedSvgContainer svg={n1Diagram?.svg || ''} containerRef={n1SvgContainerRef} display="block" tabId="n-1" hideVlLabels={!showVoltageLevelNames} />
                         {n1Loading && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Generating N-1 Diagram...
                             </div>
                         )}
                         {!n1Loading && !n1Diagram?.svg && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', fontStyle: 'italic', textAlign: 'center', padding: '40px', background: 'white' }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, fontStyle: 'italic', textAlign: 'center', padding: '40px', background: 'white' }}>
                                 Select a contingency element from the dropdown to view the N-1 state.
                             </div>
                         )}
                         {renderTabOverlay('n-1', true)}
                     </div>
                 </DetachableTabHost>
-                {activeTab === 'n-1' && detachedTabs['n-1'] && renderDetachedPlaceholder('n-1', 'Contingency (N-1)', '#e74c3c')}
+                {activeTab === 'n-1' && detachedTabs['n-1'] && renderDetachedPlaceholder('n-1', 'Contingency (N-1)', colors.danger)}
 
                 {/* Action Variant Container — always mounted, but `display: none`
                     when inactive so its SVG does not enter Blink's layout tree.
@@ -1127,15 +1128,15 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         {detachedTabs['action'] && renderDetachedHeader(
     'action',
     selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview',
-    '#ff4081',
+    'var(--signal-action-target)',
     selectedActionId ? () => onActionSelect?.(null) : undefined,
 )}
                         {/* Convergence warning banner */}
                         {actionDiagram && actionDiagram.lf_converged === false && (
                             <div style={{
                                 position: 'absolute', top: 0, left: 0, right: 0, zIndex: 30,
-                                background: '#fff3cd', color: '#856404', padding: '6px 12px',
-                                fontSize: '0.8rem', borderBottom: '1px solid #ffc107',
+                                background: colors.warningSoft, color: colors.warningText, padding: '6px 12px',
+                                fontSize: '0.8rem', borderBottom: `1px solid ${colors.warning}`,
                                 textAlign: 'center', pointerEvents: 'none',
                             }}>
                                 AC load flow: {actionDiagram.lf_status || 'did not converge'} — voltage values may be missing or approximate
@@ -1178,12 +1179,12 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             onSimulateUnsimulatedAction={onSimulateUnsimulatedAction}
                         />
                         {actionDiagramLoading && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
                                 Generating Action Variant Diagram...
                             </div>
                         )}
                         {!actionDiagramLoading && !actionDiagram?.svg && selectedActionId && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#999', background: 'white' }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'white' }}>
                                 Failed to load diagram for action {selectedActionId}
                             </div>
                         )}
@@ -1196,7 +1197,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         {renderTabOverlay('action', true)}
                     </div>
                 </DetachableTabHost>
-                {activeTab === 'action' && detachedTabs['action'] && renderDetachedPlaceholder('action', selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview', '#ff4081')}
+                {activeTab === 'action' && detachedTabs['action'] && renderDetachedPlaceholder('action', selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview', 'var(--signal-action-target)')}
 
                 {/* Voltage Range Sidebar — collapsed by default, toggle to expand */}
                 {uniqueVoltages.length > 1 && (() => {
@@ -1225,7 +1226,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                 title="Hide voltage filter"
                                 style={{
                                     alignSelf: 'flex-end', background: 'none', border: 'none',
-                                    cursor: 'pointer', fontSize: '14px', color: '#666',
+                                    cursor: 'pointer', fontSize: '14px', color: colors.textTertiary,
                                     padding: '0 4px', lineHeight: 1,
                                 }}
                             >✕</button>

--- a/frontend/src/components/modals/ConfirmationDialog.tsx
+++ b/frontend/src/components/modals/ConfirmationDialog.tsx
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
+import { colors } from '../../styles/tokens';
+
 export type ConfirmDialogState = {
   type: 'contingency' | 'loadStudy' | 'applySettings' | 'changeNetwork';
   pendingBranch?: string;
@@ -49,16 +51,16 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
         role="dialog"
         data-testid={`confirm-dialog-${confirmDialog.type}`}
         style={{
-          background: 'white', padding: '25px', borderRadius: '10px',
+          background: colors.surface, padding: '25px', borderRadius: '10px',
           boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
           maxWidth: '450px', width: '90%', textAlign: 'center'
         }}
       >
         <div style={{ fontSize: '2rem', marginBottom: '12px' }}>&#9888;</div>
-        <h3 style={{ margin: '0 0 12px', color: '#2c3e50', fontSize: '1.1rem' }}>
+        <h3 style={{ margin: '0 0 12px', color: colors.chrome, fontSize: '1.1rem' }}>
           {title}
         </h3>
-        <p style={{ margin: '0 0 20px', color: '#555', fontSize: '0.9rem', lineHeight: '1.5' }}>
+        <p style={{ margin: '0 0 20px', color: colors.textSecondary, fontSize: '0.9rem', lineHeight: '1.5' }}>
           All previous analysis results, manual simulations, action selections, and diagrams will be cleared.
           {trailingMessage}
         </p>
@@ -66,7 +68,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
           <button
             onClick={onCancel}
             style={{
-              padding: '8px 20px', background: '#95a5a6', color: 'white',
+              padding: '8px 20px', background: colors.disabled, color: colors.textOnBrand,
               border: 'none', borderRadius: '5px', cursor: 'pointer',
               fontWeight: 'bold', fontSize: '0.85rem'
             }}
@@ -76,7 +78,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
           <button
             onClick={onConfirm}
             style={{
-              padding: '8px 20px', background: '#e67e22', color: 'white',
+              padding: '8px 20px', background: colors.warningStrong, color: colors.textOnBrand,
               border: 'none', borderRadius: '5px', cursor: 'pointer',
               fontWeight: 'bold', fontSize: '0.85rem'
             }}

--- a/frontend/src/components/modals/ReloadSessionModal.tsx
+++ b/frontend/src/components/modals/ReloadSessionModal.tsx
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
+import { colors } from '../../styles/tokens';
+
 interface ReloadSessionModalProps {
   showReloadModal: boolean;
   setShowReloadModal: (v: boolean) => void;
@@ -33,19 +35,19 @@ const ReloadSessionModal: React.FC<ReloadSessionModalProps> = ({
       display: 'flex', justifyContent: 'center', alignItems: 'center'
     }}>
       <div style={{
-        background: 'white', borderRadius: '10px',
+        background: colors.surface, borderRadius: '10px',
         width: '500px', maxWidth: '95vw', maxHeight: '70vh',
         display: 'flex', flexDirection: 'column',
-        boxShadow: '0 8px 32px rgba(0,0,0,0.3)', color: 'black'
+        boxShadow: '0 8px 32px rgba(0,0,0,0.3)', color: colors.textPrimary
       }}>
         <div style={{
-          padding: '15px 20px', borderBottom: '1px solid #eee',
+          padding: '15px 20px', borderBottom: `1px solid ${colors.borderSubtle}`,
           display: 'flex', justifyContent: 'space-between', alignItems: 'center'
         }}>
           <h3 style={{ margin: 0, fontSize: '1.1rem' }}>Reload Session</h3>
           <button
             onClick={() => setShowReloadModal(false)}
-            style={{ border: 'none', background: 'none', fontSize: '20px', cursor: 'pointer', color: '#999' }}
+            style={{ border: 'none', background: 'none', fontSize: '20px', cursor: 'pointer', color: colors.textTertiary }}
           >
             &times;
           </button>
@@ -53,18 +55,18 @@ const ReloadSessionModal: React.FC<ReloadSessionModalProps> = ({
 
         <div style={{
           padding: '15px 20px', fontSize: '0.8rem',
-          color: '#666', borderBottom: '1px solid #f0f0f0'
+          color: colors.textTertiary, borderBottom: `1px solid ${colors.borderSubtle}`
         }}>
           From: {outputFolderPath}
         </div>
 
         <div style={{ flex: 1, overflowY: 'auto', padding: '10px 20px' }}>
           {sessionListLoading ? (
-            <div style={{ padding: '30px', textAlign: 'center', color: '#999' }}>
+            <div style={{ padding: '30px', textAlign: 'center', color: colors.textTertiary }}>
               Loading sessions...
             </div>
           ) : sessionList.length === 0 ? (
-            <div style={{ padding: '30px', textAlign: 'center', color: '#999' }}>
+            <div style={{ padding: '30px', textAlign: 'center', color: colors.textTertiary }}>
               No saved sessions found in this folder.
             </div>
           ) : (
@@ -74,13 +76,13 @@ const ReloadSessionModal: React.FC<ReloadSessionModalProps> = ({
                 onClick={() => !sessionRestoring && onRestoreSession(name)}
                 style={{
                   padding: '10px 12px', margin: '4px 0',
-                  border: '1px solid #eee', borderRadius: '6px',
+                  border: `1px solid ${colors.borderSubtle}`, borderRadius: '6px',
                   cursor: sessionRestoring ? 'not-allowed' : 'pointer',
                   fontSize: '0.85rem', fontFamily: 'monospace',
                   transition: 'background 0.15s',
                   opacity: sessionRestoring ? 0.5 : 1,
                 }}
-                onMouseOver={e => { if (!sessionRestoring) (e.currentTarget as HTMLElement).style.background = '#e7f1ff'; }}
+                onMouseOver={e => { if (!sessionRestoring) (e.currentTarget as HTMLElement).style.background = colors.brandSoft; }}
                 onMouseOut={e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
               >
                 {name}
@@ -89,11 +91,11 @@ const ReloadSessionModal: React.FC<ReloadSessionModalProps> = ({
           )}
         </div>
 
-        <div style={{ padding: '12px 20px', borderTop: '1px solid #eee', display: 'flex', justifyContent: 'flex-end' }}>
+        <div style={{ padding: '12px 20px', borderTop: `1px solid ${colors.borderSubtle}`, display: 'flex', justifyContent: 'flex-end' }}>
           <button
             onClick={() => setShowReloadModal(false)}
             style={{
-              padding: '8px 20px', background: '#95a5a6', color: 'white',
+              padding: '8px 20px', background: colors.disabled, color: colors.textOnBrand,
               border: 'none', borderRadius: '5px', cursor: 'pointer',
               fontWeight: 'bold', fontSize: '0.85rem'
             }}

--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -7,6 +7,7 @@
 
 import { interactionLogger } from '../../utils/interactionLogger';
 import type { SettingsState } from '../../hooks/useSettings';
+import { colors } from '../../styles/tokens';
 
 interface SettingsModalProps {
   settings: SettingsState;
@@ -54,9 +55,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
       }}
       style={{
         flex: 1, padding: '10px', cursor: 'pointer', background: 'none',
-        border: 'none', borderBottom: settingsTab === id ? '2px solid #3498db' : 'none',
+        border: 'none', borderBottom: settingsTab === id ? `2px solid ${colors.brand}` : 'none',
         fontWeight: settingsTab === id ? 'bold' : 'normal',
-        color: settingsTab === id ? '#3498db' : '#555'
+        color: settingsTab === id ? colors.brand : colors.textSecondary
       }}
     >
       {label}
@@ -72,13 +73,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
       <div
         role="dialog"
         style={{
-          background: 'white', padding: '25px', borderRadius: '8px',
+          background: colors.surface, padding: '25px', borderRadius: '8px',
           width: '450px', boxShadow: '0 4px 15px rgba(0,0,0,0.2)',
-          display: 'flex', flexDirection: 'column', gap: '15px', color: 'black'
+          display: 'flex', flexDirection: 'column', gap: '15px', color: colors.textPrimary
         }}
       >
         {/* Tabs */}
-        <div style={{ display: 'flex', borderBottom: '1px solid #eee', marginBottom: '15px' }}>
+        <div style={{ display: 'flex', borderBottom: `1px solid ${colors.borderSubtle}`, marginBottom: '15px' }}>
           {tabButton('paths', 'Paths')}
           {tabButton('recommender', 'Recommender')}
           {tabButton('configurations', 'Configurations')}
@@ -89,38 +90,38 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
           <div style={{ display: 'flex', flexDirection: 'column', gap: '15px' }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
               <label htmlFor="networkPathInput" style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>Network File Path (.xiidm)</label>
-              <div style={{ fontSize: '0.75rem', color: '#666', marginTop: '-3px' }}>Synchronized with the banner field</div>
+              <div style={{ fontSize: '0.75rem', color: colors.textTertiary, marginTop: '-3px' }}>Synchronized with the banner field</div>
               <div style={{ display: 'flex', gap: '5px' }}>
-                <input id="networkPathInput" type="text" value={networkPath} onChange={e => setNetworkPath(e.target.value)} placeholder="load your grid xiidm file path" style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
-                <button onClick={() => pickSettingsPath('file', setNetworkPath)} style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📄</button>
+                <input id="networkPathInput" type="text" value={networkPath} onChange={e => setNetworkPath(e.target.value)} placeholder="load your grid xiidm file path" style={{ flex: 1, padding: '8px', border: `1px solid ${colors.border}`, borderRadius: '4px' }} />
+                <button onClick={() => pickSettingsPath('file', setNetworkPath)} style={{ padding: '8px', background: colors.chromeSoft, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📄</button>
               </div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
               <label htmlFor="actionPathInput" style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>Action Dictionary File Path</label>
               <div style={{ display: 'flex', gap: '5px' }}>
-                <input id="actionPathInput" type="text" value={actionPath} onChange={e => setActionPath(e.target.value)} style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
-                <button onClick={() => pickSettingsPath('file', setActionPath)} style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📄</button>
+                <input id="actionPathInput" type="text" value={actionPath} onChange={e => setActionPath(e.target.value)} style={{ flex: 1, padding: '8px', border: `1px solid ${colors.border}`, borderRadius: '4px' }} />
+                <button onClick={() => pickSettingsPath('file', setActionPath)} style={{ padding: '8px', background: colors.chromeSoft, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📄</button>
               </div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
               <label htmlFor="layoutPathInput" style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>Layout File Path (.json)</label>
               <div style={{ display: 'flex', gap: '5px' }}>
-                <input id="layoutPathInput" type="text" value={layoutPath} onChange={e => setLayoutPath(e.target.value)} style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
-                <button onClick={() => pickSettingsPath('file', setLayoutPath)} style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📄</button>
+                <input id="layoutPathInput" type="text" value={layoutPath} onChange={e => setLayoutPath(e.target.value)} style={{ flex: 1, padding: '8px', border: `1px solid ${colors.border}`, borderRadius: '4px' }} />
+                <button onClick={() => pickSettingsPath('file', setLayoutPath)} style={{ padding: '8px', background: colors.chromeSoft, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📄</button>
               </div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
               <label style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>Output Folder Path</label>
-              <div style={{ fontSize: '0.75rem', color: '#666', marginTop: '-3px' }}>Session folders (JSON + PDF) are saved here. Leave empty to download JSON to browser.</div>
+              <div style={{ fontSize: '0.75rem', color: colors.textTertiary, marginTop: '-3px' }}>Session folders (JSON + PDF) are saved here. Leave empty to download JSON to browser.</div>
               <div style={{ display: 'flex', gap: '5px' }}>
-                <input type="text" value={outputFolderPath} onChange={e => setOutputFolderPath(e.target.value)} placeholder="e.g. /home/user/sessions" style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }} />
-                <button onClick={() => pickSettingsPath('dir', setOutputFolderPath)} style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📂</button>
+                <input type="text" value={outputFolderPath} onChange={e => setOutputFolderPath(e.target.value)} placeholder="e.g. /home/user/sessions" style={{ flex: 1, padding: '8px', border: `1px solid ${colors.border}`, borderRadius: '4px' }} />
+                <button onClick={() => pickSettingsPath('dir', setOutputFolderPath)} style={{ padding: '8px', background: colors.chromeSoft, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📂</button>
               </div>
             </div>
-            <hr style={{ border: 'none', borderTop: '1px solid #eee', margin: '5px 0' }} />
+            <hr style={{ border: 'none', borderTop: `1px solid ${colors.borderSubtle}`, margin: '5px 0' }} />
             <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
               <label htmlFor="configFilePathInput" style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>Config File Path</label>
-              <div style={{ fontSize: '0.75rem', color: '#666', marginTop: '-3px' }}>
+              <div style={{ fontSize: '0.75rem', color: colors.textTertiary, marginTop: '-3px' }}>
                 Path to the <code>config.json</code> settings file. Change this to use a config stored outside the repository.
                 The file will be created from defaults if it does not exist.
               </div>
@@ -132,11 +133,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                   onChange={e => setConfigFilePath(e.target.value)}
                   onBlur={e => changeConfigFilePath(e.target.value).catch(err => console.error('Failed to change config file path', err))}
                   placeholder="e.g. /home/user/my_costudy4grid_config.json"
-                  style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }}
+                  style={{ flex: 1, padding: '8px', border: `1px solid ${colors.border}`, borderRadius: '4px' }}
                 />
                 <button
                   onClick={() => pickSettingsPath('file', (p) => changeConfigFilePath(p).catch(err => console.error('Failed to change config file path', err)))}
-                  style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}
+                  style={{ padding: '8px', background: colors.chromeSoft, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}
                 >📄</button>
               </div>
             </div>
@@ -161,7 +162,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                   id={id}
                   type="number" step="0.1" value={value}
                   onChange={e => setter(parseFloat(e.target.value))}
-                  style={{ width: '80px', padding: '5px', border: '1px solid #ccc', borderRadius: '4px' }}
+                  style={{ width: '80px', padding: '5px', border: `1px solid ${colors.border}`, borderRadius: '4px' }}
                 />
               </div>
             ))}
@@ -171,10 +172,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                 id="nPrioritizedActions"
                 type="number" step="1" value={nPrioritizedActions}
                 onChange={e => setNPrioritizedActions(parseInt(e.target.value, 10))}
-                style={{ width: '80px', padding: '5px', border: '1px solid #ccc', borderRadius: '4px' }}
+                style={{ width: '80px', padding: '5px', border: `1px solid ${colors.border}`, borderRadius: '4px' }}
               />
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '10px', background: '#f8f9fa', borderRadius: '4px', border: '1px solid #eee' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '10px', background: colors.surfaceMuted, borderRadius: '4px', border: `1px solid ${colors.borderSubtle}` }}>
               <input
                 type="checkbox" id="ignoreRec" checked={ignoreReconnections}
                 onChange={e => setIgnoreReconnections(e.target.checked)}
@@ -194,9 +195,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                 <input
                   id="monitoringFactor" type="number" step="0.01" min="0" max="2"
                   value={monitoringFactor} onChange={e => setMonitoringFactor(parseFloat(e.target.value))}
-                  style={{ padding: '6px', width: '80px', border: '1px solid #ccc', borderRadius: '4px' }}
+                  style={{ padding: '6px', width: '80px', border: `1px solid ${colors.border}`, borderRadius: '4px' }}
                 />
-                <span style={{ fontSize: '0.85rem', color: '#666' }}>Multiplier applied to standard limits (e.g., 0.95)</span>
+                <span style={{ fontSize: '0.85rem', color: colors.textTertiary }}>Multiplier applied to standard limits (e.g., 0.95)</span>
               </div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
@@ -207,9 +208,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                   type="text" value={linesMonitoringPath}
                   onChange={e => setLinesMonitoringPath(e.target.value)}
                   placeholder="Leave empty for IGNORE_LINES_MONITORING=True"
-                  style={{ flex: 1, padding: '8px', border: '1px solid #ccc', borderRadius: '4px' }}
+                  style={{ flex: 1, padding: '8px', border: `1px solid ${colors.border}`, borderRadius: '4px' }}
                 />
-                <button onClick={() => pickSettingsPath('file', setLinesMonitoringPath)} style={{ padding: '8px', background: '#7f8c8d', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📁</button>
+                <button onClick={() => pickSettingsPath('file', setLinesMonitoringPath)} style={{ padding: '8px', background: colors.chromeSoft, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', flexShrink: 0 }}>📁</button>
               </div>
             </div>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -218,13 +219,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                 id="preExistingOverloadThreshold"
                 type="number" step="0.01" min="0" max="1" value={preExistingOverloadThreshold}
                 onChange={e => setPreExistingOverloadThreshold(parseFloat(e.target.value))}
-                style={{ width: '80px', padding: '5px', border: '1px solid #ccc', borderRadius: '4px' }}
+                style={{ width: '80px', padding: '5px', border: `1px solid ${colors.border}`, borderRadius: '4px' }}
               />
             </div>
-            <div style={{ fontSize: '0.75rem', color: '#666', marginTop: '-10px' }}>
+            <div style={{ fontSize: '0.75rem', color: colors.textTertiary, marginTop: '-10px' }}>
               Pre-existing overloads excluded from N-1 &amp; max loading unless worsened by this fraction (default 2%)
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', padding: '10px', background: '#f8f9fa', borderRadius: '4px', border: '1px solid #eee' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', padding: '10px', background: colors.surfaceMuted, borderRadius: '4px', border: `1px solid ${colors.borderSubtle}` }}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
                   <input
@@ -234,7 +235,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                   />
                   <label htmlFor="fastMode" style={{ fontWeight: 'bold', fontSize: '0.9rem', cursor: 'pointer' }}>Pypowsybl Fast Mode</label>
                 </div>
-                <div style={{ fontSize: '0.75rem', color: '#666', fontStyle: 'italic', marginLeft: '26px' }}>
+                <div style={{ fontSize: '0.75rem', color: colors.textTertiary, fontStyle: 'italic', marginLeft: '26px' }}>
                   Disable voltage control in pypowsybl for faster simulations (may affect convergence)
                 </div>
               </div>
@@ -246,13 +247,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
         <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '10px', gap: '10px' }}>
           <button
             onClick={handleCloseSettings}
-            style={{ padding: '8px 20px', background: '#e74c3c', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold' }}
+            style={{ padding: '8px 20px', background: colors.danger, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold' }}
           >
             Close
           </button>
           <button
             onClick={onApply}
-            style={{ padding: '8px 20px', background: '#3498db', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold' }}
+            style={{ padding: '8px 20px', background: colors.brand, color: colors.textOnBrand, border: 'none', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold' }}
           >
             Apply
           </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,7 +14,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424; /* dark-mode placeholder; overridden below */
+  background-color: var(--color-surface-dark);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,7 +14,7 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #242424; /* dark-mode placeholder; overridden below */
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -26,7 +26,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 #root {
@@ -37,8 +37,8 @@ body {
 /* Light mode overrides for this specific app style */
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: var(--color-text-primary);
+    background-color: var(--color-surface);
   }
 }
 
@@ -51,9 +51,9 @@ body {
 
 .action-table th,
 .action-table td {
-  padding: 8px;
+  padding: var(--space-2);
   text-align: left;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-subtle);
   /* Long equipment IDs (LINE.XYZ_ABC_LONG_NAME) would otherwise stretch
      the table past the modal container and either trigger a horizontal
      scrollbar or get clipped invisibly by the parent's `overflow: hidden`.
@@ -64,47 +64,47 @@ body {
 }
 
 .action-table th {
-  background: #f8f9fa;
+  background: var(--color-surface-muted);
   font-weight: 600;
 }
 
 .action-table tr:hover {
-  background: #f1f8ff;
+  background: var(--color-brand-soft);
 }
 
 .action-table tr.selected {
-  background: #e7f1ff;
+  background: var(--color-brand-soft);
 }
 
 .metric-badge {
   display: inline-block;
   padding: 1px 5px;
   border-radius: 3px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   font-weight: bold;
 }
 
 .metric-score {
-  background: #e1f5fe;
-  color: #01579b;
+  background: var(--color-brand-soft);
+  color: var(--color-brand);
 }
 
 .metric-rho {
-  background: #fff3e0;
-  color: #e65100;
+  background: var(--color-warning-soft);
+  color: var(--color-warning-text);
 }
 
 .modal-tab {
-  padding: 10px 20px;
+  padding: var(--space-3) var(--space-5);
   cursor: pointer;
   border-bottom: 3px solid transparent;
   font-weight: bold;
-  color: #666;
+  color: var(--color-text-tertiary);
   transition: all 0.2s;
 }
 
 .modal-tab.active {
-  border-bottom-color: #3498db;
-  color: #3498db;
-  background: #f8f9fa;
+  border-bottom-color: var(--color-brand);
+  color: var(--color-brand);
+  background: var(--color-surface-muted);
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './styles/tokens.css'
 import './index.css'
 import App from './App.tsx'
 import ErrorBoundary from './components/ErrorBoundary.tsx'

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,109 @@
+/*
+Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+you can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+
+Design tokens — single source of truth for color, spacing, type, radius.
+
+Why this file exists: docs/proposals/ui-design-critique.md flagged 273
+hex literals across 24 files (three competing palettes: Flat UI,
+Bootstrap, Tailwind). All blues consolidate onto the Tailwind blue
+ramp (closest fit to existing values — #1e40af and #dbeafe are
+already on it).
+
+How to consume:
+  - Inside .css files:    color: var(--color-brand);
+  - Inside inline styles: color: 'var(--color-brand)'
+                          (or import { colors } from 'styles/tokens')
+
+How to extend: add a NEW token here before introducing a new hex
+in a component. The check_code_quality.py gate ratchets down the
+remaining hex-literal count after each migration.
+*/
+
+:root {
+  /* ----- Color: surfaces ----- */
+  --color-surface: #ffffff;
+  --color-surface-muted: #f8f9fa;
+  --color-surface-raised: #fcfcfc;
+
+  /* ----- Color: borders ----- */
+  --color-border: #cccccc;
+  --color-border-subtle: #eeeeee;
+  --color-border-strong: #999999;
+
+  /* ----- Color: text ----- */
+  --color-text-primary: #1f2937;
+  --color-text-secondary: #555555;
+  --color-text-tertiary: #888888;
+  --color-text-on-brand: #ffffff;
+
+  /* ----- Color: brand (Tailwind blue ramp) ----- */
+  --color-brand: #1e40af;          /* blue-800 — primary links + active CTAs */
+  --color-brand-strong: #1d4ed8;   /* blue-700 — hover / pressed */
+  --color-brand-soft: #dbeafe;     /* blue-100 — selection bg, hint pills */
+  --color-brand-mid: #3b82f6;      /* blue-500 — fills (slider, range bar) */
+
+  /* ----- Color: state — success ----- */
+  --color-success: #28a745;
+  --color-success-strong: #2e7d32;
+  --color-success-soft: #d1fae5;
+  --color-success-text: #065f46;
+
+  /* ----- Color: state — warning ----- */
+  --color-warning: #ffc107;
+  --color-warning-strong: #f0ad4e;
+  --color-warning-soft: #fff3cd;
+  --color-warning-border: #ffeeba;
+  --color-warning-text: #856404;
+
+  /* ----- Color: state — danger ----- */
+  --color-danger: #dc3545;
+  --color-danger-strong: #b91c1c;
+  --color-danger-soft: #f8d7da;
+  --color-danger-text: #c62828;
+
+  /* ----- Color: accent + chrome ----- */
+  --color-accent: #8e44ad;         /* save/secondary action */
+  --color-chrome: #2c3e50;         /* header / dark backgrounds */
+  --color-chrome-soft: #7f8c8d;    /* settings cog, neutral chrome */
+  --color-disabled: #95a5a6;       /* disabled buttons */
+
+  /* ----- Spacing (4 / 8 grid) ----- */
+  --space-0: 0;
+  --space-half: 2px;               /* tight cases (badge padding, inline gaps) */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-7: 32px;
+
+  /* ----- Type sizes ----- */
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-xxl: 24px;
+
+  /* ----- Radii ----- */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+
+  /* ----- Diagram-signal colors (domain-specific, not semantic state) -----
+     Used by NAD/SLD highlight CSS in App.css. These are visual signals
+     for grid concepts (contingency, action target, overload, breaker)
+     and intentionally bright/saturated to read on top of the diagram. */
+  --signal-overload: #ff8c00;
+  --signal-contingency: #ffe033;
+  --signal-action-target: #ff4081;
+  --signal-breaker: #ce93d8;
+  --signal-delta-positive: #ff9800;
+  --signal-delta-negative: #2196f3;
+  --signal-delta-neutral: #999999;
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -120,4 +120,38 @@ remaining hex-literal count after each migration.
   --signal-delta-positive: #ff9800;
   --signal-delta-negative: #2196f3;
   --signal-delta-neutral: #999999;
+
+  /* ----- Action-overview pin palette -----
+     Severity buckets for Remedial Action overview pins
+     (utils/svg/actionPin{Data,Render}.ts + ActionOverviewDiagram.tsx).
+     Three triplets per bucket: base, dimmed (rejected / filtered-out),
+     highlighted (selected on hover). The TS mirror in tokens.ts is the
+     runtime source of truth because pin fills are written to raw SVG
+     `fill="…"` attributes via setAttribute, which doesn't reliably
+     resolve var() across older browsers. CSS variables here are kept
+     in sync for any future CSS-only consumers. */
+  --pin-green: #28a745;
+  --pin-orange: #f0ad4e;
+  --pin-red: #dc3545;
+  --pin-grey: #9ca3af;
+  --pin-green-dimmed: #a3c9ab;
+  --pin-orange-dimmed: #dcd0b8;
+  --pin-red-dimmed: #d4a5ab;
+  --pin-grey-dimmed: #c8cdd2;
+  --pin-green-highlighted: #1e9e3a;
+  --pin-orange-highlighted: #e89e20;
+  --pin-red-highlighted: #c82333;
+  --pin-grey-highlighted: #7b8a96;
+  --pin-glyph-bg: #ffffff;            /* white inner circle behind label */
+  --pin-glyph-text: #1f2937;          /* label text (= text-primary) */
+  --pin-stroke-neutral: #6b7280;      /* unsimulated pin outline */
+  --pin-gold: #eab308;                /* selected-pin star fill + outline */
+  --pin-gold-dark: #a16207;           /* selected-pin star stroke */
+  --pin-cross-fill: #ef4444;          /* rejected-pin cross fill */
+  --pin-cross-stroke: #b91c1c;        /* rejected-pin cross stroke */
+
+  /* Vite template carryover — visible only during the first paint
+     before body { background-color: var(--color-surface) } takes over.
+     Kept as a token so the dark-mode initial-paint color has a name. */
+  --color-surface-dark: #242424;
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -67,9 +67,20 @@ remaining hex-literal count after each migration.
 
   /* ----- Color: accent + chrome ----- */
   --color-accent: #8e44ad;         /* save/secondary action */
+  --color-accent-soft: #f3e8ff;    /* PST tap-edit row bg */
+  --color-accent-border: #c084fc;  /* PST tap-edit row border */
+  --color-accent-text: #6b21a8;    /* PST tap-edit row text */
   --color-chrome: #2c3e50;         /* header / dark backgrounds */
   --color-chrome-soft: #7f8c8d;    /* settings cog, neutral chrome */
   --color-disabled: #95a5a6;       /* disabled buttons */
+
+  /* ----- Color: info (cyan — distinct from brand blue) -----
+     Used by curtailment edit rows and metric badges where the
+     intent is "informational" rather than "primary action". */
+  --color-info: #0284c7;
+  --color-info-soft: #e0f2fe;
+  --color-info-border: #7dd3fc;
+  --color-info-text: #075985;
 
   /* ----- Spacing (4 / 8 grid) ----- */
   --space-0: 0;
@@ -102,6 +113,9 @@ remaining hex-literal count after each migration.
   --signal-overload: #ff8c00;
   --signal-contingency: #ffe033;
   --signal-action-target: #ff4081;
+  --signal-action-target-strong: #ec407a;
+  --signal-action-target-darker: #ad1457;
+  --signal-action-target-soft: #fce4ec;
   --signal-breaker: #ce93d8;
   --signal-delta-positive: #ff9800;
   --signal-delta-negative: #2196f3;

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -50,9 +50,17 @@ export const colors = {
   dangerText: 'var(--color-danger-text)',
 
   accent: 'var(--color-accent)',
+  accentSoft: 'var(--color-accent-soft)',
+  accentBorder: 'var(--color-accent-border)',
+  accentText: 'var(--color-accent-text)',
   chrome: 'var(--color-chrome)',
   chromeSoft: 'var(--color-chrome-soft)',
   disabled: 'var(--color-disabled)',
+
+  info: 'var(--color-info)',
+  infoSoft: 'var(--color-info-soft)',
+  infoBorder: 'var(--color-info-border)',
+  infoText: 'var(--color-info-text)',
 } as const;
 
 export const space = {

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -89,3 +89,49 @@ export const radius = {
   md: 'var(--radius-md)',
   lg: 'var(--radius-lg)',
 } as const;
+
+// Action-overview pin palette — RAW HEX VALUES (not var() refs).
+//
+// The pin renderer (utils/svg/actionPinRender.ts) writes these into
+// raw SVG `fill="…"` attributes via setAttribute. Browsers don't
+// reliably resolve `var(--…)` inside SVG presentation attributes
+// (only via CSS), and the unit tests in
+// `ActionOverviewDiagram.test.tsx` assert on the resolved hex value
+// (`getAttribute('fill') === '#28a745'`). So this file IS the
+// source-of-truth for pin colours; `tokens.css` mirrors them only
+// for future CSS consumers.
+//
+// Adding a hex literal here is permitted (`tokens.ts` is exempt from
+// the hex-literal gate alongside `tokens.css`). Anywhere else,
+// import and reuse these constants instead of inlining the hex.
+
+export const pinColors = {
+  green: '#28a745',
+  orange: '#f0ad4e',
+  red: '#dc3545',
+  grey: '#9ca3af',
+} as const;
+
+export const pinColorsDimmed = {
+  green: '#a3c9ab',
+  orange: '#dcd0b8',
+  red: '#d4a5ab',
+  grey: '#c8cdd2',
+} as const;
+
+export const pinColorsHighlighted = {
+  green: '#1e9e3a',
+  orange: '#e89e20',
+  red: '#c82333',
+  grey: '#7b8a96',
+} as const;
+
+export const pinChrome = {
+  glyphBg: '#ffffff',
+  glyphText: '#1f2937',
+  strokeNeutral: '#6b7280',
+  gold: '#eab308',
+  goldDark: '#a16207',
+  crossFill: '#ef4444',
+  crossStroke: '#b91c1c',
+} as const;

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+// Token consumers for inline styles. Mirrors `tokens.css`. Values are
+// `var(--…)` strings so the resolved color/size lives in one place
+// (the CSS custom property) — TypeScript is just a typed accessor.
+//
+// Use this in components that build `style={{ … }}` objects:
+//   import { colors, space, text, radius } from '../styles/tokens';
+//   <div style={{ background: colors.surface, padding: space[3] }} />
+//
+// CSS files keep using `var(--color-brand)` directly.
+
+export const colors = {
+  surface: 'var(--color-surface)',
+  surfaceMuted: 'var(--color-surface-muted)',
+  surfaceRaised: 'var(--color-surface-raised)',
+
+  border: 'var(--color-border)',
+  borderSubtle: 'var(--color-border-subtle)',
+  borderStrong: 'var(--color-border-strong)',
+
+  textPrimary: 'var(--color-text-primary)',
+  textSecondary: 'var(--color-text-secondary)',
+  textTertiary: 'var(--color-text-tertiary)',
+  textOnBrand: 'var(--color-text-on-brand)',
+
+  brand: 'var(--color-brand)',
+  brandStrong: 'var(--color-brand-strong)',
+  brandSoft: 'var(--color-brand-soft)',
+  brandMid: 'var(--color-brand-mid)',
+
+  success: 'var(--color-success)',
+  successStrong: 'var(--color-success-strong)',
+  successSoft: 'var(--color-success-soft)',
+  successText: 'var(--color-success-text)',
+
+  warning: 'var(--color-warning)',
+  warningStrong: 'var(--color-warning-strong)',
+  warningSoft: 'var(--color-warning-soft)',
+  warningBorder: 'var(--color-warning-border)',
+  warningText: 'var(--color-warning-text)',
+
+  danger: 'var(--color-danger)',
+  dangerStrong: 'var(--color-danger-strong)',
+  dangerSoft: 'var(--color-danger-soft)',
+  dangerText: 'var(--color-danger-text)',
+
+  accent: 'var(--color-accent)',
+  chrome: 'var(--color-chrome)',
+  chromeSoft: 'var(--color-chrome-soft)',
+  disabled: 'var(--color-disabled)',
+} as const;
+
+export const space = {
+  0: 'var(--space-0)',
+  half: 'var(--space-half)',
+  1: 'var(--space-1)',
+  2: 'var(--space-2)',
+  3: 'var(--space-3)',
+  4: 'var(--space-4)',
+  5: 'var(--space-5)',
+  6: 'var(--space-6)',
+  7: 'var(--space-7)',
+} as const;
+
+export const text = {
+  xs: 'var(--text-xs)',
+  sm: 'var(--text-sm)',
+  md: 'var(--text-md)',
+  lg: 'var(--text-lg)',
+  xl: 'var(--text-xl)',
+  xxl: 'var(--text-xxl)',
+} as const;
+
+export const radius = {
+  sm: 'var(--radius-sm)',
+  md: 'var(--radius-md)',
+  lg: 'var(--radius-lg)',
+} as const;

--- a/frontend/src/utils/svg/actionPinData.ts
+++ b/frontend/src/utils/svg/actionPinData.ts
@@ -19,6 +19,7 @@ import type {
     NodeMeta,
     UnsimulatedActionScoreInfo,
 } from '../../types';
+import { pinColors, pinColorsDimmed, pinColorsHighlighted } from '../../styles/tokens';
 import { getActionTargetLines, getActionTargetVoltageLevels } from './highlights';
 
 export interface ActionPinInfo {
@@ -66,35 +67,20 @@ export interface CombinedPinInfo {
     severity: ActionPinInfo['severity'];
 }
 
-export const severityFill: Record<ActionPinInfo['severity'], string> = {
-    green: '#28a745',
-    orange: '#f0ad4e',
-    red: '#dc3545',
-    grey: '#9ca3af',
-};
+export const severityFill: Record<ActionPinInfo['severity'], string> = pinColors;
 
 /**
  * Dimmed fill colours for rejected actions — each severity hue is
  * shifted toward grey and lowered in saturation so the pin recedes
  * visually while still being colour-identifiable.
  */
-export const severityFillDimmed: Record<ActionPinInfo['severity'], string> = {
-    green: '#a3c9ab',
-    orange: '#dcd0b8',
-    red: '#d4a5ab',
-    grey: '#c8cdd2',
-};
+export const severityFillDimmed: Record<ActionPinInfo['severity'], string> = pinColorsDimmed;
 
 /**
  * Highlighted (selected) fill colours — slightly more vivid/brighter
  * versions of the severity palette so the pin stands out.
  */
-export const severityFillHighlighted: Record<ActionPinInfo['severity'], string> = {
-    green: '#1e9e3a',
-    orange: '#e89e20',
-    red: '#c82333',
-    grey: '#7b8a96',
-};
+export const severityFillHighlighted: Record<ActionPinInfo['severity'], string> = pinColorsHighlighted;
 
 export const computeActionSeverity = (
     details: ActionDetail,

--- a/frontend/src/utils/svg/actionPinRender.ts
+++ b/frontend/src/utils/svg/actionPinRender.ts
@@ -11,6 +11,7 @@
  */
 
 import type { MetadataIndex } from '../../types';
+import { pinChrome } from '../../styles/tokens';
 import { getIdMap } from './idMap';
 import {
     severityFill,
@@ -323,7 +324,7 @@ const buildPinGlyph = (
     inner.setAttribute('cx', '0');
     inner.setAttribute('cy', String(-R - tail));
     inner.setAttribute('r', String(R * 0.72));
-    inner.setAttribute('fill', '#ffffff');
+    inner.setAttribute('fill', pinChrome.glyphBg);
     inner.setAttribute('fill-opacity', '0.92');
     inner.setAttribute('pointer-events', 'none');
     body.appendChild(inner);
@@ -336,7 +337,7 @@ const buildPinGlyph = (
     text.setAttribute('font-size', String(labelFont));
     text.setAttribute('font-weight', '800');
     text.setAttribute('font-family', 'system-ui, -apple-system, Arial, sans-serif');
-    text.setAttribute('fill', '#1f2937');
+    text.setAttribute('fill', pinChrome.glyphText);
     text.setAttribute('pointer-events', 'none');
     text.textContent = label;
     body.appendChild(text);
@@ -348,7 +349,7 @@ const resolvePinFill = (
     isRejected: boolean,
     isDimmedByFilter: boolean = false,
 ): { fill: string; stroke?: string } => {
-    if (isSelected) return { fill: severityFillHighlighted[severity], stroke: '#eab308' };
+    if (isSelected) return { fill: severityFillHighlighted[severity], stroke: pinChrome.gold };
     // Filter-dimmed constituents reuse the same washed-out palette as
     // rejected pins so the operator reads them as "context, not a
     // first-class action" at a glance.
@@ -468,16 +469,16 @@ const renderUnitaryPin = (
     if (isSelected) {
         const starEl = document.createElementNS(SVG_NS, 'path');
         starEl.setAttribute('d', starPath(0, symbolCy, R * 0.45));
-        starEl.setAttribute('fill', '#eab308');
-        starEl.setAttribute('stroke', '#a16207');
+        starEl.setAttribute('fill', pinChrome.gold);
+        starEl.setAttribute('stroke', pinChrome.goldDark);
         starEl.setAttribute('stroke-width', String(R * 0.05));
         starEl.setAttribute('pointer-events', 'none');
         body.appendChild(starEl);
     } else if (isRejected) {
         const crossEl = document.createElementNS(SVG_NS, 'path');
         crossEl.setAttribute('d', crossPath(0, symbolCy, R * 0.35));
-        crossEl.setAttribute('fill', '#ef4444');
-        crossEl.setAttribute('stroke', '#b91c1c');
+        crossEl.setAttribute('fill', pinChrome.crossFill);
+        crossEl.setAttribute('stroke', pinChrome.crossStroke);
         crossEl.setAttribute('stroke-width', String(R * 0.05));
         crossEl.setAttribute('pointer-events', 'none');
         body.appendChild(crossEl);
@@ -526,7 +527,7 @@ const renderUnsimulatedPin = (
     g.appendChild(body);
 
     const fill = severityFillDimmed[pin.severity];
-    buildPinGlyph(body, r, labelFont, fill, pin.label, pin.title, '#6b7280', r * 0.08);
+    buildPinGlyph(body, r, labelFont, fill, pin.label, pin.title, pinChrome.strokeNeutral, r * 0.08);
 
     // Override the stroke with a dashed pattern to visually
     // distinguish un-simulated pins from the solid-outline simulated

--- a/scripts/check_code_quality.py
+++ b/scripts/check_code_quality.py
@@ -22,17 +22,18 @@ Thresholds (see also CONTRIBUTING.md):
 | Frontend component size (lines)            | 1500|
 | `any` type annotations in frontend source  |  0  |
 | `@ts-ignore` directives in frontend source |  0  |
-| Hex color literals outside tokens.css      | 56  |
+| Hex color literals outside tokens.{css,ts} |  0  |
 
 `App.tsx` is exempt from the frontend size ceiling — it is the state
-orchestration hub by design.
+orchestration hub by design. `tokens.css` and `tokens.ts` are the
+token-source-of-truth files and are exempt from the hex-literal
+count.
 
-The hex-literal ceiling is a ratchet: it encodes the count after the
-Phase A + B token migrations (see docs/proposals/ui-design-critique.md
-recommendation #1). Lowering it as more files migrate is welcome and
-required when the count drops; raising it is a regression — add the
-new color to `frontend/src/styles/tokens.css` and consume it via
-`var(--…)` instead of inlining a hex.
+The hex-literal ceiling is now zero — every colour in frontend
+source must come from a named token in
+`frontend/src/styles/tokens.{css,ts}`. Adding a new colour means
+defining it in tokens first, then importing it; raising this ceiling
+is a regression.
 """
 from __future__ import annotations
 
@@ -45,18 +46,13 @@ from code_quality_report import build_report  # type: ignore[import-not-found]
 BACKEND_MODULE_MAX = 1200
 FRONTEND_COMPONENT_MAX = 1500
 FRONTEND_UTIL_MAX = 2000
-# Ceiling on hex color literals in frontend source (excluding
-# `frontend/src/styles/tokens.css`, the token-definition file). Set to
-# the count after Phase A + B of the design-token migration. This is
-# a ratchet — lowering it as files migrate is welcome and required
-# when the count drops; raising it is a regression.
-#
-# The remaining 56 are concentrated in three SVG-emitting files
-# (utils/svg/actionPin{Data,Render}.ts and
-# components/ActionOverviewDiagram.tsx), pending a Phase C
-# pin-palette extension to tokens.css — see
-# docs/proposals/ui-design-critique.md.
-FRONTEND_HEX_LITERAL_MAX = 56
+# Ceiling on hex color literals in frontend source. The
+# token-source-of-truth files (`frontend/src/styles/tokens.css` and
+# `frontend/src/styles/tokens.ts`) are exempt — they ARE the named
+# palette every other file consumes. Phase A + B + C of the
+# design-token migration drove this to zero; new colours must be
+# added to the token files first, then imported.
+FRONTEND_HEX_LITERAL_MAX = 0
 # Files exempt from the component-size ceiling. `App.tsx` is the state
 # orchestration hub by design; `utils/svgUtils.ts` is a stable shared
 # util library (SVG helpers, highlight ops, metadata parsing) and is

--- a/scripts/check_code_quality.py
+++ b/scripts/check_code_quality.py
@@ -22,9 +22,17 @@ Thresholds (see also CONTRIBUTING.md):
 | Frontend component size (lines)            | 1500|
 | `any` type annotations in frontend source  |  0  |
 | `@ts-ignore` directives in frontend source |  0  |
+| Hex color literals outside tokens.css      | 518 |
 
 `App.tsx` is exempt from the frontend size ceiling — it is the state
 orchestration hub by design.
+
+The hex-literal ceiling is a ratchet: it encodes the count after the
+Phase A token migration (see docs/proposals/ui-design-critique.md
+recommendation #1). Lowering it as more files migrate is welcome and
+required when the count drops; raising it is a regression — add the
+new color to `frontend/src/styles/tokens.css` and consume it via
+`var(--…)` instead of inlining a hex.
 """
 from __future__ import annotations
 
@@ -37,6 +45,12 @@ from code_quality_report import build_report  # type: ignore[import-not-found]
 BACKEND_MODULE_MAX = 1200
 FRONTEND_COMPONENT_MAX = 1500
 FRONTEND_UTIL_MAX = 2000
+# Ceiling on hex color literals in frontend source (excluding
+# `frontend/src/styles/tokens.css`, the token-definition file). Set to
+# the count after Phase A of the design-token migration. This is a
+# ratchet — lowering it as files migrate is welcome and required when
+# the count drops; raising it is a regression.
+FRONTEND_HEX_LITERAL_MAX = 518
 # Files exempt from the component-size ceiling. `App.tsx` is the state
 # orchestration hub by design; `utils/svgUtils.ts` is a stable shared
 # util library (SVG helpers, highlight ops, metadata parsing) and is
@@ -77,6 +91,15 @@ def main() -> int:
         )
     if fe.ts_ignores:
         errors.append(f"frontend: {fe.ts_ignores} `@ts-ignore` directives")
+    if fe.hex_literals > FRONTEND_HEX_LITERAL_MAX:
+        worst = ", ".join(
+            f"{fm.path}({fm.lines})" for fm in fe.hex_literals_by_file[:3]
+        )
+        errors.append(
+            f"frontend: {fe.hex_literals} hex color literals "
+            f"(ceiling {FRONTEND_HEX_LITERAL_MAX}) — replace with tokens "
+            f"from `frontend/src/styles/tokens.css`. Worst offenders: {worst}"
+        )
     for comp in fe.components:
         if comp.path in FRONTEND_SIZE_EXEMPTIONS:
             continue

--- a/scripts/check_code_quality.py
+++ b/scripts/check_code_quality.py
@@ -22,13 +22,13 @@ Thresholds (see also CONTRIBUTING.md):
 | Frontend component size (lines)            | 1500|
 | `any` type annotations in frontend source  |  0  |
 | `@ts-ignore` directives in frontend source |  0  |
-| Hex color literals outside tokens.css      | 518 |
+| Hex color literals outside tokens.css      | 56  |
 
 `App.tsx` is exempt from the frontend size ceiling — it is the state
 orchestration hub by design.
 
 The hex-literal ceiling is a ratchet: it encodes the count after the
-Phase A token migration (see docs/proposals/ui-design-critique.md
+Phase A + B token migrations (see docs/proposals/ui-design-critique.md
 recommendation #1). Lowering it as more files migrate is welcome and
 required when the count drops; raising it is a regression — add the
 new color to `frontend/src/styles/tokens.css` and consume it via
@@ -47,10 +47,16 @@ FRONTEND_COMPONENT_MAX = 1500
 FRONTEND_UTIL_MAX = 2000
 # Ceiling on hex color literals in frontend source (excluding
 # `frontend/src/styles/tokens.css`, the token-definition file). Set to
-# the count after Phase A of the design-token migration. This is a
-# ratchet — lowering it as files migrate is welcome and required when
-# the count drops; raising it is a regression.
-FRONTEND_HEX_LITERAL_MAX = 518
+# the count after Phase A + B of the design-token migration. This is
+# a ratchet — lowering it as files migrate is welcome and required
+# when the count drops; raising it is a regression.
+#
+# The remaining 56 are concentrated in three SVG-emitting files
+# (utils/svg/actionPin{Data,Render}.ts and
+# components/ActionOverviewDiagram.tsx), pending a Phase C
+# pin-palette extension to tokens.css — see
+# docs/proposals/ui-design-critique.md.
+FRONTEND_HEX_LITERAL_MAX = 56
 # Files exempt from the component-size ceiling. `App.tsx` is the state
 # orchestration hub by design; `utils/svgUtils.ts` is a stable shared
 # util library (SVG helpers, highlight ops, metadata parsing) and is

--- a/scripts/code_quality_report.py
+++ b/scripts/code_quality_report.py
@@ -52,12 +52,19 @@ AS_UNKNOWN_RE = re.compile(r"as\s+unknown\s+as\b")
 RECORD_STR_UNK_RE = re.compile(r"Record<string,\s*unknown>")
 # Hex color literals: #RGB, #RGBA, #RRGGBB, #RRGGBBAA. Excludes HTML
 # numeric entities like `&#9881;` via the negative lookbehind.
-# `frontend/src/styles/tokens.css` is the source of truth and is
-# exempt from the count (see FRONTEND_HEX_EXEMPT_FILES).
+# Token-source-of-truth files are exempt from the count (see
+# FRONTEND_HEX_EXEMPT_FILES).
 HEX_LITERAL_RE = re.compile(
     r"(?<![\w&#])#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})\b"
 )
-FRONTEND_HEX_EXEMPT_FILES = {"frontend/src/styles/tokens.css"}
+FRONTEND_HEX_EXEMPT_FILES = {
+    "frontend/src/styles/tokens.css",
+    # `tokens.ts` carries the raw-hex pin palette consumed by
+    # `setAttribute('fill', …)` calls in utils/svg/actionPin*.ts,
+    # which can't reliably resolve var() inside SVG presentation
+    # attributes. See the comment block in tokens.ts.
+    "frontend/src/styles/tokens.ts",
+}
 
 
 def _count_python_smells(tree: ast.AST) -> tuple[int, int, int]:

--- a/scripts/code_quality_report.py
+++ b/scripts/code_quality_report.py
@@ -50,6 +50,14 @@ ANY_TYPE_RE = re.compile(r":\s*any\b|<\s*any\s*>|\bany\[\]")
 TS_IGNORE_RE = re.compile(r"@ts-ignore")
 AS_UNKNOWN_RE = re.compile(r"as\s+unknown\s+as\b")
 RECORD_STR_UNK_RE = re.compile(r"Record<string,\s*unknown>")
+# Hex color literals: #RGB, #RGBA, #RRGGBB, #RRGGBBAA. Excludes HTML
+# numeric entities like `&#9881;` via the negative lookbehind.
+# `frontend/src/styles/tokens.css` is the source of truth and is
+# exempt from the count (see FRONTEND_HEX_EXEMPT_FILES).
+HEX_LITERAL_RE = re.compile(
+    r"(?<![\w&#])#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})\b"
+)
+FRONTEND_HEX_EXEMPT_FILES = {"frontend/src/styles/tokens.css"}
 
 
 def _count_python_smells(tree: ast.AST) -> tuple[int, int, int]:
@@ -127,6 +135,8 @@ class FrontendReport:
     record_str_unknown: int = 0
     test_files: int = 0
     source_files: int = 0
+    hex_literals: int = 0
+    hex_literals_by_file: list[FileMetric] = field(default_factory=list)
 
 
 @dataclass
@@ -162,6 +172,20 @@ def iter_frontend_tests() -> list[Path]:
     if not FRONTEND_SRC_ROOT.is_dir():
         return []
     return sorted(p for p in FRONTEND_SRC_ROOT.rglob("*") if ".test." in p.name)
+
+
+def iter_frontend_styled_sources() -> list[Path]:
+    """Source files where hex-color literals can occur — .ts/.tsx/.css."""
+    if not FRONTEND_SRC_ROOT.is_dir():
+        return []
+    files = []
+    for p in FRONTEND_SRC_ROOT.rglob("*"):
+        if p.suffix not in {".ts", ".tsx", ".css"}:
+            continue
+        if ".test." in p.name:
+            continue
+        files.append(p)
+    return sorted(files)
 
 
 def extract_longest_functions(path: Path, top_n: int = 5) -> list[FunctionMetric]:
@@ -250,6 +274,22 @@ def scan_frontend() -> FrontendReport:
     if rep.components:
         rep.largest_component = rep.components[0]
     rep.test_files = len(iter_frontend_tests())
+
+    # Count hex literals across .ts/.tsx/.css sources, excluding the
+    # token-definition file (the source of truth for hex values).
+    for path in iter_frontend_styled_sources():
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel in FRONTEND_HEX_EXEMPT_FILES:
+            continue
+        try:
+            src = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        hits = len(HEX_LITERAL_RE.findall(src))
+        if hits:
+            rep.hex_literals += hits
+            rep.hex_literals_by_file.append(FileMetric(path=rel, lines=hits))
+    rep.hex_literals_by_file.sort(key=lambda m: m.lines, reverse=True)
     return rep
 
 
@@ -310,9 +350,22 @@ def to_markdown(report: QualityReport) -> str:
             f"- `@ts-ignore` directives: **{fe.ts_ignores}**",
             f"- `as unknown as` casts: **{fe.weak_casts}**",
             f"- `Record<string, unknown>` usages: **{fe.record_str_unknown}**",
+            f"- Hex color literals (outside tokens.css): **{fe.hex_literals}**",
             "",
         ]
     )
+    if fe.hex_literals_by_file:
+        lines.extend(
+            [
+                "### Top files by hex-literal count",
+                "",
+                "| File | Hex literals |",
+                "|------|-------------:|",
+            ]
+        )
+        for fm in fe.hex_literals_by_file[:10]:
+            lines.append(f"| `{fm.path}` | {fm.lines} |")
+        lines.append("")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

Implements [recommendation #1](docs/proposals/ui-design-critique.md) of the UI design critique: stand up a design-token layer and migrate every inline hex literal in the frontend to a named token. Three commits, three phases:

- **Phase A** (`47a2700`) — token scaffold + global CSS + 4 representative components. **654 → 518** hex literals.
- **Phase B** (`0e60059`) — 14 inline-style components + test-assertion updates. **518 → 56**.
- **Phase C** (`b8de481`) — 3 SVG-emitting files + dark-mode placeholder. **56 → 0**.

## What's in `frontend/src/styles/tokens.{css,ts}`

- ~24 semantic colours, consolidated onto the **Tailwind blue ramp** for brand (the critique's recommended palette). Bootstrap-aligned `success` / `warning` / `danger` triplets. Three new families introduced during the migration: `info` (cyan, for curtailment edit rows), `accent-soft/border/text` (purple, for PST tap edits), and `signal-action-target-strong/darker/soft` (pink hierarchy).
- 4/8 spacing scale (`--space-1` … `--space-7` plus `--space-half`).
- 6 type sizes (`--text-xs` 11 … `--text-xxl` 24).
- 3 radii (`--radius-sm` 4, `--radius-md` 6, `--radius-lg` 8).
- Diagram-signal colours (overload, contingency, action-target, breaker, deltas).
- Action-overview pin palette (severity green/orange/red/grey × base/dimmed/highlighted, plus pin chrome — glyph background, label text, gold star, rejected cross, neutral stroke). These live in `tokens.ts` as raw hex values because browsers don't reliably resolve `var(--…)` inside SVG presentation attributes set via `setAttribute`, and unit tests assert on `getAttribute('fill')`. `tokens.css` mirrors them as `--pin-*` for future CSS-only consumers.

## Quality gate

`scripts/check_code_quality.py` now refuses to let any new hex literal land outside the two token files. The ceiling is **zero** — every colour must come from a named token. `tokens.css` and `tokens.ts` are the only exempt files.

```
| Hex color literals outside tokens.{css,ts} |  0  |
```

## Visual changes (intentional)

The migration consolidates three competing palettes (Flat UI, Bootstrap, Tailwind) onto one. Some buttons / pills shift slightly:
- Brand blues converge on Tailwind `#1e40af` — Flat-UI `#3498db` and Bootstrap `#007bff` no longer appear in source.
- Severity reds converge on Bootstrap `#dc3545` — Flat-UI `#e74c3c` no longer appears.
- Severity greens converge on Bootstrap `#28a745` — Flat-UI `#27ae60` no longer appears.

Pin colours (the SVG attribute-emitting kind) are byte-identical to the previous values, so the action-overview map looks unchanged.

## Test plan

- [x] `npm run lint` — clean.
- [x] `tsc -b` — clean.
- [x] `npm run test` — 1100 pass / 75 pre-existing localStorage-jsdom failures unrelated to this work (verified by stashing the branch and running on `main` — same 75/1100 split).
- [x] `python3 scripts/check_code_quality.py` — passes at the new zero-hex ceiling.
- [x] Component-level tests for every migrated file: ActionCard (31), ActionFeed (101), ActionSearchDropdown (25), ExplorePairsTab (37), VisualizationPanel (59), OverloadPanel (14), ComputedPairsTable (16), SldOverlay (34), CombinedActionsModal (18), ErrorBoundary (7), ActionTypeFilterChips (5), ActionCardPopover (8), SettingsModal (11), ActionOverviewDiagram (82) — all green.
- [ ] **Manual visual smoke-test recommended** before merge: load `bare_env_small_grid_test`, run a contingency analysis, open the Combine modal, hover a few action cards, open SLD overlay. Watch for any unintended colour shift.

## Reviewer notes

- The critique doc ([`docs/proposals/ui-design-critique.md`](docs/proposals/ui-design-critique.md)) carries the full status entry at the top — it's the running record for recommendation #1.
- For tests that previously asserted on resolved RGB (`'rgb(220, 53, 69)'`), the new assertions read the `var(--color-…)` string directly. jsdom returns inline-style values verbatim, so this is more robust than the RGB form (which broke whenever the underlying token value moved).
- New colours? Add them to `tokens.css` first, mirror in `tokens.ts`, then import. The gate will reject hex literals introduced anywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)