### PR TITLE
Add force-layout toggle for PyPSA-derived grid diagrams

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -15,5 +15,6 @@
     "monitoring_factor": 0.95,
     "pre_existing_overload_threshold": 0.02,
     "ignore_reconnections": false,
-    "pypowsybl_fast_mode": true
+    "pypowsybl_fast_mode": true,
+    "force_layout": false
 }

--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -294,6 +294,7 @@ class ConfigRequest(BaseModel):
     ignore_reconnections: bool = False
     pypowsybl_fast_mode: bool = True
     layout_path: str | None = None
+    force_layout: bool = False
 
 class AnalysisRequest(BaseModel):
     disconnected_element: str

--- a/expert_backend/services/diagram/nad_params.py
+++ b/expert_backend/services/diagram/nad_params.py
@@ -18,13 +18,27 @@ Measured trade-offs (see docs/performance/history/):
   injections_added=False (default):               keeps SVG small
 
 Combined gain vs prior defaults:                  ~-130 ms, ~-1.2 MB.
+
+The ``force_layout`` opt-in flag swaps GEOGRAPHICAL for FORCE_LAYOUT at
+~+450 ms generation cost. It is intended as an escape hatch for
+PyPSA-derived grids whose collocated voltage levels (e.g. Paris,
+Lyon on the French 225/400 kV slice) chevauchent visuellement when
+rendered at their real lat/lon coordinates. The force layout
+spreads them out at the cost of losing geographic faithfulness.
 """
 from __future__ import annotations
 
 
-def default_nad_parameters():
-    """Return the default ``NadParameters`` used by every diagram call."""
+def default_nad_parameters(*, force_layout: bool = False):
+    """Return the default ``NadParameters`` used by every diagram call.
+
+    Pass ``force_layout=True`` to switch from GEOGRAPHICAL to
+    FORCE_LAYOUT. Geographic layout is the default because it preserves
+    real-world positioning and saves ~450 ms on large grids; force
+    layout is the readability fallback for dense urban substations.
+    """
     from pypowsybl.network import NadLayoutType, NadParameters
+    layout = NadLayoutType.FORCE_LAYOUT if force_layout else NadLayoutType.GEOGRAPHICAL
     return NadParameters(
         edge_name_displayed=False,
         id_displayed=False,
@@ -37,5 +51,5 @@ def default_nad_parameters():
         substation_description_displayed=False,
         voltage_level_details=False,
         injections_added=False,
-        layout_type=NadLayoutType.GEOGRAPHICAL,
+        layout_type=layout,
     )

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -73,8 +73,17 @@ class DiagramMixin:
         )
 
     def _default_nad_parameters(self):
-        """Return default ``NadParameters`` for diagram generation."""
-        return default_nad_parameters()
+        """Return default ``NadParameters`` for diagram generation.
+
+        Reads the per-study ``_force_layout`` flag from the service so
+        the toggle exposed in the Settings modal flips every NAD
+        endpoint (base / N-1 / action / focused) consistently. Defaults
+        to ``False`` to preserve the GEOGRAPHICAL layout that is
+        ~450 ms cheaper on large grids.
+        """
+        return default_nad_parameters(
+            force_layout=getattr(self, "_force_layout", False),
+        )
 
     def _generate_diagram(self, network, voltage_level_ids=None, depth=0):
         """Generate NAD and return svg + metadata dict."""

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -108,6 +108,13 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         # `/api/regenerate-overflow-graph` can re-invoke graph generation
         # without redoing step1 setup or action discovery.
         self._last_step2_context = None
+        # NAD layout-type opt-in. Default GEOGRAPHICAL is ~450 ms cheaper
+        # on large grids; FORCE_LAYOUT is the readability fallback for
+        # PyPSA-derived networks with collocated VLs at urban substations.
+        # Read by `DiagramMixin._default_nad_parameters` on every NAD call
+        # so the toggle flips base / N-1 / action / focused diagrams in
+        # lockstep. Set from `settings.force_layout` in `update_config`.
+        self._force_layout = False
 
     def reset(self):
         """Clear all cached analysis state. Called when loading a new study."""
@@ -152,6 +159,9 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         self._overflow_layout_mode = "hierarchical"
         self._overflow_layout_cache = {}
         self._last_step2_context = None
+        # NAD layout opt-in: revert to the geographic default. The next
+        # `update_config` call will re-apply the user's setting.
+        self._force_layout = False
 
     # ------------------------------------------------------------------
     # Overflow-graph layout (Hierarchical / Geo)
@@ -349,6 +359,13 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
             config.LAYOUT_FILE_PATH = Path(settings.layout_path)
         else:
             config.LAYOUT_FILE_PATH = None
+
+        # NAD layout opt-in (read by DiagramMixin._default_nad_parameters).
+        # Pinned BEFORE prefetch_base_nad_async so the prefetched base
+        # NAD already uses the requested layout type — otherwise the
+        # first `/api/network-diagram` would serve a stale cache rendered
+        # under the previous toggle state.
+        self._force_layout = bool(getattr(settings, 'force_layout', False) or False)
 
         # Force the requested global flags
         config.MAX_RHO_BOTH_EXTREMITIES = True

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,6 +65,23 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
     display: none;
 }
 
+/* Halo behind edge-info flow values so digits stay readable when arrows
+   from neighbouring branches overlap them on dense PyPSA-derived grids.
+   `paint-order: stroke fill` paints the white stroke first, so the fill
+   (pypowsybl's native flow-value colour) lands on top — the halo only
+   widens the glyph silhouette, it does not change the text colour. The
+   stroke uses `non-scaling-stroke` (declared in the global rule above)
+   so the halo width stays constant on screen across zoom levels. The
+   `!important` matches the precedent on `.nad-hide-vl-labels` — pypowsybl
+   appends its own `<style>` block AFTER App.css when injecting the SVG,
+   so plain rules can be defeated by the upstream defaults. */
+.nad-edge-infos text {
+    paint-order: stroke fill !important;
+    stroke: var(--color-surface) !important;
+    stroke-width: 3px !important;
+    stroke-linejoin: round !important;
+}
+
 /* User-toggle: hide every voltage-level label on the diagram. pypowsybl
    emits VL labels in two interchangeable shapes depending on the diagram
    configuration: a root-level `<foreignObject class="nad-text-nodes">`

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -28,6 +28,7 @@ export interface UserConfig {
     pre_existing_overload_threshold: number;
     ignore_reconnections: boolean;
     pypowsybl_fast_mode: boolean;
+    force_layout?: boolean;
 }
 
 export const api = {

--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -36,6 +36,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
     linesMonitoringPath, setLinesMonitoringPath,
     preExistingOverloadThreshold, setPreExistingOverloadThreshold,
     pypowsyblFastMode, setPypowsyblFastMode,
+    forceLayout, setForceLayout,
     pickSettingsPath,
     handleCloseSettings,
   } = settings;
@@ -237,6 +238,19 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                 </div>
                 <div style={{ fontSize: '0.75rem', color: colors.textTertiary, fontStyle: 'italic', marginLeft: '26px' }}>
                   Disable voltage control in pypowsybl for faster simulations (may affect convergence)
+                </div>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                  <input
+                    type="checkbox" id="forceLayout" checked={forceLayout}
+                    onChange={e => setForceLayout(e.target.checked)}
+                    style={{ width: '16px', height: '16px' }}
+                  />
+                  <label htmlFor="forceLayout" style={{ fontWeight: 'bold', fontSize: '0.9rem', cursor: 'pointer' }}>Force-Layout Network Diagram</label>
+                </div>
+                <div style={{ fontSize: '0.75rem', color: colors.textTertiary, fontStyle: 'italic', marginLeft: '26px' }}>
+                  Spread overlapping voltage levels (helps PyPSA-derived grids with collocated VLs at urban substations). Adds ~450 ms per diagram and discards real-world coordinates.
                 </div>
               </div>
             </div>

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -63,6 +63,8 @@ export interface SettingsState {
   setPreExistingOverloadThreshold: (v: number) => void;
   pypowsyblFastMode: boolean;
   setPypowsyblFastMode: (v: boolean) => void;
+  forceLayout: boolean;
+  setForceLayout: (v: boolean) => void;
 
   // Action dict info
   actionDictFileName: string | null;
@@ -99,6 +101,7 @@ export interface SettingsState {
     pre_existing_overload_threshold: number;
     ignore_reconnections: boolean;
     pypowsybl_fast_mode: boolean;
+    force_layout: boolean;
   };
   applyConfigResponse: (configRes: Record<string, unknown>) => void;
   createCurrentBackup: () => SettingsBackup;
@@ -130,6 +133,7 @@ export function useSettings(): SettingsState {
   const [monitoringFactor, setMonitoringFactor] = useState(0.95);
   const [preExistingOverloadThreshold, setPreExistingOverloadThreshold] = useState(0.02);
   const [pypowsyblFastMode, setPypowsyblFastMode] = useState(true);
+  const [forceLayout, setForceLayout] = useState(false);
 
   const [actionDictFileName, setActionDictFileName] = useState<string | null>(null);
   const [actionDictStats, setActionDictStats] = useState<{ reco: number; disco: number; pst: number; open_coupling: number; close_coupling: number; total: number } | null>(null);
@@ -160,6 +164,7 @@ export function useSettings(): SettingsState {
     if (cfg.pre_existing_overload_threshold !== undefined) setPreExistingOverloadThreshold(cfg.pre_existing_overload_threshold);
     if (cfg.ignore_reconnections !== undefined) setIgnoreReconnections(cfg.ignore_reconnections);
     if (cfg.pypowsybl_fast_mode !== undefined) setPypowsyblFastMode(cfg.pypowsybl_fast_mode);
+    if (cfg.force_layout !== undefined) setForceLayout(cfg.force_layout);
   }, []);
 
   // Load persisted config from backend on mount
@@ -209,6 +214,7 @@ export function useSettings(): SettingsState {
       pre_existing_overload_threshold: preExistingOverloadThreshold,
       ignore_reconnections: ignoreReconnections,
       pypowsybl_fast_mode: pypowsyblFastMode,
+      force_layout: forceLayout,
     };
 
     // Sync to localStorage for instant UI availability on next reload/test
@@ -223,7 +229,7 @@ export function useSettings(): SettingsState {
   }, [networkPath, actionPath, layoutPath, outputFolderPath, linesMonitoringPath,
     minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections,
     minPst, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, monitoringFactor, preExistingOverloadThreshold,
-    ignoreReconnections, pypowsyblFastMode]);
+    ignoreReconnections, pypowsyblFastMode, forceLayout]);
 
   const pickSettingsPath = useCallback(async (type: 'file' | 'dir', setter: (path: string) => void) => {
     try {
@@ -276,7 +282,8 @@ export function useSettings(): SettingsState {
     preExistingOverloadThreshold,
     ignoreReconnections,
     pypowsyblFastMode,
-  }), [networkPath, actionPath, layoutPath, outputFolderPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode]);
+    forceLayout,
+  }), [networkPath, actionPath, layoutPath, outputFolderPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode, forceLayout]);
 
   const handleOpenSettings = useCallback((tab: 'recommender' | 'configurations' | 'paths' = 'paths') => {
     interactionLogger.record('settings_opened', { tab });
@@ -304,6 +311,7 @@ export function useSettings(): SettingsState {
       setPreExistingOverloadThreshold(settingsBackup.preExistingOverloadThreshold);
       setIgnoreReconnections(settingsBackup.ignoreReconnections ?? false);
       setPypowsyblFastMode(settingsBackup.pypowsyblFastMode ?? true);
+      setForceLayout(settingsBackup.forceLayout ?? false);
     }
     setIsSettingsOpen(false);
   }, [settingsBackup]);
@@ -325,7 +333,8 @@ export function useSettings(): SettingsState {
     pre_existing_overload_threshold: preExistingOverloadThreshold,
     ignore_reconnections: ignoreReconnections,
     pypowsybl_fast_mode: pypowsyblFastMode,
-  }), [networkPath, actionPath, layoutPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minPst, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode]);
+    force_layout: forceLayout,
+  }), [networkPath, actionPath, layoutPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minPst, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode, forceLayout]);
 
   const applyConfigResponse = useCallback((configRes: Record<string, unknown>) => {
     if (configRes && configRes.total_lines_count !== undefined) {
@@ -361,6 +370,7 @@ export function useSettings(): SettingsState {
     monitoringFactor, setMonitoringFactor,
     preExistingOverloadThreshold, setPreExistingOverloadThreshold,
     pypowsyblFastMode, setPypowsyblFastMode,
+    forceLayout, setForceLayout,
     actionDictFileName, setActionDictFileName,
     actionDictStats, setActionDictStats,
     isSettingsOpen, setIsSettingsOpen,
@@ -376,7 +386,7 @@ export function useSettings(): SettingsState {
     networkPath, actionPath, layoutPath, outputFolderPath,
     minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections,
     nPrioritizedActions, minPst, minLoadShedding, minRenewableCurtailmentActions, ignoreReconnections,
-    linesMonitoringPath, monitoredLinesCount, totalLinesCount, showMonitoringWarning, monitoringFactor, preExistingOverloadThreshold, pypowsyblFastMode,
+    linesMonitoringPath, monitoredLinesCount, totalLinesCount, showMonitoringWarning, monitoringFactor, preExistingOverloadThreshold, pypowsyblFastMode, forceLayout,
     actionDictFileName, actionDictStats,
     isSettingsOpen, settingsTab, settingsBackup,
     configFilePath, changeConfigFilePath,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,7 @@ export interface ConfigRequest {
     ignore_reconnections?: boolean;
     pypowsybl_fast_mode?: boolean;
     layout_path?: string;
+    force_layout?: boolean;
 }
 
 export interface AnalysisRequest {
@@ -310,6 +311,7 @@ export interface SettingsBackup {
     ignoreReconnections?: boolean;
     pypowsyblFastMode?: boolean;
     layoutPath?: string;
+    forceLayout?: boolean;
 }
 
 export interface RecommenderDisplayConfig {

--- a/frontend/src/utils/svg/svgBoost.test.ts
+++ b/frontend/src/utils/svg/svgBoost.test.ts
@@ -25,14 +25,19 @@ describe('boostSvgForLargeGrid', () => {
         expect(boostSvgForLargeGrid(stableSvg, vb, 1000)).toBe(stableSvg);
     });
 
-    it('applies scale transforms to circle parents when ratio exceeds threshold', () => {
+    it('applies a milder scale to circle parents than to edge-info groups', () => {
         const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20000 20000">'
-            + '<g><circle cx="10" cy="10" r="5"/></g></svg>';
+            + '<g><circle cx="10" cy="10" r="5"/></g>'
+            + '<g class="nad-edge-infos"><g transform="translate(50,50)"/></g></svg>';
         const vb = { x: 0, y: 0, w: 20000, h: 20000 };
         const out = boostSvgForLargeGrid(svg, vb, 1000);
         expect(out).not.toBe(svg);
-        // Scale math: ratio=16 > 3 → boost = sqrt(16/3).
-        expect(out).toMatch(/translate\(10,10\) scale\(2\.31\)/);
+        // ratio = 16 > 3, so boost = sqrt(16/3) ≈ 2.31. Node circles get the
+        // damped factor sqrt(boost) ≈ 1.52 to avoid pushing neighbouring
+        // nodes into each other on dense grids; edge-info groups (flow
+        // arrows + values) keep the full boost so flow text stays readable.
+        expect(out).toMatch(/translate\(10,10\) scale\(1\.52\)/);
+        expect(out).toMatch(/translate\(50,50\) scale\(2\.31\)/);
     });
 });
 

--- a/frontend/src/utils/svg/svgBoost.ts
+++ b/frontend/src/utils/svg/svgBoost.ts
@@ -25,6 +25,15 @@ export const boostSvgForLargeGrid = (svgString: string, viewBox: ViewBox | null,
 
     const boost = Math.sqrt(ratio / BOOST_THRESHOLD);
     const boostStr = boost.toFixed(2);
+    // Apply a milder factor to node circles than to text / edge-info groups.
+    // On dense PyPSA-derived grids (lots of voltage levels collocated at the
+    // same urban substation) scaling the node radii by the full text-boost
+    // factor pushes neighbouring nodes into each other and produces the
+    // overlapping-circle blob the operator sees on fr225_400. Damping the
+    // node scale by a sqrt keeps zoomed-in labels readable while leaving
+    // enough whitespace around each VL to distinguish it from its peers.
+    const nodeBoost = Math.sqrt(boost);
+    const nodeBoostStr = nodeBoost.toFixed(2);
 
     try {
         const parser = new DOMParser();
@@ -75,7 +84,7 @@ export const boostSvgForLargeGrid = (svgString: string, viewBox: ViewBox | null,
             const cyNum = parseFloat(cy || '0');
 
             if (!isNaN(cxNum) && !isNaN(cyNum)) {
-                targetEl.setAttribute('transform', `${t} translate(${cxNum},${cyNum}) scale(${boostStr}) translate(${-cxNum},${-cyNum})`);
+                targetEl.setAttribute('transform', `${t} translate(${cxNum},${cyNum}) scale(${nodeBoostStr}) translate(${-cxNum},${-cyNum})`);
             }
 
             if (i % 100 === 0 && Date.now() - start > 5000) {


### PR DESCRIPTION
## Summary
Adds a user-configurable toggle to switch network diagrams from GEOGRAPHICAL to FORCE_LAYOUT rendering mode. This addresses visual overlap issues in PyPSA-derived grids with collocated voltage levels at urban substations (e.g., Paris/Lyon on French 225/400 kV slice), at the cost of ~450 ms generation time and loss of geographic faithfulness.

## Key Changes

- **Backend NAD Parameters**: Modified `default_nad_parameters()` to accept a `force_layout` parameter that switches between `NadLayoutType.GEOGRAPHICAL` (default) and `NadLayoutType.FORCE_LAYOUT`

- **Recommender Service**: Added `_force_layout` instance variable to track the user's layout preference and expose it to all diagram generation endpoints (base/N-1/action/focused) consistently

- **Settings Management**: 
  - Extended `useSettings` hook to manage `forceLayout` state
  - Added UI checkbox in SettingsModal with explanatory text
  - Integrated with config persistence (localStorage and backend sync)

- **Type Definitions**: Updated `ConfigRequest`, `UserConfig`, and `SettingsBackup` interfaces to include `force_layout` field

- **SVG Rendering Improvements**:
  - Added CSS halo effect (white stroke) behind edge-info flow values for readability on dense grids
  - Modified `boostSvgForLargeGrid` to apply differentiated scaling: milder damping (√boost) to node circles to prevent overlap, full boost to edge-info groups to maintain text readability

- **Configuration**: Added `force_layout: false` default to `config.default.json`

## Implementation Details

The toggle is wired end-to-end: the Settings modal updates `forceLayout` state → syncs to backend via `update_config()` → sets `_force_layout` on the recommender service → `DiagramMixin._default_nad_parameters()` reads it on every NAD call. This ensures all diagram types flip layout modes in lockstep.

The SVG boost logic now distinguishes between node circles (which get damped scaling to preserve whitespace on dense grids) and edge-info groups (which get full scaling to keep flow values readable when arrows overlap).

https://claude.ai/code/session_01LepsfexSXMPPdKLRXFPphH