### PR TITLE
Redesign ActionCard with progressive disclosure and severity icons

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -185,6 +185,58 @@ circle.nad-highlight {
     stroke-linejoin: round !important;
 }
 
+/* At zoomed-in tiers (region + detail) the grid-unit halo strokes
+   above (120 / 150 px in user-space coordinates) cover so much of
+   the network they obscure the very lines they identify. Switch
+   to a screen-space stroke capped at 24px so the halo stays a
+   reading aid instead of a smear. The base
+   `.svg-container svg path { vector-effect: non-scaling-stroke }`
+   rule does NOT apply here because pypowsybl appends its own
+   inline `<style>` block AFTER App.css that re-asserts the
+   default `vector-effect: none` on equipment paths — so we set
+   it !important on the halos themselves. */
+[data-zoom-tier="region"] .nad-overloaded path,
+[data-zoom-tier="region"] .nad-overloaded line,
+[data-zoom-tier="region"] .nad-overloaded polyline,
+[data-zoom-tier="region"] .nad-overloaded rect,
+[data-zoom-tier="region"] .nad-overloaded polygon,
+[data-zoom-tier="detail"] .nad-overloaded path,
+[data-zoom-tier="detail"] .nad-overloaded line,
+[data-zoom-tier="detail"] .nad-overloaded polyline,
+[data-zoom-tier="detail"] .nad-overloaded rect,
+[data-zoom-tier="detail"] .nad-overloaded polygon {
+    stroke-width: 24px !important;
+    vector-effect: non-scaling-stroke !important;
+}
+
+[data-zoom-tier="region"] .nad-action-target path,
+[data-zoom-tier="region"] .nad-action-target line,
+[data-zoom-tier="region"] .nad-action-target polyline,
+[data-zoom-tier="region"] .nad-action-target rect,
+[data-zoom-tier="region"] .nad-action-target polygon,
+[data-zoom-tier="detail"] .nad-action-target path,
+[data-zoom-tier="detail"] .nad-action-target line,
+[data-zoom-tier="detail"] .nad-action-target polyline,
+[data-zoom-tier="detail"] .nad-action-target rect,
+[data-zoom-tier="detail"] .nad-action-target polygon {
+    stroke-width: 24px !important;
+    vector-effect: non-scaling-stroke !important;
+}
+
+[data-zoom-tier="region"] .nad-contingency-highlight path,
+[data-zoom-tier="region"] .nad-contingency-highlight line,
+[data-zoom-tier="region"] .nad-contingency-highlight polyline,
+[data-zoom-tier="region"] .nad-contingency-highlight rect,
+[data-zoom-tier="region"] .nad-contingency-highlight polygon,
+[data-zoom-tier="detail"] .nad-contingency-highlight path,
+[data-zoom-tier="detail"] .nad-contingency-highlight line,
+[data-zoom-tier="detail"] .nad-contingency-highlight polyline,
+[data-zoom-tier="detail"] .nad-contingency-highlight rect,
+[data-zoom-tier="detail"] .nad-contingency-highlight polygon {
+    stroke-width: 24px !important;
+    vector-effect: non-scaling-stroke !important;
+}
+
 /* For nodes (circles and rects), add a screen-space stroke to create a glowing
    background halo that doesn't shrink into invisibility on large grids. */
 .nad-action-target circle,
@@ -532,6 +584,29 @@ circle.nad-highlight {
     background: rgba(220, 220, 220, 0.95);
     color: var(--color-text-primary);
 }
+/* ============================================================
+   ActionCard progressive disclosure
+   ============================================================
+   The star (⭐) and reject (✕) controls live in a "rail" that
+   fades in on hover, on focus, and whenever the card is the
+   currently-viewed action. This trims the at-rest visual load
+   to five fields (rank, ID, severity, max ρ, primary target)
+   while keeping the controls a single mouse-move away.
+
+   Implemented in CSS (not React state) so hover doesn't trigger
+   a re-render on every card. */
+.action-card-rail {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+}
+.action-card:hover .action-card-rail,
+.action-card:focus-within .action-card-rail,
+.action-card.is-viewing .action-card-rail {
+    opacity: 1;
+    pointer-events: auto;
+}
+
 /* ============================================================
    Action-overview pins (Remedial Action tab, no card selected)
    ============================================================ */

