### PR TITLE
fix(build): restore quality extras under optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,15 +46,15 @@ test = [
     "lxml",
     "pandas",
 ]
+quality = [
+    "ruff>=0.6",
+    "radon>=6.0",
+]
 
 [project.scripts]
 # Manual fallback when the post-install hook can't elevate to install
 # the Graphviz ``dot`` binary on a user's machine.
 costudy4grid-install-graphviz = "expert_backend.install_graphviz:ensure_dot"
-quality = [
-    "ruff>=0.6",
-    "radon>=6.0",
-]
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
The previous commit's edit accidentally landed the `quality` group under `[project.scripts]`, which expects string values and broke `pip install ".[quality]"` with a pyproject validation error.