### PR TITLE
fix(monitoring): correct obs.rho threshold + symmetric impact rule + N-Overloads alignment

### DIFF
--- a/docs/features/combined-actions.md
+++ b/docs/features/combined-actions.md
@@ -294,14 +294,18 @@ if action1_id not in all_actions:
     all_actions = self._last_result["prioritized_actions"]
 ```
 
-### Pre-existing overload filtering
+### Pre-existing overload filtering (symmetric impact rule)
 
-The superposition result filters out lines with pre-existing overloads (lines already overloaded in N state) unless the combined action **worsens** them beyond a configurable threshold (default 2%):
+The superposition result filters out lines with pre-existing overloads (lines already overloaded in N state) **only when the combined action does not impact them** — i.e. their combined rho stays inside a symmetric ±`worsening_threshold` band around the N-state baseline (default 2%). Lines that the action significantly **worsens OR improves** belong to its sensitive area and remain monitored:
 
 ```python
-worsened_mask = rho_combined > pre_existing_baseline * (1 + worsening_threshold)
-eligible_mask = care_mask & (~is_pre_existing | worsened_mask)
+is_pre_existing = base_rho_n >= monitoring_factor
+not_impacted = (rho_combined >= base_rho_n * (1 - worsening_threshold)) & \
+               (rho_combined <= base_rho_n * (1 + worsening_threshold))
+eligible_mask = care_mask & ~(is_pre_existing & not_impacted)
 ```
+
+The symmetric form replaces the previous one-sided `not_worsened` rule, which silently dropped lines whose pre-existing overload was significantly *reduced* by the action — hiding genuine action impact from the operator. The same rule is applied uniformly across `simulation_helpers.build_care_mask`, `simulation_helpers.resolve_lines_overloaded`, `simulation_mixin._augment_superposition_result`, `simulation_mixin._superposition_lines_overloaded`, and `diagram/overloads.get_overloaded_lines` so the N Overloads UI panel, the simulation `max_rho`, and the superposition estimate all agree.
 
 ### Analysis-time combined actions
 

--- a/expert_backend/services/diagram/overloads.py
+++ b/expert_backend/services/diagram/overloads.py
@@ -84,10 +84,19 @@ def get_overloaded_lines(
     Rules:
       1. Only elements with a permanent current limit are monitored.
       2. Restricted to ``lines_we_care_about`` when provided.
-      3. An element is "overloaded" when ``max_i > limit * monitoring_factor``.
+      3. An element is "overloaded" when ``max_i >= limit * monitoring_factor``.
+         The ``>=`` comparison aligns the N Overloads UI panel with the
+         backend simulation filter (``simulation_helpers.build_care_mask``)
+         which uses ``base_rho >= mf``. Without this alignment a line
+         sitting just at the threshold would surface as "no N overload"
+         in the UI but be silently filtered as "pre-existing overload"
+         by the simulation.
       4. When ``n_state_currents`` is provided, pre-existing overloads
          (elements already overloaded in N) are excluded UNLESS the
-         current increased by more than ``worsening_threshold`` (relative).
+         current moved outside the symmetric ``±worsening_threshold``
+         band around its N value. This keeps lines in the action's
+         sensitive area (whether worsened or improved) while still
+         filtering out lines that belong to other issues.
 
     Returns a sanitised list by default; with ``with_rho=True`` returns
     ``(names, rhos)`` parallel lists.
@@ -116,12 +125,16 @@ def get_overloaded_lines(
                 continue
 
             max_i = max_i_arr[j]
-            if max_i > limit * monitoring_factor:
+            if max_i >= limit * monitoring_factor:
                 if n_state_currents is not None and element_id in n_state_currents:
                     n_max_i = n_state_currents[element_id]
-                    if n_max_i > limit * monitoring_factor:
-                        # Was already overloaded in N — only keep if worsened
-                        if max_i <= n_max_i * (1 + worsening_threshold):
+                    if n_max_i >= limit * monitoring_factor:
+                        # Was already overloaded in N — keep only if the
+                        # action moved the line outside the symmetric
+                        # ±worsening_threshold band around its N value.
+                        lower = n_max_i * (1 - worsening_threshold)
+                        upper = n_max_i * (1 + worsening_threshold)
+                        if lower <= max_i <= upper:
                             continue
                 overloaded.append(element_id)
                 overloaded_rho.append(float(max_i / limit) if limit else 0.0)

--- a/expert_backend/services/simulation_helpers.py
+++ b/expert_backend/services/simulation_helpers.py
@@ -188,20 +188,39 @@ def build_care_mask(
 
     Rules:
       1. Must be in ``lines_we_care_about`` AND ``branches_with_limits``.
-      2. Exclude pre-existing N-state overloads unless the action worsens them.
+      2. Exclude pre-existing N-state overloads UNLESS the action moved
+         the line outside the symmetric ``±worsening_threshold`` band
+         around its N value (``not_impacted``). Lines whose rho barely
+         changes belong to "other issues" and should not pollute the
+         action's max_rho; lines whose rho moved significantly — in
+         either direction — belong to the action's sensitive area and
+         must remain monitored, even when they were already overloaded.
       3. Always force-include lines at ``lines_overloaded_ids`` (active monitoring).
+
+    NOTE: ``action_rho`` and ``base_rho`` come from grid2op observations,
+    where ``obs.rho`` is already pre-scaled by the monitoring factor:
+    ``obs.rho = current / (permanent_limit * monitoring_factor)``. So
+    ``obs.rho >= 1.0`` already means "at or above the monitoring
+    threshold", and the comparison MUST use 1.0 — not
+    ``monitoring_factor`` — otherwise we double-apply the factor and
+    flag lines as overloaded at ``mf**2 ≈ 90.25 %`` of the permanent
+    limit instead of 95 %. The ``monitoring_factor`` parameter is kept
+    only because it sets the symmetric-impact band scale via
+    ``worsening_threshold`` and for parity with the diagram-side
+    ``get_overloaded_lines``, which compares pypowsybl currents (NOT
+    pre-scaled) against ``limit * monitoring_factor``.
 
     Falls back to an all-False mask if numpy comparisons fail (legacy tests
     pass MagicMocks for observations).
     """
     mask = np.isin(action_names, list(lines_we_care_about))
     mask &= np.isin(action_names, list(branches_with_limits))
-    mf = float(monitoring_factor)
     wt = float(worsening_threshold)
+    OBS_RHO_OVERLOAD_THRESHOLD = 1.0  # see docstring — obs.rho is mf-scaled
     try:
-        pre_existing = base_rho >= mf
-        not_worsened = action_rho <= base_rho * (1 + wt)
-        mask &= ~(pre_existing & not_worsened)
+        pre_existing = base_rho >= OBS_RHO_OVERLOAD_THRESHOLD
+        not_impacted = (action_rho >= base_rho * (1 - wt)) & (action_rho <= base_rho * (1 + wt))
+        mask &= ~(pre_existing & not_impacted)
     except Exception as e:
         logger.warning("build_care_mask: vectorised comparison failed (mock context?): %s", e)
         mask = np.zeros(len(action_names), dtype=bool)
@@ -240,16 +259,19 @@ def resolve_lines_overloaded(
     action_names = _to_1d(obs_simu_defaut.name_line)
     action_rho = _to_1d(obs_simu_defaut.rho)
     base_rho = _to_1d(obs_n.rho)
-    mf = float(monitoring_factor)
     wt = float(worsening_threshold)
+    # obs.rho is already pre-scaled by monitoring_factor — see
+    # ``build_care_mask`` docstring. Threshold is 1.0, not mf.
+    OBS_RHO_OVERLOAD_THRESHOLD = 1.0
 
     mask = np.isin(action_names, list(lines_we_care_about))
     mask &= np.isin(action_names, list(branches_with_limits))
     try:
-        rho_mask = action_rho >= mf
-        pre_existing = base_rho >= mf
-        not_worsened = action_rho <= base_rho * (1 + wt)
-        mask &= rho_mask & ~(pre_existing & not_worsened)
+        rho_mask = action_rho >= OBS_RHO_OVERLOAD_THRESHOLD
+        pre_existing = base_rho >= OBS_RHO_OVERLOAD_THRESHOLD
+        # Symmetric impact rule — see ``build_care_mask`` for rationale.
+        not_impacted = (action_rho >= base_rho * (1 - wt)) & (action_rho <= base_rho * (1 + wt))
+        mask &= rho_mask & ~(pre_existing & not_impacted)
     except Exception as e:
         logger.warning("resolve_lines_overloaded: vectorised comparison failed: %s", e)
         mask = np.zeros(len(action_names), dtype=bool)
@@ -343,7 +365,9 @@ def compute_action_metrics(
     try:
         monitored_rho = action_rho[care_mask]
         monitored_names = action_names[care_mask]
-        overload_mask = monitored_rho >= mf
+        # obs.rho is mf-scaled — see ``build_care_mask`` docstring — so
+        # the "overloaded" boundary on ``monitored_rho`` is 1.0, not mf.
+        overload_mask = monitored_rho >= 1.0
         result["lines_overloaded_after"] = monitored_names[overload_mask].tolist()
         if len(monitored_rho) > 0:
             result["max_rho"] = float(np.max(monitored_rho)) * mf

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -692,10 +692,15 @@ class SimulationMixin:
 
         n.set_working_variant(self._get_n_variant())
         obs_n = env.get_obs()
+        # obs.rho is already pre-scaled by monitoring_factor (grid2op
+        # divides current by ``limit * mf``), so the overload threshold
+        # on obs.rho is 1.0 — not mf. Using mf here would double-apply
+        # the factor and treat lines at ~90 % of the permanent limit as
+        # "already overloaded". See simulation_helpers.build_care_mask.
         pre_existing_rho = {
             i: obs_n.rho[i]
             for i in range(len(obs_n.rho))
-            if obs_n.rho[i] >= monitoring_factor
+            if obs_n.rho[i] >= 1.0
         }
 
         lines_we_care_about, branches_with_limits = self._get_monitoring_parameters(obs_start)
@@ -844,16 +849,21 @@ class SimulationMixin:
             )
             return ids
 
-        mf = float(monitoring_factor)
         wt = float(worsening_threshold)
         lwca_set = set(lines_we_care_about) if lines_we_care_about else set(name_line_list)
         bwl_set = set(branches_with_limits)
+        # obs.rho is already pre-scaled by monitoring_factor — threshold
+        # is 1.0, not mf. See simulation_helpers.build_care_mask docstring.
         ids = []
         for i in range(len(obs_start.rho)):
             ln = name_line_list[i]
-            if obs_start.rho[i] >= mf and ln in lwca_set and ln in bwl_set:
-                if i in pre_existing_rho and obs_start.rho[i] <= pre_existing_rho[i] * (1 + wt):
-                    continue
+            if obs_start.rho[i] >= 1.0 and ln in lwca_set and ln in bwl_set:
+                # Symmetric impact rule — see ``simulation_helpers.build_care_mask``.
+                if i in pre_existing_rho:
+                    lower = pre_existing_rho[i] * (1 - wt)
+                    upper = pre_existing_rho[i] * (1 + wt)
+                    if lower <= obs_start.rho[i] <= upper:
+                        continue
                 ids.append(i)
         logger.info(
             "[compute_superposition] Computed lines_overloaded from N-1 state: %d lines "
@@ -905,9 +915,15 @@ class SimulationMixin:
             if len(obs_n.rho) >= num_lines
             else np.array(obs_n.rho)
         )
-        pre_existing = base_rho_n >= mf
-        not_worsened = rho_combined[:num_lines] <= base_rho_n * (1 + wt)
-        care_mask &= ~(pre_existing & not_worsened)
+        # obs.rho is already pre-scaled by monitoring_factor — threshold
+        # is 1.0, not mf. See simulation_helpers.build_care_mask docstring.
+        # ``rho_combined`` is in the same scale (linear combination of
+        # obs.rho values).
+        pre_existing = base_rho_n >= 1.0
+        # Symmetric impact rule — see ``simulation_helpers.build_care_mask``.
+        rho_c = rho_combined[:num_lines]
+        not_impacted = (rho_c >= base_rho_n * (1 - wt)) & (rho_c <= base_rho_n * (1 + wt))
+        care_mask &= ~(pre_existing & not_impacted)
 
         for idx in lines_overloaded_ids:
             if idx < len(care_mask):

--- a/expert_backend/tests/test_diagram_helpers.py
+++ b/expert_backend/tests/test_diagram_helpers.py
@@ -181,14 +181,19 @@ class TestGetElementMaxCurrents:
 
 
 class TestGetOverloadedLines:
-    def test_flags_lines_over_monitoring_factor(self):
-        lines = pd.DataFrame({"i1": [100.0, 50.0], "i2": [0.0, 0.0]},
-                             index=["L1", "L2"])
-        limits = _limits({"L1": 100.0, "L2": 100.0})
+    def test_flags_lines_at_or_above_monitoring_factor(self):
+        # `get_overloaded_lines` uses `>=` to match the backend simulation
+        # filter (`simulation_helpers.build_care_mask`), so a line sitting
+        # exactly at the threshold IS treated as overloaded — no silent
+        # disagreement between the N Overloads UI panel and the simulator.
+        lines = pd.DataFrame({"i1": [100.0, 50.0, 49.0], "i2": [0.0, 0.0, 0.0]},
+                             index=["L1", "L2", "L3"])
+        limits = _limits({"L1": 100.0, "L2": 100.0, "L3": 100.0})
         net = _mock_network(lines_df=lines, limits_df=limits)
         result = overloads.get_overloaded_lines(net, monitoring_factor=0.5)
-        # L1: 100 > 50 → overloaded. L2: 50 == 50 → not overloaded.
-        assert result == ["L1"]
+        # L1: 100 ≥ 50 → overloaded. L2: 50 ≥ 50 → overloaded.
+        # L3: 49 < 50 → not overloaded.
+        assert sorted(result) == ["L1", "L2"]
 
     def test_skips_elements_without_a_limit(self):
         lines = pd.DataFrame({"i1": [1000.0], "i2": [0.0]}, index=["L1"])
@@ -205,11 +210,12 @@ class TestGetOverloadedLines:
         )
         assert result == ["L1"]
 
-    def test_excludes_pre_existing_overloads_not_worsened(self):
+    def test_excludes_pre_existing_overloads_not_impacted(self):
         lines = pd.DataFrame({"i1": [100.0], "i2": [0.0]}, index=["L1"])
         limits = _limits({"L1": 50.0})
         net = _mock_network(lines_df=lines, limits_df=limits)
-        # In N-state the line was already at 100 → not worsened, excluded.
+        # In N-state the line was already at 100 → the action did not
+        # move it outside the symmetric ±2 % band → not_impacted, excluded.
         result = overloads.get_overloaded_lines(
             net,
             n_state_currents={"L1": 100.0},
@@ -225,6 +231,21 @@ class TestGetOverloadedLines:
         # N-state was 100 → 200 exceeds 100 * (1 + 0.02) → kept.
         result = overloads.get_overloaded_lines(
             net, n_state_currents={"L1": 100.0}, monitoring_factor=0.95,
+        )
+        assert result == ["L1"]
+
+    def test_keeps_pre_existing_overloads_when_significantly_improved(self):
+        # Symmetric impact rule: a line whose pre-existing overload is
+        # significantly *reduced* by the action is in the action's
+        # sensitive area and must remain monitored.
+        lines = pd.DataFrame({"i1": [80.0], "i2": [0.0]}, index=["L1"])
+        limits = _limits({"L1": 50.0})
+        net = _mock_network(lines_df=lines, limits_df=limits)
+        # N-state was 100 (rho=2.0) → action brought it to 80 (rho=1.6),
+        # well below 100 * (1 - 0.02) → kept by the symmetric rule.
+        result = overloads.get_overloaded_lines(
+            net, n_state_currents={"L1": 100.0}, monitoring_factor=0.95,
+            worsening_threshold=0.02,
         )
         assert result == ["L1"]
 

--- a/expert_backend/tests/test_resimulate_regression.py
+++ b/expert_backend/tests/test_resimulate_regression.py
@@ -48,7 +48,9 @@ def _setup_env_mock(name_load=None, load_p=None, name_gen=None, gen_p=None):
     obs_n1.n_components = 1
     obs_n1.main_component_load_mw = 1000.0
     obs_n1.name_line = ["LINE_1"]
-    obs_n1.rho = np.array([0.98]) # Overloaded in N-1
+    # Overloaded in N-1. obs.rho is mf-scaled (grid2op divides by
+    # ``limit * mf``), so values >= 1.0 are above the monitoring threshold.
+    obs_n1.rho = np.array([1.05])
     obs_n1.name_load = obs_n.name_load
     obs_n1.load_p = obs_n.load_p
     obs_n1.name_gen = obs_n.name_gen

--- a/expert_backend/tests/test_simulation_helpers.py
+++ b/expert_backend/tests/test_simulation_helpers.py
@@ -239,20 +239,65 @@ class TestBuildCareMask:
         )
         assert mask.tolist() == [True, False, True]
 
-    def test_excludes_preexisting_overloads_not_worsened(self):
-        # Line A pre-existing overload (base rho=1.0), action rho=1.0 → not worsened → excluded
-        # Line B pre-existing overload (base rho=1.0), action rho=1.5 → worsened → included
+    def test_excludes_preexisting_overloads_not_impacted(self):
+        # Symmetric impact rule: a pre-existing overload is excluded only
+        # when the action leaves it inside the ±worsening_threshold band.
+        # A: pre-existing 1.0, action 1.0 → not_impacted → excluded.
+        # B: pre-existing 1.0, action 1.5 → worsened beyond +2% → included.
+        # C: pre-existing 1.0, action 0.7 → improved beyond -2% → included
+        #    (the action operates in this line's sensitive area).
+        mask = build_care_mask(
+            action_names=np.array(["A", "B", "C"]),
+            action_rho=np.array([1.0, 1.5, 0.7]),
+            base_rho=np.array([1.0, 1.0, 1.0]),
+            lines_we_care_about={"A", "B", "C"},
+            branches_with_limits={"A", "B", "C"},
+            lines_overloaded_ids=[],
+            monitoring_factor=0.95,
+            worsening_threshold=0.02,
+        )
+        assert mask.tolist() == [False, True, True]
+
+    def test_excludes_only_strictly_inert_preexisting_overloads(self):
+        # Inside the symmetric ±2% band the line is treated as "not impacted".
+        # Just outside the band (either direction) → kept.
+        mask = build_care_mask(
+            action_names=np.array(["INSIDE_BAND", "JUST_BELOW_BAND", "JUST_ABOVE_BAND"]),
+            action_rho=np.array([0.99, 0.97, 1.03]),
+            base_rho=np.array([1.0, 1.0, 1.0]),
+            lines_we_care_about={"INSIDE_BAND", "JUST_BELOW_BAND", "JUST_ABOVE_BAND"},
+            branches_with_limits={"INSIDE_BAND", "JUST_BELOW_BAND", "JUST_ABOVE_BAND"},
+            lines_overloaded_ids=[],
+            monitoring_factor=0.95,
+            worsening_threshold=0.02,
+        )
+        assert mask.tolist() == [False, True, True]
+
+    def test_obs_rho_threshold_is_one_not_monitoring_factor(self):
+        # Regression: grid2op's ``obs.rho`` is already pre-scaled by
+        # ``monitoring_factor`` (rho = current / (limit * mf)), so the
+        # "is overloaded" boundary on ``base_rho`` / ``action_rho`` is
+        # 1.0 — not ``mf``. The earlier code used ``>= mf`` here, which
+        # double-applied the factor and treated lines at ~mf**2 ≈ 90.25 %
+        # of the permanent limit as already overloaded — silently dropping
+        # them from the simulator's max_rho through the pre-existing
+        # filter. This test pins the corrected boundary.
+        #
+        # A: pre-existing 0.97 (between mf and 1.0) → NOT pre-existing,
+        #    action 0.50 → included (no exclusion fires).
+        # B: pre-existing 1.05 (above 1.0) → pre-existing, action 1.05
+        #    is inside the ±2 % band → excluded.
         mask = build_care_mask(
             action_names=np.array(["A", "B"]),
-            action_rho=np.array([1.0, 1.5]),
-            base_rho=np.array([1.0, 1.0]),
+            action_rho=np.array([0.50, 1.05]),
+            base_rho=np.array([0.97, 1.05]),
             lines_we_care_about={"A", "B"},
             branches_with_limits={"A", "B"},
             lines_overloaded_ids=[],
             monitoring_factor=0.95,
             worsening_threshold=0.02,
         )
-        assert mask.tolist() == [False, True]
+        assert mask.tolist() == [True, False]
 
     def test_force_includes_overloaded_ids(self):
         mask = build_care_mask(
@@ -323,6 +368,28 @@ class TestResolveLinesOverloaded:
         # Both A (1.2) and C (1.1) are overloaded and not pre-existing
         assert ids == [0, 2]
         assert names == ["A", "C"]
+
+    def test_recompute_threshold_is_one_not_monitoring_factor(self):
+        # Regression for the obs.rho double-scaling fix. Grid2op's
+        # ``obs.rho`` is already divided by ``limit * mf``, so a line is
+        # "overloaded" only when ``obs.rho >= 1.0`` — not when
+        # ``>= monitoring_factor``. The earlier check ``action_rho >= mf``
+        # wrongly treated 0.96 as overloaded.
+        obs_n1 = self._obs([0.96, 1.05, 0.50])
+        obs_n = self._obs([0.10, 0.10, 0.10])
+        ids, names = resolve_lines_overloaded(
+            obs_n1, obs_n,
+            analysis_context_overloaded=None,
+            caller_overloaded=None,
+            lines_we_care_about={"A", "B", "C"},
+            branches_with_limits={"A", "B", "C"},
+            monitoring_factor=0.95,
+            worsening_threshold=0.02,
+        )
+        # Only B (1.05 >= 1.0) is overloaded. A (0.96) is below the
+        # corrected threshold; the old code wrongly flagged it as well.
+        assert ids == [1]
+        assert names == ["B"]
 
     def test_ignores_missing_context_lines(self):
         obs_n1 = self._obs([0.1, 0.1, 0.1])

--- a/expert_backend/tests/test_superposition_monitoring_consistency.py
+++ b/expert_backend/tests/test_superposition_monitoring_consistency.py
@@ -235,12 +235,17 @@ class TestOverloadedLinesForceInclusion:
 # ---------------------------------------------------------------------------
 
 class TestPreExistingOverloadHandling:
-    """Pre-existing N-state overloads should be excluded unless the combined
-    action worsens them. The worsening check must use rho_combined."""
+    """Pre-existing N-state overloads should be excluded only when the
+    combined action does not impact them (rho stays inside the symmetric
+    ±impact_threshold band around its N value). Lines that the action
+    significantly impacts — worsened OR improved — belong to the
+    action's sensitive area and must remain monitored."""
 
-    def test_preexisting_excluded_when_not_worsened(self):
-        """A pre-existing N-state overload that improves should be excluded
-        from max_rho (unless force-included as lines_overloaded)."""
+    def test_preexisting_included_when_significantly_improved(self):
+        """Symmetric impact rule: a pre-existing overload that the combined
+        action significantly *improves* belongs to the action's sensitive
+        area and must remain in max_rho. The previous one-sided rule used
+        to silently drop it; the new rule keeps it."""
         svc = RecommenderService()
         name_line = ["PRE_EXISTING", "OTHER"]
 
@@ -248,6 +253,9 @@ class TestPreExistingOverloadHandling:
         # PRE_EXISTING is overloaded in N (>= 0.95)
         obs_n_rho = [0.97, 0.40]
 
+        # Combined formula: |(1 - 1.0)*rho_n1 + 0.5*obs1 + 0.5*obs2|
+        # PRE_EXISTING: |0.5*0.70 + 0.5*0.65| = 0.675 — well below
+        # 0.97*(1-0.02)=0.9506, so the action clearly impacted it.
         obs_act1 = _make_obs([0.70, 0.65], name_line=name_line)
         obs_act2 = _make_obs([0.65, 0.60], name_line=name_line)
         actions = {
@@ -255,8 +263,6 @@ class TestPreExistingOverloadHandling:
             "act2": {"action": MagicMock(), "observation": obs_act2},
         }
 
-        # No analysis context — so force-inclusion won't add PRE_EXISTING
-        # (it's not in N-1 overloaded because rho_N1=0.80 < 0.95)
         _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
                    analysis_context=None)
 
@@ -267,8 +273,47 @@ class TestPreExistingOverloadHandling:
             mock_sp.return_value = {"betas": [0.5, 0.5]}
             result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
 
-        # PRE_EXISTING (N-state overload at 97%, combined action improves it)
-        # should be excluded, so OTHER should be max
+        # Symmetric rule keeps PRE_EXISTING — 0.675 > 0.625 (OTHER) — so
+        # the operator can see the action did materially affect this line.
+        assert result["max_rho_line"] == "PRE_EXISTING"
+
+    def test_preexisting_excluded_when_not_impacted(self):
+        """A pre-existing N-state overload whose combined rho stays inside
+        the symmetric ±impact_threshold band is unrelated to the action's
+        sensitive area and should be excluded from max_rho.
+
+        obs.rho is mf-scaled (grid2op divides by ``limit * mf``), so a
+        line is "pre-existing overloaded" only when ``obs.rho >= 1.0``.
+        """
+        svc = RecommenderService()
+        name_line = ["PRE_EXISTING", "OTHER"]
+
+        # PRE_EXISTING is overloaded in N at 1.05 (above mf-scaled 1.0).
+        obs_n_rho = [1.05, 0.40]
+        obs_n1_rho = [1.05, 0.70]
+
+        # Combined formula: |0.5*obs1 + 0.5*obs2|
+        # PRE_EXISTING: |0.5*1.045 + 0.5*1.055| = 1.05 — inside the band
+        # 1.05*(1±0.02) = [1.029, 1.071]. 1.05 is right at base → inside.
+        obs_act1 = _make_obs([1.045, 0.65], name_line=name_line)
+        obs_act2 = _make_obs([1.055, 0.60], name_line=name_line)
+        actions = {
+            "act1": {"action": MagicMock(), "observation": obs_act1},
+            "act2": {"action": MagicMock(), "observation": obs_act2},
+        }
+
+        _setup_env(svc, name_line, obs_n1_rho, obs_n_rho, actions,
+                   analysis_context=None)
+
+        with patch('expert_backend.services.simulation_mixin._identify_action_elements',
+                   return_value=([0], [])), \
+             patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_sp:
+
+            mock_sp.return_value = {"betas": [0.5, 0.5]}
+            result = svc.compute_superposition("act1", "act2", "CONTINGENCY")
+
+        # PRE_EXISTING is unimpacted by the action (combined rho ≡ N)
+        # → excluded → OTHER (0.625) is the headline max.
         assert result["max_rho_line"] == "OTHER"
 
     def test_preexisting_included_when_worsened(self):

--- a/expert_backend/tests/test_vectorized_monitoring.py
+++ b/expert_backend/tests/test_vectorized_monitoring.py
@@ -73,51 +73,63 @@ class TestVectorizedMonitoringLogic:
             assert not mask[1] # 0.950 (Exactly at threshold)
             assert mask[2]     # 0.951 (Just above)
 
-    def test_care_mask_logic_with_worsening_threshold(self):
-        """Detailed check of the complex care_mask used in simulate_manual_action."""
+    def test_care_mask_logic_with_impact_threshold(self):
+        """Detailed check of the symmetric impact-based care_mask used in
+        simulate_manual_action. A pre-existing overload is excluded only
+        when the contingency leaves it inside the ±impact_threshold band
+        around its N value (i.e. the line is unaffected by the contingency
+        and the issue belongs to other root causes).
+        """
         service = RecommenderService()
-        line_names = ["PRE_EXISTING", "NEW_OVERLOAD", "IMPROVED", "STABLE"]
-        
+        line_names = ["PRE_EXISTING", "NEW_OVERLOAD", "IMPROVED", "STABLE", "INERT_PREEXISTING"]
+
         # N state
         # PRE_EXISTING: 1.1 (already overloaded)
         # NEW_OVERLOAD: 0.8 (healthy)
         # IMPROVED: 1.2 (already overloaded)
         # STABLE: 0.5 (healthy)
-        obs_n = self._make_obs([1.1, 0.8, 1.2, 0.5], line_names)
-        
+        # INERT_PREEXISTING: 1.0 (already overloaded)
+        obs_n = self._make_obs([1.1, 0.8, 1.2, 0.5, 1.0], line_names)
+
         # N-1 state (after contingency)
-        # PRE_EXISTING: 1.15 (worsened from 1.1)
+        # PRE_EXISTING: 1.15 (worsened from 1.1, ratio=1.045 → outside +2% band)
         # NEW_OVERLOAD: 1.05 (now overloaded)
-        # IMPROVED: 1.1 (improved from 1.2)
+        # IMPROVED: 1.1 (improved from 1.2, ratio=0.917 → outside -2% band)
         # STABLE: 0.55 (worsened but still healthy)
-        obs_n1 = self._make_obs([1.15, 1.05, 1.1, 0.55], line_names)
-        
+        # INERT_PREEXISTING: 1.005 (barely changed, ratio=1.005 → inside band)
+        obs_n1 = self._make_obs([1.15, 1.05, 1.1, 0.55, 1.005], line_names)
+
         with patch.object(config, 'MONITORING_FACTOR_THERMAL_LIMITS', 0.95), \
              patch.object(config, 'PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD', 0.02):
-            
+
             rho_n = np.atleast_1d(obs_n.rho).astype(float)
             rho_n1 = np.atleast_1d(obs_n1.rho).astype(float)
-            
-            # Logic from RecommenderService:
-            was_overloaded = rho_n > config.MONITORING_FACTOR_THERMAL_LIMITS
-            is_overloaded = rho_n1 > config.MONITORING_FACTOR_THERMAL_LIMITS
-            ratio = rho_n1 / np.maximum(rho_n, 1e-9)
-            worsened = ratio > (1.0 + config.PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD)
-            
-            # CARE MASK: (is_overloaded & ~was_overloaded) | (is_overloaded & was_overloaded & worsened)
-            care_mask = (is_overloaded & ~was_overloaded) | (is_overloaded & was_overloaded & worsened)
-            
-            # PRE_EXISTING: Overloaded in both. Ratio = 1.15/1.1 = 1.045 > 1.02. SHOULD BE TRUE.
+
+            mf = config.MONITORING_FACTOR_THERMAL_LIMITS
+            wt = config.PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD
+
+            was_overloaded = rho_n > mf
+            is_overloaded = rho_n1 > mf
+            # Symmetric impact rule — see services.simulation_helpers.
+            impacted = (rho_n1 < rho_n * (1 - wt)) | (rho_n1 > rho_n * (1 + wt))
+
+            care_mask = (is_overloaded & ~was_overloaded) | (is_overloaded & was_overloaded & impacted)
+
+            # PRE_EXISTING: Overloaded in both, ratio 1.045 > 1.02. → TRUE.
             assert care_mask[0] == True
-            
-            # NEW_OVERLOAD: Healthy in N, Overloaded in N-1. SHOULD BE TRUE.
+
+            # NEW_OVERLOAD: Healthy in N, Overloaded in N-1. → TRUE.
             assert care_mask[1] == True
-            
-            # IMPROVED: Overloaded in both. Ratio = 1.1/1.2 = 0.91 < 1.02. SHOULD BE FALSE.
-            assert care_mask[2] == False
-            
-            # STABLE: Healthy in both. SHOULD BE FALSE.
+
+            # IMPROVED: Overloaded in both, ratio 0.917 < 0.98. Symmetric
+            # rule keeps it because the contingency clearly *impacted* it. → TRUE.
+            assert care_mask[2] == True
+
+            # STABLE: Healthy in both. → FALSE.
             assert care_mask[3] == False
+
+            # INERT_PREEXISTING: Overloaded in both, ratio 1.005 inside band. → FALSE.
+            assert care_mask[4] == False
 
     def test_mask_integrity_with_real_thermal_limits(self):
         """Ensure care_mask respects branches_with_limits (thermal limits)."""


### PR DESCRIPTION
## Summary

Three related fixes that align the **N Overloads UI panel**, the **simulator's `max_rho`**, and the **superposition estimator** on a single, consistent definition of "overloaded".

### 1. obs.rho double-scaling (the headline bug)

Grid2op's `obs.rho` is already pre-scaled by `monitoring_factor`:
```
obs.rho = current / (permanent_limit * monitoring_factor)
```
So a line is "above the monitoring threshold" when `obs.rho >= 1.0` — **not** `>= mf`. The simulator was double-applying the factor at six sites, treating lines at ~`mf**2 ≈ 90 %` of the permanent limit as already overloaded and silently dropping them through the pre-existing filter.

Fixed in:
- `simulation_helpers.build_care_mask`
- `simulation_helpers.resolve_lines_overloaded`
- `simulation_helpers.compute_action_metrics` (`overload_mask`)
- `simulation_mixin._superposition_lines_overloaded`
- `simulation_mixin._augment_superposition_result`
- `simulation_mixin.compute_superposition` (`pre_existing_rho` dict)

The display path `obs.rho * mf` (which converts back to raw % of permanent limit for the UI) is left untouched — it's the correct inverse operation.

### 2. Symmetric impact rule (`not_worsened` → `not_impacted`)

The pre-existing-overload exclusion now uses a symmetric band (`action_rho` inside `base_rho * (1 ± worsening_threshold)`) instead of the one-sided `not_worsened`. Lines where the action significantly **improves** a pre-existing overload now correctly remain in `max_rho` — they belong to the action's sensitive area. Applied uniformly across `simulation_helpers`, `simulation_mixin`, and `diagram/overloads`.

### 3. N Overloads UI threshold alignment (`>` → `>=`)

`get_overloaded_lines` now uses `>=` instead of strict `>` so a line sitting exactly at `limit * mf` surfaces in the panel, matching the simulator's `>=` boundary.

## Concrete effect (BEON L31CPVAN / DONGEL31PTCHA case)

- DONGEL N-state: actual current 613.29 A / 679 A limit = **90.3 %** of permanent limit → genuinely **not** overloaded.
- **Old simulator**: `obs.rho (0.9514) >= mf (0.95)` → wrongly flagged as pre-existing → silently filtered → headline showed `LOUHAL31PYMON 88.2 %`.
- **New simulator**: `obs.rho (0.9514) >= 1.0` → False → correctly **not** treated as pre-existing. If an action moves it past 100 % monitoring threshold, it surfaces in `max_rho` and `lines_overloaded_after` as it should.
- **Panel**: still says "None" because pypowsybl-side `0.9032 < 0.95` — which is now the *correct* answer, and the panel and simulator finally agree.

## Test plan

- [x] All 738 backend tests pass
- [x] New regression tests pinning the `>= 1.0` boundary:
  - `test_obs_rho_threshold_is_one_not_monitoring_factor` (build_care_mask)
  - `test_recompute_threshold_is_one_not_monitoring_factor` (resolve_lines_overloaded)
- [x] New regression tests for the symmetric impact rule:
  - `test_excludes_only_strictly_inert_preexisting_overloads`
  - `test_keeps_pre_existing_overloads_when_significantly_improved`
- [x] Existing fixtures bumped to use obs.rho values that remain meaningful under the corrected `>= 1.0` threshold (test_resimulate_regression, test_superposition_monitoring_consistency, test_vectorized_monitoring)

## Files changed

| File | Change |
|---|---|
| `expert_backend/services/diagram/overloads.py` | `>` → `>=` boundary + symmetric impact band |
| `expert_backend/services/simulation_helpers.py` | obs.rho threshold `>= 1.0` (3 sites) + symmetric impact rule |
| `expert_backend/services/simulation_mixin.py` | obs.rho threshold `>= 1.0` (3 sites) + symmetric impact rule |
| `expert_backend/tests/test_simulation_helpers.py` | +4 regression tests, renamed legacy test |
| `expert_backend/tests/test_diagram_helpers.py` | New `keeps_when_significantly_improved` test, updated boundary inclusion test |
| `expert_backend/tests/test_vectorized_monitoring.py` | Added INERT_PREEXISTING line, IMPROVED case now expected `True` |
| `expert_backend/tests/test_superposition_monitoring_consistency.py` | Fixtures bumped to `obs.rho >= 1.0`, scenario reframed |
| `expert_backend/tests/test_resimulate_regression.py` | `obs_n1.rho` bumped from `0.98` to `1.05` |
| `docs/features/combined-actions.md` | Symmetric impact rule explained |

🤖 Generated with [Claude Code](https://claude.com/claude-code)