--- a/frontend/src/components/ActionCard.test.tsx
+++ b/frontend/src/components/ActionCard.test.tsx
@@ -56,10 +56,21 @@ describe('ActionCard', () => {
         onResimulateTap: vi.fn(),
     };
 
-    it('renders action card with description and id', () => {
+    it('renders the action card with index and id in the header', () => {
         render(<ActionCard {...defaultProps} />);
-        expect(screen.getByText('Open line L1')).toBeInTheDocument();
         expect(screen.getByTestId('action-card-act_1')).toBeInTheDocument();
+        expect(screen.getByText(/^#1/)).toBeInTheDocument();
+    });
+
+    it('hides the description at rest (progressive disclosure)', () => {
+        render(<ActionCard {...defaultProps} />);
+        expect(screen.queryByText('Open line L1')).not.toBeInTheDocument();
+    });
+
+    it('reveals the description and disclosure region when viewing', () => {
+        render(<ActionCard {...defaultProps} isViewing={true} />);
+        expect(screen.getByText('Open line L1')).toBeInTheDocument();
+        expect(screen.getByTestId('action-card-act_1-disclosure')).toBeInTheDocument();
     });
 
     it('displays action index and id in header', () => {
@@ -98,42 +109,38 @@ describe('ActionCard', () => {
         expect(screen.getByText(/12\.5 MW disconnected/)).toBeInTheDocument();
     });
 
-    it('shows VIEWING indicator when isViewing is true', () => {
+    it('marks the card with data-viewing="true" when isViewing is true', () => {
+        // The viewing-state signal is now a higher-saturation left-edge
+        // accent stripe + a `data-viewing` attribute on the card root,
+        // not the old vertical "VIEWING" ribbon.  Replacing the ribbon
+        // was the largest scannability win in the progressive-disclosure
+        // pass (docs/proposals/ui-design-critique.md, recommendation 2).
         render(<ActionCard {...defaultProps} isViewing={true} />);
-        expect(screen.getByText('VIEWING')).toBeInTheDocument();
-    });
-
-    it('does not show VIEWING indicator when isViewing is false', () => {
-        render(<ActionCard {...defaultProps} isViewing={false} />);
+        expect(screen.getByTestId('action-card-act_1')).toHaveAttribute('data-viewing', 'true');
         expect(screen.queryByText('VIEWING')).not.toBeInTheDocument();
     });
 
-    it('renders the VIEWING marker as a vertical ribbon on the left edge', () => {
-        // The ribbon sits flush against the left border to free a full
-        // row of horizontal space inside the card header (long action
-        // IDs on a narrow sidebar).  It must be a sibling of the
-        // content column — not inside the header — and must use
-        // vertical writing mode.
-        render(<ActionCard {...defaultProps} isViewing={true} />);
-        const ribbon = screen.getByTestId('action-card-act_1-viewing-ribbon');
-        expect(ribbon).toBeInTheDocument();
-        expect(ribbon).toHaveTextContent('VIEWING');
-        expect(ribbon).toHaveStyle({ writingMode: 'vertical-rl' });
-
-        // And the inline top-right VIEWING pill is gone (the severity
-        // badge — "Solves overload" — is still rendered next to the
-        // title, but not the old rectangular "VIEWING" pill).
-        const card = screen.getByTestId('action-card-act_1');
-        const inlinePill = card.querySelectorAll('span');
-        const pillTexts = Array.from(inlinePill).map(el => el.textContent);
-        // The vertical ribbon is a <div>, not a <span>, so no <span>
-        // should contain exactly "VIEWING".
-        expect(pillTexts).not.toContain('VIEWING');
+    it('marks the card with data-viewing="false" when isViewing is false', () => {
+        render(<ActionCard {...defaultProps} isViewing={false} />);
+        expect(screen.getByTestId('action-card-act_1')).toHaveAttribute('data-viewing', 'false');
+        expect(screen.queryByText('VIEWING')).not.toBeInTheDocument();
     });
 
-    it('does not render the vertical ribbon when isViewing is false', () => {
+    it('does not render the disclosure region when isViewing is false', () => {
         render(<ActionCard {...defaultProps} isViewing={false} />);
-        expect(screen.queryByTestId('action-card-act_1-viewing-ribbon')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('action-card-act_1-disclosure')).not.toBeInTheDocument();
+    });
+
+    it('hosts the star/reject buttons in a hover-revealed rail (always present in DOM)', () => {
+        // The rail's visibility is controlled by CSS (`.action-card-rail`
+        // → opacity 0/1 driven by :hover and .is-viewing on the card).
+        // The buttons remain in the DOM at all times so keyboard /
+        // automation users can reach them.
+        const { container } = render(<ActionCard {...defaultProps} />);
+        const rail = container.querySelector('.action-card-rail');
+        expect(rail).not.toBeNull();
+        expect(screen.getByTitle('Select this action')).toBeInTheDocument();
+        expect(screen.getByTitle('Reject this action')).toBeInTheDocument();
     });
 
     it('calls onActionSelect when card is clicked', () => {
@@ -180,7 +187,6 @@ describe('ActionCard', () => {
     it('displays max loading percentage and line name', () => {
         render(<ActionCard {...defaultProps} />);
         expect(screen.getByText('Max loading:')).toBeInTheDocument();
-        // Multiple elements contain 85.0% (rho_after + max_rho); check at least one is present
         expect(screen.getAllByText(/85\.0%/).length).toBeGreaterThan(0);
         expect(screen.getAllByTitle('Zoom to LINE_A').length).toBeGreaterThan(0);
     });
@@ -222,47 +228,67 @@ describe('ActionCard', () => {
         expect(onAssetClick).toHaveBeenCalledWith('act_1', 'LINE_B', 'action');
     });
 
-    it('renders loading after rho section (loading before is shown in the sticky Overloads panel)', () => {
-        render(<ActionCard {...defaultProps} />);
+    it('renders loading after only inside the viewing disclosure', () => {
+        // At rest the "Loading after" detail is hidden — the per-card
+        // max ρ% summary above replaces it.  Only the viewing card
+        // expands the per-line breakdown.  "Loading before" remains in
+        // the sticky Overloads panel and never appears on the card.
+        const { rerender } = render(<ActionCard {...defaultProps} />);
+        expect(screen.queryByText(/Loading after/)).not.toBeInTheDocument();
         expect(screen.queryByText(/Loading before/)).not.toBeInTheDocument();
+
+        rerender(<ActionCard {...defaultProps} isViewing={true} />);
         expect(screen.getByText(/Loading after/)).toBeInTheDocument();
+        expect(screen.queryByText(/Loading before/)).not.toBeInTheDocument();
     });
 
-    it('renders load shedding details with MW input and re-simulate button', () => {
+    it('renders load shedding details with MW input and re-simulate button when viewing', () => {
         const details: ActionDetail = {
             ...baseDetails,
             load_shedding_details: [
                 { load_name: 'LOAD_X', voltage_level_id: 'VL1', shedded_mw: 5.0 }
             ],
         };
-        render(<ActionCard {...defaultProps} details={details} />);
+        render(<ActionCard {...defaultProps} details={details} isViewing={true} />);
         expect(screen.getByText(/Shedding on/)).toBeInTheDocument();
         expect(screen.getByText('LOAD_X')).toBeInTheDocument();
         expect(screen.getByTestId('edit-mw-act_1')).toBeInTheDocument();
         expect(screen.getByTestId('resimulate-act_1')).toBeInTheDocument();
     });
 
-    it('renders curtailment details with MW input and re-simulate button', () => {
+    it('hides the load shedding editor at rest (progressive disclosure)', () => {
+        const details: ActionDetail = {
+            ...baseDetails,
+            load_shedding_details: [
+                { load_name: 'LOAD_X', voltage_level_id: 'VL1', shedded_mw: 5.0 }
+            ],
+        };
+        render(<ActionCard {...defaultProps} details={details} isViewing={false} />);
+        expect(screen.queryByText(/Shedding on/)).not.toBeInTheDocument();
+        expect(screen.queryByTestId('edit-mw-act_1')).not.toBeInTheDocument();
+    });
+
+    it('renders curtailment details with MW input and re-simulate button when viewing', () => {
         const details: ActionDetail = {
             ...baseDetails,
             curtailment_details: [
                 { gen_name: 'GEN_Y', voltage_level_id: 'VL2', curtailed_mw: 3.0 }
             ],
         };
-        render(<ActionCard {...defaultProps} details={details} />);
+        render(<ActionCard {...defaultProps} details={details} isViewing={true} />);
         expect(screen.getByText(/Curtailment on/)).toBeInTheDocument();
         expect(screen.getByText('GEN_Y')).toBeInTheDocument();
         expect(screen.getByTestId('edit-mw-act_1')).toBeInTheDocument();
     });
 
-    it('renders PST details with tap input and re-simulate button', () => {
+    it('renders PST details with tap input and re-simulate button when viewing', () => {
         const details: ActionDetail = {
             ...baseDetails,
             pst_details: [
                 { pst_name: 'PST_Z', tap_position: 5, low_tap: -10, high_tap: 10 }
             ],
         };
-        render(<ActionCard {...defaultProps} details={details} />);
+        render(<ActionCard {...defaultProps} details={details} isViewing={true} />);
         expect(screen.getByText('PST_Z')).toBeInTheDocument();
         expect(screen.getByTestId('edit-tap-act_1')).toBeInTheDocument();
         expect(screen.getByText('[-10..10]')).toBeInTheDocument();
@@ -276,7 +302,7 @@ describe('ActionCard', () => {
                 { load_name: 'LOAD_X', voltage_level_id: 'VL1', shedded_mw: 5.0 }
             ],
         };
-        render(<ActionCard {...defaultProps} details={details} onResimulate={onResimulate} />);
+        render(<ActionCard {...defaultProps} details={details} isViewing={true} onResimulate={onResimulate} />);
         fireEvent.click(screen.getByTestId('resimulate-act_1'));
         expect(onResimulate).toHaveBeenCalledWith('act_1', 5.0);
     });
@@ -289,7 +315,7 @@ describe('ActionCard', () => {
                 { pst_name: 'PST_Z', tap_position: 5, low_tap: -10, high_tap: 10 }
             ],
         };
-        render(<ActionCard {...defaultProps} details={details} onResimulateTap={onResimulateTap} />);
+        render(<ActionCard {...defaultProps} details={details} isViewing={true} onResimulateTap={onResimulateTap} />);
         fireEvent.click(screen.getByTestId('resimulate-tap-act_1'));
         expect(onResimulateTap).toHaveBeenCalledWith('act_1', 5);
     });
@@ -301,7 +327,7 @@ describe('ActionCard', () => {
                 { load_name: 'LOAD_X', voltage_level_id: 'VL1', shedded_mw: 5.0 }
             ],
         };
-        render(<ActionCard {...defaultProps} details={details} resimulating="act_1" />);
+        render(<ActionCard {...defaultProps} details={details} isViewing={true} resimulating="act_1" />);
         expect(screen.getByText('Simulating...')).toBeInTheDocument();
     });
 
@@ -313,7 +339,7 @@ describe('ActionCard', () => {
                 { load_name: 'LOAD_X', voltage_level_id: 'VL1', shedded_mw: 5.0 }
             ],
         };
-        render(<ActionCard {...defaultProps} details={details} onCardEditMwChange={onCardEditMwChange} />);
+        render(<ActionCard {...defaultProps} details={details} isViewing={true} onCardEditMwChange={onCardEditMwChange} />);
         fireEvent.change(screen.getByTestId('edit-mw-act_1'), { target: { value: '7.5' } });
         expect(onCardEditMwChange).toHaveBeenCalledWith('act_1', '7.5');
     });

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -48,6 +48,36 @@ const clickableLinkStyle: React.CSSProperties = {
     textDecoration: 'underline dotted',
 };
 
+type SeverityKind = 'solves' | 'lowMargin' | 'unsolved' | 'divergent' | 'islanded';
+
+const SeverityIcon: React.FC<{ kind: SeverityKind }> = ({ kind }) => {
+    const common = { width: 11, height: 11, viewBox: '0 0 16 16', 'aria-hidden': true } as const;
+    if (kind === 'solves') {
+        return (
+            <svg {...common}>
+                <circle cx="8" cy="8" r="7" fill="currentColor" fillOpacity="0.18" />
+                <path d="M4.5 8.2 L7 10.5 L11.5 5.8" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+        );
+    }
+    if (kind === 'lowMargin') {
+        return (
+            <svg {...common}>
+                <path d="M8 1.6 L15 13.5 L1 13.5 Z" fill="currentColor" fillOpacity="0.18" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+                <path d="M8 6 L8 9.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                <circle cx="8" cy="11.5" r="0.9" fill="currentColor" />
+            </svg>
+        );
+    }
+    // unsolved / divergent / islanded → X-circle
+    return (
+        <svg {...common}>
+            <circle cx="8" cy="8" r="7" fill="currentColor" fillOpacity="0.18" />
+            <path d="M5 5 L11 11 M11 5 L5 11" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+        </svg>
+    );
+};
+
 const ActionCard: React.FC<ActionCardProps> = ({
     id,
     details,
@@ -78,18 +108,18 @@ const ActionCard: React.FC<ActionCardProps> = ({
         ? (details.max_rho > monitoringFactor ? 'red' as const : details.max_rho > (monitoringFactor - 0.05) ? 'orange' as const : 'green' as const)
         : (details.is_rho_reduction ? 'green' as const : 'red' as const);
     const severityColors = {
-        green: { border: colors.success, badgeBg: colors.successSoft, badgeText: colors.successText, label: 'Solves overload' },
-        orange: { border: colors.warningStrong, badgeBg: colors.warningSoft, badgeText: colors.warningText, label: 'Solved \u2014 low margin' },
-        red: { border: colors.danger, badgeBg: colors.dangerSoft, badgeText: colors.dangerText, label: details.is_rho_reduction ? 'Still overloaded' : 'No reduction' },
+        green: { border: colors.success, badgeBg: colors.successSoft, badgeText: colors.successText, label: 'Solves overload', kind: 'solves' as SeverityKind },
+        orange: { border: colors.warningStrong, badgeBg: colors.warningSoft, badgeText: colors.warningText, label: 'Solved — low margin', kind: 'lowMargin' as SeverityKind },
+        red: { border: colors.danger, badgeBg: colors.dangerSoft, badgeText: colors.dangerText, label: details.is_rho_reduction ? 'Still overloaded' : 'No reduction', kind: 'unsolved' as SeverityKind },
     };
     const sc = details.non_convergence
-        ? { border: colors.danger, badgeBg: colors.danger, badgeText: colors.textOnBrand, label: 'divergent' }
+        ? { border: colors.danger, badgeBg: colors.danger, badgeText: colors.textOnBrand, label: 'divergent', kind: 'divergent' as SeverityKind }
         : details.is_islanded
-            ? { border: colors.danger, badgeBg: colors.danger, badgeText: colors.textOnBrand, label: 'islanded' }
+            ? { border: colors.danger, badgeBg: colors.danger, badgeText: colors.textOnBrand, label: 'islanded', kind: 'islanded' as SeverityKind }
             : severityColors[severity];
 
     const renderRho = (arr: number[] | null, actionId: string, tab: 'action' | 'n-1' = 'action'): React.ReactNode => {
-        if (!arr || arr.length === 0) return '\u2014';
+        if (!arr || arr.length === 0) return '—';
         return arr.map((v, i) => {
             const lineName = linesOverloaded[i] || `line ${i}`;
             return (
@@ -185,87 +215,143 @@ const ActionCard: React.FC<ActionCardProps> = ({
         }
 
         return (
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', flexShrink: 0, maxWidth: '180px', justifyContent: 'flex-end' }}>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', flexShrink: 0, justifyContent: 'flex-end' }}>
                 {badges}
             </div>
         );
     };
 
+    const isFault = !!(details.non_convergence || details.is_islanded);
+    // Higher-saturation accent stripe for the viewing card — replaces
+    // the old vertical "VIEWING" ribbon with a quieter signal that
+    // doesn't steal a column of horizontal space inside the card.
+    const accentColor = isViewing ? colors.brandStrong : sc.border;
+
+    const editorRowStyle: React.CSSProperties = {
+        fontSize: '12px',
+        padding: '6px 10px',
+        marginTop: '5px',
+        borderRadius: '4px',
+        fontWeight: 500,
+    };
+
     return (
         <div
             data-testid={`action-card-${id}`}
+            data-viewing={isViewing ? 'true' : 'false'}
+            className={`action-card${isViewing ? ' is-viewing' : ''}`}
             style={{
-                background: (details.non_convergence || details.is_islanded) ? colors.dangerSoft : (isViewing ? colors.brandSoft : colors.surface),
-                border: (details.non_convergence || details.is_islanded) ? `1px solid ${colors.danger}` : `1px solid ${colors.border}`,
+                background: isFault ? colors.dangerSoft : (isViewing ? colors.brandSoft : colors.surface),
+                border: isFault ? `1px solid ${colors.danger}` : `1px solid ${colors.border}`,
                 borderRadius: '8px',
                 marginBottom: '10px',
-                boxShadow: isViewing ? '0 0 0 2px rgba(0,123,255,0.3), 0 2px 8px rgba(0,0,0,0.15)' : '0 2px 4px rgba(0,0,0,0.1)',
-                borderLeft: `5px solid ${isViewing ? colors.brand : sc.border}`,
+                boxShadow: isViewing ? '0 2px 8px rgba(0,0,0,0.15)' : '0 2px 4px rgba(0,0,0,0.1)',
+                borderLeft: `5px solid ${accentColor}`,
                 cursor: 'pointer',
                 transition: 'all 0.15s ease',
-                display: 'flex',
-                alignItems: 'stretch',
                 overflow: 'hidden',
+                padding: '10px',
+                position: 'relative',
             }} onClick={() => onActionSelect(id)}>
-            {/*
-              When the card is the currently-viewed action, the
-              VIEWING marker is rendered as a vertical ribbon flush
-              against the left edge (between the colored border and
-              the content) — this frees up a full line of horizontal
-              space inside the header, which matters on a narrow
-              sidebar with long equipment IDs.
-
-              Implementation note: `writing-mode: vertical-rl` +
-              `transform: rotate(180deg)` yields bottom-to-top text
-              with letters rotated the "book-spine" way — the
-              cross-browser combination that works consistently on
-              Chromium / Firefox / Safari (unlike the newer
-              `sideways-lr`, which is still WebKit-patchy).
-            */}
-            {isViewing && (
-                <div
-                    data-testid={`action-card-${id}-viewing-ribbon`}
-                    style={{
-                        writingMode: 'vertical-rl',
-                        transform: 'rotate(180deg)',
-                        background: colors.brand,
-                        color: colors.textOnBrand,
-                        fontSize: '10px',
-                        fontWeight: 700,
-                        letterSpacing: '1.5px',
-                        padding: '8px 3px',
-                        textAlign: 'center',
-                        flexShrink: 0,
-                        userSelect: 'none',
-                    }}
-                    aria-label="Currently viewing this action"
-                >
-                    VIEWING
-                </div>
-            )}
-            <div style={{ flex: 1, padding: '10px', minWidth: 0 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '6px' }}>
                 <h4 style={{
                     margin: 0,
                     fontSize: '12px',
                     color: isViewing ? colors.brandStrong : undefined,
                     flex: 1,
                     minWidth: 0,
-                    overflowWrap: 'anywhere'
+                    overflowWrap: 'anywhere',
+                    fontWeight: 700,
                 }}>
-                    #{index + 1} {'\u2014'} {id}
+                    #{index + 1} {'—'} {id}
                 </h4>
-                <div style={{ display: 'flex', gap: '5px', alignItems: 'center' }}>
-                    <span style={{ fontSize: '11px', fontWeight: 600, padding: '2px 8px', borderRadius: '12px', background: sc.badgeBg, color: sc.badgeText }}>
-                        {sc.label}
-                    </span>
+                <span
+                    data-testid={`action-card-${id}-severity`}
+                    style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '4px',
+                        fontSize: '11px',
+                        fontWeight: 600,
+                        padding: '2px 8px',
+                        borderRadius: '12px',
+                        background: sc.badgeBg,
+                        color: sc.badgeText,
+                        flexShrink: 0,
+                    }}
+                >
+                    <SeverityIcon kind={sc.kind} />
+                    {sc.label}
+                </span>
+            </div>
+
+            {/* Compact at-rest body: max loading + target badges. The
+                rail (⭐ / ❌) sits to the right and fades in on
+                hover or when this card is being viewed. */}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', gap: '8px', marginTop: '6px' }}>
+                <div style={{ flex: 1, fontSize: '12px', minWidth: 0 }}>
+                    {maxRhoPct != null ? (
+                        <div>
+                            Max loading: <strong style={{ color: sc.border }}>{maxRhoPct}%</strong>
+                            {details.max_rho_line && (
+                                <span style={{ color: colors.textTertiary }}> on <button
+                                    style={{ ...clickableLinkStyle, color: colors.textTertiary }}
+                                    title={`Zoom to ${details.max_rho_line}`}
+                                    onClick={(e) => { e.stopPropagation(); onAssetClick(id, details.max_rho_line, 'action'); }}
+                                >{displayName(details.max_rho_line)}</button></span>
+                            )}
+                        </div>
+                    ) : (
+                        <div style={{ color: colors.textTertiary }}>No loading metric</div>
+                    )}
+                </div>
+                {renderBadges()}
+                <div className="action-card-rail" style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
+                    {!isSelected && (
+                        <button
+                            onClick={(e) => { e.stopPropagation(); onActionFavorite(id); }}
+                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                            title="Select this action"
+                        ><span style={{ fontSize: '14px' }}>⭐</span></button>
+                    )}
+                    {!isRejected && (
+                        <button
+                            onClick={(e) => { e.stopPropagation(); onActionReject(id); }}
+                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                            title={isSelected ? "Remove from selected" : "Reject this action"}
+                        ><span style={{ fontSize: '14px' }}>❌</span></button>
+                    )}
                 </div>
             </div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', margin: '4px 0 5px' }}>
-                <div style={{ flex: 1 }}>
-                    <p style={{ fontSize: '12px', margin: 0 }}>{details.description_unitaire}</p>
+
+            {/* Fault states (divergent / islanded) are primary signals
+                and stay visible regardless of the viewing-state — they
+                replace the missing max-loading indicator. */}
+            {details.non_convergence && (
+                <div style={{ fontSize: '11px', color: colors.warningText, backgroundColor: colors.warningSoft, padding: '2px 6px', borderRadius: '4px', marginTop: '6px', border: `1px solid ${colors.warningBorder}`, display: 'inline-block' }}>
+                    ⚠️ LoadFlow failure: {details.non_convergence}
+                </div>
+            )}
+            {details.is_islanded && (
+                <div style={{ fontSize: '12px', background: colors.dangerSoft, color: colors.danger, padding: '6px 10px', marginTop: '6px', borderRadius: '4px', border: `1px solid ${colors.danger}`, fontWeight: 500 }}>
+                    🏝️ Islanding detected ({details.disconnected_mw?.toFixed(1)} MW disconnected)
+                </div>
+            )}
+
+            {/* Progressive disclosure: description, parameter editors,
+                and per-line "Loading after" only render on the viewing
+                card. Keeps non-viewing cards to five fields each. */}
+            {isViewing && (
+                <div
+                    data-testid={`action-card-${id}-disclosure`}
+                    style={{ marginTop: '8px', borderTop: `1px solid ${colors.borderSubtle}`, paddingTop: '8px' }}
+                    onClick={(e) => e.stopPropagation()}
+                    onMouseDown={(e) => e.stopPropagation()}
+                >
+                    <p style={{ fontSize: '12px', margin: 0, color: colors.textPrimary }}>{details.description_unitaire}</p>
+
                     {details.load_shedding_details && details.load_shedding_details.length > 0 && (
-                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: colors.warningSoft, color: colors.warningText, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.warningBorder}`, fontWeight: 500 }}>
+                        <div style={{ ...editorRowStyle, background: colors.warningSoft, color: colors.warningText, border: `1px solid ${colors.warningBorder}` }}>
                             {details.load_shedding_details.map((ls, i) => (
                                 <div key={ls.load_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
                                     <span>Shedding on <strong>{ls.load_name}</strong> in MW:</span>
@@ -293,8 +379,9 @@ const ActionCard: React.FC<ActionCardProps> = ({
                             ))}
                         </div>
                     )}
+
                     {details.curtailment_details && details.curtailment_details.length > 0 && (
-                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: colors.infoSoft, color: colors.infoText, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.infoBorder}`, fontWeight: 500 }}>
+                        <div style={{ ...editorRowStyle, background: colors.infoSoft, color: colors.infoText, border: `1px solid ${colors.infoBorder}` }}>
                             {details.curtailment_details.map((rc, i) => (
                                 <div key={rc.gen_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
                                     <span>Curtailment on <strong>{rc.gen_name}</strong> in MW:</span>
@@ -322,8 +409,9 @@ const ActionCard: React.FC<ActionCardProps> = ({
                             ))}
                         </div>
                     )}
+
                     {details.pst_details && details.pst_details.length > 0 && (
-                        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()} style={{ fontSize: '12px', background: colors.accentSoft, color: colors.accentText, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.accentBorder}`, fontWeight: 500 }}>
+                        <div style={{ ...editorRowStyle, background: colors.accentSoft, color: colors.accentText, border: `1px solid ${colors.accentBorder}` }}>
                             {details.pst_details.map((pst, i) => (
                                 <div key={pst.pst_name} style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', marginTop: i > 0 ? '4px' : 0 }}>
                                     <span>PST <strong>{pst.pst_name}</strong> tap:</span>
@@ -357,59 +445,16 @@ const ActionCard: React.FC<ActionCardProps> = ({
                             ))}
                         </div>
                     )}
-                    {details.non_convergence && (
-                        <div style={{ fontSize: '11px', color: colors.warningText, backgroundColor: colors.warningSoft, padding: '2px 6px', borderRadius: '4px', marginTop: '4px', border: `1px solid ${colors.warningBorder}`, display: 'inline-block' }}>
-                            ⚠️ LoadFlow failure: {details.non_convergence}
-                        </div>
-                    )}
-                    {details.is_islanded && (
-                        <div style={{ fontSize: '12px', background: colors.dangerSoft, color: colors.danger, padding: '6px 10px', marginTop: '5px', borderRadius: '4px', border: `1px solid ${colors.danger}`, fontWeight: 500 }}>
-                            🏝️ Islanding detected ({details.disconnected_mw?.toFixed(1)} MW disconnected)
-                        </div>
-                    )}
+
+                    {/* "Loading before" stays in the sticky Overloads N-1
+                        section of the left feed — no need to duplicate
+                        it per card (see git blame for the original
+                        rationale). */}
+                    <div style={{ fontSize: '12px', background: colors.brandSoft, padding: '5px', marginTop: '8px', borderRadius: '4px' }}>
+                        Loading after: {renderRho(details.rho_after, id, 'action')}
+                    </div>
                 </div>
-                {renderBadges()}
-            </div>
-            <div style={{ fontSize: '12px', background: isViewing ? colors.brandSoft : colors.surfaceMuted, padding: '5px', marginTop: '5px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
-                <div>
-                    {/*
-                      "Loading before" removed — the N-1 pre-action loading
-                      is already shown in the sticky Overloads N-1 section
-                      of the left feed, with percentages next to each
-                      overloaded line. No need to duplicate it per card.
-                    */}
-                    <div>Loading after: {renderRho(details.rho_after, id, 'action')}</div>
-                    {maxRhoPct != null && (
-                        <div style={{ marginTop: '3px' }}>
-                            Max loading: <strong style={{ color: sc.border }}>{maxRhoPct}%</strong>
-                            {details.max_rho_line && (
-                                <span style={{ color: colors.textTertiary }}> on <button
-                                    style={{ ...clickableLinkStyle, color: colors.textTertiary }}
-                                    title={`Zoom to ${details.max_rho_line}`}
-                                    onClick={(e) => { e.stopPropagation(); onAssetClick(id, details.max_rho_line, 'action'); }}
-                                >{displayName(details.max_rho_line)}</button></span>
-                            )}
-                        </div>
-                    )}
-                </div>
-                <div style={{ display: 'flex', gap: '4px', flexShrink: 0, paddingBottom: '2px' }}>
-                    {!isSelected && (
-                        <button
-                            onClick={(e) => { e.stopPropagation(); onActionFavorite(id); }}
-                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                            title="Select this action"
-                        ><span style={{ fontSize: '14px' }}>⭐</span></button>
-                    )}
-                    {!isRejected && (
-                        <button
-                            onClick={(e) => { e.stopPropagation(); onActionReject(id); }}
-                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                            title={isSelected ? "Remove from selected" : "Reject this action"}
-                        ><span style={{ fontSize: '14px' }}>❌</span></button>
-                    )}
-                </div>
-            </div>
-            </div>{/* /content column */}
+            )}
         </div>
     );
 };

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -214,8 +214,10 @@ describe('ActionFeed', () => {
             },
         };
         render(<ActionFeed {...props} />);
-        // Selected Actions section still shows the card.
-        expect(screen.getByText('Shared action')).toBeInTheDocument();
+        // Selected Actions section still shows the card. (The
+        // description is now progressive-disclosure, so we assert on
+        // the card root by testId rather than its description text.)
+        expect(screen.getByTestId(`action-card-${actionId}`)).toBeInTheDocument();
         // Overlap warning is visible and mentions the overlapping id.
         const warning = screen.getByText(/also recommended by the recent analysis run/);
         expect(warning).toBeInTheDocument();
@@ -307,7 +309,8 @@ describe('ActionFeed', () => {
         };
         render(<ActionFeed {...props} />);
 
-        expect(screen.getByText('Manual Action')).toBeInTheDocument();
+        // Card is rendered (description is progressive-disclosure).
+        expect(screen.getByTestId(`action-card-${actionId}`)).toBeInTheDocument();
         // Processing indicator is visible even when viewing selected actions
         expect(screen.getByText('⚙️ Analyzing…')).toBeInTheDocument();
     });
@@ -460,11 +463,15 @@ describe('ActionFeed', () => {
         };
         render(<ActionFeed {...props} />);
 
-        const cards = screen.getAllByTestId(/action-card-/);
-        const cardTexts = cards.map(el => el.textContent);
+        // Cards are referenced by their testIds — the description text
+        // is hidden at-rest under progressive disclosure, so the
+        // ordering check has to walk the action-card-${id} test IDs in
+        // DOM order instead of scanning rendered text.
+        const cards = screen.getAllByTestId(/^action-card-(act_good|act_bad)$/);
+        const cardIds = cards.map(el => el.getAttribute('data-testid'));
 
-        const goodIndex = cardTexts.findIndex(t => t?.includes('Good Action'));
-        const badIndex = cardTexts.findIndex(t => t?.includes('Bad Action'));
+        const goodIndex = cardIds.indexOf('action-card-act_good');
+        const badIndex = cardIds.indexOf('action-card-act_bad');
 
         expect(goodIndex).toBeLessThan(badIndex);
     });
@@ -815,7 +822,8 @@ describe('ActionFeed', () => {
         };
         render(<ActionFeed {...props} />);
 
-        expect(screen.getByText('Simulated Combined Action')).toBeInTheDocument();
+        // Card is rendered (description is progressive-disclosure).
+        expect(screen.getByTestId(`action-card-${combinedId}`)).toBeInTheDocument();
     });
 
     it('renders multiple asset badges for combined actions', () => {
@@ -908,6 +916,11 @@ describe('ActionFeed', () => {
         const actionId = 'load_shed_1';
         const props = {
             ...defaultProps,
+            // Editor disclosure is gated on the viewing state — set
+            // selectedActionId so the load-shedding details panel
+            // (which carries the LOAD_1 / Shedding-on copy this test
+            // checks for) actually renders.
+            selectedActionId: actionId,
             actions: {
                 [actionId]: {
                     description_unitaire: 'Shedding action on load',
@@ -969,6 +982,7 @@ describe('ActionFeed', () => {
         const actionId = 'load_shed_multi';
         const props = {
             ...defaultProps,
+            selectedActionId: actionId,
             actions: {
                 [actionId]: {
                     description_unitaire: 'Multi-load shedding',
@@ -1116,6 +1130,7 @@ describe('ActionFeed', () => {
         const actionId = 'load_shed_new_format';
         const props = {
             ...defaultProps,
+            selectedActionId: actionId,
             actions: {
                 [actionId]: {
                     description_unitaire: 'Load shedding (power reduction)',
@@ -1146,6 +1161,7 @@ describe('ActionFeed', () => {
         const actionId = 'curtail_new_format';
         const props = {
             ...defaultProps,
+            selectedActionId: actionId,
             actions: {
                 [actionId]: {
                     description_unitaire: 'Curtailment (power reduction)',
@@ -1173,6 +1189,9 @@ describe('ActionFeed', () => {
     });
 
     it('displays load shedding with loads_p and curtailment with gens_p in same action list', () => {
+        // Only one card can be the viewing card at a time, so we
+        // assert each editor through a focused rerender rather than
+        // expecting both editor panels open simultaneously.
         const lsId = 'ls_new_1';
         const rcId = 'rc_new_1';
         const props = {
@@ -1205,13 +1224,18 @@ describe('ActionFeed', () => {
             },
             selectedActionIds: new Set([lsId, rcId]),
         };
-        render(<ActionFeed {...props} />);
 
-        // Load shedding details with new format
+        // Both cards must be in the list regardless of viewing state.
+        const { rerender } = render(<ActionFeed {...props} selectedActionId={lsId} />);
+        expect(screen.getByTestId(`action-card-${lsId}`)).toBeInTheDocument();
+        expect(screen.getByTestId(`action-card-${rcId}`)).toBeInTheDocument();
+
+        // Viewing the LS card discloses the load-shedding editor.
         expect(screen.getByText(/Shedding on/)).toBeInTheDocument();
         expect(screen.getByText('LOAD_NEW')).toBeInTheDocument();
 
-        // Curtailment details with new format
+        // Viewing the RC card discloses the curtailment editor.
+        rerender(<ActionFeed {...props} selectedActionId={rcId} />);
         expect(screen.getByText(/Curtailment on/)).toBeInTheDocument();
         expect(screen.getByText('GEN_NEW')).toBeInTheDocument();
     });
@@ -1268,9 +1292,14 @@ describe('ActionFeed', () => {
     });
 
     it('shows editable MW and re-simulate button on load shedding action card', () => {
+        // Parameter editors are progressive-disclosure (PR
+        // claude/redesign-actioncard-…): they only render on the
+        // currently-viewed card to keep at-rest cards to five
+        // fields. Set `selectedActionId` so the editor is visible.
         const actionId = 'load_shedding_LOAD_X';
         const props = {
             ...defaultProps,
+            selectedActionId: actionId,
             actions: {
                 [actionId]: {
                     description_unitaire: 'Load shedding on LOAD_X',
@@ -1295,6 +1324,7 @@ describe('ActionFeed', () => {
         const actionId = 'curtail_GEN_Y';
         const props = {
             ...defaultProps,
+            selectedActionId: actionId,
             actions: {
                 [actionId]: {
                     description_unitaire: 'Curtailment on GEN_Y',
@@ -1332,6 +1362,7 @@ describe('ActionFeed', () => {
 
         const props = {
             ...defaultProps,
+            selectedActionId: actionId,
             actions: {
                 [actionId]: {
                     description_unitaire: 'Load shedding on LOAD_X',
@@ -1375,6 +1406,7 @@ describe('ActionFeed', () => {
             const actionId = 'load_shedding_LOAD_B5';
             const props = {
                 ...defaultProps,
+                selectedActionId: actionId,
                 onManualActionAdded: vi.fn(),
                 onActionResimulated: vi.fn(),
                 actions: {
@@ -1439,6 +1471,7 @@ describe('ActionFeed', () => {
             const pstActionId = 'pst_B5';
             const props = {
                 ...defaultProps,
+                selectedActionId: pstActionId,
                 onManualActionAdded: vi.fn(),
                 onActionResimulated: vi.fn(),
                 actions: {
@@ -1505,6 +1538,7 @@ describe('ActionFeed', () => {
             const actionId = 'load_shedding_LOG_A1';
             const props = {
                 ...defaultProps,
+                selectedActionId: actionId,
                 onActionResimulated: vi.fn(),
                 actions: {
                     [actionId]: {
@@ -1587,6 +1621,7 @@ describe('ActionFeed', () => {
             const pstActionId = 'pst_A1';
             const props = {
                 ...defaultProps,
+                selectedActionId: pstActionId,
                 onActionResimulated: vi.fn(),
                 actions: {
                     [pstActionId]: {
@@ -2190,6 +2225,7 @@ describe('ActionFeed', () => {
             const onUpdateCombinedEstimation = vi.fn();
             const props = {
                 ...defaultProps,
+                selectedActionId: actionId,
                 actions: {
                     [actionId]: {
                         description_unitaire: 'Load shedding on LOAD_X',
@@ -2260,6 +2296,7 @@ describe('ActionFeed', () => {
             };
             const props = {
                 ...defaultProps,
+                selectedActionId: pstActionId,
                 actions: {
                     [pstActionId]: {
                         description_unitaire: 'Variation PST ARKA TD 661',
@@ -2314,6 +2351,7 @@ describe('ActionFeed', () => {
             const onUpdateCombinedEstimation = vi.fn();
             const props = {
                 ...defaultProps,
+                selectedActionId: actionId,
                 actions: {
                     [actionId]: {
                         description_unitaire: 'Load shedding on LOAD_X',
@@ -2370,6 +2408,7 @@ describe('ActionFeed', () => {
             const onUpdateCombinedEstimation = vi.fn();
             const props = {
                 ...defaultProps,
+                selectedActionId: actionId,
                 actions: {
                     [actionId]: {
                         description_unitaire: 'Load shedding on LOAD_X',
@@ -2428,6 +2467,7 @@ describe('ActionFeed', () => {
             const combined2: CombinedAction = { ...baseCombined, action2_id: thirdActionId };
             const props = {
                 ...defaultProps,
+                selectedActionId: actionId,
                 actions: {
                     [actionId]: {
                         description_unitaire: 'Load shedding on LOAD_X',


### PR DESCRIPTION
## Summary

Redesigns the ActionCard component to implement progressive disclosure, reducing visual clutter at rest while keeping detailed information one click away. Replaces the vertical "VIEWING" ribbon with a higher-saturation left-edge accent stripe and adds semantic severity icons to the status badge.

## Key Changes

- **Progressive Disclosure**: Hides description, parameter editors (load shedding, curtailment, PST), and per-line loading details until the card is selected for viewing. At rest, cards show only: rank, ID, severity badge, max loading %, and primary target line.

- **Severity Icons**: Introduces a new `SeverityIcon` component that renders context-specific SVG icons:
  - ✓ checkmark in circle for "Solves overload"
  - ⚠ warning triangle for "Solved — low margin"
  - ✕ X in circle for "Still overloaded", "No reduction", "divergent", and "islanded"

- **Viewing State Signal**: Replaces the vertical "VIEWING" ribbon (which consumed horizontal space on narrow sidebars) with:
  - A higher-saturation left-edge accent stripe (`accentColor` = `colors.brandStrong` when viewing)
  - A `data-viewing` attribute on the card root for CSS-driven styling
  - An `.is-viewing` class for hover-state control

- **Hover-Revealed Rail**: Moves star (⭐) and reject (❌) buttons into a `.action-card-rail` that fades in on hover, focus, or when the card is being viewed. Implemented in CSS to avoid re-renders on every hover.

- **Restructured Layout**: 
  - Removes the flex-based two-column layout (ribbon + content)
  - Simplifies to a single-column card with padding
  - Moves max loading and target line info to the compact at-rest body
  - Moves "Loading after" detail into the disclosure region (only visible when viewing)

- **Fault State Visibility**: Divergent and islanded states now display prominently at rest (not hidden in disclosure) since they are primary failure signals.

- **Test Updates**: Updates 40+ test cases to reflect progressive disclosure:
  - Assertions on description text now check `isViewing={true}` state
  - Replaces "VIEWING" ribbon checks with `data-viewing` attribute assertions
  - Adds new tests for disclosure region visibility
  - Updates ActionFeed tests to set `selectedActionId` when testing editor panels

- **CSS Enhancements**: Adds `.action-card-rail` opacity transitions and zoom-tier-specific stroke rules for overloaded/action-target/contingency highlights at region and detail zoom levels.

## Implementation Details

- The `SeverityIcon` component uses a type-safe `SeverityKind` union to map severity states to icon variants.
- Fault states (non_convergence, is_islanded) are checked once and stored in `isFault` variable to avoid duplication.
- The `editorRowStyle` constant consolidates common styling for load shedding, curtailment, and PST editor rows.
- All disclosure content is wrapped in a conditional block that only renders when `isViewing === true`, with `onClick` and `onMouseDown` stopPropagation to prevent card selection when interacting with editors.
- The rail's visibility is controlled entirely by CSS (`:hover`, `:focus-within`, `.is-viewing`), keeping the DOM stable and avoiding React re-renders.

https://claude.ai/code/session_0189j1LB4owdR4ZHaRBdeoAY