### PR TITLE
Remove force-layout feature for network diagrams

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -15,6 +15,5 @@
     "monitoring_factor": 0.95,
     "pre_existing_overload_threshold": 0.02,
     "ignore_reconnections": false,
-    "pypowsybl_fast_mode": true,
-    "force_layout": false
+    "pypowsybl_fast_mode": true
 }

--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -294,7 +294,6 @@ class ConfigRequest(BaseModel):
     ignore_reconnections: bool = False
     pypowsybl_fast_mode: bool = True
     layout_path: str | None = None
-    force_layout: bool = False
 
 class AnalysisRequest(BaseModel):
     # List of element IDs to disconnect simultaneously. A single-item list

--- a/expert_backend/services/diagram/nad_params.py
+++ b/expert_backend/services/diagram/nad_params.py
@@ -18,27 +18,13 @@ Measured trade-offs (see docs/performance/history/):
   injections_added=False (default):               keeps SVG small
 
 Combined gain vs prior defaults:                  ~-130 ms, ~-1.2 MB.
-
-The ``force_layout`` opt-in flag swaps GEOGRAPHICAL for FORCE_LAYOUT at
-~+450 ms generation cost. It is intended as an escape hatch for
-PyPSA-derived grids whose collocated voltage levels (e.g. Paris,
-Lyon on the French 225/400 kV slice) chevauchent visuellement when
-rendered at their real lat/lon coordinates. The force layout
-spreads them out at the cost of losing geographic faithfulness.
 """
 from __future__ import annotations
 
 
-def default_nad_parameters(*, force_layout: bool = False):
-    """Return the default ``NadParameters`` used by every diagram call.
-
-    Pass ``force_layout=True`` to switch from GEOGRAPHICAL to
-    FORCE_LAYOUT. Geographic layout is the default because it preserves
-    real-world positioning and saves ~450 ms on large grids; force
-    layout is the readability fallback for dense urban substations.
-    """
+def default_nad_parameters():
+    """Return the default ``NadParameters`` used by every diagram call."""
     from pypowsybl.network import NadLayoutType, NadParameters
-    layout = NadLayoutType.FORCE_LAYOUT if force_layout else NadLayoutType.GEOGRAPHICAL
     return NadParameters(
         edge_name_displayed=False,
         id_displayed=False,
@@ -51,5 +37,5 @@ def default_nad_parameters(*, force_layout: bool = False):
         substation_description_displayed=False,
         voltage_level_details=False,
         injections_added=False,
-        layout_type=layout,
+        layout_type=NadLayoutType.GEOGRAPHICAL,
     )

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -73,17 +73,8 @@ class DiagramMixin:
         )
 
     def _default_nad_parameters(self):
-        """Return default ``NadParameters`` for diagram generation.
-
-        Reads the per-study ``_force_layout`` flag from the service so
-        the toggle exposed in the Settings modal flips every NAD
-        endpoint (base / N-1 / action / focused) consistently. Defaults
-        to ``False`` to preserve the GEOGRAPHICAL layout that is
-        ~450 ms cheaper on large grids.
-        """
-        return default_nad_parameters(
-            force_layout=getattr(self, "_force_layout", False),
-        )
+        """Return default ``NadParameters`` for diagram generation."""
+        return default_nad_parameters()
 
     def _generate_diagram(self, network, voltage_level_ids=None, depth=0):
         """Generate NAD and return svg + metadata dict."""

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -108,13 +108,6 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         # `/api/regenerate-overflow-graph` can re-invoke graph generation
         # without redoing step1 setup or action discovery.
         self._last_step2_context = None
-        # NAD layout-type opt-in. Default GEOGRAPHICAL is ~450 ms cheaper
-        # on large grids; FORCE_LAYOUT is the readability fallback for
-        # PyPSA-derived networks with collocated VLs at urban substations.
-        # Read by `DiagramMixin._default_nad_parameters` on every NAD call
-        # so the toggle flips base / N-1 / action / focused diagrams in
-        # lockstep. Set from `settings.force_layout` in `update_config`.
-        self._force_layout = False
 
     def reset(self):
         """Clear all cached analysis state. Called when loading a new study."""
@@ -159,9 +152,6 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         self._overflow_layout_mode = "hierarchical"
         self._overflow_layout_cache = {}
         self._last_step2_context = None
-        # NAD layout opt-in: revert to the geographic default. The next
-        # `update_config` call will re-apply the user's setting.
-        self._force_layout = False
 
     # ------------------------------------------------------------------
     # Overflow-graph layout (Hierarchical / Geo)
@@ -359,13 +349,6 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
             config.LAYOUT_FILE_PATH = Path(settings.layout_path)
         else:
             config.LAYOUT_FILE_PATH = None
-
-        # NAD layout opt-in (read by DiagramMixin._default_nad_parameters).
-        # Pinned BEFORE prefetch_base_nad_async so the prefetched base
-        # NAD already uses the requested layout type — otherwise the
-        # first `/api/network-diagram` would serve a stale cache rendered
-        # under the previous toggle state.
-        self._force_layout = bool(getattr(settings, 'force_layout', False) or False)
 
         # Force the requested global flags
         config.MAX_RHO_BOTH_EXTREMITIES = True

--- a/frontend/src/App.configUpload.test.tsx
+++ b/frontend/src/App.configUpload.test.tsx
@@ -43,7 +43,6 @@ const mockApi = vi.hoisted(() => ({
     pre_existing_overload_threshold: 0.02,
     ignore_reconnections: false,
     pypowsybl_fast_mode: true,
-    force_layout: false,
   }),
   saveUserConfig: vi.fn().mockResolvedValue({}),
   getConfigFilePath: vi.fn().mockResolvedValue('/old/config.json'),
@@ -66,7 +65,6 @@ const mockApi = vi.hoisted(() => ({
       pre_existing_overload_threshold: 0.02,
       ignore_reconnections: false,
       pypowsybl_fast_mode: true,
-      force_layout: true,
     },
   }),
   pickPath: vi.fn().mockResolvedValue('/picked/new_config.json'),
@@ -212,8 +210,8 @@ describe('Config upload state propagation', () => {
   it('configRequestFromUserConfig falls back to safe defaults when the UserConfig is missing optional fields', async () => {
     // Hook-level unit test: drive `configRequestFromUserConfig` directly
     // with a stripped-down UserConfig (older pypowsybl-side configs
-    // predate `layout_path` / `lines_monitoring_path` / `force_layout`).
-    // The helper MUST apply `?? ''` / `?? false` defaults so the
+    // predate `layout_path` / `lines_monitoring_path`).
+    // The helper MUST apply `?? ''` defaults so the
     // backend never receives `undefined` — otherwise FastAPI rejects
     // the body with a validation error and the operator's Apply
     // silently fails. Driving this from the integration test surface
@@ -230,7 +228,6 @@ describe('Config upload state propagation', () => {
       action_file_path: '/picked/legacy_actions.json',
       // layout_path: missing on purpose
       // lines_monitoring_path: missing on purpose
-      // force_layout: missing on purpose
       min_line_reconnections: 2,
       min_close_coupling: 3,
       min_open_coupling: 2,
@@ -250,7 +247,6 @@ describe('Config upload state propagation', () => {
     // Defaults — no `undefined` ever leaks past the helper.
     expect(req.layout_path).toBe('');
     expect(req.lines_monitoring_path).toBe('');
-    expect(req.force_layout).toBe(false);
     // Required fields pass through verbatim.
     expect(req.min_line_reconnections).toBe(2);
     expect(req.monitoring_factor).toBe(0.95);
@@ -281,12 +277,10 @@ describe('Config upload state propagation', () => {
       pre_existing_overload_threshold: 0.01,
       ignore_reconnections: true,
       pypowsybl_fast_mode: false,
-      force_layout: true,
     };
     const req = result.current.configRequestFromUserConfig(full);
     expect(req.layout_path).toBe('/picked/full_layout.json');
     expect(req.lines_monitoring_path).toBe('/picked/full_monitoring.json');
-    expect(req.force_layout).toBe(true);
     expect(req.ignore_reconnections).toBe(true);
     expect(req.pypowsybl_fast_mode).toBe(false);
     expect(req.n_prioritized_actions).toBe(42);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,23 +65,6 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
     display: none;
 }
 
-/* Halo behind edge-info flow values so digits stay readable when arrows
-   from neighbouring branches overlap them on dense PyPSA-derived grids.
-   `paint-order: stroke fill` paints the white stroke first, so the fill
-   (pypowsybl's native flow-value colour) lands on top — the halo only
-   widens the glyph silhouette, it does not change the text colour. The
-   stroke uses `non-scaling-stroke` (declared in the global rule above)
-   so the halo width stays constant on screen across zoom levels. The
-   `!important` matches the precedent on `.nad-hide-vl-labels` — pypowsybl
-   appends its own `<style>` block AFTER App.css when injecting the SVG,
-   so plain rules can be defeated by the upstream defaults. */
-.nad-edge-infos text {
-    paint-order: stroke fill !important;
-    stroke: var(--color-surface) !important;
-    stroke-width: 3px !important;
-    stroke-linejoin: round !important;
-}
-
 /* User-toggle: hide every voltage-level label on the diagram. pypowsybl
    emits VL labels in two interchangeable shapes depending on the diagram
    configuration: a root-level `<foreignObject class="nad-text-nodes">`

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -28,7 +28,6 @@ export interface UserConfig {
     pre_existing_overload_threshold: number;
     ignore_reconnections: boolean;
     pypowsybl_fast_mode: boolean;
-    force_layout?: boolean;
 }
 
 export const api = {

--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -36,7 +36,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
     linesMonitoringPath, setLinesMonitoringPath,
     preExistingOverloadThreshold, setPreExistingOverloadThreshold,
     pypowsyblFastMode, setPypowsyblFastMode,
-    forceLayout, setForceLayout,
     pickSettingsPath,
     handleCloseSettings,
   } = settings;
@@ -238,19 +237,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ settings, onApply }) => {
                 </div>
                 <div style={{ fontSize: '0.75rem', color: colors.textTertiary, fontStyle: 'italic', marginLeft: '26px' }}>
                   Disable voltage control in pypowsybl for faster simulations (may affect convergence)
-                </div>
-              </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                  <input
-                    type="checkbox" id="forceLayout" checked={forceLayout}
-                    onChange={e => setForceLayout(e.target.checked)}
-                    style={{ width: '16px', height: '16px' }}
-                  />
-                  <label htmlFor="forceLayout" style={{ fontWeight: 'bold', fontSize: '0.9rem', cursor: 'pointer' }}>Force-Layout Network Diagram</label>
-                </div>
-                <div style={{ fontSize: '0.75rem', color: colors.textTertiary, fontStyle: 'italic', marginLeft: '26px' }}>
-                  Spread overlapping voltage levels (helps PyPSA-derived grids with collocated VLs at urban substations). Adds ~450 ms per diagram and discards real-world coordinates.
                 </div>
               </div>
             </div>

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -78,8 +78,6 @@ export interface SettingsState {
   setPreExistingOverloadThreshold: (v: number) => void;
   pypowsyblFastMode: boolean;
   setPypowsyblFastMode: (v: boolean) => void;
-  forceLayout: boolean;
-  setForceLayout: (v: boolean) => void;
 
   // Action dict info
   actionDictFileName: string | null;
@@ -116,7 +114,6 @@ export interface SettingsState {
     pre_existing_overload_threshold: number;
     ignore_reconnections: boolean;
     pypowsybl_fast_mode: boolean;
-    force_layout: boolean;
   };
   applyConfigResponse: (configRes: Record<string, unknown>) => void;
   createCurrentBackup: () => SettingsBackup;
@@ -148,7 +145,6 @@ export function useSettings(): SettingsState {
   const [monitoringFactor, setMonitoringFactor] = useState(0.95);
   const [preExistingOverloadThreshold, setPreExistingOverloadThreshold] = useState(0.02);
   const [pypowsyblFastMode, setPypowsyblFastMode] = useState(true);
-  const [forceLayout, setForceLayout] = useState(false);
 
   const [actionDictFileName, setActionDictFileName] = useState<string | null>(null);
   const [actionDictStats, setActionDictStats] = useState<{ reco: number; disco: number; pst: number; open_coupling: number; close_coupling: number; total: number } | null>(null);
@@ -179,7 +175,6 @@ export function useSettings(): SettingsState {
     if (cfg.pre_existing_overload_threshold !== undefined) setPreExistingOverloadThreshold(cfg.pre_existing_overload_threshold);
     if (cfg.ignore_reconnections !== undefined) setIgnoreReconnections(cfg.ignore_reconnections);
     if (cfg.pypowsybl_fast_mode !== undefined) setPypowsyblFastMode(cfg.pypowsybl_fast_mode);
-    if (cfg.force_layout !== undefined) setForceLayout(cfg.force_layout);
   }, []);
 
   // Load persisted config from backend on mount
@@ -261,7 +256,6 @@ export function useSettings(): SettingsState {
       pre_existing_overload_threshold: preExistingOverloadThreshold,
       ignore_reconnections: ignoreReconnections,
       pypowsybl_fast_mode: pypowsyblFastMode,
-      force_layout: forceLayout,
     };
 
     // Sync to localStorage for instant UI availability on next reload/test
@@ -276,7 +270,7 @@ export function useSettings(): SettingsState {
   }, [networkPath, actionPath, layoutPath, outputFolderPath, linesMonitoringPath,
     minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections,
     minPst, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, monitoringFactor, preExistingOverloadThreshold,
-    ignoreReconnections, pypowsyblFastMode, forceLayout]);
+    ignoreReconnections, pypowsyblFastMode]);
 
   const pickSettingsPath = useCallback(async (type: 'file' | 'dir', setter: (path: string) => void) => {
     try {
@@ -329,8 +323,7 @@ export function useSettings(): SettingsState {
     preExistingOverloadThreshold,
     ignoreReconnections,
     pypowsyblFastMode,
-    forceLayout,
-  }), [networkPath, actionPath, layoutPath, outputFolderPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode, forceLayout]);
+  }), [networkPath, actionPath, layoutPath, outputFolderPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode]);
 
   const handleOpenSettings = useCallback((tab: 'recommender' | 'configurations' | 'paths' = 'paths') => {
     interactionLogger.record('settings_opened', { tab });
@@ -358,7 +351,6 @@ export function useSettings(): SettingsState {
       setPreExistingOverloadThreshold(settingsBackup.preExistingOverloadThreshold);
       setIgnoreReconnections(settingsBackup.ignoreReconnections ?? false);
       setPypowsyblFastMode(settingsBackup.pypowsyblFastMode ?? true);
-      setForceLayout(settingsBackup.forceLayout ?? false);
     }
     setIsSettingsOpen(false);
   }, [settingsBackup]);
@@ -380,8 +372,7 @@ export function useSettings(): SettingsState {
     pre_existing_overload_threshold: preExistingOverloadThreshold,
     ignore_reconnections: ignoreReconnections,
     pypowsybl_fast_mode: pypowsyblFastMode,
-    force_layout: forceLayout,
-  }), [networkPath, actionPath, layoutPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minPst, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode, forceLayout]);
+  }), [networkPath, actionPath, layoutPath, minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections, minPst, minLoadShedding, minRenewableCurtailmentActions, nPrioritizedActions, linesMonitoringPath, monitoringFactor, preExistingOverloadThreshold, ignoreReconnections, pypowsyblFastMode]);
 
   const applyConfigResponse = useCallback((configRes: Record<string, unknown>) => {
     if (configRes && configRes.total_lines_count !== undefined) {
@@ -417,7 +408,6 @@ export function useSettings(): SettingsState {
     monitoringFactor, setMonitoringFactor,
     preExistingOverloadThreshold, setPreExistingOverloadThreshold,
     pypowsyblFastMode, setPypowsyblFastMode,
-    forceLayout, setForceLayout,
     actionDictFileName, setActionDictFileName,
     actionDictStats, setActionDictStats,
     isSettingsOpen, setIsSettingsOpen,
@@ -434,7 +424,7 @@ export function useSettings(): SettingsState {
     networkPath, actionPath, layoutPath, outputFolderPath,
     minLineReconnections, minCloseCoupling, minOpenCoupling, minLineDisconnections,
     nPrioritizedActions, minPst, minLoadShedding, minRenewableCurtailmentActions, ignoreReconnections,
-    linesMonitoringPath, monitoredLinesCount, totalLinesCount, showMonitoringWarning, monitoringFactor, preExistingOverloadThreshold, pypowsyblFastMode, forceLayout,
+    linesMonitoringPath, monitoredLinesCount, totalLinesCount, showMonitoringWarning, monitoringFactor, preExistingOverloadThreshold, pypowsyblFastMode,
     actionDictFileName, actionDictStats,
     isSettingsOpen, settingsTab, settingsBackup,
     configFilePath, changeConfigFilePath,

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -232,7 +232,6 @@ export function useSettings(): SettingsState {
     pre_existing_overload_threshold: cfg.pre_existing_overload_threshold,
     ignore_reconnections: cfg.ignore_reconnections,
     pypowsybl_fast_mode: cfg.pypowsybl_fast_mode,
-    force_layout: cfg.force_layout ?? false,
   }), []);
 
   // Persist settings to backend config file whenever they change

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,7 +22,6 @@ export interface ConfigRequest {
     ignore_reconnections?: boolean;
     pypowsybl_fast_mode?: boolean;
     layout_path?: string;
-    force_layout?: boolean;
 }
 
 export interface AnalysisRequest {
@@ -316,7 +315,6 @@ export interface SettingsBackup {
     ignoreReconnections?: boolean;
     pypowsyblFastMode?: boolean;
     layoutPath?: string;
-    forceLayout?: boolean;
 }
 
 export interface RecommenderDisplayConfig {

--- a/frontend/src/utils/svg/svgBoost.test.ts
+++ b/frontend/src/utils/svg/svgBoost.test.ts
@@ -25,19 +25,14 @@ describe('boostSvgForLargeGrid', () => {
         expect(boostSvgForLargeGrid(stableSvg, vb, 1000)).toBe(stableSvg);
     });
 
-    it('applies a milder scale to circle parents than to edge-info groups', () => {
+    it('applies scale transforms to circle parents when ratio exceeds threshold', () => {
         const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20000 20000">'
-            + '<g><circle cx="10" cy="10" r="5"/></g>'
-            + '<g class="nad-edge-infos"><g transform="translate(50,50)"/></g></svg>';
+            + '<g><circle cx="10" cy="10" r="5"/></g></svg>';
         const vb = { x: 0, y: 0, w: 20000, h: 20000 };
         const out = boostSvgForLargeGrid(svg, vb, 1000);
         expect(out).not.toBe(svg);
-        // ratio = 16 > 3, so boost = sqrt(16/3) ≈ 2.31. Node circles get the
-        // damped factor sqrt(boost) ≈ 1.52 to avoid pushing neighbouring
-        // nodes into each other on dense grids; edge-info groups (flow
-        // arrows + values) keep the full boost so flow text stays readable.
-        expect(out).toMatch(/translate\(10,10\) scale\(1\.52\)/);
-        expect(out).toMatch(/translate\(50,50\) scale\(2\.31\)/);
+        // Scale math: ratio=16 > 3 → boost = sqrt(16/3).
+        expect(out).toMatch(/translate\(10,10\) scale\(2\.31\)/);
     });
 });
 

--- a/frontend/src/utils/svg/svgBoost.ts
+++ b/frontend/src/utils/svg/svgBoost.ts
@@ -25,15 +25,6 @@ export const boostSvgForLargeGrid = (svgString: string, viewBox: ViewBox | null,
 
     const boost = Math.sqrt(ratio / BOOST_THRESHOLD);
     const boostStr = boost.toFixed(2);
-    // Apply a milder factor to node circles than to text / edge-info groups.
-    // On dense PyPSA-derived grids (lots of voltage levels collocated at the
-    // same urban substation) scaling the node radii by the full text-boost
-    // factor pushes neighbouring nodes into each other and produces the
-    // overlapping-circle blob the operator sees on fr225_400. Damping the
-    // node scale by a sqrt keeps zoomed-in labels readable while leaving
-    // enough whitespace around each VL to distinguish it from its peers.
-    const nodeBoost = Math.sqrt(boost);
-    const nodeBoostStr = nodeBoost.toFixed(2);
 
     try {
         const parser = new DOMParser();
@@ -84,7 +75,7 @@ export const boostSvgForLargeGrid = (svgString: string, viewBox: ViewBox | null,
             const cyNum = parseFloat(cy || '0');
 
             if (!isNaN(cxNum) && !isNaN(cyNum)) {
-                targetEl.setAttribute('transform', `${t} translate(${cxNum},${cyNum}) scale(${nodeBoostStr}) translate(${-cxNum},${-cyNum})`);
+                targetEl.setAttribute('transform', `${t} translate(${cxNum},${cyNum}) scale(${boostStr}) translate(${-cxNum},${-cyNum})`);
             }
 
             if (i % 100 === 0 && Date.now() - start > 5000) {


### PR DESCRIPTION
## Summary
This PR removes the force-layout feature that was previously used as a workaround for overlapping voltage levels in PyPSA-derived grids. The feature is being deprecated in favor of relying on the default geographical layout.

## Key Changes

- **Backend**: Removed `force_layout` parameter from `default_nad_parameters()` function and `_force_layout` instance variable from `RecommenderService`
- **Frontend**: Removed `forceLayout` state and setter from `useSettings` hook, including all related configuration handling
- **UI**: Removed the "Force-Layout Network Diagram" checkbox from the Settings modal
- **SVG Rendering**: Simplified `boostSvgForLargeGrid()` to apply uniform scaling to all elements instead of applying different scale factors to node circles vs. edge-info groups
- **CSS**: Removed the `.nad-edge-infos text` styling rule that provided a halo effect for flow value readability on dense grids
- **Configuration**: Removed `force_layout` field from default config, API types, and settings backup interfaces

## Implementation Details

- The geographical layout (GEOGRAPHICAL) is now the only supported layout type for network diagrams
- Removed the ~450ms performance penalty that was incurred when using force layout
- Simplified the SVG boost logic by eliminating the dual-scale approach (nodeBoost vs. full boost)
- All diagram generation endpoints (base, N-1, action, focused) now consistently use the geographical layout without any toggle option

https://claude.ai/code/session_01Y8BQBPyjFs8X1PPcmbYfno