### PR TITLE
Fix NoticesPanel popover clipping by rendering via portal

### DIFF
--- a/docs/architecture/development-cycle.md
+++ b/docs/architecture/development-cycle.md
@@ -45,6 +45,10 @@ gantt
     section 4. PyPSA-EUR
     Pipeline + datasets (#112)         :done, p4,  2026-04-16, 2026-04-24
     Post-merge (overflow viewer)       :done, p4b, 2026-04-24, 2026-04-30
+
+    section 5. UX iterations
+    Design tokens + ActionCard         :done, p5a, 2026-04-26, 2026-04-29
+    Tier warning system + popover fix  :done, p5b, 2026-04-29, 2026-05-03
 ```
 
 ### Architecture d'ensemble
@@ -639,3 +643,115 @@ itérations *Overflow HTML viewer* (PR #116, toggle Hierarchical/Geo,
 mise à l'échelle des canvas géographiques), un fix d'islanding
 (`d9b1652`, 29/04) et le rafraîchissement des `CLAUDE.md` /
 `README.md` en 0.6.5.
+
+## 5. Itérations UX post-0.6.5 (26/04 → 03/05/2026, PRs #118 → #122 + suivis)
+
+Une fois la base PyPSA-EUR stabilisée, le travail bascule sur la
+critique UX consolidée dans
+[`docs/proposals/ui-design-critique.md`](../proposals/ui-design-critique.md).
+Quatre PRs successives — plus le suivi de surface qui les
+accompagne — refondent l'apparence et la lisibilité de l'app sans
+toucher au moteur d'analyse.
+
+### 5.1. Toggle des noms de voltage levels (PR #118, 24-26/04)
+
+- Bouton **🏷 VL** ajouté à côté du champ Inspect (`72d65ad`,
+  `5871b59`) : flippe la classe `nad-hide-vl-labels` sur chaque
+  `MemoizedSvgContainer` pour cacher / réafficher les étiquettes VL
+  sur les diagrammes NAD.
+- La règle CSS associée (`App.css`) cible toutes les formes
+  pypowsybl (`foreignObject.nad-text-nodes`, `<text>` sous
+  `.nad-vl-nodes` / `.nad-label-nodes`, et `.nad-label-box` au
+  niveau racine) avec `!important` pour battre l'inline style block
+  injecté par pypowsybl après App.css.
+- Quand les labels sont cachés, le nom du VL reste accessible via
+  un `<title>` natif sur chaque cercle de bus
+  (`utils/svg/vlTitles.ts:applyVlTitles`).
+- Nouvel évènement `vl_names_toggled { show }` dans le journal
+  d'interactions (`4ed9bdb`).
+
+### 5.2. Migration vers les design tokens (PR #120, 26/04)
+
+Trois phases livrées en cascade :
+
+- **Phase A** (`47a2700`) — introduction de `src/styles/tokens.ts`
+  (palette de couleurs, espaces, rayons, échelle typographique) et
+  `src/styles/tokens.css` (variables CSS associées). Les composants
+  consomment `colors.brand`, `space[2]`, `radius.lg`, `text.xs`…
+  au lieu de littéraux.
+- **Phase B** (`0e60059`) — migration des composants un par un
+  vers les tokens. Côté SVG, les attributs de présentation ne
+  passent pas par les variables CSS (Chrome ne les résout pas
+  toujours dans les attributs SVG) : `pinColors`, `pinColorsDimmed`,
+  `pinColorsHighlighted`, `pinChrome` exposent les hex pour les
+  appels `setAttribute('fill', …)`.
+- **Phase C** (`b8de481`) — fin de la migration ; le code-quality
+  gate refuse désormais tout littéral hex hors de `tokens.ts`.
+
+### 5.3. Refonte progressive-disclosure des ActionCard (PR #121, 28/04)
+
+- `fbfb2b0` — refonte des cartes d'action en *progressive disclosure* :
+  une vue compacte (titre + score résumé) pour la liste, expansion
+  *on demand* avec les détails de simulation, le delta MW et les
+  badges d'équipement.
+- Même PR : **plafond du halo NAD** quand on zoome très près. Le
+  halo des cibles d'action ne doit pas envahir tout l'écran à fort
+  niveau de zoom — un cap calculé sur la taille du viewBox borne le
+  rayon visuel.
+
+### 5.4. Tier warning system, NoticesPanel et legend de diagramme (PR #122, 29/04 → 03/05)
+
+C'est la PR qui materialise la *recommandation #4* de la critique UX
+(« remplacer la pile de bannières jaunes par un point d'entrée
+unique »).
+
+- `9a354f2` — **`NoticesPanel.tsx`** : composant pill ⚠️
+  *Notices N* qui s'ancre dans le header de la sidebar et déroule
+  une liste consolidée des avertissements de fond (couverture
+  monitoring, seuils recommender, action dictionary). Chaque notice
+  porte sa propre `severity`, `onDismiss` et bouton d'action
+  optionnel. Le pill se cache de lui-même à zéro notice. Une
+  **legend de diagramme** unifiée est ajoutée au bas-droit du panneau
+  de visualisation.
+- `4458d48` — **landing du pill sur la ligne contingence / N-1** :
+  `SidebarSummary` passe en `display:flex` + `justifyContent:
+  space-between` pour héberger le pill dans la même bande
+  horizontale que les liens contingence et surcharges N-1.
+- `37f3e98` — `uxConsistency.test.tsx` : suite de garde-fous qui
+  vérifie que les recommandations de la critique UX restent
+  appliquées (palette unique, un seul header, action panel
+  consolidé, etc.).
+
+### 5.5. Suivi : NoticesPanel popover en portail (`claude/fix-notice-panel-overlap-UVYra`, 03/05)
+
+Suivi UX rapporté pendant la session de validation : sur les écrans
+où le sidebar fait 25% de la largeur, le popover des notices
+(largeur 320 px ancré à gauche du pill) débordait dans la zone du
+diagramme et se faisait **clipper** par le `overflow: hidden` du
+`AppSidebar`, donnant l'impression que la visualisation passait
+au-dessus.
+
+Correctif :
+
+- `NoticesPanel.tsx` rend désormais le panneau via
+  `ReactDOM.createPortal(…, document.body)` avec `position: fixed`
+  et des coordonnées calculées à partir du `getBoundingClientRect()`
+  du pill. Ré-aligné sur le bord droit du pill pour pousser le
+  panneau vers la sidebar plutôt que vers la zone diagramme. Recalcul
+  sur `resize` et `scroll` (capture).
+- `zIndex: 1000` pour battre toute hiérarchie de stacking context
+  ascendante. Le clic à l'extérieur exempte le contenu du portail.
+- Test ajouté (`NoticesPanel.test.tsx`) : monte le composant à
+  l'intérieur d'un parent `overflow:hidden` et vérifie que la liste
+  ouverte n'est PAS un descendant du parent — elle vit sous
+  `document.body`. Garantit que l'échappement portail ne régressera pas.
+
+### 5.6. Récapitulatif des PRs UX 0.6.5+
+
+| Feature                                           | PR                  | Date       |
+|---------------------------------------------------|---------------------|------------|
+| Toggle VL-names sur les NAD                       | #118                | 24-26/04   |
+| Design tokens (palette + espaces + typo)          | #120                | 26/04      |
+| ActionCard progressive disclosure + cap halo      | #121                | 28/04      |
+| Tier warning system + NoticesPanel + legend       | #122                | 29/04-03/05|
+| Fix occlusion popover Notices (portal)            | `fix-notice-panel-…`| 03/05      |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -117,11 +117,53 @@ Flat config (v9+) in `eslint.config.js` with `typescript-eslint`,
 and `@ts-ignore` in source files — see
 [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
 
+## Recent UX iterations (post-0.6.5)
+
+The following PRs reshaped the look-and-feel of the app without
+touching the analysis pipeline. The full retrospective lives in
+[`../docs/architecture/development-cycle.md`](../docs/architecture/development-cycle.md)
+section 5; design rationale comes from
+[`../docs/proposals/ui-design-critique.md`](../docs/proposals/ui-design-critique.md).
+
+- **PR #118 — VL-names toggle.** A `🏷 VL` button next to the
+  Inspect field hides / shows the voltage-level labels on NAD
+  diagrams. Hidden labels remain reachable via a native `<title>`
+  tooltip on each bus circle. New `vl_names_toggled { show }`
+  interaction event.
+- **PR #120 — Design tokens (Phases A → C).** Palette / space /
+  radius / typography moved into `src/styles/tokens.{ts,css}`.
+  Components consume `colors.brand`, `space[2]`, `text.xs`…
+  Hex literals are forbidden outside the token files; SVG
+  presentation attributes use the `pinColors` family for
+  Chrome-safe `setAttribute` calls.
+- **PR #121 — Progressive-disclosure ActionCard + halo cap.** Action
+  cards default to a compact summary and expand on demand. The NAD
+  highlight halo radius is now capped relative to the viewBox so it
+  cannot swamp the screen at high zoom.
+- **PR #122 — Tier warning system + NoticesPanel + diagram legend.**
+  Replaces the stack of yellow banners with a single `⚠️ Notices N`
+  pill in the sidebar header that opens a consolidated list (one
+  entry, one place to dismiss). A unified diagram legend lands at
+  the bottom-right of the visualization panel.
+  `uxConsistency.test.tsx` enforces the recommendations going
+  forward.
+- **`fix-notice-panel-overlap` follow-up.** The Notices popover now
+  renders via `ReactDOM.createPortal(…, document.body)` with
+  `position: fixed` so it escapes the sidebar's `overflow: hidden`
+  clip and any ancestor stacking context — the visualization panel
+  no longer paints over it on narrow sidebars. Right-aligned to the
+  pill so it grows leftward into the sidebar rather than bleeding
+  into the diagram. Regression test in `NoticesPanel.test.tsx`
+  asserts the popover is NOT a descendant of an `overflow:hidden`
+  ancestor.
+
 ## Further reading
 
 - [`CLAUDE.md`](./CLAUDE.md) — architecture deep dive
 - [`../CLAUDE.md`](../CLAUDE.md) — project-wide overview + API table
 - [`../docs/README.md`](../docs/README.md) — design, feature and
   performance docs index
+- [`../docs/architecture/development-cycle.md`](../docs/architecture/development-cycle.md)
+  — chronological retrospective of all five development phases
 - [`PARITY_AUDIT.md`](./PARITY_AUDIT.md) — standalone-bundle parity
   audit (Layer 1–4 conformity, regression matrix)

--- a/frontend/src/components/NoticesPanel.test.tsx
+++ b/frontend/src/components/NoticesPanel.test.tsx
@@ -88,6 +88,28 @@ describe('NoticesPanel', () => {
         expect(list).toHaveStyle({ position: 'fixed' });
     });
 
+    it('wraps long unbreakable strings inside the notice card so they cannot bleed out', async () => {
+        const user = userEvent.setup();
+        render(
+            <NoticesPanel
+                notices={[{
+                    id: 'long-path',
+                    title: 'Action dictionary',
+                    body: <code>feature_actions_from_REPAS.2024.12.10_withPSTs.json</code>,
+                    severity: 'info',
+                }]}
+            />,
+        );
+        await user.click(screen.getByTestId('notices-pill'));
+        const card = screen.getByTestId('notice-long-path');
+        // overflowWrap: anywhere + wordBreak: break-word are what allow
+        // a long filename or path to break inside the 320 px panel
+        // instead of pushing past the card edges.
+        expect(card).toHaveStyle({ overflow: 'hidden' });
+        expect(card).toHaveStyle({ overflowWrap: 'anywhere' });
+        expect(card).toHaveStyle({ wordBreak: 'break-word' });
+    });
+
     it('hides the panel when the underlying notice list becomes empty', async () => {
         const user = userEvent.setup();
         const { rerender } = render(<NoticesPanel notices={baseNotices} />);

--- a/frontend/src/components/NoticesPanel.test.tsx
+++ b/frontend/src/components/NoticesPanel.test.tsx
@@ -70,6 +70,24 @@ describe('NoticesPanel', () => {
         expect(onClick).toHaveBeenCalledTimes(1);
     });
 
+    it('renders the popover via a portal so it escapes ancestor overflow:hidden clipping', async () => {
+        const user = userEvent.setup();
+        render(
+            <div data-testid="clipping-parent" style={{ overflow: 'hidden', position: 'relative', width: 200, height: 50 }}>
+                <NoticesPanel notices={baseNotices} />
+            </div>,
+        );
+        await user.click(screen.getByTestId('notices-pill'));
+        const list = screen.getByTestId('notices-list');
+        const clippingParent = screen.getByTestId('clipping-parent');
+        // The portal target is document.body, so the popover must NOT
+        // be a DOM descendant of the clipping container — that's how
+        // it escapes the sidebar's `overflow: hidden`.
+        expect(clippingParent.contains(list)).toBe(false);
+        expect(document.body.contains(list)).toBe(true);
+        expect(list).toHaveStyle({ position: 'fixed' });
+    });
+
     it('hides the panel when the underlying notice list becomes empty', async () => {
         const user = userEvent.setup();
         const { rerender } = render(<NoticesPanel notices={baseNotices} />);

--- a/frontend/src/components/NoticesPanel.tsx
+++ b/frontend/src/components/NoticesPanel.tsx
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { colors, radius, space, text } from '../styles/tokens';
 
 export interface Notice {
@@ -47,17 +48,64 @@ interface NoticesPanelProps {
  * sidebar header stays clean once the operator has dismissed
  * everything they wanted to dismiss.
  */
+const PANEL_WIDTH = 320;
+const PANEL_GAP = 4;
+const VIEWPORT_MARGIN = 8;
+
 export default function NoticesPanel({ notices }: NoticesPanelProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [panelPos, setPanelPos] = useState<{ top: number; left: number } | null>(null);
+
+  // Anchor the floating panel to the pill button using viewport
+  // coordinates. We render it in a portal so it escapes the sidebar's
+  // `overflow: hidden` clip and any ancestor stacking contexts that
+  // would otherwise let the visualization panel paint over it.
+  const recomputePosition = useCallback(() => {
+    const btn = buttonRef.current;
+    if (!btn) return;
+    const rect = btn.getBoundingClientRect();
+    const viewportW = window.innerWidth;
+    const top = rect.bottom + PANEL_GAP;
+    // Right-align the panel with the pill so it grows leftward into
+    // the sidebar instead of bleeding into the visualization area.
+    let left = rect.right - PANEL_WIDTH;
+    if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
+    if (left + PANEL_WIDTH > viewportW - VIEWPORT_MARGIN) {
+      left = viewportW - VIEWPORT_MARGIN - PANEL_WIDTH;
+    }
+    setPanelPos({ top, left });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    recomputePosition();
+  }, [open, recomputePosition, notices.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handle = () => recomputePosition();
+    window.addEventListener('resize', handle);
+    window.addEventListener('scroll', handle, true);
+    return () => {
+      window.removeEventListener('resize', handle);
+      window.removeEventListener('scroll', handle, true);
+    };
+  }, [open, recomputePosition]);
 
   // Close-on-outside-click — keeps the panel modal-light without
   // requiring a backdrop layer that would compete with the rest of
-  // the chrome.
+  // the chrome. The panel itself lives in a portal, so we also have
+  // to exempt clicks that land inside it.
   useEffect(() => {
     if (!open) return;
     const handleClick = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Node;
+      const insidePill = containerRef.current?.contains(target);
+      const insidePanel = panelRef.current?.contains(target);
+      if (!insidePill && !insidePanel) {
         setOpen(false);
       }
     };
@@ -80,6 +128,7 @@ export default function NoticesPanel({ notices }: NoticesPanelProps) {
       style={{ position: 'relative', flexShrink: 0 }}
     >
       <button
+        ref={buttonRef}
         type="button"
         data-testid="notices-pill"
         onClick={() => setOpen(prev => !prev)}
@@ -121,18 +170,18 @@ export default function NoticesPanel({ notices }: NoticesPanelProps) {
         </span>
       </button>
 
-      {open && (
+      {open && createPortal(
         <div
+          ref={panelRef}
           data-testid="notices-list"
           role="dialog"
           aria-label="Active notices"
           style={{
-            position: 'absolute',
-            top: 'calc(100% + 4px)',
-            left: 0,
-            right: 'auto',
-            zIndex: 50,
-            width: '320px',
+            position: 'fixed',
+            top: panelPos?.top ?? -9999,
+            left: panelPos?.left ?? -9999,
+            zIndex: 1000,
+            width: `${PANEL_WIDTH}px`,
             maxHeight: '60vh',
             overflowY: 'auto',
             background: colors.surface,
@@ -143,6 +192,7 @@ export default function NoticesPanel({ notices }: NoticesPanelProps) {
             display: 'flex',
             flexDirection: 'column',
             gap: space[2],
+            visibility: panelPos ? 'visible' : 'hidden',
           }}
         >
           {notices.map(notice => {
@@ -210,7 +260,8 @@ export default function NoticesPanel({ notices }: NoticesPanelProps) {
               </div>
             );
           })}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/frontend/src/components/NoticesPanel.tsx
+++ b/frontend/src/components/NoticesPanel.tsx
@@ -213,9 +213,12 @@ export default function NoticesPanel({ notices }: NoticesPanelProps) {
                   fontSize: text.sm,
                   color: isInfo ? colors.infoText : colors.warningText,
                   lineHeight: 1.45,
+                  overflow: 'hidden',
+                  overflowWrap: 'anywhere',
+                  wordBreak: 'break-word',
                 }}
               >
-                <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ flex: 1, minWidth: 0, overflowWrap: 'anywhere', wordBreak: 'break-word' }}>
                   <div style={{ fontWeight: 700, marginBottom: space[1] }}>{notice.title}</div>
                   <div>{notice.body}</div>
                   {notice.action && (


### PR DESCRIPTION
## Summary

The NoticesPanel popover was being clipped by the sidebar's `overflow: hidden` CSS rule on narrow layouts, causing the visualization panel to paint over it. This PR moves the popover to a React portal anchored to `document.body` with `position: fixed`, allowing it to escape ancestor clipping contexts while remaining properly positioned relative to the pill button.

## Key Changes

- **Portal rendering**: NoticesPanel now uses `ReactDOM.createPortal(…, document.body)` to render the popover outside the sidebar's DOM hierarchy, preventing `overflow: hidden` clipping.
- **Fixed positioning with viewport math**: The popover position is calculated from the pill button's `getBoundingClientRect()` and updated on `resize` and `scroll` events. Right-aligned to the pill so it grows leftward into the sidebar rather than bleeding into the diagram area.
- **Improved click-outside detection**: Updated the close-on-outside-click handler to exempt clicks inside both the pill button and the portal-rendered panel, since they're no longer in the same DOM subtree.
- **High z-index**: Set `zIndex: 1000` to ensure the popover stays above any ancestor stacking contexts.
- **Regression test**: Added `NoticesPanel.test.tsx` test that verifies the popover is rendered via portal (not a descendant of `overflow: hidden` ancestors) and uses `position: fixed`.

## Implementation Details

- The popover width is constrained to 320px and positioned with viewport margins (8px) to prevent edge-of-screen overflow.
- Position state is hidden (`visibility: hidden`) until coordinates are computed to avoid layout flashing.
- Event listeners for `resize` and `scroll` use capture phase for `scroll` to catch events on any ancestor.
- Documentation updated in `frontend/README.md` and `docs/architecture/development-cycle.md` to reflect the fix and broader UX iteration context (PRs #118–#122).

https://claude.ai/code/session_01JgG5Q9HPFyEy2bWoQk4BxK