### PR TITLE
Fix variable name in SVG boost transform for circles

### DIFF
--- a/frontend/src/utils/svg/svgBoost.ts
+++ b/frontend/src/utils/svg/svgBoost.ts
@@ -224,7 +224,7 @@ export const boostSvgForLargeGrid = (svgString: string, viewBox: ViewBox | null,
             const cyNum = parseFloat(cy || '0');
 
             if (!isNaN(cxNum) && !isNaN(cyNum)) {
-                targetEl.setAttribute('transform', `${t} translate(${cxNum},${cyNum}) scale(${boostStr}) translate(${-cxNum},${-cyNum})`);
+                targetEl.setAttribute('transform', `${t} translate(${cxNum},${cyNum}) scale(${nodeBoostStr}) translate(${-cxNum},${-cyNum})`);
             }
 
             if (i % 100 === 0 && Date.now() - start > 5000) {


### PR DESCRIPTION
## Summary
Fixed a variable name bug in the SVG boost function where the wrong variable was being referenced when applying scale transforms to circle elements.

## Key Changes
- Changed `boostStr` to `nodeBoostStr` in the transform attribute for circle elements in `boostSvgForLargeGrid()`
- This ensures the correct boost scale value is applied when transforming circles around their center point

## Details
The transform was incorrectly referencing `boostStr` instead of `nodeBoostStr` when setting the scale transformation for circle elements. This would have caused circles to be scaled using an undefined or incorrect variable value. The fix ensures the proper node-specific boost scale value is used in the translate-scale-translate transformation sequence.

https://claude.ai/code/session_014WRY48XbSFHA12EA28xHGy