### PR TITLE
fix(overflow-pins): apply action-type chip filter to unsimulated pins

### DIFF
--- a/docs/features/interactive-overflow-analysis.md
+++ b/docs/features/interactive-overflow-analysis.md
@@ -445,6 +445,17 @@ the simulated-pin builder but:
   layer (exported from `actionPinData.ts` for cross-module reuse).
   Multi-line content: `"<id> — not yet simulated (double-click to
   run)\nType: …\nScore: … — rank N of M (max …)\nMW start: …\n…"`.
+- Accepts the same optional `overviewFilters` argument as the
+  simulated builder. When `overviewFilters.actionType !== 'all'`
+  ids that don't match the active type chip are skipped before
+  anchor resolution — mirroring the Action Overview's
+  `unsimulatedPins` memo (`ActionOverviewDiagram.tsx:383-397`).
+  The match precedence is identical: prefer `scoreInfo[id].type`
+  when supplied, fall back to id-based heuristics in
+  `classifyActionType`. Without this the Overflow Analysis tab's
+  ACTION PINS FILTERS chip row would appear inert because the
+  unsimulated layer is usually the dominant pin set on the graph
+  (regression fix 2026-05-05).
 
 #### Wire-format addition
 
@@ -609,6 +620,16 @@ parameter. When passed, each action is dropped if either:
 `App.tsx` always passes `overviewFilters` to the builder, so the
 overflow pin set is filtered identically to the Action Overview pin
 set.
+
+**Unsimulated pins honour the same chip.** `buildOverflowUnsimulatedPinPayload`
+also receives `overviewFilters` and applies the action-type chip
+before anchor resolution — mirroring the Action Overview's
+`unsimulatedPins` memo. Without this, the iframe's chip row would
+filter only the simulated layer while the (typically larger)
+unsimulated layer stayed on screen, making the chip appear inert
+(regression fix 2026-05-05). The `App.tsx` memo therefore tracks
+the full `overviewFilters` object in its dependency array so an
+`actionType` change triggers a rebuild + re-broadcast to the iframe.
 
 The `showUnsimulated` field is the **gate** for the un-simulated
 pin layer (§6.10): when `true`, `App.tsx` invokes

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -440,9 +440,11 @@ function App() {
           diagrams.n1MetaIndex ?? null,
           vlToSubstation,
           unsimulatedActionInfo,
+          undefined,
+          overviewFilters,
         )
       : [],
-    [overflowPinsAvailable, overviewFilters?.showUnsimulated,
+    [overflowPinsAvailable, overviewFilters,
      unsimulatedActionIds, unsimulatedActionInfo,
      result?.actions, diagrams.n1MetaIndex, vlToSubstation],
   );

--- a/frontend/src/utils/svg/overflowPinPayload.test.ts
+++ b/frontend/src/utils/svg/overflowPinPayload.test.ts
@@ -711,4 +711,83 @@ describe('buildOverflowUnsimulatedPinPayload', () => {
             'load_shedding_V1 — not yet simulated (double-click to run)',
         );
     });
+
+    it('action-type chip drops unsimulated ids of other types (LS-only filter)', () => {
+        // Regression for the Overflow Analysis pin filter bug: the
+        // ACTION PINS FILTERS chip row (DISCO / RECO / LS / OPEN /
+        // CLOSE / PST) must filter unsimulated pins the same way the
+        // Action Overview's `unsimulatedPins` memo does — otherwise
+        // the operator sees pins for action types they explicitly
+        // hid. Fixed by passing `overviewFilters` through to the
+        // builder.
+        const out = buildOverflowUnsimulatedPinPayload(
+            ['load_shedding_V1', 'disco_LINE_AB'],
+            new Set(),
+            meta,
+            { V1: 'SUB_A', V2: 'SUB_B' },
+            undefined,
+            undefined,
+            {
+                categories: { green: true, orange: true, red: true, grey: true },
+                threshold: 200,
+                actionType: 'ls',
+                showUnsimulated: true,
+            },
+        );
+        expect(out.map(p => p.actionId)).toEqual(['load_shedding_V1']);
+    });
+
+    it('action-type chip prefers scoreInfo.type over id-based heuristics', () => {
+        // When the score-info supplies a type, that wins over the
+        // id-based `classifyActionType` fallback — same precedence
+        // ActionOverviewDiagram applies. Use a load_shedding score-
+        // type on an id whose tokens ("ambiguous_id_V1") would not
+        // otherwise classify as `ls`.
+        const out = buildOverflowUnsimulatedPinPayload(
+            ['ambiguous_id_V1'],
+            new Set(),
+            meta,
+            { V1: 'SUB_A' },
+            {
+                ambiguous_id_V1: {
+                    type: 'load_shedding',
+                    score: 0.5,
+                    mwStart: 10,
+                    tapStart: null,
+                    rankInType: 1,
+                    countInType: 1,
+                    maxScoreInType: 0.5,
+                },
+            },
+            undefined,
+            {
+                categories: { green: true, orange: true, red: true, grey: true },
+                threshold: 200,
+                actionType: 'ls',
+                showUnsimulated: true,
+            },
+        );
+        expect(out).toHaveLength(1);
+        expect(out[0].actionId).toBe('ambiguous_id_V1');
+    });
+
+    it('action-type chip set to "all" keeps every unsimulated pin (no filter)', () => {
+        const out = buildOverflowUnsimulatedPinPayload(
+            ['load_shedding_V1', 'disco_LINE_AB'],
+            new Set(),
+            meta,
+            { V1: 'SUB_A', V2: 'SUB_B' },
+            undefined,
+            undefined,
+            {
+                categories: { green: true, orange: true, red: true, grey: true },
+                threshold: 200,
+                actionType: 'all',
+                showUnsimulated: true,
+            },
+        );
+        expect(out.map(p => p.actionId).sort()).toEqual(
+            ['disco_LINE_AB', 'load_shedding_V1'],
+        );
+    });
 });

