### PR TITLE
Add Graphviz auto-installer and pydot dependency for graph rendering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install Graphviz (provides ``dot``)
+          command: sudo apt-get update && sudo apt-get install -y graphviz
+      - run:
           name: Install Dependencies
           command: |
             python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+      - name: Install Graphviz (provides ``dot``)
+        run: sudo apt-get update && sudo apt-get install -y graphviz
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,36 @@ pip install --no-deps expert_op4grid_recommender
 uvicorn expert_backend.main:app --host 0.0.0.0 --port 8000
 ```
 
+#### System prerequisite — Graphviz (`dot`)
+
+The overflow-graph rendering pipeline shells out to Graphviz's
+`dot` binary. `pip install` attempts a best-effort auto-install via
+the platform's package manager (apt / dnf / pacman / apk on Linux,
+Homebrew or MacPorts on macOS, Chocolatey / winget / Scoop on
+Windows); set `COSTUDY4GRID_SKIP_GRAPHVIZ_INSTALL=1` to opt out.
+Modern wheel-based installs may skip the `setup.py` post-install
+hook — re-run it manually with the bundled console script if
+`dot -V` fails:
+
+```bash
+costudy4grid-install-graphviz
+```
+
+If the auto-install can't elevate (no `sudo`, locked package DB,
+unsupported package manager), install Graphviz by hand:
+
+| Platform                | Command                                           |
+|-------------------------|---------------------------------------------------|
+| Debian / Ubuntu         | `sudo apt-get install graphviz`                   |
+| RHEL / Fedora           | `sudo dnf install graphviz` (or `yum`)            |
+| Arch                    | `sudo pacman -S graphviz`                         |
+| Alpine                  | `sudo apk add graphviz`                           |
+| macOS (Homebrew)        | `brew install graphviz`                           |
+| macOS (MacPorts)        | `sudo port install graphviz`                      |
+| Windows (Chocolatey)    | `choco install graphviz`                          |
+| Windows (winget)        | `winget install Graphviz.Graphviz`                |
+| Windows (Scoop)         | `scoop install graphviz`                          |
+
 ### Frontend
 
 ```bash

