### PR TITLE
Implement tiered warning system and diagram legend (UI critique #4-5)

### DIFF
--- a/docs/proposals/ui-design-critique.md
+++ b/docs/proposals/ui-design-critique.md
@@ -1,6 +1,85 @@
 # UI design critique — Co-Study4Grid frontend
 
-**Status**: Proposal / review. **Recommendation #1 (design-token layer)
+**Status**: Proposal / review. **Recommendations 1-5 have all landed
+between 2026-05-01 and 2026-05-02.**
+
+| # | Recommendation | Status | Landed in |
+|---|---|---|---|
+| 1 | Design-token layer | ✅ Full | 47a2700 / 0e60059 / b8de481 (2026-05-01 → 2026-05-02) — Phases A/B/C |
+| 2 | Progressive-disclosure ActionCard | ✅ Full | fbfb2b0 (PR #121, 2026-05-02) |
+| 3 | Cap NAD overload halo at zoom | ✅ Full | fbfb2b0 (PR #121, 2026-05-02) — `vector-effect: non-scaling-stroke` capped at the `region` and `detail` zoom tiers |
+| 4 | Tier the warning system | ✅ Full | tier-warning-system PR (2026-05-02) — NoticesPanel pill + inline contextual hints |
+| 5 | Diagram legend | ✅ Full | tier-warning-system PR (2026-05-02) — collapsible bottom-right per tab |
+
+**Recommendation #4 (tier the warning system, 2026-05-02).** The
+five concurrent yellow `#fff3cd` banners called out below were
+consolidated into a single sidebar-header **NoticesPanel** pill plus
+small grey **inline contextual hints** under the relevant control,
+following the recommendation verbatim:
+
+- New `frontend/src/components/NoticesPanel.tsx` — pill with a
+  count badge in the sidebar header (above `SidebarSummary`).
+  Clicking expands a panel of `Notice` cards. Each card carries an
+  optional `action` (e.g. "Open settings") and optional `onDismiss`
+  handler. The pill self-hides when the live notice list goes to
+  zero.
+- `App.tsx` builds the active `Notice[]` from the existing
+  dismissable state machinery (`showActionDictNotice`,
+  `showRecommenderNotice`, `showMonitoringWarning`). Three notices
+  feed the panel today: `action-dict` (info), `monitoring-coverage`
+  (warning), `recommender-thresholds` (info).
+- `OverloadPanel.tsx` — the inline yellow monitoring-coverage
+  banner is gone. The component now accepts a `monitoringHint`
+  string and renders it as one short grey line under the heading
+  ("130/150 lines monitored — see Notices for details.").
+- `ActionFeed.tsx` — the inline "Action dictionary" yellow banner
+  and the "Recommender Settings" yellow banner have been removed.
+  The two overlap warnings (manual / rejected vs. analysis) have
+  been **demoted to inline contextual hints** — small grey italic
+  text instead of a full yellow box. A new
+  `overviewFilteredOutCount` hint surfaces under the Suggested /
+  Rejected header when the overview filter hides cards: "5 actions
+  hidden by the overview filter." — closing the loop the
+  recommendation specifically called for.
+- New tests: `NoticesPanel.test.tsx` (6 cases — pill counter, dialog
+  toggle, dismiss callback, action button, auto-hide on empty),
+  `DiagramLegend.test.tsx` (8 cases — collapse/expand, per-tab row
+  set, voltage-level note, VL-names hidden hint).
+- Test churn: the obsolete inline-banner tests in
+  `ActionFeed.test.tsx`, `OverloadPanel.test.tsx`, and
+  `App.stateManagement.test.tsx` were removed or rewritten to
+  match the new contract; two App-level prop-passing tests are
+  `it.skip`-ped with rationale comments because the props they
+  guarded (`recommenderConfig`, `onDismissWarning`,
+  `onOpenSettings` on OverloadPanel) no longer flow through the
+  ActionFeed / OverloadPanel boundary.
+
+**Recommendation #5 (add a diagram legend, 2026-05-02).** New
+`frontend/src/components/DiagramLegend.tsx` — a small "Legend"
+pill in the bottom-right of every diagram tab that expands into a
+collapsible panel listing the on-screen colour conventions:
+- N tab: overloaded line (orange halo), disconnected branch (dashed
+  grey), voltage-level palette note.
+- N-1 tab: contingency (yellow halo), overloaded line, flow-up
+  delta (orange line), flow-down delta (blue line), disconnected
+  branch, voltage-level palette note.
+- Action tab: contingency, action target (pink halo), overloaded
+  line, flow-up / flow-down deltas, disconnected branch, voltage-
+  level palette note.
+- The panel also surfaces a "Voltage-level names are hidden — toggle
+  VL next to Inspect to show them" hint when the operator has the
+  VL-names toggle off, closing the largest onboarding gap visible
+  in the original screenshot review.
+- The legend is collapsed by default — the bottom-right pill is
+  small enough to never compete with the network when the operator
+  is scanning; click to expand, click ✕ to collapse.
+
+The original recommendations from the code-only review and
+screenshot review remain below for traceability. The
+recommendations they describe are now historical — see the table
+above for the landing commits.
+
+**Recommendation #1 (design-token layer)
 landed in full 2026-05-01 → 2026-05-02** across three commits.
 `frontend/src/styles/tokens.{css,ts}` defines the semantic palette:
 ~24 colors (Tailwind blue-ramp brand, Bootstrap warning/danger/success,
@@ -390,7 +469,7 @@ at `region` and `detail` zoom tiers. This is a small CSS change with
 a disproportionately large legibility win — it is the cheapest of the
 top three to land.
 
-### 4. Tier the warning system
+### 4. Tier the warning system  *(Landed 2026-05-02 — see header summary.)*
 
 Replace the five concurrent yellow banners with:
 
@@ -408,12 +487,32 @@ and only one non-zero overload condition active, so none of the five
 banners are visible — this finding remains a code-only inference. It
 should be re-validated by replicating the multi-warning state.*
 
-### 5. Add a diagram legend
+**What landed:** new `NoticesPanel` (sidebar pill +
+collapsible panel), three `Notice` entries fed from App.tsx
+(`action-dict`, `monitoring-coverage`, `recommender-thresholds`),
+inline `monitoringHint` on `OverloadPanel`, inline grey overlap
+hints inside `ActionFeed`, and a brand-new "X actions hidden by
+the overview filter" inline counter. Multi-warning state was
+reproducible during development by leaving an action dictionary
+loaded but unused while the recommender thresholds were still in
+their default values — all three notices appear at once and
+collapse into the single pill.
+
+### 5. Add a diagram legend  *(Landed 2026-05-02 — see header summary.)*
 
 Smallest standalone improvement on the list. A collapsible legend in
 the bottom-right of each diagram tab — covering halo colors,
 disconnection styling, and voltage-level color mapping — would close
 the largest onboarding gap visible in the screenshot.
+
+**What landed:** `frontend/src/components/DiagramLegend.tsx`. A
+small bottom-right "Legend" pill on the N / N-1 / Action tabs that
+expands into a panel listing contingency / action-target /
+overload halos, flow-delta direction colours, the dashed-grey
+disconnection convention, and a voltage-level palette note plus
+a VL-names-hidden reminder. Per-tab row sets (e.g. action target
+only on the action tab) so the legend never claims more than the
+diagram itself shows.
 
 ---
 

--- a/frontend/src/App.stateManagement.test.tsx
+++ b/frontend/src/App.stateManagement.test.tsx
@@ -175,7 +175,12 @@ describe('Phase 2: State Management Optimization', () => {
   });
 
   describe('RecommenderDisplayConfig grouped prop', () => {
-    it('passes recommenderConfig as a single grouped object to ActionFeed', async () => {
+    // tier-warning-system PR: the recommender threshold display moved from a yellow
+    // banner inside ActionFeed into a unified "Notices" pill in the
+    // sidebar header (`docs/proposals/ui-design-critique.md`
+    // recommendation #4). ActionFeed therefore no longer receives the
+    // grouped `recommenderConfig` prop.
+    it.skip('passes recommenderConfig as a single grouped object to ActionFeed', async () => {
       await renderAndLoadStudy();
 
       // ActionFeed should have been rendered at least once
@@ -245,12 +250,14 @@ describe('Phase 2: State Management Optimization', () => {
       expect(typeof lastRender.onManualActionAdded).toBe('function');
     });
 
-    it('provides stable onDismissWarning and onOpenSettings to OverloadPanel', async () => {
+    it('provides stable toggle callbacks to OverloadPanel', async () => {
+      // tier-warning-system PR retired the inline yellow monitoring banner —
+      // OverloadPanel now receives a one-line `monitoringHint` string
+      // and the dismiss/openSettings affordances live in NoticesPanel.
+      // What remains stable here are the overload-toggle callbacks.
       await renderAndLoadStudy();
 
       const lastRender = overloadPanelRenderLog[overloadPanelRenderLog.length - 1];
-      expect(typeof lastRender.onDismissWarning).toBe('function');
-      expect(typeof lastRender.onOpenSettings).toBe('function');
       expect(typeof lastRender.onToggleOverload).toBe('function');
       expect(typeof lastRender.onToggleMonitorDeselected).toBe('function');
     });
@@ -298,7 +305,10 @@ describe('Phase 2: State Management Optimization', () => {
   });
 
   describe('React.memo integration', () => {
-    it('renders ActionFeed with data-has-recommender-config attribute', async () => {
+    it.skip('renders ActionFeed with data-has-recommender-config attribute', async () => {
+      // tier-warning-system PR: the recommenderConfig prop was retired when the
+      // recommender-thresholds notice moved to NoticesPanel. The mock
+      // attribute it set is no longer meaningful.
       await renderAndLoadStudy();
 
       const actionFeed = screen.getByTestId('action-feed');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import OverloadPanel from './components/OverloadPanel';
 import Header from './components/Header';
 import AppSidebar from './components/AppSidebar';
 import StatusToasts from './components/StatusToasts';
+import type { Notice } from './components/NoticesPanel';
 import SettingsModal from './components/modals/SettingsModal';
 import ReloadSessionModal from './components/modals/ReloadSessionModal';
 import ConfirmationDialog from './components/modals/ConfirmationDialog';
@@ -1011,6 +1012,99 @@ function App() {
     setConfirmDialog(null);
   }, [confirmDialog, setNetworkPath]);
 
+  // ===== Tiered notice system =====
+  // The previous UI stacked up to five concurrent yellow banners in
+  // the sidebar. They now feed a single "Notices" pill at the top
+  // of the sidebar. Each notice owns its dismissal state via the
+  // existing showXxxWarning state (kept where it lived to preserve
+  // the reset-on-apply-settings behaviour).
+  const [showActionDictNotice, setShowActionDictNotice] = useState(true);
+  const [showRecommenderNotice, setShowRecommenderNotice] = useState(true);
+
+  // Re-arm the notices whenever a fresh study is loaded — same
+  // semantics as the local state ActionFeed used to own.
+  useEffect(() => {
+    setShowActionDictNotice(true);
+    setShowRecommenderNotice(true);
+  }, [networkPath, actionPath]);
+
+  const sidebarNotices = useMemo(() => {
+    const list: Notice[] = [];
+
+    // Action-dictionary info — shown until the operator simulates
+    // anything OR dismisses it.
+    if (showActionDictNotice && actionDictFileName && actionDictStats && Object.keys(result?.actions || {}).length === 0) {
+      list.push({
+        id: 'action-dict',
+        severity: 'info',
+        title: 'Action dictionary',
+        body: (
+          <>
+            <code style={{ fontFamily: 'monospace', padding: '0 4px' }}>{actionDictFileName}</code>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginTop: '4px' }}>
+              <span>🔄 Reco: <strong>{actionDictStats.reco}</strong></span>
+              <span>⛔ Disco: <strong>{actionDictStats.disco}</strong></span>
+              <span>📐 PST: <strong>{actionDictStats.pst}</strong></span>
+              <span>🔓 Open coupling: <strong>{actionDictStats.open_coupling}</strong></span>
+              <span>🔒 Close coupling: <strong>{actionDictStats.close_coupling}</strong></span>
+            </div>
+          </>
+        ),
+        action: { label: 'Change in settings', onClick: () => handleOpenSettings('paths') },
+        onDismiss: () => setShowActionDictNotice(false),
+      });
+    }
+
+    // Monitoring coverage warning — surfaces the reduced monitoring
+    // scope before the operator runs an analysis.
+    if (showMonitoringWarning && totalLinesCount && totalLinesCount > 0) {
+      const monitored = monitoredLinesCount || 0;
+      list.push({
+        id: 'monitoring-coverage',
+        severity: 'warning',
+        title: 'Monitoring coverage',
+        body: (
+          <>
+            <strong>{monitored}</strong> of <strong>{totalLinesCount}</strong> lines monitored
+            {' '}({totalLinesCount - monitored} without permanent limits). Monitoring factor:
+            {' '}{Math.round((monitoringFactor || 0.95) * 100)}%, pre-existing overload threshold:
+            {' '}{Math.round((preExistingOverloadThreshold || 0.02) * 100)}%.
+          </>
+        ),
+        action: { label: 'Change in settings', onClick: handleOpenConfigSettings },
+        onDismiss: handleDismissWarning,
+      });
+    }
+
+    // Recommender thresholds — only relevant before an analysis has
+    // actually run, since once we have results the operator can read
+    // the values back from the actions themselves.
+    if (showRecommenderNotice && !pendingAnalysisResult && !result) {
+      list.push({
+        id: 'recommender-thresholds',
+        severity: 'info',
+        title: 'Recommender thresholds',
+        body: (
+          <>
+            <div>• Minimum actions: {recommenderConfig.minLineReconnections} reco, {recommenderConfig.minCloseCoupling} close, {recommenderConfig.minOpenCoupling} open, {recommenderConfig.minLineDisconnections} disco, {recommenderConfig.minPst} PST, {recommenderConfig.minLoadShedding} load shedding, {recommenderConfig.minRenewableCurtailmentActions} RC</div>
+            <div>• Maximum suggestions: {recommenderConfig.nPrioritizedActions}</div>
+            <div>• Ignore reconnections: {recommenderConfig.ignoreReconnections ? 'Yes' : 'No'}</div>
+          </>
+        ),
+        action: { label: 'Change in settings', onClick: () => handleOpenSettings('recommender') },
+        onDismiss: () => setShowRecommenderNotice(false),
+      });
+    }
+
+    return list;
+  }, [
+    showActionDictNotice, actionDictFileName, actionDictStats, result,
+    showMonitoringWarning, monitoredLinesCount, totalLinesCount,
+    monitoringFactor, preExistingOverloadThreshold,
+    showRecommenderNotice, pendingAnalysisResult, recommenderConfig,
+    handleOpenSettings, handleOpenConfigSettings, handleDismissWarning,
+  ]);
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <Header
@@ -1055,6 +1149,7 @@ function App() {
           displayName={displayName}
           onContingencyZoom={handleZoomOnActiveTab}
           onOverloadClick={wrappedAssetClick as (actionId: string, assetName: string, tab: 'n' | 'n-1') => void}
+          notices={sidebarNotices}
         >
           <div style={{ flexShrink: 0 }}>
             <OverloadPanel
@@ -1063,13 +1158,11 @@ function App() {
               nOverloadsRho={nDiagram?.lines_overloaded_rho}
               n1OverloadsRho={n1Diagram?.lines_overloaded_rho}
               onAssetClick={wrappedAssetClick as (actionId: string, assetName: string, tab?: 'n' | 'n-1') => void}
-              showMonitoringWarning={showMonitoringWarning}
-              monitoredLinesCount={monitoredLinesCount}
-              totalLinesCount={totalLinesCount}
-              monitoringFactor={monitoringFactor}
-              preExistingOverloadThreshold={preExistingOverloadThreshold}
-              onDismissWarning={handleDismissWarning}
-              onOpenSettings={handleOpenConfigSettings}
+              monitoringHint={
+                showMonitoringWarning && totalLinesCount && totalLinesCount > 0
+                  ? `${monitoredLinesCount || 0}/${totalLinesCount} lines monitored — see Notices for details.`
+                  : null
+              }
               selectedOverloads={selectedOverloads}
               onToggleOverload={analysis.handleToggleOverload}
               monitorDeselected={monitorDeselected}
@@ -1103,10 +1196,6 @@ function App() {
             analysisLoading={analysisLoading}
             monitoringFactor={monitoringFactor}
             onVlDoubleClick={handleVlDoubleClick}
-            recommenderConfig={recommenderConfig}
-            actionDictFileName={actionDictFileName}
-            actionDictStats={actionDictStats}
-            onOpenSettings={handleOpenSettings}
             onUpdateCombinedEstimation={handleUpdateCombinedEstimation}
             displayName={displayName}
             onActionDiagramPrimed={diagrams.primeActionDiagram}

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -66,21 +66,7 @@ describe('ActionFeed', () => {
         analysisLoading: false,
         monitoringFactor: 0.95,
         manuallyAddedIds: new Set<string>(),
-        recommenderConfig: {
-            minLineReconnections: 2,
-            minCloseCoupling: 3,
-            minOpenCoupling: 2,
-            minLineDisconnections: 3,
-            minPst: 1,
-            minLoadShedding: 0,
-            minRenewableCurtailmentActions: 0,
-            nPrioritizedActions: 10,
-            ignoreReconnections: false,
-        },
         pendingAnalysisResult: null as AnalysisResult | null,
-        onOpenSettings: vi.fn(),
-        actionDictFileName: null as string | null,
-        actionDictStats: null as { reco: number; disco: number; pst: number; open_coupling: number; close_coupling: number; total: number } | null,
         combinedActions: null as Record<string, CombinedAction> | null,
     };
 
@@ -218,10 +204,12 @@ describe('ActionFeed', () => {
         // description is now progressive-disclosure, so we assert on
         // the card root by testId rather than its description text.)
         expect(screen.getByTestId(`action-card-${actionId}`)).toBeInTheDocument();
-        // Overlap warning is visible and mentions the overlapping id.
-        const warning = screen.getByText(/also recommended by the recent analysis run/);
-        expect(warning).toBeInTheDocument();
-        expect(warning.textContent).toContain(actionId);
+        // Overlap is now an inline contextual hint (tier-warning-system PR — see
+        // `docs/proposals/ui-design-critique.md` recommendation #4).
+        const hint = screen.getByTestId('selected-overlap-hint');
+        expect(hint).toBeInTheDocument();
+        expect(hint.textContent).toMatch(/also recommended by the recent analysis/i);
+        expect(hint.textContent).toContain(actionId);
     });
 
     it('hides "Make a first guess" when there are already selected actions', () => {
@@ -616,57 +604,10 @@ describe('ActionFeed', () => {
         expect(screen.queryByText('disco_pst_branch')).not.toBeInTheDocument();
         expect(screen.getByText('All actions already added')).toBeInTheDocument();
     });
-    it('shows action dict stats warning when actionDictFileName and actionDictStats are provided', () => {
-        const props = {
-            ...defaultProps,
-            actionDictFileName: 'actions.json',
-            actionDictStats: { reco: 3, disco: 5, pst: 2, open_coupling: 1, close_coupling: 1, total: 12 },
-        };
-        render(<ActionFeed {...props} />);
-
-        expect(screen.getByText(/Action dictionary/)).toBeInTheDocument();
-        expect(screen.getByText(/actions.json/)).toBeInTheDocument();
-        expect(screen.getByText(/Reco:/)).toBeInTheDocument();
-        expect(screen.getByText(/Disco:/)).toBeInTheDocument();
-        expect(screen.getByText(/PST:/)).toBeInTheDocument();
-        expect(screen.getByText(/Open coupling:/)).toBeInTheDocument();
-        expect(screen.getByText(/Close coupling:/)).toBeInTheDocument();
-    });
-
-    it('dismisses action dict stats warning when close button is clicked', () => {
-        const props = {
-            ...defaultProps,
-            actionDictFileName: 'actions.json',
-            actionDictStats: { reco: 3, disco: 5, pst: 2, open_coupling: 1, close_coupling: 1, total: 12 },
-        };
-        render(<ActionFeed {...props} />);
-
-        expect(screen.getByText(/Action dictionary/)).toBeInTheDocument();
-        // Multiple dismiss buttons exist; action dict one renders first
-        const dismissBtns = screen.getAllByTitle('Dismiss');
-        fireEvent.click(dismissBtns[0]);
-        expect(screen.queryByText(/Action dictionary/)).not.toBeInTheDocument();
-    });
-
-    it('shows action dict warning while analysis is loading with yellow theme', () => {
-        const props = {
-            ...defaultProps,
-            actionDictFileName: 'actions.json',
-            actionDictStats: { reco: 3, disco: 5, pst: 2, open_coupling: 1, close_coupling: 1, total: 12 },
-            analysisLoading: true,
-        };
-        render(<ActionFeed {...props} />);
-        // Timing fix: it should appear at the same time as other user warnings (even during analysis)
-        const warning = screen.getByText(/Action dictionary/);
-        expect(warning).toBeInTheDocument();
-        // Check warning theme via design tokens (jsdom returns the var() string for inline styles)
-        const parent = warning.closest('div[style*="background"]') as HTMLDivElement;
-        if (parent) {
-            expect(parent.style.background).toContain('var(--color-warning-soft)');
-            expect(parent.style.border).toContain('var(--color-warning-border)');
-            expect(parent.style.color).toContain('var(--color-warning-text)');
-        }
-    });
+    // Action-dictionary stats and recommender thresholds were moved
+    // out of ActionFeed and into NoticesPanel (tier-warning-system PR — see
+    // `docs/proposals/ui-design-critique.md` recommendation #4). The
+    // matching coverage now lives in `NoticesPanel.test.tsx`.
 
     it('shows yellow processing button during analysisLoading', () => {
         const props = {
@@ -681,37 +622,9 @@ describe('ActionFeed', () => {
         expect(banner.style.color).toContain('var(--color-warning-text)');
     });
 
-    it('includes minPst in the recommender settings warning', () => {
-        const props = {
-            ...defaultProps,
-            recommenderConfig: {
-                ...defaultProps.recommenderConfig,
-                minPst: 2,
-                minLineReconnections: 3,
-                minLineDisconnections: 4,
-            },
-        };
-        render(<ActionFeed {...props} />);
-        // The recommender settings warning appears when no analysis has been run
-        expect(screen.getByText(/2 PST/)).toBeInTheDocument();
-    });
-
-    it('shows change in settings link in action dict warning calling paths tab', () => {
-        const onOpenSettings = vi.fn();
-        const props = {
-            ...defaultProps,
-            actionDictFileName: 'actions.json',
-            actionDictStats: { reco: 3, disco: 5, pst: 2, open_coupling: 1, close_coupling: 1, total: 12 },
-            onOpenSettings,
-        };
-        render(<ActionFeed {...props} />);
-
-        // "Change in settings" button in the action dict warning
-        const changeLinks = screen.getAllByText('Change in settings');
-        // Click the first one (action dict warning)
-        fireEvent.click(changeLinks[0]);
-        expect(onOpenSettings).toHaveBeenCalledWith('paths');
-    });
+    // The recommender-settings hint and the action-dict "Change in
+    // settings" affordance live in NoticesPanel after tier-warning-system PR. See
+    // `NoticesPanel.test.tsx` for the moved coverage.
     it('awaits simulation before calling onManualActionAdded to prevent race conditions', async () => {
         const actionId = 'act1';
         const mockResult = {

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -6,7 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import type { ActionDetail, ActionTypeFilterToken, NodeMeta, EdgeMeta, AvailableAction, AnalysisResult, CombinedAction, RecommenderDisplayConfig, DiagramData, ActionOverviewFilters } from '../types';
+import type { ActionDetail, ActionTypeFilterToken, NodeMeta, EdgeMeta, AvailableAction, AnalysisResult, CombinedAction, DiagramData, ActionOverviewFilters } from '../types';
 import { actionPassesOverviewFilter } from '../utils/svgUtils';
 import { classifyActionType, matchesActionTypeFilter } from '../utils/actionTypes';
 import { api } from '../api';
@@ -47,10 +47,6 @@ interface ActionFeedProps {
     monitoringFactor: number;
     manuallyAddedIds: Set<string>;
     onVlDoubleClick?: (actionId: string, vlName: string) => void;
-    recommenderConfig: RecommenderDisplayConfig;
-    onOpenSettings?: (tab?: 'recommender' | 'configurations' | 'paths') => void;
-    actionDictFileName?: string | null;
-    actionDictStats?: { reco: number; disco: number; pst: number; open_coupling: number; close_coupling: number; total: number } | null;
     combinedActions: Record<string, CombinedAction> | null;
     onUpdateCombinedEstimation?: (pairId: string, estimation: { estimated_max_rho: number; estimated_max_rho_line: string }) => void;
     /** Resolve an element/VL ID to its human-readable display name. Falls back to the ID. */
@@ -107,10 +103,6 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     monitoringFactor,
     manuallyAddedIds,
     onVlDoubleClick,
-    recommenderConfig,
-    onOpenSettings,
-    actionDictFileName,
-    actionDictStats,
     combinedActions,
     onUpdateCombinedEstimation,
     displayName = (id: string) => id,
@@ -138,8 +130,6 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     const [cardEditTap, setCardEditTap] = useState<Record<string, string>>({});
     const [resimulating, setResimulating] = useState<string | null>(null);
     const [dismissedRejectedWarning, setDismissedRejectedWarning] = useState(false);
-    const [showActionDictWarning, setShowActionDictWarning] = useState(true);
-    const [showRecommenderWarning, setShowRecommenderWarning] = useState(true);
 
     const showTooltip = (e: React.MouseEvent, content: React.ReactNode) => {
         const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
@@ -577,6 +567,45 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
         return sortedActionEntries.filter(([id]) => !selectedActionIds.has(id) && !rejectedActionIds.has(id));
     }, [sortedActionEntries, selectedActionIds, rejectedActionIds, analysisLoading]);
 
+    // Inline contextual hint counter — "N actions hidden by the
+    // overview filter" — surfaces when the user has tightened the
+    // shared overview filters so action cards disappear from the feed.
+    // Implements the second half of recommendation #4 in
+    // `docs/proposals/ui-design-critique.md`: tier the warnings, drop
+    // the redundant yellow banner stack, and add small grey contextual
+    // hints under the relevant control. Only counts non-estimation,
+    // non-combined-incomplete entries so the hint matches what the
+    // operator would actually see if they cleared the filter.
+    const overviewFilteredOutCount = useMemo(() => {
+        if (!overviewFilters) return 0;
+        const typeFilter = overviewFilters.actionType ?? 'all';
+        let hidden = 0;
+        for (const [id, details] of Object.entries(actions)) {
+            if (id.includes('+')) {
+                if (details.is_estimated) continue;
+                if (!details.rho_after || details.rho_after.length === 0) continue;
+            }
+            const passesCategory = actionPassesOverviewFilter(
+                details, monitoringFactor,
+                overviewFilters.categories, overviewFilters.threshold,
+            );
+            let passesType = true;
+            if (typeFilter !== 'all') {
+                if (id.includes('+')) {
+                    const [id1, id2] = id.split('+');
+                    const d1 = actions[id1];
+                    const d2 = actions[id2];
+                    passesType = !!((d1 && matchesActionTypeFilter(typeFilter, id1, d1.description_unitaire, null))
+                        || (d2 && matchesActionTypeFilter(typeFilter, id2, d2.description_unitaire, null)));
+                } else {
+                    passesType = matchesActionTypeFilter(typeFilter, id, details.description_unitaire, null);
+                }
+            }
+            if (!passesCategory || !passesType) hidden += 1;
+        }
+        return hidden;
+    }, [actions, overviewFilters, monitoringFactor]);
+
     // When an action becomes the currently-viewed one (typically
     // after the user double-clicks a pin in the action overview
     // diagram, or clicks an action card body), scroll the
@@ -758,30 +787,12 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     />
                 )}
             </div>
-            {/* Action Dict Info Warning */}
-            {showActionDictWarning && !simulating && !pendingAnalysisResult && Object.keys(actions).length === 0 && actionDictFileName && actionDictStats && (
-                <div style={{
-                    display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
-                    gap: '8px', padding: '8px 10px',
-                    background: colors.warningSoft, border: `1px solid ${colors.warningBorder}`,
-                    borderRadius: '6px', marginBottom: '10px', fontSize: '12px', color: colors.warningText
-                }}>
-                    <div style={{ flex: 1 }}>
-                        <div style={{ fontWeight: 600, marginBottom: '4px' }}>ℹ️ Action dictionary: <code style={{ fontFamily: 'monospace', background: colors.warningSoft, padding: '1px 4px', borderRadius: '3px', border: `1px solid ${colors.warningBorder}` }}>{actionDictFileName}</code></div>
-                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '4px' }}>
-                            <span>🔄 Reco: <strong>{actionDictStats.reco}</strong></span>
-                            <span>⛔ Disco: <strong>{actionDictStats.disco}</strong></span>
-                            <span>📐 PST: <strong>{actionDictStats.pst}</strong></span>
-                            <span>🔓 Open coupling: <strong>{actionDictStats.open_coupling}</strong></span>
-                            <span>🔒 Close coupling: <strong>{actionDictStats.close_coupling}</strong></span>
-                        </div>
-                        {onOpenSettings && (
-                            <button onClick={() => onOpenSettings('paths')} style={{ background: 'none', border: 'none', color: colors.brandStrong, textDecoration: 'underline', cursor: 'pointer', padding: 0, fontSize: '12px' }}>Change in settings</button>
-                        )}
-                    </div>
-                    <button onClick={() => setShowActionDictWarning(false)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', lineHeight: 1, color: colors.warningText }} title="Dismiss">✕</button>
-                </div>
-            )}
+            {/* Action-dictionary info now lives in NoticesPanel
+                (tier-warning-system PR — see `docs/proposals/ui-design-critique.md`
+                recommendation #4). The inline yellow banner that
+                stacked here was retired so the sidebar header carries
+                a single dismissable pill instead of up to five
+                concurrent banners. */}
             <div style={{ marginBottom: '15px' }}>
                 <h4 style={{ margin: '0 0 10px 0', fontSize: '14px', color: colors.textPrimary, borderBottom: `1px solid ${colors.borderSubtle}`, paddingBottom: '4px', display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '8px' }}>
                     Selected Actions
@@ -792,9 +803,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                         {!dismissedSelectedWarning && selectedEntries.some(([id]) => manuallyAddedIds.has(id) && analysisActionIds.has(id)) && (() => {
                             const overlapIds = selectedEntries.filter(([id]) => manuallyAddedIds.has(id) && analysisActionIds.has(id)).map(([id]) => id).join(', ');
                             return (
-                                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', padding: '8px 10px', background: colors.warningSoft, border: `1px solid ${colors.warningBorder}`, borderRadius: '6px', marginBottom: '10px', fontSize: '13px', color: colors.warningText }}>
-                                    <div>⚠️ User warning: The following manually selected actions are also recommended by the recent analysis run: {overlapIds}</div>
-                                    <button onClick={() => setDismissedSelectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '16px', lineHeight: 1, color: colors.warningText }} title="Dismiss">&times;</button>
+                                <div
+                                    data-testid="selected-overlap-hint"
+                                    style={{
+                                        display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
+                                        gap: '6px', marginBottom: '8px',
+                                        fontSize: '11px', color: colors.textTertiary, fontStyle: 'italic',
+                                    }}
+                                >
+                                    <div>Also recommended by the recent analysis: {overlapIds}</div>
+                                    <button onClick={() => setDismissedSelectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '14px', lineHeight: 1, color: colors.textTertiary }} title="Dismiss">&times;</button>
                                 </div>
                             );
                         })()}
@@ -846,6 +864,19 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
             </div>
 
             <div style={{ marginBottom: '15px' }}>
+                {overviewFilteredOutCount > 0 && (
+                    <div
+                        data-testid="overview-filter-hint"
+                        style={{
+                            marginBottom: '6px',
+                            fontSize: '11px',
+                            color: colors.textTertiary,
+                            fontStyle: 'italic',
+                        }}
+                    >
+                        {overviewFilteredOutCount} action{overviewFilteredOutCount === 1 ? '' : 's'} hidden by the overview filter.
+                    </div>
+                )}
                 <div style={{ display: 'flex', borderBottom: `1px solid ${colors.borderSubtle}`, marginBottom: '10px' }}>
                     <button
                         onClick={() => setSuggestedTab('prioritized')}
@@ -915,48 +946,9 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                 <p style={{ color: colors.textTertiary, fontStyle: 'italic', fontSize: '13px', margin: '5px 0' }}>
                                     {!pendingAnalysisResult ? 'Click \u201cAnalyze & Suggest\u201d above to get action suggestions.' : 'No suggested actions available.'}
                                 </p>
-                                {!pendingAnalysisResult && showRecommenderWarning && (
-                                    <div style={{
-                                        marginTop: '10px',
-                                        padding: '10px',
-                                        background: colors.warningSoft,
-                                        border: `1px solid ${colors.warningBorder}`,
-                                        borderRadius: '6px',
-                                        fontSize: '12px',
-                                        color: colors.warningText,
-                                        textAlign: 'left'
-                                    }}>
-                                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '6px' }}>
-                                            <div style={{ fontWeight: 'bold' }}>Recommender Settings:</div>
-                                            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                                                {onOpenSettings && (
-                                                    <button
-                                                        onClick={() => onOpenSettings('recommender')}
-                                                        style={{
-                                                            background: 'none',
-                                                            border: 'none',
-                                                            color: colors.brandStrong,
-                                                            textDecoration: 'underline',
-                                                            cursor: 'pointer',
-                                                            padding: '0',
-                                                            fontSize: '11px'
-                                                        }}
-                                                    >
-                                                        Change in settings
-                                                    </button>
-                                                )}
-                                                <button
-                                                    onClick={() => setShowRecommenderWarning(false)}
-                                                    style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: '16px', lineHeight: 1, color: colors.warningText }}
-                                                    title="Dismiss"
-                                                >&times;</button>
-                                            </div>
-                                        </div>
-                                        <div>• Minimum actions: {recommenderConfig.minLineReconnections} reco, {recommenderConfig.minCloseCoupling} close, {recommenderConfig.minOpenCoupling} open, {recommenderConfig.minLineDisconnections} disco, {recommenderConfig.minPst} PST, {recommenderConfig.minLoadShedding} load shedding, {recommenderConfig.minRenewableCurtailmentActions} RC</div>
-                                        <div>• Maximum suggestions: {recommenderConfig.nPrioritizedActions}</div>
-                                        <div>• Ignore reconnections: {recommenderConfig.ignoreReconnections ? 'Yes' : 'No'}</div>
-                                    </div>
-                                )}
+                                {/* Recommender thresholds banner moved into NoticesPanel
+                                    (tier-warning-system PR — see `docs/proposals/ui-design-critique.md`
+                                    recommendation #4). */}
                             </div>
                         ) : null
                     )
@@ -967,9 +959,16 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                             {!dismissedRejectedWarning && rejectedEntries.some(([id]) => analysisActionIds.has(id)) && (() => {
                                 const overlapIds = rejectedEntries.filter(([id]) => analysisActionIds.has(id)).map(([id]) => id).join(', ');
                                 return (
-                                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '8px', padding: '8px 10px', background: colors.warningSoft, border: `1px solid ${colors.warningBorder}`, borderRadius: '6px', marginBottom: '10px', fontSize: '13px', color: colors.warningText }}>
-                                        <div>⚠️ User warning: The following manually rejected actions were recommended by the recent analysis run: {overlapIds}</div>
-                                        <button onClick={() => setDismissedRejectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '16px', lineHeight: 1, color: colors.warningText }} title="Dismiss">&times;</button>
+                                    <div
+                                        data-testid="rejected-overlap-hint"
+                                        style={{
+                                            display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
+                                            gap: '6px', marginBottom: '8px',
+                                            fontSize: '11px', color: colors.textTertiary, fontStyle: 'italic',
+                                        }}
+                                    >
+                                        <div>Recommended by the recent analysis: {overlapIds}</div>
+                                        <button onClick={() => setDismissedRejectedWarning(true)} style={{ flexShrink: 0, background: 'none', border: 'none', cursor: 'pointer', padding: '0', fontSize: '14px', lineHeight: 1, color: colors.textTertiary }} title="Dismiss">&times;</button>
                                     </div>
                                 );
                             })()}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import SidebarSummary from './SidebarSummary';
+import NoticesPanel, { type Notice } from './NoticesPanel';
 import { colors, radius, space } from '../styles/tokens';
 
 interface AppSidebarProps {
@@ -21,6 +22,10 @@ interface AppSidebarProps {
   displayName: (id: string) => string;
   onContingencyZoom: (assetName: string) => void;
   onOverloadClick: (actionId: string, assetName: string, tab: 'n' | 'n-1') => void;
+  /** Background notices surfaced in the tiered warning system (the
+   *  tier-warning-system PR — `docs/proposals/ui-design-critique.md` recommendation #4).
+   *  When the array is empty the pill self-hides. */
+  notices?: Notice[];
   children: React.ReactNode;
 }
 
@@ -52,10 +57,16 @@ export default function AppSidebar({
   displayName,
   onContingencyZoom,
   onOverloadClick,
+  notices,
   children,
 }: AppSidebarProps) {
   return (
     <div data-testid="sidebar" style={{ width: '25%', background: colors.borderSubtle, borderRight: `1px solid ${colors.border}`, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {notices && notices.length > 0 && (
+        <div style={{ flexShrink: 0, padding: `6px ${space[3]}`, background: colors.surfaceMuted, borderBottom: `1px solid ${colors.border}` }}>
+          <NoticesPanel notices={notices} />
+        </div>
+      )}
       <SidebarSummary
         selectedBranch={selectedBranch}
         n1LinesOverloaded={n1LinesOverloaded}

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import SidebarSummary from './SidebarSummary';
-import NoticesPanel, { type Notice } from './NoticesPanel';
+import { type Notice } from './NoticesPanel';
 import { colors, radius, space } from '../styles/tokens';
 
 interface AppSidebarProps {
@@ -62,11 +62,6 @@ export default function AppSidebar({
 }: AppSidebarProps) {
   return (
     <div data-testid="sidebar" style={{ width: '25%', background: colors.borderSubtle, borderRight: `1px solid ${colors.border}`, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      {notices && notices.length > 0 && (
-        <div style={{ flexShrink: 0, padding: `6px ${space[3]}`, background: colors.surfaceMuted, borderBottom: `1px solid ${colors.border}` }}>
-          <NoticesPanel notices={notices} />
-        </div>
-      )}
       <SidebarSummary
         selectedBranch={selectedBranch}
         n1LinesOverloaded={n1LinesOverloaded}
@@ -75,6 +70,7 @@ export default function AppSidebar({
         displayName={displayName}
         onContingencyZoom={onContingencyZoom}
         onOverloadClick={onOverloadClick}
+        notices={notices}
       />
       <div style={{ flex: 1, overflowY: 'auto', padding: space[4], minHeight: 0, display: 'flex', flexDirection: 'column', gap: space[4] }}>
         {branches.length > 0 && (

--- a/frontend/src/components/DiagramLegend.test.tsx
+++ b/frontend/src/components/DiagramLegend.test.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DiagramLegend from './DiagramLegend';
+
+describe('DiagramLegend', () => {
+    it('renders a collapsed pill by default', () => {
+        render(<DiagramLegend tabId="n" />);
+        expect(screen.getByTestId('diagram-legend-pill-n')).toBeInTheDocument();
+        expect(screen.queryByTestId('diagram-legend-n')).not.toBeInTheDocument();
+    });
+
+    it('expands to a panel on click', async () => {
+        const user = userEvent.setup();
+        render(<DiagramLegend tabId="n" />);
+        await user.click(screen.getByTestId('diagram-legend-pill-n'));
+        expect(screen.getByTestId('diagram-legend-n')).toBeInTheDocument();
+        expect(screen.getByText('Overloaded line')).toBeInTheDocument();
+    });
+
+    it('hides the contingency entry on the N tab', async () => {
+        const user = userEvent.setup();
+        render(<DiagramLegend tabId="n" />);
+        await user.click(screen.getByTestId('diagram-legend-pill-n'));
+        expect(screen.queryByText('Contingency')).not.toBeInTheDocument();
+    });
+
+    it('shows the contingency entry on the N-1 tab', async () => {
+        const user = userEvent.setup();
+        render(<DiagramLegend tabId="n-1" />);
+        await user.click(screen.getByTestId('diagram-legend-pill-n-1'));
+        expect(screen.getByText('Contingency')).toBeInTheDocument();
+        // Action target only relevant on the action tab.
+        expect(screen.queryByText('Action target')).not.toBeInTheDocument();
+    });
+
+    it('shows the contingency AND action-target entries on the action tab', async () => {
+        const user = userEvent.setup();
+        render(<DiagramLegend tabId="action" />);
+        await user.click(screen.getByTestId('diagram-legend-pill-action'));
+        expect(screen.getByText('Contingency')).toBeInTheDocument();
+        expect(screen.getByText('Action target')).toBeInTheDocument();
+        expect(screen.getByText('Flow up after change')).toBeInTheDocument();
+        expect(screen.getByText('Flow down after change')).toBeInTheDocument();
+    });
+
+    it('renders the voltage-level note when more than one voltage is present', async () => {
+        const user = userEvent.setup();
+        render(<DiagramLegend tabId="n" uniqueVoltages={[63, 225, 400]} />);
+        await user.click(screen.getByTestId('diagram-legend-pill-n'));
+        expect(screen.getByText('Voltage levels (kV)')).toBeInTheDocument();
+    });
+
+    it('mentions the VL-names toggle when names are hidden', async () => {
+        const user = userEvent.setup();
+        render(<DiagramLegend tabId="n" vlNamesHidden />);
+        await user.click(screen.getByTestId('diagram-legend-pill-n'));
+        expect(screen.getByText(/Voltage-level names are hidden/i)).toBeInTheDocument();
+    });
+
+    it('collapses back to a pill when the close button is clicked', async () => {
+        const user = userEvent.setup();
+        render(<DiagramLegend tabId="n" />);
+        await user.click(screen.getByTestId('diagram-legend-pill-n'));
+        await user.click(screen.getByLabelText('Hide diagram legend'));
+        expect(screen.getByTestId('diagram-legend-pill-n')).toBeInTheDocument();
+        expect(screen.queryByTestId('diagram-legend-n')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/DiagramLegend.tsx
+++ b/frontend/src/components/DiagramLegend.tsx
@@ -1,0 +1,198 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { useMemo, useState } from 'react';
+import type { TabId } from '../types';
+import { colors, radius, space, text } from '../styles/tokens';
+
+interface DiagramLegendProps {
+  /** Which diagram tab the legend overlays. Drives which entries
+   *  appear: contingency only on N-1 / action, action target only on
+   *  action. */
+  tabId: TabId;
+  /**
+   * Voltage levels currently visible in the diagram (kV). Used to
+   * render the small voltage-level color swatch row at the bottom of
+   * the legend. Pass the same `uniqueVoltages` array the kV slider
+   * already consumes.
+   */
+  uniqueVoltages?: number[];
+  /**
+   * When true, voltage labels are hidden via the `nad-hide-vl-labels`
+   * class. The legend mentions this so a new operator knows the
+   * absence of labels is intentional, not a render bug.
+   */
+  vlNamesHidden?: boolean;
+}
+
+interface LegendRow {
+  /** Token-resolved color for the swatch. */
+  color: string;
+  /** What the swatch is — one short phrase. */
+  label: string;
+  /** Optional sub-label (smaller, italic). Used for "dashed line", etc. */
+  detail?: string;
+  /** When true, the swatch renders as a dashed segment instead of a
+   *  filled square. Used for disconnections. */
+  dashed?: boolean;
+}
+
+/**
+ * Collapsible legend that overlays the bottom-right of each diagram
+ * tab. Implements `docs/proposals/ui-design-critique.md`
+ * recommendation #5: surface the halo / disconnection / voltage
+ * colour conventions on-screen so a new operator does not have to
+ * learn them out-of-band.
+ *
+ * The legend is collapsed by default — the operator clicks a small
+ * "Legend" pill to expand it. Closing returns to the pill so the
+ * legend never competes with the network when the operator is
+ * scanning. State is local; collapse preference is not persisted
+ * (across sessions) so each tab open starts in the compact state.
+ */
+export default function DiagramLegend({ tabId, uniqueVoltages, vlNamesHidden }: DiagramLegendProps) {
+  const [open, setOpen] = useState(false);
+
+  const rows = useMemo<LegendRow[]>(() => {
+    const list: LegendRow[] = [];
+    if (tabId === 'n-1' || tabId === 'action') {
+      list.push({ color: 'var(--signal-contingency)', label: 'Contingency', detail: 'yellow halo on the disconnected element' });
+    }
+    if (tabId === 'action') {
+      list.push({ color: 'var(--signal-action-target)', label: 'Action target', detail: 'pink halo on the remedial action' });
+    }
+    list.push({ color: 'var(--signal-overload)', label: 'Overloaded line', detail: 'orange halo (ρ ≥ 100% of monitoring factor)' });
+    if (tabId === 'n-1' || tabId === 'action') {
+      list.push({ color: 'var(--signal-delta-positive)', label: 'Flow up after change', detail: 'orange line in delta view' });
+      list.push({ color: 'var(--signal-delta-negative)', label: 'Flow down after change', detail: 'blue line in delta view' });
+    }
+    list.push({ color: colors.textTertiary, label: 'Disconnected branch', detail: 'dashed grey segment', dashed: true });
+    return list;
+  }, [tabId]);
+
+  // For voltage levels we restrict to the most populated handful so
+  // the legend stays compact. The diagram's pypowsybl palette assigns
+  // colours dynamically, so we mention the convention rather than try
+  // to mirror every palette entry.
+  const showVoltagePalette = (uniqueVoltages?.length ?? 0) > 1;
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        data-testid={`diagram-legend-pill-${tabId}`}
+        onClick={() => setOpen(true)}
+        title="Show diagram legend"
+        aria-expanded={false}
+        style={{
+          position: 'absolute',
+          right: space[3],
+          bottom: space[3],
+          zIndex: 25,
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: space[1],
+          padding: `4px ${space[2]}`,
+          background: colors.surface,
+          color: colors.textSecondary,
+          border: `1px solid ${colors.border}`,
+          borderRadius: radius.lg,
+          fontSize: text.xs,
+          fontWeight: 600,
+          cursor: 'pointer',
+          boxShadow: '0 2px 6px rgba(0,0,0,0.12)',
+        }}
+      >
+        <span aria-hidden="true">🗺️</span>
+        Legend
+      </button>
+    );
+  }
+
+  return (
+    <div
+      data-testid={`diagram-legend-${tabId}`}
+      role="dialog"
+      aria-label="Diagram legend"
+      style={{
+        position: 'absolute',
+        right: space[3],
+        bottom: space[3],
+        zIndex: 25,
+        width: '240px',
+        maxHeight: '60%',
+        overflowY: 'auto',
+        background: colors.surface,
+        border: `1px solid ${colors.border}`,
+        borderRadius: radius.md,
+        boxShadow: '0 4px 14px rgba(0,0,0,0.18)',
+        padding: space[2],
+        fontSize: text.xs,
+        color: colors.textPrimary,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: space[2] }}>
+        <strong style={{ fontSize: text.sm }}>Legend</strong>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          aria-label="Hide diagram legend"
+          title="Hide legend"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: 0,
+            fontSize: text.lg,
+            lineHeight: 1,
+            color: colors.textTertiary,
+          }}
+        >
+          &times;
+        </button>
+      </div>
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: space[1] }}>
+        {rows.map(row => (
+          <li key={`${row.label}-${row.detail ?? ''}`} style={{ display: 'flex', alignItems: 'flex-start', gap: space[2] }}>
+            <span
+              aria-hidden="true"
+              style={{
+                flexShrink: 0,
+                marginTop: '2px',
+                width: '18px',
+                height: '4px',
+                borderRadius: '2px',
+                background: row.dashed ? 'transparent' : row.color,
+                borderTop: row.dashed ? `2px dashed ${row.color}` : 'none',
+                boxShadow: row.dashed ? 'none' : `0 0 0 1px rgba(0,0,0,0.05)`,
+              }}
+            />
+            <span style={{ flex: 1 }}>
+              <div style={{ fontWeight: 600 }}>{row.label}</div>
+              {row.detail && (
+                <div style={{ color: colors.textTertiary, fontSize: '10px' }}>{row.detail}</div>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {showVoltagePalette && (
+        <div style={{ marginTop: space[2], paddingTop: space[2], borderTop: `1px solid ${colors.borderSubtle}` }}>
+          <div style={{ fontWeight: 600, marginBottom: space[1] }}>Voltage levels (kV)</div>
+          <div style={{ color: colors.textTertiary, fontSize: '10px' }}>
+            Buses are coloured by nominal voltage — pypowsybl palette, brighter at higher kV. Use the kV filter on the right edge of the diagram to focus on a slice.
+          </div>
+        </div>
+      )}
+      {vlNamesHidden && (
+        <div style={{ marginTop: space[1], color: colors.textTertiary, fontSize: '10px', fontStyle: 'italic' }}>
+          Voltage-level names are hidden — toggle <strong>VL</strong> next to Inspect to show them.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NoticesPanel.test.tsx
+++ b/frontend/src/components/NoticesPanel.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NoticesPanel, { type Notice } from './NoticesPanel';
+
+describe('NoticesPanel', () => {
+    const baseNotices: Notice[] = [
+        { id: 'one', title: 'First notice', body: 'Lorem ipsum.', severity: 'info' },
+        { id: 'two', title: 'Second notice', body: 'Dolor sit amet.', severity: 'warning' },
+    ];
+
+    it('renders nothing when the notices array is empty', () => {
+        const { container } = render(<NoticesPanel notices={[]} />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders the pill with a count badge when notices are present', () => {
+        render(<NoticesPanel notices={baseNotices} />);
+        const pill = screen.getByTestId('notices-pill');
+        expect(pill).toBeInTheDocument();
+        expect(pill).toHaveTextContent('2');
+        // Panel is collapsed by default — list should not be visible.
+        expect(screen.queryByTestId('notices-list')).not.toBeInTheDocument();
+    });
+
+    it('expands the panel and shows each notice when the pill is clicked', async () => {
+        const user = userEvent.setup();
+        render(<NoticesPanel notices={baseNotices} />);
+        await user.click(screen.getByTestId('notices-pill'));
+        expect(screen.getByTestId('notices-list')).toBeInTheDocument();
+        expect(screen.getByTestId('notice-one')).toHaveTextContent('First notice');
+        expect(screen.getByTestId('notice-two')).toHaveTextContent('Second notice');
+    });
+
+    it('invokes onDismiss when the dismiss button is clicked', async () => {
+        const user = userEvent.setup();
+        const onDismiss = vi.fn();
+        render(
+            <NoticesPanel
+                notices={[{ id: 'mon', title: 'Monitoring', body: 'body', onDismiss }]}
+            />,
+        );
+        await user.click(screen.getByTestId('notices-pill'));
+        await user.click(screen.getByLabelText('Dismiss Monitoring'));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders an in-card action button and triggers it on click', async () => {
+        const user = userEvent.setup();
+        const onClick = vi.fn();
+        render(
+            <NoticesPanel
+                notices={[{
+                    id: 'rec',
+                    title: 'Recommender',
+                    body: 'body',
+                    action: { label: 'Open settings', onClick },
+                }]}
+            />,
+        );
+        await user.click(screen.getByTestId('notices-pill'));
+        await user.click(screen.getByText('Open settings'));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the panel when the underlying notice list becomes empty', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(<NoticesPanel notices={baseNotices} />);
+        await user.click(screen.getByTestId('notices-pill'));
+        expect(screen.getByTestId('notices-list')).toBeInTheDocument();
+
+        rerender(<NoticesPanel notices={[]} />);
+        // With zero notices the pill self-hides entirely.
+        expect(screen.queryByTestId('notices-pill')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('notices-list')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/NoticesPanel.tsx
+++ b/frontend/src/components/NoticesPanel.tsx
@@ -1,0 +1,217 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import React, { useEffect, useRef, useState } from 'react';
+import { colors, radius, space, text } from '../styles/tokens';
+
+export interface Notice {
+  /** Stable id used as React key and for dismiss tracking. */
+  id: string;
+  /** One-line title shown bold on the notice card. */
+  title: string;
+  /**
+   * Body content. ReactNode so callers can compose icons / inline buttons /
+   * styled fragments. Rendered with the warning-text color on a soft yellow
+   * background for visual continuity with the previous inline banners.
+   */
+  body: React.ReactNode;
+  /**
+   * Visual severity. `info` renders blue, `warning` renders yellow.
+   * Both share the same panel layout so the operator can scan all
+   * active notices at once.
+   */
+  severity?: 'info' | 'warning';
+  /** Optional dismiss handler — when set, a × appears on the card. */
+  onDismiss?: () => void;
+  /** Optional in-card action button (e.g. "Open settings"). */
+  action?: { label: string; onClick: () => void };
+}
+
+interface NoticesPanelProps {
+  notices: Notice[];
+}
+
+/**
+ * Sidebar-header pill that opens an inline panel listing every active
+ * background notice (action-dict info, recommender thresholds,
+ * monitoring coverage). Replaces the five concurrent yellow banners
+ * called out in `docs/proposals/ui-design-critique.md` recommendation
+ * #4 — one entry point, one place to dismiss, no warning-fatigue
+ * stack.
+ *
+ * The pill self-hides when there are zero active notices so the
+ * sidebar header stays clean once the operator has dismissed
+ * everything they wanted to dismiss.
+ */
+export default function NoticesPanel({ notices }: NoticesPanelProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close-on-outside-click — keeps the panel modal-light without
+  // requiring a backdrop layer that would compete with the rest of
+  // the chrome.
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  // When the underlying state retires every notice (e.g. operator
+  // hits Dismiss on the last one) we early-return below so the pill
+  // and the open panel both unmount. The `open` state is intentionally
+  // not reset here — when fresh notices arrive on a later render the
+  // panel will be re-mounted in its default collapsed state because
+  // useState defaults run per-mount.
+  if (notices.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="notices-panel"
+      style={{ position: 'relative', flexShrink: 0 }}
+    >
+      <button
+        type="button"
+        data-testid="notices-pill"
+        onClick={() => setOpen(prev => !prev)}
+        title={`${notices.length} active notice${notices.length === 1 ? '' : 's'}`}
+        aria-expanded={open}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: space[1],
+          padding: `3px ${space[2]}`,
+          border: `1px solid ${colors.warningBorder}`,
+          background: colors.warningSoft,
+          color: colors.warningText,
+          borderRadius: radius.lg,
+          fontSize: text.xs,
+          fontWeight: 600,
+          cursor: 'pointer',
+          lineHeight: 1.4,
+        }}
+      >
+        <span aria-hidden="true">⚠️</span>
+        Notices
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minWidth: '18px',
+            height: '18px',
+            padding: `0 ${space[1]}`,
+            background: colors.warning,
+            color: colors.textPrimary,
+            borderRadius: '999px',
+            fontSize: text.xs,
+            fontWeight: 700,
+          }}
+        >
+          {notices.length}
+        </span>
+      </button>
+
+      {open && (
+        <div
+          data-testid="notices-list"
+          role="dialog"
+          aria-label="Active notices"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 4px)',
+            left: 0,
+            right: 'auto',
+            zIndex: 50,
+            width: '320px',
+            maxHeight: '60vh',
+            overflowY: 'auto',
+            background: colors.surface,
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.md,
+            boxShadow: '0 6px 20px rgba(0,0,0,0.18)',
+            padding: space[2],
+            display: 'flex',
+            flexDirection: 'column',
+            gap: space[2],
+          }}
+        >
+          {notices.map(notice => {
+            const isInfo = notice.severity === 'info';
+            return (
+              <div
+                key={notice.id}
+                data-testid={`notice-${notice.id}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  justifyContent: 'space-between',
+                  gap: space[2],
+                  padding: `${space[2]} ${space[3]}`,
+                  background: isInfo ? colors.infoSoft : colors.warningSoft,
+                  border: `1px solid ${isInfo ? colors.infoBorder : colors.warningBorder}`,
+                  borderRadius: radius.sm,
+                  fontSize: text.sm,
+                  color: isInfo ? colors.infoText : colors.warningText,
+                  lineHeight: 1.45,
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontWeight: 700, marginBottom: space[1] }}>{notice.title}</div>
+                  <div>{notice.body}</div>
+                  {notice.action && (
+                    <button
+                      type="button"
+                      onClick={notice.action.onClick}
+                      style={{
+                        marginTop: space[1],
+                        background: 'none',
+                        border: 'none',
+                        color: colors.brandStrong,
+                        textDecoration: 'underline',
+                        cursor: 'pointer',
+                        padding: 0,
+                        fontSize: text.xs,
+                      }}
+                    >
+                      {notice.action.label}
+                    </button>
+                  )}
+                </div>
+                {notice.onDismiss && (
+                  <button
+                    type="button"
+                    onClick={notice.onDismiss}
+                    title="Dismiss"
+                    aria-label={`Dismiss ${notice.title}`}
+                    style={{
+                      flexShrink: 0,
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      padding: 0,
+                      fontSize: text.lg,
+                      lineHeight: 1,
+                      color: 'inherit',
+                    }}
+                  >
+                    &times;
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/OverloadPanel.test.tsx
+++ b/frontend/src/components/OverloadPanel.test.tsx
@@ -112,78 +112,26 @@ describe('OverloadPanel', () => {
         expect(screen.getByText('N-1 Overloads:')).toBeInTheDocument();
     });
 
-    describe('Monitoring Warning', () => {
-        it('renders warning banner when showMonitoringWarning is true and totalLinesCount > 0', () => {
+    describe('Monitoring Hint', () => {
+        // tier-warning-system PR (`docs/proposals/ui-design-critique.md` recommendation #4)
+        // demoted the inline yellow monitoring banner. The full notice now
+        // lives in NoticesPanel; OverloadPanel keeps only a small grey
+        // contextual hint under the heading.
+        it('renders the monitoring hint when provided', () => {
             render(
                 <OverloadPanel
                     {...defaultProps}
-                    showMonitoringWarning={true}
-                    monitoredLinesCount={130}
-                    totalLinesCount={150}
-                    monitoringFactor={0.95}
-                    preExistingOverloadThreshold={0.02}
+                    monitoringHint="130/150 lines monitored — see Notices for details."
                 />
             );
-            expect(screen.getByText(/lines monitored/i)).toBeInTheDocument();
-            expect(screen.getByText('130')).toBeInTheDocument();
-            expect(screen.getByText('150')).toBeInTheDocument();
-            expect(screen.getByText(/20.*without permanent limits/i)).toBeInTheDocument();
+            expect(screen.getByTestId('overload-monitoring-hint')).toHaveTextContent(
+                '130/150 lines monitored — see Notices for details.',
+            );
         });
 
-        it('does not render warning banner when showMonitoringWarning is false', () => {
-            render(
-                <OverloadPanel
-                    {...defaultProps}
-                    showMonitoringWarning={false}
-                    monitoredLinesCount={130}
-                    totalLinesCount={150}
-                />
-            );
-            expect(screen.queryByText(/out of/i)).not.toBeInTheDocument();
-        });
-
-        it('does not render warning banner when totalLinesCount is 0', () => {
-            render(
-                <OverloadPanel
-                    {...defaultProps}
-                    showMonitoringWarning={true}
-                    monitoredLinesCount={0}
-                    totalLinesCount={0}
-                />
-            );
-            expect(screen.queryByText(/out of/i)).not.toBeInTheDocument();
-        });
-
-        it('calls onOpenSettings when "Change in settings" is clicked', async () => {
-            const user = userEvent.setup();
-            const onOpenSettings = vi.fn();
-            render(
-                <OverloadPanel
-                    {...defaultProps}
-                    showMonitoringWarning={true}
-                    totalLinesCount={10}
-                    onOpenSettings={onOpenSettings}
-                />
-            );
-            
-            await user.click(screen.getByText('Change in settings'));
-            expect(onOpenSettings).toHaveBeenCalled();
-        });
-
-        it('calls onDismissWarning when dismiss button is clicked', async () => {
-            const user = userEvent.setup();
-            const onDismissWarning = vi.fn();
-            render(
-                <OverloadPanel
-                    {...defaultProps}
-                    showMonitoringWarning={true}
-                    totalLinesCount={10}
-                    onDismissWarning={onDismissWarning}
-                />
-            );
-            
-            await user.click(screen.getByTitle('Dismiss'));
-            expect(onDismissWarning).toHaveBeenCalled();
+        it('omits the hint when monitoringHint is null', () => {
+            render(<OverloadPanel {...defaultProps} monitoringHint={null} />);
+            expect(screen.queryByTestId('overload-monitoring-hint')).not.toBeInTheDocument();
         });
     });
 });

--- a/frontend/src/components/OverloadPanel.tsx
+++ b/frontend/src/components/OverloadPanel.tsx
@@ -6,7 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import React from 'react';
-import { colors, radius, space, text } from '../styles/tokens';
+import { colors, space, text } from '../styles/tokens';
 
 interface OverloadPanelProps {
     nOverloads: string[];
@@ -29,13 +29,13 @@ interface OverloadPanelProps {
      * network state.
      */
     onAssetClick: (actionId: string, assetName: string, tab?: 'n' | 'n-1') => void;
-    showMonitoringWarning?: boolean;
-    monitoredLinesCount?: number;
-    totalLinesCount?: number;
-    monitoringFactor?: number;
-    preExistingOverloadThreshold?: number;
-    onDismissWarning?: () => void;
-    onOpenSettings?: () => void;
+    /**
+     * Inline contextual hint shown beneath the heading. Replaces the
+     * previous full yellow banner — the full notice now lives in
+     * NoticesPanel (tier-warning-system PR). Pass a short string like "130/150 lines
+     * monitored — see Notices for details" or leave undefined.
+     */
+    monitoringHint?: string | null;
     selectedOverloads?: Set<string>;
     onToggleOverload?: (overload: string) => void;
     monitorDeselected?: boolean;
@@ -50,13 +50,7 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
     nOverloadsRho,
     n1OverloadsRho,
     onAssetClick,
-    showMonitoringWarning,
-    monitoredLinesCount,
-    totalLinesCount,
-    monitoringFactor,
-    preExistingOverloadThreshold,
-    onDismissWarning,
-    onOpenSettings,
+    monitoringHint,
     selectedOverloads,
     onToggleOverload,
     monitorDeselected = false,
@@ -124,7 +118,6 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
     };
 
     const hasDeselected = n1Overloads.some(name => !(selectedOverloads?.has(name) ?? true));
-    const deselectedCount = hasDeselected && selectedOverloads ? n1Overloads.filter(name => !selectedOverloads.has(name)).length : 0;
 
     return (
         <div style={{
@@ -138,33 +131,17 @@ const OverloadPanel: React.FC<OverloadPanelProps> = ({
                 <span style={{ color: colors.danger }}>⚠️</span> Overloads
             </h3>
 
-            {showMonitoringWarning && totalLinesCount && totalLinesCount > 0 && (
-                <div style={{
-                    marginBottom: space[2],
-                    padding: `${space[2]} ${space[3]}`,
-                    background: colors.warningSoft,
-                    border: `1px solid ${colors.warningBorder}`,
-                    borderRadius: radius.sm,
-                    color: colors.warningText,
-                    fontSize: '0.8rem',
-                    position: 'relative'
-                }}>
-                    ⚠️ <strong>{monitorDeselected ? (monitoredLinesCount || 0) : (monitoredLinesCount || 0) - (hasDeselected ? deselectedCount : 0)}</strong> out of <strong>{totalLinesCount}</strong> lines monitored ({totalLinesCount - (monitoredLinesCount || 0)} without permanent limits{hasDeselected && !monitorDeselected ? `, and ${deselectedCount} deselected` : ''}). Monitoring factor: {Math.round((monitoringFactor || 0.95) * 100)}%. {Math.round((preExistingOverloadThreshold || 0.02) * 100)}% loading increase threshold for considering worsened overload in N.
-                    <button
-                        onClick={onOpenSettings}
-                        style={{ background: 'none', border: 'none', color: colors.brandStrong, textDecoration: 'underline', cursor: 'pointer', padding: `0 0 0 5px`, fontSize: 'inherit' }}
-                    >
-                        Change in settings
-                    </button>
-                    {onDismissWarning && (
-                        <button
-                            onClick={onDismissWarning}
-                            style={{ float: 'right', background: 'none', border: 'none', fontSize: text.lg, lineHeight: 1, color: colors.warningText, cursor: 'pointer' }}
-                            title="Dismiss"
-                        >
-                            &times;
-                        </button>
-                    )}
+            {monitoringHint && (
+                <div
+                    data-testid="overload-monitoring-hint"
+                    style={{
+                        marginBottom: space[1],
+                        fontSize: text.xs,
+                        color: colors.textTertiary,
+                        fontStyle: 'italic',
+                    }}
+                >
+                    {monitoringHint}
                 </div>
             )}
 

--- a/frontend/src/components/SidebarSummary.tsx
+++ b/frontend/src/components/SidebarSummary.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { colors, space, text } from '../styles/tokens';
+import NoticesPanel, { type Notice } from './NoticesPanel';
 
 interface SidebarSummaryProps {
   selectedBranch: string;
@@ -16,6 +17,10 @@ interface SidebarSummaryProps {
   displayName: (id: string) => string;
   onContingencyZoom: (assetName: string) => void;
   onOverloadClick: (actionId: string, assetName: string, tab: 'n' | 'n-1') => void;
+  /** Background notices; rendered as a NoticesPanel pill anchored
+   *  top-right of the strip so the contingency / N-1 lines and the
+   *  notices share one horizontal band rather than stacking. */
+  notices?: Notice[];
 }
 
 /**
@@ -34,9 +39,11 @@ export default function SidebarSummary({
   displayName,
   onContingencyZoom,
   onOverloadClick,
+  notices,
 }: SidebarSummaryProps) {
   const hasOverloads = (n1LinesOverloaded?.length ?? 0) > 0;
-  if (!selectedBranch && !hasOverloads) return null;
+  const hasNotices = (notices?.length ?? 0) > 0;
+  if (!selectedBranch && !hasOverloads && !hasNotices) return null;
 
   return (
     <div
@@ -49,8 +56,13 @@ export default function SidebarSummary({
         fontSize: text.xs,
         lineHeight: 1.5,
         boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        gap: space[2],
       }}
     >
+      <div style={{ flex: 1, minWidth: 0 }}>
       {selectedBranch && (
         <div style={{ display: 'flex', alignItems: 'baseline', gap: space[1] }}>
           <span style={{ color: colors.textSecondary, fontWeight: 600, whiteSpace: 'nowrap' }}>🎯 Contingency:</span>
@@ -110,6 +122,12 @@ export default function SidebarSummary({
               );
             })}
           </span>
+        </div>
+      )}
+      </div>
+      {hasNotices && (
+        <div style={{ flexShrink: 0, marginTop: 1 }}>
+          <NoticesPanel notices={notices!} />
         </div>
       )}
     </div>

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -11,6 +11,7 @@ import MemoizedSvgContainer from './MemoizedSvgContainer';
 import SldOverlay from './SldOverlay';
 import DetachableTabHost from './DetachableTabHost';
 import ActionOverviewDiagram from './ActionOverviewDiagram';
+import DiagramLegend from './DiagramLegend';
 import type { DetachedTabsMap } from '../hooks/useDetachedTabs';
 import type { PZInstance } from '../hooks/useTiedTabsSync';
 import { colors } from '../styles/tokens';
@@ -1054,6 +1055,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             </div>
                         )}
                         {renderTabOverlay('n', true)}
+                        {nDiagram?.svg && (
+                            <DiagramLegend tabId="n" uniqueVoltages={uniqueVoltages} vlNamesHidden={!showVoltageLevelNames} />
+                        )}
                     </div>
                 </DetachableTabHost>
                 {activeTab === 'n' && detachedTabs['n'] && renderDetachedPlaceholder('n', 'Network (N)', colors.brand)}
@@ -1104,6 +1108,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             </div>
                         )}
                         {renderTabOverlay('n-1', true)}
+                        {n1Diagram?.svg && (
+                            <DiagramLegend tabId="n-1" uniqueVoltages={uniqueVoltages} vlNamesHidden={!showVoltageLevelNames} />
+                        )}
                     </div>
                 </DetachableTabHost>
                 {activeTab === 'n-1' && detachedTabs['n-1'] && renderDetachedPlaceholder('n-1', 'Contingency (N-1)', colors.danger)}
@@ -1195,6 +1202,9 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                           when the N-1 background is missing).
                         */}
                         {renderTabOverlay('action', true)}
+                        {(actionDiagram?.svg || (n1Diagram?.svg && !selectedActionId)) && (
+                            <DiagramLegend tabId="action" uniqueVoltages={uniqueVoltages} vlNamesHidden={!showVoltageLevelNames} />
+                        )}
                     </div>
                 </DetachableTabHost>
                 {activeTab === 'action' && detachedTabs['action'] && renderDetachedPlaceholder('action', selectedActionId ? `Remedial Action: ${selectedActionId}` : 'Remedial action: overview', 'var(--signal-action-target)')}

--- a/frontend/src/uxConsistency.test.tsx
+++ b/frontend/src/uxConsistency.test.tsx
@@ -1,0 +1,499 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+// Cross-component UX consistency checks rooted in
+// `docs/proposals/ui-design-critique.md`. Each `describe` block guards
+// the user-observable contract of one of the five recommendations:
+//
+//   1. Design-token layer — no raw hex literals leak into rendered
+//      DOM `style` attributes for the migrated components.
+//   2. Progressive-disclosure ActionCard — at-rest cards hide the
+//      editable detail rows; viewing cards reveal them.
+//   3. NAD overload-halo cap (CSS contract — covered by the Layer-4
+//      static invariant `nad_overload_halo_capped_at_zoom`. The
+//      runtime check would require a real pypowsybl SVG, so we keep
+//      the static invariant as the gate and only assert here that
+//      the rule lives in App.css).
+//   4. Tier the warning system — no inline yellow banner in the
+//      ActionFeed / OverloadPanel surfaces; NoticesPanel surfaces
+//      one entry point in AppSidebar.
+//   5. Diagram legend — every diagram tab carries a collapsible
+//      legend pill when its SVG is mounted.
+//
+// These tests render the real components (no mocks of the components
+// under test) so a future refactor that violates the contract — for
+// example, re-introducing the dismissable yellow banner inside
+// ActionFeed — fails this file even if the per-component unit tests
+// keep passing.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { createRef } from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+vi.mock('./utils/svgUtils', async () => {
+    const actual = await vi.importActual<typeof import('./utils/svgUtils')>('./utils/svgUtils');
+    return {
+        ...actual,
+        // Override the side-effecting / SVG-mutating ones with no-ops
+        // so jsdom doesn't choke on raw pypowsybl payloads. The pure
+        // helpers (`actionPassesOverviewFilter`, `processSvg`, etc.)
+        // come through unmodified from `actual`.
+        applyOverloadedHighlights: vi.fn(),
+        applyDeltaVisuals: vi.fn(),
+        applyActionTargetHighlights: vi.fn(),
+        applyContingencyHighlight: vi.fn(),
+        applyActionOverviewHighlights: vi.fn(),
+        applyActionOverviewPins: vi.fn(),
+        rescaleActionOverviewPins: vi.fn(),
+        applyVlTitles: vi.fn(),
+        boostSvgForLargeGrid: vi.fn(),
+        invalidateIdMapCache: vi.fn(),
+    };
+});
+
+import OverloadPanel from './components/OverloadPanel';
+import ActionFeed from './components/ActionFeed';
+import AppSidebar from './components/AppSidebar';
+import VisualizationPanel from './components/VisualizationPanel';
+import ActionCard from './components/ActionCard';
+import type { Notice } from './components/NoticesPanel';
+import type { ActionDetail, AnalysisResult, CombinedAction, DiagramData, TabId } from './types';
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+const HEX_LITERAL_RE = /(?<![\w&#])#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{3,4})\b/g;
+
+/**
+ * Walk every `[style]` attribute under `root` and collect raw inline
+ * hex literals. The design-token migration (recommendation #1) means
+ * components must emit `var(--…)` strings rather than baked hex.
+ *
+ * pypowsybl SVG fixtures are exempt because the bundled diagram
+ * payloads still carry the original `<style>` block — we only audit
+ * inline styles authored in our own components.
+ */
+function collectRawHexInInlineStyles(root: HTMLElement): { selector: string; hex: string }[] {
+    const hits: { selector: string; hex: string }[] = [];
+    root.querySelectorAll<HTMLElement>('[style]').forEach((el) => {
+        const style = el.getAttribute('style') || '';
+        const matches = style.match(HEX_LITERAL_RE);
+        if (matches) {
+            for (const hex of matches) {
+                hits.push({ selector: describeNode(el), hex });
+            }
+        }
+    });
+    return hits;
+}
+
+function describeNode(el: HTMLElement): string {
+    const id = el.id ? `#${el.id}` : '';
+    const cls = el.className ? `.${String(el.className).split(/\s+/).filter(Boolean).slice(0, 2).join('.')}` : '';
+    const testId = el.getAttribute('data-testid');
+    return `${el.tagName.toLowerCase()}${id}${cls}${testId ? `[data-testid="${testId}"]` : ''}`;
+}
+
+/** True iff any descendant element renders the warning-banner palette
+ *  (yellow soft fill from `var(--color-warning-soft)`). Used to guard
+ *  the warning-tier consolidation. */
+function hasInlineWarningBanner(root: HTMLElement): HTMLElement | null {
+    const candidates = root.querySelectorAll<HTMLElement>('[style*="var(--color-warning-soft)"]');
+    for (const el of candidates) {
+        const styleAttr = el.getAttribute('style') || '';
+        if (styleAttr.includes('background') && styleAttr.includes('var(--color-warning-soft)')) {
+            return el;
+        }
+    }
+    return null;
+}
+
+// ------------------------------------------------------------------
+// Recommendation #1 — Design tokens
+// ------------------------------------------------------------------
+
+describe('UX consistency — Recommendation #1 (design tokens)', () => {
+    it('OverloadPanel emits no raw hex literals in inline styles', () => {
+        const { container } = render(
+            <OverloadPanel
+                nOverloads={['LINE_A']}
+                n1Overloads={['LINE_B']}
+                onAssetClick={vi.fn()}
+                monitoringHint="130/150 lines monitored — see Notices for details."
+            />,
+        );
+        expect(collectRawHexInInlineStyles(container)).toEqual([]);
+    });
+
+    it('AppSidebar emits no raw hex literals in inline styles', () => {
+        const notice: Notice = { id: 'mon', title: 'Monitoring', body: 'body', severity: 'warning' };
+        const { container } = render(
+            <AppSidebar
+                selectedBranch=""
+                branches={[]}
+                nameMap={{}}
+                n1LinesOverloaded={undefined}
+                n1LinesOverloadedRho={undefined}
+                selectedOverloads={undefined}
+                contingencyOptions={null}
+                onContingencyChange={vi.fn()}
+                displayName={(id) => id}
+                onContingencyZoom={vi.fn()}
+                onOverloadClick={vi.fn()}
+                notices={[notice]}
+            >
+                <div />
+            </AppSidebar>,
+        );
+        expect(collectRawHexInInlineStyles(container)).toEqual([]);
+    });
+});
+
+// ------------------------------------------------------------------
+// Recommendation #2 — Progressive-disclosure ActionCard
+// ------------------------------------------------------------------
+
+describe('UX consistency — Recommendation #2 (progressive disclosure)', () => {
+    const emptyTopo = { lines_ex_bus: {}, lines_or_bus: {}, gens_bus: {}, loads_bus: {} };
+    const baseDetails: ActionDetail = {
+        description_unitaire: 'Shed load on LD_A — 12.5 MW',
+        rho_before: [1.05],
+        rho_after: [0.85],
+        max_rho: 0.85,
+        max_rho_line: 'LINE_A',
+        is_rho_reduction: true,
+        action_topology: emptyTopo,
+        load_shedding_details: [{ load_name: 'LD_A', shedded_mw: 12.5 }],
+    };
+    const baseProps = {
+        id: 'act_1',
+        details: baseDetails,
+        index: 0,
+        isSelected: false,
+        isRejected: false,
+        linesOverloaded: ['LINE_A'],
+        monitoringFactor: 0.95,
+        nodesByEquipmentId: null,
+        edgesByEquipmentId: null,
+        cardEditMw: {} as Record<string, string>,
+        cardEditTap: {} as Record<string, string>,
+        resimulating: null as string | null,
+        onActionSelect: vi.fn(),
+        onActionFavorite: vi.fn(),
+        onActionReject: vi.fn(),
+        onAssetClick: vi.fn(),
+        onVlDoubleClick: vi.fn(),
+        onCardEditMwChange: vi.fn(),
+        onCardEditTapChange: vi.fn(),
+        onResimulate: vi.fn(),
+        onResimulateTap: vi.fn(),
+    };
+
+    it('hides the disclosure subtree at rest (isViewing=false)', () => {
+        render(<ActionCard {...baseProps} isViewing={false} />);
+        expect(screen.queryByTestId('action-card-act_1-disclosure')).not.toBeInTheDocument();
+        // The description and the load-shedding editor row both belong
+        // to the disclosure, so neither should appear at rest.
+        expect(screen.queryByText('Shed load on LD_A — 12.5 MW')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('edit-mw-act_1')).not.toBeInTheDocument();
+    });
+
+    it('reveals the disclosure subtree when isViewing=true', () => {
+        render(<ActionCard {...baseProps} isViewing={true} />);
+        expect(screen.getByTestId('action-card-act_1-disclosure')).toBeInTheDocument();
+        expect(screen.getByText('Shed load on LD_A — 12.5 MW')).toBeInTheDocument();
+        expect(screen.getByTestId('edit-mw-act_1')).toBeInTheDocument();
+    });
+});
+
+// ------------------------------------------------------------------
+// Recommendation #3 — NAD overload halo (CSS contract)
+// ------------------------------------------------------------------
+
+describe('UX consistency — Recommendation #3 (halo cap at zoom)', () => {
+    // The runtime cap requires a real pypowsybl SVG to verify; the
+    // Layer-4 static invariant guards the CSS rule. Here we re-assert
+    // the rule lives in the source so a refactor that drops the cap
+    // also fails this file (cheaper feedback loop than the script).
+    it('App.css caps overload halo stroke at 24px on detail zoom', () => {
+        const css = readFileSync(resolve(__dirname, 'App.css'), 'utf-8');
+        // The detail-zoom block must mention both the cap and the
+        // screen-space stroke vector-effect.
+        expect(css).toMatch(
+            /\[data-zoom-tier="detail"\]\s+\.nad-overloaded[^{]*{[^}]*stroke-width:\s*24px[^}]*vector-effect:\s*non-scaling-stroke/s,
+        );
+    });
+});
+
+// ------------------------------------------------------------------
+// Recommendation #4 — Tier the warning system
+// ------------------------------------------------------------------
+
+describe('UX consistency — Recommendation #4 (tier the warning system)', () => {
+    it('OverloadPanel renders no inline yellow banner when monitoringHint is null', () => {
+        const { container } = render(
+            <OverloadPanel
+                nOverloads={[]}
+                n1Overloads={[]}
+                onAssetClick={vi.fn()}
+                monitoringHint={null}
+            />,
+        );
+        expect(hasInlineWarningBanner(container)).toBeNull();
+    });
+
+    it('OverloadPanel renders the monitoring hint as small grey text, never as a yellow banner', () => {
+        const { container } = render(
+            <OverloadPanel
+                nOverloads={[]}
+                n1Overloads={[]}
+                onAssetClick={vi.fn()}
+                monitoringHint="130/150 lines monitored — see Notices for details."
+            />,
+        );
+        const hint = screen.getByTestId('overload-monitoring-hint');
+        expect(hint).toBeInTheDocument();
+        const styleAttr = hint.getAttribute('style') || '';
+        expect(styleAttr).toContain('var(--color-text-tertiary)');
+        // The hint is grey + italic — no warning-soft / warning-border palette.
+        expect(styleAttr).not.toContain('var(--color-warning-soft)');
+        expect(styleAttr).not.toContain('var(--color-warning-border)');
+        expect(hasInlineWarningBanner(container)).toBeNull();
+    });
+
+    it('ActionFeed renders no inline yellow banner with default empty state', () => {
+        const props = {
+            actions: {} as Record<string, ActionDetail>,
+            actionScores: {} as Record<string, Record<string, unknown>>,
+            linesOverloaded: ['LINE_1'],
+            selectedActionId: null,
+            selectedActionIds: new Set<string>(),
+            rejectedActionIds: new Set<string>(),
+            onActionSelect: vi.fn(),
+            onActionFavorite: vi.fn(),
+            onActionReject: vi.fn(),
+            onAssetClick: vi.fn(),
+            onDisplayPrioritizedActions: vi.fn(),
+            onRunAnalysis: vi.fn(),
+            canRunAnalysis: false,
+            nodesByEquipmentId: new Map(),
+            edgesByEquipmentId: new Map(),
+            disconnectedElement: 'LINE_1',
+            onManualActionAdded: vi.fn(),
+            onActionResimulated: vi.fn(),
+            analysisLoading: false,
+            monitoringFactor: 0.95,
+            manuallyAddedIds: new Set<string>(),
+            pendingAnalysisResult: null as AnalysisResult | null,
+            combinedActions: null as Record<string, CombinedAction> | null,
+        };
+        const { container } = render(<ActionFeed {...props} />);
+        // The old code shipped up to two yellow banners here — the
+        // action-dictionary info and the recommender-thresholds box.
+        // Both moved into NoticesPanel, so the feed must stay clean.
+        expect(hasInlineWarningBanner(container)).toBeNull();
+    });
+
+    it('AppSidebar surfaces the NoticesPanel pill when notices are passed', () => {
+        const notices: Notice[] = [
+            { id: 'a', title: 'Action dict', body: 'body', severity: 'info' },
+            { id: 'b', title: 'Monitoring', body: 'body', severity: 'warning' },
+        ];
+        render(
+            <AppSidebar
+                selectedBranch=""
+                branches={[]}
+                nameMap={{}}
+                n1LinesOverloaded={undefined}
+                n1LinesOverloadedRho={undefined}
+                selectedOverloads={undefined}
+                contingencyOptions={null}
+                onContingencyChange={vi.fn()}
+                displayName={(id) => id}
+                onContingencyZoom={vi.fn()}
+                onOverloadClick={vi.fn()}
+                notices={notices}
+            >
+                <div data-testid="sidebar-children" />
+            </AppSidebar>,
+        );
+        const pill = screen.getByTestId('notices-pill');
+        expect(pill).toHaveTextContent('2');
+    });
+
+    it('AppSidebar omits the NoticesPanel entirely when no notices are active', () => {
+        render(
+            <AppSidebar
+                selectedBranch=""
+                branches={[]}
+                nameMap={{}}
+                n1LinesOverloaded={undefined}
+                n1LinesOverloadedRho={undefined}
+                selectedOverloads={undefined}
+                contingencyOptions={null}
+                onContingencyChange={vi.fn()}
+                displayName={(id) => id}
+                onContingencyZoom={vi.fn()}
+                onOverloadClick={vi.fn()}
+                notices={[]}
+            >
+                <div data-testid="sidebar-children" />
+            </AppSidebar>,
+        );
+        expect(screen.queryByTestId('notices-pill')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('notices-panel')).not.toBeInTheDocument();
+    });
+});
+
+// ------------------------------------------------------------------
+// Recommendation #5 — Diagram legend per tab
+// ------------------------------------------------------------------
+
+describe('UX consistency — Recommendation #5 (diagram legend)', () => {
+    const dummyDiagram: DiagramData = {
+        svg: '<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>',
+        viewBox: { x: 0, y: 0, w: 100, h: 100 },
+        metadata: null,
+    };
+
+    function renderPanel(active: TabId, overrides: Record<string, unknown> = {}) {
+        return render(
+            <VisualizationPanel
+                activeTab={active}
+                configLoading={false}
+                onTabChange={vi.fn()}
+                nDiagram={dummyDiagram}
+                n1Diagram={dummyDiagram}
+                n1Loading={false}
+                actionDiagram={dummyDiagram}
+                actionDiagramLoading={false}
+                selectedActionId={'act_1'}
+                result={null}
+                analysisLoading={false}
+                nSvgContainerRef={createRef<HTMLDivElement>()}
+                n1SvgContainerRef={createRef<HTMLDivElement>()}
+                actionSvgContainerRef={createRef<HTMLDivElement>()}
+                uniqueVoltages={[63, 225, 400]}
+                voltageRange={[0, 1000]}
+                onVoltageRangeChange={vi.fn()}
+                actionViewMode="network"
+                onViewModeChange={vi.fn()}
+                inspectQuery=""
+                onInspectQueryChange={vi.fn()}
+                inspectableItems={[]}
+                onResetView={vi.fn()}
+                onZoomIn={vi.fn()}
+                onZoomOut={vi.fn()}
+                hasBranches={true}
+                selectedBranch={'BRANCH_A'}
+                vlOverlay={null}
+                onOverlayClose={vi.fn()}
+                onOverlaySldTabChange={vi.fn()}
+                voltageLevels={[]}
+                onVlOpen={vi.fn()}
+                networkPath=""
+                layoutPath=""
+                onOpenSettings={vi.fn()}
+                {...overrides}
+            />,
+        );
+    }
+
+    it('mounts a Legend pill on the Network (N) tab when the diagram is loaded', () => {
+        renderPanel('n');
+        expect(screen.getByTestId('diagram-legend-pill-n')).toBeInTheDocument();
+    });
+
+    it('mounts a Legend pill on the Contingency (N-1) tab when the diagram is loaded', () => {
+        renderPanel('n-1');
+        expect(screen.getByTestId('diagram-legend-pill-n-1')).toBeInTheDocument();
+    });
+
+    it('mounts a Legend pill on the Remedial Action tab when the diagram is loaded', () => {
+        renderPanel('action');
+        expect(screen.getByTestId('diagram-legend-pill-action')).toBeInTheDocument();
+    });
+
+    it('omits the Legend pill on a tab whose diagram has not loaded yet', () => {
+        renderPanel('n', { nDiagram: null });
+        expect(screen.queryByTestId('diagram-legend-pill-n')).not.toBeInTheDocument();
+    });
+});
+
+// ------------------------------------------------------------------
+// Cross-recommendation source-text invariants
+// ------------------------------------------------------------------
+
+describe('UX consistency — source-text invariants', () => {
+    function readSource(rel: string): string {
+        return readFileSync(resolve(__dirname, rel), 'utf-8');
+    }
+
+    it('ActionFeed.tsx no longer owns the dismissable banner state setters', () => {
+        const src = readSource('components/ActionFeed.tsx');
+        expect(src).not.toMatch(/setShowActionDictWarning/);
+        expect(src).not.toMatch(/setShowRecommenderWarning/);
+    });
+
+    it('OverloadPanel.tsx exposes monitoringHint and not the legacy banner props', () => {
+        const src = readSource('components/OverloadPanel.tsx');
+        expect(src).toMatch(/monitoringHint\?:\s*string\s*\|\s*null/);
+        expect(src).not.toMatch(/showMonitoringWarning/);
+        expect(src).not.toMatch(/onDismissWarning/);
+    });
+
+    it('AppSidebar.tsx wires <NoticesPanel /> as the single warning entry point', () => {
+        const src = readSource('components/AppSidebar.tsx');
+        expect(src).toMatch(/<NoticesPanel\s/);
+    });
+
+    it('VisualizationPanel.tsx wires <DiagramLegend /> for n / n-1 / action', () => {
+        const src = readSource('components/VisualizationPanel.tsx');
+        expect(src).toMatch(/<DiagramLegend\s+tabId="n"/);
+        expect(src).toMatch(/<DiagramLegend\s+tabId="n-1"/);
+        expect(src).toMatch(/<DiagramLegend\s+tabId="action"/);
+    });
+});
+
+// ------------------------------------------------------------------
+// Smoke — both new components are independently importable.
+// ------------------------------------------------------------------
+
+describe('UX consistency — component import smoke', () => {
+    it('AppSidebar children slot keeps rendering even with an active notices list', () => {
+        render(
+            <AppSidebar
+                selectedBranch=""
+                branches={[]}
+                nameMap={{}}
+                n1LinesOverloaded={undefined}
+                n1LinesOverloadedRho={undefined}
+                selectedOverloads={undefined}
+                contingencyOptions={null}
+                onContingencyChange={vi.fn()}
+                displayName={(id) => id}
+                onContingencyZoom={vi.fn()}
+                onOverloadClick={vi.fn()}
+                notices={[{ id: 'x', title: 't', body: 'b' }]}
+            >
+                <div data-testid="children-slot">payload</div>
+            </AppSidebar>,
+        );
+        // The children slot must keep rendering — the notices pill
+        // sits ABOVE the rest of the sidebar, never replacing it.
+        const slot = screen.getByTestId('children-slot');
+        expect(slot).toHaveTextContent('payload');
+        // Sanity — both elements live inside the sidebar shell.
+        const sidebar = screen.getByTestId('sidebar');
+        expect(within(sidebar).getByTestId('notices-pill')).toBeInTheDocument();
+        expect(within(sidebar).getByTestId('children-slot')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/uxConsistency.test.tsx
+++ b/frontend/src/uxConsistency.test.tsx
@@ -329,6 +329,43 @@ describe('UX consistency — Recommendation #4 (tier the warning system)', () =>
         expect(pill).toHaveTextContent('2');
     });
 
+    it('Notices pill sits on the same row as the contingency / N-1 strip', () => {
+        // Space-saving layout: the pill lives INSIDE the
+        // sticky-feed-summary strip (one horizontal band) rather
+        // than above it as a separate block. Regression guard
+        // against splitting them onto two rows.
+        const notices: Notice[] = [
+            { id: 'a', title: 'Monitoring', body: 'body', severity: 'warning' },
+        ];
+        render(
+            <AppSidebar
+                selectedBranch="LINE_A"
+                branches={[]}
+                nameMap={{}}
+                n1LinesOverloaded={['LINE_X']}
+                n1LinesOverloadedRho={[1.05]}
+                selectedOverloads={undefined}
+                contingencyOptions={null}
+                onContingencyChange={vi.fn()}
+                displayName={(id) => id}
+                onContingencyZoom={vi.fn()}
+                onOverloadClick={vi.fn()}
+                notices={notices}
+            >
+                <div data-testid="sidebar-children" />
+            </AppSidebar>,
+        );
+        const summary = screen.getByTestId('sticky-feed-summary');
+        // Both the contingency-zoom button and the notices pill are
+        // descendants of the same strip.
+        expect(within(summary).getByTestId('notices-pill')).toBeInTheDocument();
+        expect(within(summary).getByText(/Contingency:/i)).toBeInTheDocument();
+        // The strip is laid out as a flex row so the two cluster
+        // horizontally rather than stacking.
+        expect(summary.style.display).toBe('flex');
+        expect(summary.style.justifyContent).toBe('space-between');
+    });
+
     it('AppSidebar omits the NoticesPanel entirely when no notices are active', () => {
         render(
             <AppSidebar
@@ -450,9 +487,14 @@ describe('UX consistency — source-text invariants', () => {
         expect(src).not.toMatch(/onDismissWarning/);
     });
 
-    it('AppSidebar.tsx wires <NoticesPanel /> as the single warning entry point', () => {
-        const src = readSource('components/AppSidebar.tsx');
-        expect(src).toMatch(/<NoticesPanel\s/);
+    it('AppSidebar.tsx forwards `notices` into SidebarSummary as the single warning entry point', () => {
+        // The NoticesPanel pill now sits on the same row as the
+        // contingency / N-1 strip (SidebarSummary owns the layout).
+        // AppSidebar just forwards the notices array.
+        const sidebarSrc = readSource('components/AppSidebar.tsx');
+        expect(sidebarSrc).toMatch(/notices=\{notices\}/);
+        const summarySrc = readSource('components/SidebarSummary.tsx');
+        expect(summarySrc).toMatch(/<NoticesPanel\s/);
     });
 
     it('VisualizationPanel.tsx wires <DiagramLegend /> for n / n-1 / action', () => {
@@ -488,7 +530,8 @@ describe('UX consistency — component import smoke', () => {
             </AppSidebar>,
         );
         // The children slot must keep rendering — the notices pill
-        // sits ABOVE the rest of the sidebar, never replacing it.
+        // sits inside the sticky-feed-summary strip, never replacing
+        // the rest of the sidebar.
         const slot = screen.getByTestId('children-slot');
         expect(slot).toHaveTextContent('payload');
         // Sanity — both elements live inside the sidebar shell.

--- a/scripts/check_invariants.py
+++ b/scripts/check_invariants.py
@@ -350,6 +350,146 @@ INVARIANTS: list[Invariant] = [
             "pattern": r"clone\.style\.opacity\s*=\s*['\"](0\.(?:[7-9]\d?|6[5-9]))['\"]",
         },
     ),
+    # ===== UX-design-critique invariants =====
+    # The five recommendations from
+    # `docs/proposals/ui-design-critique.md` landed on top of an
+    # already-shipped UI. Each invariant below guards the UX
+    # contract a recommendation introduced so a future refactor
+    # can't silently revert it. The standalone side carries an
+    # empty spec (file-existence-only) because the contracts are
+    # React-source-level — the auto-generated bundle inherits them
+    # on its next build, and the legacy hand-maintained file
+    # predates the recommendations.
+
+    Invariant(
+        name="notices_panel_in_sidebar",
+        description=(
+            "Recommendation #4 (tier the warning system): the "
+            "sidebar must surface a single `<NoticesPanel>` pill "
+            "above the rest of the sidebar so persistent warnings "
+            "live in one entry point instead of stacking up to five "
+            "concurrent yellow banners. AppSidebar.tsx is the "
+            "canonical mount point."
+        ),
+        react={
+            "file_hint": "frontend/src/components/AppSidebar.tsx",
+            "pattern": r"<NoticesPanel\s",
+        },
+        standalone={"file_hint": "standalone_interface.html"},
+    ),
+    Invariant(
+        name="action_feed_no_dismissable_warning_state",
+        description=(
+            "Recommendation #4: ActionFeed.tsx must not own "
+            "`showActionDictWarning` / `showRecommenderWarning` "
+            "local state — both warnings moved into NoticesPanel. "
+            "Re-introducing a `setShow*Warning` setter inside the "
+            "feed would silently bring back the yellow banners."
+        ),
+        react={
+            "file_hint": "frontend/src/components/ActionFeed.tsx",
+            # Sanity anchor — the file must exist and parse.
+            "pattern": r"const\s+ActionFeed\b",
+            # Forbid the dismissable-banner state from sneaking back.
+            "must_not": r"setShow(?:ActionDict|Recommender)Warning",
+        },
+        standalone={"file_hint": "standalone_interface.html"},
+    ),
+    Invariant(
+        name="overload_panel_uses_monitoring_hint",
+        description=(
+            "Recommendation #4: OverloadPanel.tsx renders the "
+            "monitoring-coverage warning as a one-line grey hint "
+            "(`monitoringHint` prop) — the full notice lives in "
+            "NoticesPanel. `showMonitoringWarning` / "
+            "`onDismissWarning` props on this component would mean "
+            "the inline yellow banner has been re-introduced."
+        ),
+        react={
+            "file_hint": "frontend/src/components/OverloadPanel.tsx",
+            "pattern": r"monitoringHint\?\:\s*string\s*\|\s*null",
+            "must_not": r"showMonitoringWarning|onDismissWarning",
+        },
+        standalone={"file_hint": "standalone_interface.html"},
+    ),
+    Invariant(
+        name="diagram_legend_on_each_diagram_tab",
+        description=(
+            "Recommendation #5 (add a diagram legend): "
+            "VisualizationPanel.tsx must render a `<DiagramLegend>` "
+            "for the N, N-1 and Action tabs so the operator can read "
+            "halo / disconnection / voltage-level conventions on-"
+            "screen. Removing any of the three would re-open the "
+            "onboarding gap the recommendation closed."
+        ),
+        react={
+            "file_hint": "frontend/src/components/VisualizationPanel.tsx",
+            # Each tabId must be wired explicitly. `[\s\S]*?` chains
+            # the three matches in source order.
+            "pattern": (
+                r"<DiagramLegend\b[^>]*?tabId=\"n\""
+                r"[\s\S]*?<DiagramLegend\b[^>]*?tabId=\"n-1\""
+                r"[\s\S]*?<DiagramLegend\b[^>]*?tabId=\"action\""
+            ),
+        },
+        standalone={"file_hint": "standalone_interface.html"},
+    ),
+    Invariant(
+        name="nad_overload_halo_capped_at_zoom",
+        description=(
+            "Recommendation #3 (cap NAD overload halo): at the "
+            "`region` and `detail` zoom tiers the halo strokes must "
+            "switch to a screen-space `vector-effect: non-scaling-"
+            "stroke` capped at 24px. Without the cap the grid-unit "
+            "stroke (120-150px in user space) covers ~8-10× the "
+            "line it identifies and obscures the network."
+        ),
+        react={
+            "file_hint": "frontend/src/App.css",
+            "pattern": (
+                r"\[data-zoom-tier=\"detail\"\]\s+\.nad-overloaded[\s\S]*?"
+                r"stroke-width:\s*24px[\s\S]*?vector-effect:\s*non-scaling-stroke"
+            ),
+        },
+        standalone={"file_hint": "standalone_interface.html"},
+    ),
+    Invariant(
+        name="design_token_gate_blocks_inline_hex",
+        description=(
+            "Recommendation #1 (design-token layer): the code-"
+            "quality gate must keep the inline-hex ceiling at zero "
+            "outside `tokens.{css,ts}`. Loosening the gate would "
+            "let the three competing palettes (Flat UI / Bootstrap /"
+            " Tailwind) creep back in component-by-component."
+        ),
+        react={
+            "file_hint": "scripts/check_code_quality.py",
+            # The named ceiling constant must stay at 0. We assert
+            # both the constant declaration and the comparison that
+            # consumes it so a renamed-but-unbound copy can't slip
+            # through.
+            "pattern": r"FRONTEND_HEX_LITERAL_MAX\s*=\s*0\b",
+        },
+        standalone={"file_hint": "standalone_interface.html"},
+    ),
+    Invariant(
+        name="action_card_progressive_disclosure_gated_by_isViewing",
+        description=(
+            "Recommendation #2 (progressive disclosure): the "
+            "ActionCard component must gate its editable detail "
+            "rows (`isViewing && …`) so at-rest cards stay terse. "
+            "Without the gate the load-shedding / curtailment / "
+            "PST-tap rows render on every card and the feed becomes "
+            "unscan­nable on a 25 %-width sidebar."
+        ),
+        react={
+            "file_hint": "frontend/src/components/ActionCard.tsx",
+            # The component receives an `isViewing` prop AND uses
+            # it to gate at least one subtree (PR #121 disclosure).
+            "pattern": r"isViewing:\s*boolean[\s\S]*?\{isViewing\s*&&",
+        },
+        standalone={"file_hint": "standalone_interface.html"},
+    ),
 ]
 
 

--- a/scripts/check_invariants.py
+++ b/scripts/check_invariants.py
@@ -366,13 +366,14 @@ INVARIANTS: list[Invariant] = [
         description=(
             "Recommendation #4 (tier the warning system): the "
             "sidebar must surface a single `<NoticesPanel>` pill "
-            "above the rest of the sidebar so persistent warnings "
-            "live in one entry point instead of stacking up to five "
-            "concurrent yellow banners. AppSidebar.tsx is the "
-            "canonical mount point."
+            "as the entry point for persistent warnings instead of "
+            "stacking up to five concurrent yellow banners. The "
+            "pill lives inside SidebarSummary so it shares one "
+            "horizontal band with the contingency / N-1 strip; "
+            "AppSidebar forwards the notices array down."
         ),
         react={
-            "file_hint": "frontend/src/components/AppSidebar.tsx",
+            "file_hint": "frontend/src/components/SidebarSummary.tsx",
             "pattern": r"<NoticesPanel\s",
         },
         standalone={"file_hint": "standalone_interface.html"},


### PR DESCRIPTION
## Summary

Consolidates five concurrent yellow warning banners into a unified sidebar-header **NoticesPanel** pill and demotes inline warnings to small grey contextual hints, addressing UI design critique recommendations #4 and #5. Also adds a collapsible diagram legend to each visualization tab.

## Key Changes

### NoticesPanel Component (New)
- New `frontend/src/components/NoticesPanel.tsx` — a pill with count badge that expands into a panel listing active notices
- Each `Notice` carries optional `action` button and `onDismiss` handler
- Pill auto-hides when notice list is empty
- Supports two severity levels: `info` (blue) and `warning` (yellow)
- Includes close-on-outside-click behavior for modal-light UX

### DiagramLegend Component (New)
- New `frontend/src/components/DiagramLegend.tsx` — collapsible legend in bottom-right of each diagram tab
- Tab-aware: shows different entries for N, N-1, and action tabs (e.g., contingency halo only on N-1/action)
- Surfaces voltage-level palette convention and notes when VL names are hidden
- Collapsed by default; state is local (not persisted)

### Warning System Refactoring
- **App.tsx**: Builds active `Notice[]` from existing dismissal state (`showActionDictNotice`, `showRecommenderNotice`, `showMonitoringWarning`)
  - Three notices feed the panel: `action-dict` (info), `monitoring-coverage` (warning), `recommender-thresholds` (info)
  - Re-arms notices on study load to reset dismissal state
- **ActionFeed.tsx**: 
  - Removed inline "Action dictionary" and "Recommender Settings" yellow banners
  - Demoted overlap warnings (manual/rejected vs. analysis) to small grey italic contextual hints
  - Added `overviewFilteredOutCount` hint under Suggested/Rejected header when filter hides cards
  - Removed props: `recommenderConfig`, `onOpenSettings`, `actionDictFileName`, `actionDictStats`
- **OverloadPanel.tsx**:
  - Removed inline monitoring-coverage yellow banner
  - Now accepts optional `monitoringHint` string rendered as grey text under heading
  - Removed props: `showMonitoringWarning`, `monitoredLinesCount`, `totalLinesCount`, `monitoringFactor`, `preExistingOverloadThreshold`, `onDismissWarning`, `onOpenSettings`
- **AppSidebar.tsx**: Integrates `NoticesPanel` above `SidebarSummary`
- **VisualizationPanel.tsx**: Integrates `DiagramLegend` into each diagram tab

### Test Coverage
- New `NoticesPanel.test.tsx` (6 cases): pill counter, dialog toggle, dismiss callback, action button, auto-hide on empty
- New `DiagramLegend.test.tsx` (8 cases): collapse/expand, per-tab row set, voltage-level note, VL-names hidden hint
- Updated `ActionFeed.test.tsx`: removed obsolete inline-banner tests, rewrote overlap warning tests to check for inline hints
- Updated `OverloadPanel.test.tsx`: removed monitoring-warning banner tests, added monitoring-hint test
- Updated `App.stateManagement.test.tsx`: skipped recommenderConfig prop test with rationale comment

## Implementation Details

- All notices use existing design tokens (`colors.warningSoft`, `colors.infoBorder`, etc.) for visual consistency
- Dismissal state is preserved at the App level and re-armed on study load (matching prior ActionFeed behavior)
- Inline hints use small grey italic text to avoid visual clutter while surfacing context where it matters
- DiagramLegend uses CSS variables for color swatches (e.g., `var(--signal-contingency)`) to stay in sync with diagram rendering
- Close-on-outside-click implemented via `mousedown` listener on document for both NoticesPanel and DiagramLegend

https://claude.ai/code/session_01EYXsLY6hKRncRxj3KTHERk