--- a/frontend/src/utils/svg/overflowPinPayload.ts
+++ b/frontend/src/utils/svg/overflowPinPayload.ts
@@ -455,6 +455,14 @@ export const buildOverflowPinPayload = (
  *
  * Items already in ``simulatedIds`` are skipped (they're rendered
  * by ``buildOverflowPinPayload`` instead).
+ *
+ * When ``overviewFilters.actionType`` is provided and not ``'all'``,
+ * ids that don't match the active type chip (DISCO / RECO / LS /
+ * OPEN / CLOSE / PST / RC) are dropped — mirroring the Action
+ * Overview's ``unsimulatedPins`` memo so the chip filter behaves
+ * consistently across both tabs. Like the Overview, we prefer the
+ * score-info ``type`` field when available and fall back to
+ * id-based heuristics in ``classifyActionType``.
  */
 export const buildOverflowUnsimulatedPinPayload = (
     scoredActionIds: readonly string[],
@@ -463,6 +471,7 @@ export const buildOverflowUnsimulatedPinPayload = (
     vlToSubstation: Readonly<Record<string, string>>,
     scoreInfo?: Readonly<Record<string, UnsimulatedActionScoreInfo>>,
     overflowSubstations?: ReadonlySet<string>,
+    overviewFilters?: ActionOverviewFilters,
 ): OverflowPin[] => {
     if (!metaIndex || scoredActionIds.length === 0) return [];
     const knownSet = overflowSubstations ?? new Set<string>();
@@ -479,6 +488,7 @@ export const buildOverflowUnsimulatedPinPayload = (
         max_rho_line: '',
         is_rho_reduction: false,
     } as unknown as ActionDetail;
+    const activeType = overviewFilters?.actionType ?? 'all';
     const out: OverflowPin[] = [];
     const seen = new Set<string>();
     for (const rawId of scoredActionIds) {
@@ -486,6 +496,12 @@ export const buildOverflowUnsimulatedPinPayload = (
         if (!id || seen.has(id)) continue;
         seen.add(id);
         if (simulatedIds.has(id)) continue;
+        // Action-type chip filter — same rule as the Action Overview
+        // (`ActionOverviewDiagram.tsx` `unsimulatedPins` memo).
+        if (activeType !== 'all') {
+            const scoreType = scoreInfo?.[id]?.type ?? null;
+            if (!matchesActionTypeFilter(activeType, id, null, scoreType)) continue;
+        }
         const anchor = resolveActionSubstation(
             id, stub, metaIndex, vlToSubstation,
             acceptAny ? new Set(Object.values(vlToSubstation)) : knownSet,


### PR DESCRIPTION
## Summary

The **ACTION PINS FILTERS** chip row in the Overflow Analysis tab (`ALL` / `DISCO` / `RECO` / `LS` / `OPEN` / `CLOSE` / `PST`) was inert on the unsimulated-pin layer.

The simulated-pin builder (`buildOverflowPinPayload`) already applied `overviewFilters`, but `buildOverflowUnsimulatedPinPayload` did not — so pins for unsimulated actions of every type stayed visible regardless of the active chip. Because the unsimulated layer is usually the dominant pin set on the graph (the user's screenshot showed 67 pins, almost all unsimulated), the chip appeared completely inert.

## Root cause

In `App.tsx`, the `overflowUnsimulatedPins` memo built the payload without passing `overviewFilters`, and the builder itself had no parameter for it. The Action Overview's `unsimulatedPins` memo (`ActionOverviewDiagram.tsx:383-397`) does the right thing — this PR mirrors it byte-for-byte.

## Fix

`utils/svg/overflowPinPayload.ts` — `buildOverflowUnsimulatedPinPayload`:
- New optional `overviewFilters?: ActionOverviewFilters` parameter.
- For each id, when `actionType !== 'all'`, skip if `matchesActionTypeFilter(actionType, id, null, scoreInfo[id]?.type ?? null)` returns false.
- Same precedence as Overview: `scoreInfo.type` wins over id-based heuristics.

`App.tsx` — `overflowUnsimulatedPins` memo:
- Pass `overviewFilters` through to the builder.
- Tracked the whole `overviewFilters` object in deps (replacing `overviewFilters?.showUnsimulated`) so any chip change triggers a rebuild + re-broadcast to the iframe.

## Test plan

- [x] All 1260 frontend Vitest tests pass
- [x] New regression tests in `overflowPinPayload.test.ts`:
  - `action-type chip drops unsimulated ids of other types (LS-only filter)`
  - `action-type chip prefers scoreInfo.type over id-based heuristics`
  - `action-type chip set to "all" keeps every unsimulated pin (no filter)`
- [x] Documentation updated — `docs/features/interactive-overflow-analysis.md` §6.10 + §7.2 cross-reference the Action Overview's `unsimulatedPins` memo so future readers can see the working code being mirrored.

## Files changed

| File | Change |
|---|---|
| `frontend/src/utils/svg/overflowPinPayload.ts` | `buildOverflowUnsimulatedPinPayload` now accepts and applies `overviewFilters` |
| `frontend/src/App.tsx` | Pass `overviewFilters` to the builder, track full filters object in deps |
| `frontend/src/utils/svg/overflowPinPayload.test.ts` | +3 regression tests |
| `docs/features/interactive-overflow-analysis.md` | §6.10 + §7.2 document the chip filter on the unsimulated layer |

🤖 Generated with [Claude Code](https://claude.com/claude-code)