--- a/expert_backend/install_graphviz.py
+++ b/expert_backend/install_graphviz.py
@@ -1,0 +1,139 @@
+"""Best-effort cross-platform installer for the Graphviz ``dot`` binary.
+
+Co-Study4Grid renders the overflow graph through ``pydot`` /
+``networkx.drawing.nx_pydot``, which shells out to Graphviz's ``dot``
+executable. ``dot`` is a system-level binary and cannot be shipped as a
+pure-Python wheel, so we provide this helper which is invoked from
+``setup.py`` after a regular ``pip install``.
+
+The script is intentionally best-effort: if it can't find a supported
+package manager or the install fails (no sudo, locked package DB, etc.)
+it prints a clear, actionable message rather than aborting the whole
+``pip install``. Users can also run it manually:
+
+    python -m scripts.install_graphviz
+"""
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+MANUAL_HINT = """\
+Could not auto-install Graphviz. Please install it manually so the
+``dot`` binary is on PATH:
+
+  Linux (Debian/Ubuntu):  sudo apt-get install graphviz
+  Linux (RHEL/Fedora):    sudo dnf install graphviz   (or yum)
+  Linux (Arch):           sudo pacman -S graphviz
+  Linux (Alpine):         sudo apk add graphviz
+  macOS (Homebrew):       brew install graphviz
+  macOS (MacPorts):       sudo port install graphviz
+  Windows (Chocolatey):   choco install graphviz
+  Windows (winget):       winget install Graphviz.Graphviz
+  Windows (Scoop):        scoop install graphviz
+
+After installation, verify with:  dot -V
+"""
+
+
+def _run(cmd: list[str]) -> int:
+    print("+ " + " ".join(cmd), flush=True)
+    try:
+        return subprocess.call(cmd)
+    except FileNotFoundError:
+        return 127
+
+
+def _maybe_sudo(cmd: list[str]) -> list[str]:
+    if os.name == "nt":
+        return cmd
+    if os.geteuid() == 0:  # type: ignore[attr-defined]
+        return cmd
+    if shutil.which("sudo"):
+        return ["sudo", "-n", *cmd]
+    return cmd
+
+
+def _install_linux() -> bool:
+    candidates = [
+        ("apt-get", ["apt-get", "install", "-y", "graphviz"]),
+        ("dnf", ["dnf", "install", "-y", "graphviz"]),
+        ("yum", ["yum", "install", "-y", "graphviz"]),
+        ("pacman", ["pacman", "-S", "--noconfirm", "graphviz"]),
+        ("apk", ["apk", "add", "--no-cache", "graphviz"]),
+        ("zypper", ["zypper", "install", "-y", "graphviz"]),
+    ]
+    for tool, cmd in candidates:
+        if shutil.which(tool):
+            if _run(_maybe_sudo(cmd)) == 0:
+                return True
+    return False
+
+
+def _install_macos() -> bool:
+    if shutil.which("brew"):
+        if _run(["brew", "install", "graphviz"]) == 0:
+            return True
+    if shutil.which("port"):
+        if _run(_maybe_sudo(["port", "install", "graphviz"])) == 0:
+            return True
+    return False
+
+
+def _install_windows() -> bool:
+    candidates = [
+        ("choco", ["choco", "install", "graphviz", "-y", "--no-progress"]),
+        ("winget", ["winget", "install", "--id", "Graphviz.Graphviz",
+                    "-e", "--accept-source-agreements",
+                    "--accept-package-agreements"]),
+        ("scoop", ["scoop", "install", "graphviz"]),
+    ]
+    for tool, cmd in candidates:
+        if shutil.which(tool):
+            if _run(cmd) == 0:
+                return True
+    return False
+
+
+def ensure_dot() -> bool:
+    """Ensure ``dot`` is on PATH; return True if it is (after install)."""
+    if shutil.which("dot"):
+        print("Graphviz 'dot' already installed; skipping.", flush=True)
+        return True
+
+    system = platform.system()
+    print(f"Graphviz 'dot' not found on PATH; attempting install on {system}...",
+          flush=True)
+
+    ok = False
+    if system == "Linux":
+        ok = _install_linux()
+    elif system == "Darwin":
+        ok = _install_macos()
+    elif system == "Windows":
+        ok = _install_windows()
+    else:
+        print(f"Unsupported platform: {system}", flush=True)
+
+    # Re-check PATH (some installers update PATH only in new shells).
+    if shutil.which("dot"):
+        return True
+
+    if not ok:
+        print(MANUAL_HINT, file=sys.stderr, flush=True)
+    else:
+        # The package manager succeeded but PATH may not be refreshed
+        # in this shell. Don't fail loudly.
+        print(
+            "Graphviz install command completed but 'dot' is not yet on PATH "
+            "in this shell. Open a new terminal and run `dot -V` to verify.",
+            flush=True,
+        )
+    return False
+
+
+if __name__ == "__main__":
+    sys.exit(0 if ensure_dot() else 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "python-multipart",
+    # Required by the overflow-graph rendering pipeline. ``pydot`` is the
+    # Python wrapper; the ``dot`` system binary it shells out to is
+    # installed best-effort by ``setup.py`` via ``scripts/install_graphviz.py``
+    # (see also the ``costudy4grid-install-graphviz`` console script).
+    "pydot",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +46,11 @@ test = [
     "lxml",
     "pandas",
 ]
+
+[project.scripts]
+# Manual fallback when the post-install hook can't elevate to install
+# the Graphviz ``dot`` binary on a user's machine.
+costudy4grid-install-graphviz = "expert_backend.install_graphviz:ensure_dot"
 quality = [
     "ruff>=0.6",
     "radon>=6.0",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,54 @@
+"""setup.py shim — metadata lives in ``pyproject.toml``.
+
+This file exists solely to register a post-install hook that attempts to
+install Graphviz's ``dot`` binary, which is required at runtime by the
+overflow-graph rendering pipeline (pydot → dot). The binary cannot be
+shipped as a Python wheel, so we shell out to the platform's package
+manager. See ``expert_backend/install_graphviz.py`` for the per-OS logic.
+
+Note: modern pip builds a wheel before installing, so the ``install``
+``cmdclass`` only runs reliably for legacy / editable installs
+(``pip install -e .``). For wheel-based flows users (and CI) should
+run the bundled console script ``costudy4grid-install-graphviz`` —
+this remains the cross-platform entry point.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+from setuptools import setup
+from setuptools.command.develop import develop
+from setuptools.command.install import install
+
+
+def _post_install() -> None:
+    if os.environ.get("COSTUDY4GRID_SKIP_GRAPHVIZ_INSTALL"):
+        return
+    try:
+        sys.path.insert(0, os.path.dirname(__file__))
+        from expert_backend import install_graphviz  # type: ignore
+        install_graphviz.ensure_dot()
+    except Exception as exc:  # noqa: BLE001 — best-effort, never block install
+        print(f"[co-study4grid] graphviz post-install skipped: {exc}",
+              file=sys.stderr)
+
+
+class _PostInstall(install):
+    def run(self) -> None:
+        install.run(self)
+        _post_install()
+
+
+class _PostDevelop(develop):
+    def run(self) -> None:
+        develop.run(self)
+        _post_install()
+
+
+setup(
+    cmdclass={
+        "install": _PostInstall,
+        "develop": _PostDevelop,
+    },
+)


### PR DESCRIPTION
## Summary
This PR adds automatic installation of Graphviz's `dot` binary and integrates the `pydot` dependency to enable overflow-graph rendering capabilities. The implementation provides a best-effort cross-platform installer that attempts to use the system's native package manager, with clear fallback instructions for manual installation.

## Key Changes

- **New `expert_backend/install_graphviz.py`**: Cross-platform installer module that:
  - Detects the operating system and attempts installation via appropriate package managers
  - Supports Linux (apt, dnf, yum, pacman, apk, zypper), macOS (Homebrew, MacPorts), and Windows (Chocolatey, winget, Scoop)
  - Handles privilege escalation gracefully with `sudo -n` (non-interactive)
  - Provides clear, actionable error messages with manual installation instructions
  - Can be run standalone or invoked from setup hooks

- **New `setup.py`**: Post-install hook infrastructure that:
  - Registers `install` and `develop` command hooks to trigger Graphviz installation
  - Implements best-effort error handling to never block the pip install process
  - Respects `COSTUDY4GRID_SKIP_GRAPHVIZ_INSTALL` environment variable for opt-out

- **Updated `pyproject.toml`**:
  - Added `pydot` as a core dependency for graph rendering
  - Added `costudy4grid-install-graphviz` console script as a manual fallback entry point

- **Updated CI/CD configurations**:
  - Added explicit Graphviz installation steps to CircleCI and GitHub Actions workflows to ensure `dot` is available during testing

- **Updated `CONTRIBUTING.md`**: Added comprehensive documentation covering:
  - Graphviz system prerequisite explanation
  - Auto-install behavior and opt-out mechanism
  - Manual installation instructions for all supported platforms
  - Troubleshooting guidance for wheel-based installs

## Implementation Details

The installer uses a "best-effort" philosophy: if auto-installation fails (missing sudo, locked package DB, unsupported platform), it prints helpful instructions rather than aborting. Users can also manually run the console script `costudy4grid-install-graphviz` if needed. The design accounts for the fact that modern pip wheel-based installs may skip the `setup.py` post-install hook, providing the console script as a reliable fallback.

https://claude.ai/code/session_0119WxcS8sofHKoFwwujQcq1