### PR TITLE
feat(overflow-pins): mid-arc anchoring + Action-Overview-style pin la…

### DIFF
--- a/expert_backend/services/overflow_overlay.py
+++ b/expert_backend/services/overflow_overlay.py
@@ -384,6 +384,16 @@ def _build_overlay_block() -> str:
   // Overview NAD pin's edge-midpoint anchor for branch actions —
   // disco / reco / max_rho_line all land on the line's middle, not
   // on either endpoint.
+  //
+  // Graphviz draws each edge as a quadratic / cubic Bézier ``<path>``;
+  // the *visual* midpoint of that curve is generally NOT the geometric
+  // midpoint between the two endpoint nodes (e.g. parallel edges,
+  // bundled lines, or any edge that bows around an obstacle). We use
+  // the SVG DOM ``getTotalLength()`` / ``getPointAtLength()`` to land
+  // exactly on the half-way point of the rendered path, projected into
+  // the overlay layer's coordinate system. Falls back to the
+  // bbox-midpoint of the source/target nodes when the path query
+  // fails — same behaviour as before.
   function edgeCentre(lineNames, layer) {{
     const root = getRoot(getSvg());
     if (!root || !lineNames || !lineNames.length) return null;
@@ -392,6 +402,30 @@ def _build_overlay_block() -> str:
       const safe = (window.CSS && CSS.escape) ? CSS.escape(name) : name.replace(/(["\\\\])/g, '\\\\$1');
       const edge = root.querySelector('.edge[data-attr-name="' + safe + '"]');
       if (!edge) continue;
+
+      // Preferred path: walk the actual edge path's mid-arc.
+      const path = edge.querySelector('path');
+      if (path && typeof path.getTotalLength === 'function'
+          && typeof path.getPointAtLength === 'function') {{
+        try {{
+          const total = path.getTotalLength();
+          if (total > 0 && Number.isFinite(total)) {{
+            const pt = path.getPointAtLength(total / 2);
+            if (pt && Number.isFinite(pt.x) && Number.isFinite(pt.y)) {{
+              const projected = projectToLayer(path, layer, pt.x, pt.y);
+              if (projected) {{
+                return {{ x: projected.x, y: projected.y, ref: null }};
+              }}
+            }}
+          }}
+        }} catch (e) {{
+          // Fall through to bbox-midpoint fallback below.
+        }}
+      }}
+
+      // Fallback: midpoint between the two endpoint NODE bbox
+      // centres. Used when the edge has no <path> child or the
+      // browser's path-length APIs are unavailable.
       const src = edge.getAttribute('data-source');
       const tgt = edge.getAttribute('data-target');
       if (!src || !tgt) continue;
@@ -595,34 +629,207 @@ def _build_overlay_block() -> str:
     return g;
   }}
 
+  // Fan out pins that resolved to (almost) the same anchor so they
+  // don't stack on top of each other. Mirrors ``fanOutColocatedPins``
+  // in ``frontend/src/utils/svg/actionPinData.ts`` — same hash key
+  // (round to 0.01) and same evenly-spaced angular fan starting at
+  // the top.  Mutates the ``positions`` map in place.
+  function fanOutColocated(positions, baseR) {{
+    const offsetRadius = (baseR || 14) * 1.6;
+    const groups = new Map();
+    for (const [id, p] of positions) {{
+      const key = Math.round(p.x * 100) + ':' + Math.round(p.y * 100);
+      const arr = groups.get(key);
+      if (arr) arr.push(id);
+      else groups.set(key, [id]);
+    }}
+    for (const ids of groups.values()) {{
+      if (ids.length < 2) continue;
+      const angleStep = (2 * Math.PI) / ids.length;
+      ids.forEach((id, i) => {{
+        const angle = -Math.PI / 2 + i * angleStep;
+        const p = positions.get(id);
+        positions.set(id, {{
+          x: p.x + offsetRadius * Math.cos(angle),
+          y: p.y + offsetRadius * Math.sin(angle),
+          ref: p.ref,
+        }});
+      }});
+    }}
+  }}
+
+  // Quadratic-Bézier midpoint identical to ``curveMidpoint`` in
+  // ``actionPinData.ts``: control point offset perpendicular to the
+  // chord by ``dist * offsetFraction``, midpoint at t=0.5.
+  function combinedCurveMidpoint(p1, p2, offsetFraction) {{
+    const dx = p2.x - p1.x;
+    const dy = p2.y - p1.y;
+    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+    const f = (typeof offsetFraction === 'number') ? offsetFraction : 0.3;
+    const ctrlX = (p1.x + p2.x) / 2 + (-dy / dist) * dist * f;
+    const ctrlY = (p1.y + p2.y) / 2 + (dx / dist) * dist * f;
+    const t = 0.5;
+    const midX = (1 - t) * (1 - t) * p1.x + 2 * t * (1 - t) * ctrlX + t * t * p2.x;
+    const midY = (1 - t) * (1 - t) * p1.y + 2 * t * (1 - t) * ctrlY + t * t * p2.y;
+    return {{ ctrlX: ctrlX, ctrlY: ctrlY, midX: midX, midY: midY }};
+  }}
+
+  // Severity → solid fill colour, matching ``severityFill`` in
+  // ``frontend/src/styles/tokens.ts``. Used to colour the dashed
+  // connector curve between a combined pin and its constituents.
+  const SEVERITY_FILL = {{
+    green:  '#16a34a',
+    orange: '#f97316',
+    red:    '#dc2626',
+    grey:   '#6b7280',
+  }};
+
   function render() {{
     const layer = ensureLayer();
     if (!layer) return;
     while (layer.firstChild) layer.removeChild(layer.firstChild);
     cachedR = null;  // Re-sample radius after every render.
-    let drawn = 0;
-    if (lastVisible && lastPins.length) {{
-      for (const pin of lastPins) {{
-        // Branch actions (disco / reco / max_rho_line) anchor at
-        // the midpoint of the matching edge — same rule the Action
-        // Overview pins follow. Falls back to a single-node anchor
-        // when the edge isn't drawn (e.g. a line filtered out by
-        // the recommender's keep_overloads_components).
-        let centre = null;
-        if (Array.isArray(pin.lineNames) && pin.lineNames.length) {{
-          centre = edgeCentre(pin.lineNames, layer);
-        }}
-        if (!centre) {{
-          const candidates = [pin.substation].concat(
-            Array.isArray(pin.nodeCandidates) ? pin.nodeCandidates : []
-          );
-          centre = nodeCentre(candidates, layer);
-        }}
-        if (!centre) continue;
-        layer.appendChild(buildPin(pin, centre, layer));
-        drawn += 1;
+    if (!(lastVisible && lastPins.length)) {{
+      updatePinCounter(0);
+      return;
+    }}
+
+    // Pass 1 — split unitary vs combined and resolve each unitary
+    // pin's anchor (edge mid-arc preferred, node fallback).
+    const baseR = basePinRadius(layer);
+    const unitary = [];
+    const combined = [];
+    const positions = new Map();   // pin.actionId -> position record
+    for (const pin of lastPins) {{
+      if (pin && pin.isCombined && pin.action1Id && pin.action2Id) {{
+        combined.push(pin);
+        continue;
+      }}
+      let centre = null;
+      if (Array.isArray(pin.lineNames) && pin.lineNames.length) {{
+        centre = edgeCentre(pin.lineNames, layer);
+      }}
+      if (!centre) {{
+        const candidates = [pin.substation].concat(
+          Array.isArray(pin.nodeCandidates) ? pin.nodeCandidates : []
+        );
+        centre = nodeCentre(candidates, layer);
+      }}
+      if (!centre) continue;
+      positions.set(pin.actionId, centre);
+      unitary.push(pin);
+    }}
+
+    // Pass 2 — fan out colocated pins so duplicates don't occlude
+    // each other. Same rule the Action Overview applies via
+    // ``fanOutColocatedPins``.
+    fanOutColocated(positions, baseR);
+
+    // Pass 3 — collect ids that participate in any combined pin so
+    // their unitary glyph reads as "context" instead of a peer.
+    const dimmedConstituents = new Set();
+    for (const cp of combined) {{
+      const p1 = positions.get(cp.action1Id);
+      const p2 = positions.get(cp.action2Id);
+      if (p1 && p2) {{
+        dimmedConstituents.add(cp.action1Id);
+        dimmedConstituents.add(cp.action2Id);
       }}
     }}
+
+    let drawn = 0;
+
+    // Render combined-pin dashed connectors first so the unitary
+    // pins draw on top of the curve at its endpoints.
+    for (const cp of combined) {{
+      const p1 = positions.get(cp.action1Id);
+      const p2 = positions.get(cp.action2Id);
+      if (!p1 || !p2) continue;
+      const {{ ctrlX, ctrlY, midX, midY }} = combinedCurveMidpoint(p1, p2, 0.3);
+      const stroke = SEVERITY_FILL[cp.severity] || SEVERITY_FILL.grey;
+      const sw = Math.max(2, baseR * 0.18);
+
+      const svgNs = 'http://www.w3.org/2000/svg';
+      const curve = document.createElementNS(svgNs, 'path');
+      curve.setAttribute('class', 'cs4g-overflow-combined-curve');
+      curve.setAttribute('d',
+        'M ' + p1.x + ' ' + p1.y +
+        ' Q ' + ctrlX + ' ' + ctrlY +
+        ' ' + p2.x + ' ' + p2.y);
+      curve.setAttribute('fill', 'none');
+      curve.setAttribute('stroke', stroke);
+      curve.setAttribute('stroke-width', String(sw));
+      curve.setAttribute('stroke-dasharray', String(sw * 2.5) + ' ' + String(sw * 1.5));
+      curve.setAttribute('stroke-linecap', 'round');
+      curve.setAttribute('pointer-events', 'none');
+      curve.setAttribute('opacity', '0.85');
+      layer.appendChild(curve);
+
+      // Combined pin sits at the curve midpoint. Wrap as a normal
+      // pin descriptor so ``buildPin`` reuses the click / dblclick
+      // semantics — the parent receives ``cs4g:pin-clicked`` /
+      // ``cs4g:pin-double-clicked`` keyed on the pair id.
+      const pinDesc = {{
+        actionId: cp.actionId,
+        substation: cp.substation || '',
+        label: cp.label,
+        severity: cp.severity,
+        title: cp.title || cp.actionId,
+        isSelected: !!cp.isSelected,
+        isRejected: !!cp.isRejected,
+      }};
+      const g = buildPin(pinDesc, {{ x: midX, y: midY }}, layer);
+      g.setAttribute('data-combined-pair', '1');
+
+      // "+" badge on top of the body, mirroring renderCombinedPin
+      // in ``actionPinRender.ts``.
+      const r = baseR;
+      const tail = r * 0.9;
+      const badgeCy = -r - tail - r * 0.95;
+      const body = g.querySelector('.cs4g-pin-body') || g;
+      const badge = document.createElementNS(svgNs, 'circle');
+      badge.setAttribute('cx', '0');
+      badge.setAttribute('cy', String(badgeCy));
+      badge.setAttribute('r', String(r * 0.35));
+      badge.setAttribute('fill', stroke);
+      badge.setAttribute('stroke', 'white');
+      badge.setAttribute('stroke-width', String(r * 0.06));
+      badge.setAttribute('pointer-events', 'none');
+      body.appendChild(badge);
+      const plus = document.createElementNS(svgNs, 'text');
+      plus.setAttribute('x', '0');
+      plus.setAttribute('y', String(badgeCy));
+      plus.setAttribute('text-anchor', 'middle');
+      plus.setAttribute('dominant-baseline', 'central');
+      plus.setAttribute('font-size', String(r * 0.5));
+      plus.setAttribute('font-weight', '900');
+      plus.setAttribute('font-family', 'system-ui, -apple-system, Arial, sans-serif');
+      plus.setAttribute('fill', 'white');
+      plus.setAttribute('pointer-events', 'none');
+      plus.textContent = '+';
+      body.appendChild(plus);
+
+      layer.appendChild(g);
+      drawn += 1;
+    }}
+
+    // Render unitary pins. Constituents of any combined pair are
+    // dimmed so the combined pin reads as the primary actor.
+    for (const pin of unitary) {{
+      const centre = positions.get(pin.actionId);
+      if (!centre) continue;
+      const g = buildPin(pin, centre, layer);
+      if (dimmedConstituents.has(pin.actionId) && !pin.unsimulated) {{
+        // Lighter than full opacity but visibly heavier than the
+        // un-simulated 0.5 dim — mirrors the "context" feel the
+        // Action Overview applies to combined-pin constituents.
+        g.setAttribute('opacity', '0.55');
+        g.setAttribute('data-combined-constituent', '1');
+      }}
+      layer.appendChild(g);
+      drawn += 1;
+    }}
+
     updatePinCounter(drawn);
   }}
 

--- a/expert_backend/tests/test_overflow_overlay.py
+++ b/expert_backend/tests/test_overflow_overlay.py
@@ -298,6 +298,59 @@ class TestInjectOverlay:
         assert "typeof pin.title === 'string' && pin.title" in out
         assert ": pin.actionId," in out
 
+    def test_edge_midpoint_uses_getPointAtLength_on_curved_path(self) -> None:
+        """Branch-action pins land on the actual visual midpoint of
+        the curved graphviz edge path, NOT on the geometric mean of
+        the two endpoint nodes. Without ``getPointAtLength`` a
+        bow-shaped edge (parallel transformer, line skirting an
+        obstacle) puts the pin off-curve.
+        """
+        out = inject_overlay(_BASE_HTML)
+        # Preferred path uses the SVG ``<path>``'s mid-arc.
+        assert "edge.querySelector('path')" in out
+        assert "path.getTotalLength()" in out
+        assert "path.getPointAtLength(total / 2)" in out
+        # The bbox-midpoint formula remains as a fallback for paths
+        # that don't expose getTotalLength (jsdom older builds).
+        assert "(sp.x + tp.x) / 2" in out
+
+    def test_combined_pin_curve_connector_is_injected(self) -> None:
+        """Pins flagged ``isCombined: true`` cause the overlay to
+        draw a dashed quadratic-Bézier connector between the two
+        constituent unitary pins and place the combined pin at the
+        curve midpoint, mirroring the Action Overview NAD's
+        ``renderCombinedPin`` behaviour."""
+        out = inject_overlay(_BASE_HTML)
+        # Combined-pin branching is recognised in the render loop.
+        assert "pin.isCombined && pin.action1Id && pin.action2Id" in out
+        # Quadratic-Bézier midpoint helper mirroring curveMidpoint
+        # in actionPinData.ts.
+        assert "function combinedCurveMidpoint(p1, p2, offsetFraction)" in out
+        # Dashed connector path with the SVG-quadratic ``Q ctrl`` form.
+        assert "cs4g-overflow-combined-curve" in out
+        assert "stroke-dasharray" in out
+        # "+" badge mirroring the Action Overview's combined-pin badge.
+        assert "plus.textContent = '+';" in out
+
+    def test_combined_pin_dims_unitary_constituents(self) -> None:
+        """When a combined pin's two halves resolve, the unitary
+        pins themselves are rendered with a reduced opacity so the
+        combined glyph reads as the primary actor."""
+        out = inject_overlay(_BASE_HTML)
+        assert "dimmedConstituents" in out
+        assert "data-combined-constituent" in out
+        assert "setAttribute('opacity', '0.55')" in out
+
+    def test_pins_fan_out_when_colocated(self) -> None:
+        """Two pins resolving to the same anchor must be spread on a
+        small circle around the anchor so they remain individually
+        clickable. Mirrors ``fanOutColocatedPins`` in actionPinData.ts."""
+        out = inject_overlay(_BASE_HTML)
+        assert "function fanOutColocated(positions, baseR)" in out
+        # Same hash key the Action Overview uses (round * 100).
+        assert "Math.round(p.x * 100) + ':' + Math.round(p.y * 100)" in out
+        assert "(2 * Math.PI) / ids.length" in out
+
     def test_unsimulated_pin_dblclick_kicks_off_manual_simulation(self) -> None:
         """Un-simulated pins do NOT open the SLD overlay on dblclick;
         they post a distinct message that the parent routes through

--- a/frontend/src/utils/svg/overflowPinPayload.test.ts
+++ b/frontend/src/utils/svg/overflowPinPayload.test.ts
@@ -306,6 +306,74 @@ describe('buildOverflowPinPayload — anchor priority', () => {
         expect(out).toHaveLength(1);
         expect(out[0].lineNames).toContain('LINE_AB');
     });
+
+    it('combined-action key (id1+id2) emits an isCombined descriptor with both halves', () => {
+        // A simulated combined pair has its own ``actions`` entry
+        // whose key carries ``+``. The overflow overlay places the
+        // combined pin at the midpoint of a curve drawn between the
+        // two unitary pins, so the descriptor must carry the ids of
+        // both halves and skip the per-edge anchor logic.
+        const actions: Record<string, ActionDetail> = {
+            ls_a: {
+                description_unitaire: 'load shedding A',
+                max_rho: 0.4,
+                load_shedding_details: [
+                    { load_name: 'L1', voltage_level_id: 'VLA', shedded_mw: 10 },
+                ],
+            } as unknown as ActionDetail,
+            ls_b: {
+                description_unitaire: 'load shedding B',
+                max_rho: 0.5,
+                load_shedding_details: [
+                    { load_name: 'L2', voltage_level_id: 'VLB', shedded_mw: 12 },
+                ],
+            } as unknown as ActionDetail,
+            'ls_a+ls_b': {
+                description_unitaire: 'combined LS',
+                max_rho: 0.7,
+            } as unknown as ActionDetail,
+        };
+        const meta = makeMetaIndex(
+            { VLA: { equipmentId: 'VLA' }, VLB: { equipmentId: 'VLB' } },
+            {},
+        );
+        const out = buildOverflowPinPayload(
+            actions, meta, { VLA: 'SUB_A', VLB: 'SUB_B' }, 0.95,
+            new Set(), new Set(),
+        );
+        const combined = out.filter(p => p.isCombined);
+        expect(combined).toHaveLength(1);
+        expect(combined[0].action1Id).toBe('ls_a');
+        expect(combined[0].action2Id).toBe('ls_b');
+        expect(combined[0].actionId).toBe('ls_a+ls_b');
+        // Unitary halves must also be in the payload — the overlay
+        // draws the connector between THEIR positions.
+        expect(out.some(p => p.actionId === 'ls_a' && !p.isCombined)).toBe(true);
+        expect(out.some(p => p.actionId === 'ls_b' && !p.isCombined)).toBe(true);
+    });
+
+    it('combined-action descriptor is dropped when one half does not resolve', () => {
+        const actions: Record<string, ActionDetail> = {
+            // Only ls_a resolves — ls_b has no anchor (no metadata for VLB).
+            ls_a: {
+                description_unitaire: 'load shedding A',
+                max_rho: 0.4,
+                load_shedding_details: [
+                    { load_name: 'L1', voltage_level_id: 'VLA', shedded_mw: 10 },
+                ],
+            } as unknown as ActionDetail,
+            'ls_a+ls_b': {
+                description_unitaire: 'combined LS',
+                max_rho: 0.7,
+            } as unknown as ActionDetail,
+        };
+        const meta = makeMetaIndex({ VLA: { equipmentId: 'VLA' } }, {});
+        const out = buildOverflowPinPayload(
+            actions, meta, { VLA: 'SUB_A' }, 0.95,
+            new Set(), new Set(),
+        );
+        expect(out.some(p => p.isCombined)).toBe(false);
+    });
 });
 
 // ---------------------------------------------------------------------

--- a/frontend/src/utils/svg/overflowPinPayload.ts
+++ b/frontend/src/utils/svg/overflowPinPayload.ts
@@ -37,6 +37,21 @@ import { matchesActionTypeFilter } from '../actionTypes';
 export interface OverflowPin {
     actionId: string;
     /**
+     * Marks combined-action pins (action ids containing ``+``). The
+     * overlay places one such pin at the midpoint of a curved Bézier
+     * connector drawn between the two unitary constituent pins —
+     * mirroring the Action Overview NAD's ``CombinedPinInfo`` layer
+     * (see ``actionPinData.buildCombinedActionPins`` /
+     * ``actionPinRender.renderCombinedPin``). When set, ``action1Id``
+     * + ``action2Id`` MUST also be populated; ``substation`` /
+     * ``lineNames`` / ``nodeCandidates`` are ignored — the combined
+     * pin's position is derived from the constituent positions
+     * client-side.
+     */
+    isCombined?: boolean;
+    action1Id?: string;
+    action2Id?: string;
+    /**
      * Primary anchor — substation id when the overflow graph nodes are
      * substations, otherwise the first matching voltage-level id. The
      * overlay JS tries this name first against ``data-name`` and falls
@@ -288,7 +303,13 @@ export const buildOverflowPinPayload = (
     const knownSet = overflowSubstations ?? new Set<string>();
     const acceptAny = !overflowSubstations;
     const out: OverflowPin[] = [];
+    const unitaryIds = new Set<string>();
     for (const [actionId, details] of Object.entries(actions)) {
+        // Combined-action entries (key contains ``+``) are emitted
+        // separately at the end of the loop with both constituent
+        // ids attached. The overlay computes their position
+        // client-side from the unitary anchors.
+        if (actionId.includes('+')) continue;
         // Action-Overview filters: severity category, max-loading
         // threshold, action-type chip. Identical to the rules
         // applied by ``ActionOverviewDiagram`` and ``ActionFeed`` so
@@ -308,6 +329,7 @@ export const buildOverflowPinPayload = (
             acceptAny ? new Set(Object.values(vlToSubstation)) : knownSet,
         );
         if (!anchor) continue;
+        unitaryIds.add(actionId);
         out.push({
             actionId,
             substation: anchor.substation,
@@ -320,6 +342,37 @@ export const buildOverflowPinPayload = (
             // matching one of these line names — same anchoring logic
             // as the Action Overview NAD pin layer.
             lineNames: anchor.lineNames,
+            label: formatPinLabel(details),
+            severity: computeActionSeverity(details, monitoringFactor),
+            isSelected: selectedActionIds.has(actionId),
+            isRejected: rejectedActionIds.has(actionId),
+        });
+    }
+
+    // Combined-action pins. Mirrors ``buildCombinedActionPins`` in
+    // ``actionPinData.ts``: every ``actions[id]`` whose key holds a
+    // single ``+`` and whose two halves both resolved to a unitary
+    // pin emits a combined descriptor. The overlay JS draws a
+    // dashed Bézier connector between the constituent anchors and
+    // places the combined pin at the curve midpoint.
+    for (const [actionId, details] of Object.entries(actions)) {
+        if (!actionId.includes('+')) continue;
+        const parts = actionId.split('+');
+        if (parts.length !== 2) continue;
+        const [id1, id2] = parts;
+        if (!unitaryIds.has(id1) || !unitaryIds.has(id2)) continue;
+        if (overviewFilters) {
+            if (!actionPassesOverviewFilter(
+                details, monitoringFactor,
+                overviewFilters.categories, overviewFilters.threshold,
+            )) continue;
+        }
+        out.push({
+            actionId,
+            isCombined: true,
+            action1Id: id1,
+            action2Id: id2,
+            substation: '',
             label: formatPinLabel(details),
             severity: computeActionSeverity(details, monitoringFactor),
             isSelected: selectedActionIds.has(actionId),


### PR DESCRIPTION
…yout

Three improvements to the overflow-graph action pin overlay so it matches the Action Overview NAD pin behaviour the operators have calibrated against on the other diagram surfaces.

* **Mid-arc edge anchor**. Branch-action pins (disco / reco / max_rho_line) used to land on the geometric midpoint between the edge's two endpoint NODES, computed from their bbox centres. For any edge graphviz draws as a curved Bézier (parallel transformers, lines bowing around obstacles), that midpoint sits off the visible curve — e.g. ``reco_CHALOL31LOUHA`` was placed on ``FLEYRP6 -> VOUGLP6`` instead of on its own line. The overlay now walks the edge's ``<path>`` via ``getTotalLength()`` + ``getPointAtLength(len/2)`` to land on the actual visual mid-arc, projected back into the overlay's coordinate system. Falls back to the bbox-midpoint formula when the path lacks the SVG length APIs.

* **Fan-out de-overlap**. Pins resolving to the same anchor are spread on a small circle around it so duplicates stay individually clickable, mirroring ``fanOutColocatedPins`` in ``frontend/src/utils/svg/actionPinData.ts`` byte-for-byte (same hash key, same angular fan starting at the top).

* **Combined-action pin curves**. Action ids carrying ``+`` are now emitted by ``buildOverflowPinPayload`` as a separate ``isCombined: true`` descriptor with both constituent ids. The overlay JS draws a dashed quadratic-Bézier connector between the two unitary anchors, places a combined pin at the curve midpoint with a "+" badge, and dims the constituent unitary pins (opacity 0.55) so the combined glyph reads as the primary actor — same UX contract as ``renderCombinedPin`` / ``CombinedPinInfo`` on the Action Overview NAD.

Test coverage:
- ``test_overflow_overlay.py`` adds four cases asserting the path midpoint walk, combined-pin connector / "+" badge / constituent dimming, and the colocated fan-out helper.
- ``overflowPinPayload.test.ts`` adds two cases asserting that combined-action keys (id1+id2) emit the new descriptor and that it's dropped when one half doesn't resolve.