### PR TITLE
Add simulation result columns and multi-simulation modal flow

### DIFF
--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -219,7 +219,20 @@ class SimulationMixin:
         monitoring_factor = getattr(config, "MONITORING_FACTOR_THERMAL_LIMITS", 0.95)
         worsening_threshold = getattr(config, "PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD", 0.02)
 
-        ctx_overloaded = (self._analysis_context or {}).get("lines_overloaded")
+        # Step1 stores the resolved friendly names under
+        # ``lines_overloaded_names``; session reload writes them
+        # under ``lines_overloaded`` (see
+        # ``RecommenderService.restore_analysis_context``). Check both
+        # so manual simulations triggered after step1 reuse the same
+        # pypowsybl-style identifiers the rest of the UI is wired
+        # against — the previous single-key read silently fell through
+        # to the vectorised obs-based path and re-emitted grid2op's
+        # synthetic ``line_<i>`` names, which the frontend's
+        # ``displayName`` resolver has no mapping for. Same lookup
+        # order as ``compute_superposition`` (see ``simulation_mixin``
+        # bottom-half). ``ctx`` is the same dict captured earlier in
+        # the function for ``ctx_obs_n1`` / ``ctx_obs_n``.
+        ctx_overloaded = ctx.get("lines_overloaded_names") or ctx.get("lines_overloaded")
         lines_overloaded_ids, lines_overloaded_names = resolve_lines_overloaded(
             obs_simu_defaut,
             obs,

--- a/expert_backend/tests/test_recommender_filtering.py
+++ b/expert_backend/tests/test_recommender_filtering.py
@@ -147,5 +147,160 @@ def test_simulate_manual_action_for_combined(recommender):
     assert stored["is_estimated"] is False
     assert stored["rho_after"] is not None
 
+
+def _wire_manual_action_mocks(recommender, name_line, base_rho, n1_rho, after_rho):
+    """Common scaffolding for simulate_manual_action ctx-key tests.
+
+    Mocks the smallest service surface needed to drive
+    ``simulation_mixin.simulate_manual_action`` end-to-end with two
+    monitored lines and a single-action ``"act_solo"`` entry. Returns
+    the obs mocks so tests can poke them post-call.
+    """
+    config.MONITORING_FACTOR_THERMAL_LIMITS = 0.95
+    config.PRE_EXISTING_OVERLOAD_WORSENING_THRESHOLD = 0.02
+
+    env = MagicMock()
+    recommender._get_simulation_env = MagicMock(return_value=env)
+    recommender._get_monitoring_parameters = MagicMock(
+        return_value=(set(name_line), {l: 100 for l in name_line})
+    )
+    recommender._get_n_variant = MagicMock()
+    recommender._get_contingency_variant = MagicMock()
+    recommender._ensure_contingency_state_ready = MagicMock()
+    recommender._fetch_n_and_contingency_observations = MagicMock()
+
+    obs_n = MagicMock(
+        rho=np.array(base_rho), name_line=name_line,
+        n_components=1, main_component_load_mw=1000.0,
+    )
+    obs_n1 = MagicMock(
+        rho=np.array(n1_rho), name_line=name_line,
+        n_components=1, main_component_load_mw=1000.0,
+    )
+    obs_after = MagicMock(
+        rho=np.array(after_rho), name_line=name_line,
+        n_components=1, main_component_load_mw=1000.0,
+    )
+    obs_n1.simulate.return_value = (obs_after, None, None, {"exception": None})
+    recommender._fetch_n_and_contingency_observations.return_value = (obs_n, obs_n1)
+
+    env.action_space.return_value = MagicMock()
+    recommender._dict_action = {
+        "act_solo": {"content": "c", "description_unitaire": "Desc"}
+    }
+    return obs_n, obs_n1, obs_after
+
+
+# Regression for the ``lines_overloaded_names`` ctx-key fix in
+# ``simulation_mixin.simulate_manual_action``. Step1 populates
+# ``_analysis_context["lines_overloaded_names"]`` (see
+# ``test_overload_filtering.py``) but the consumer only read
+# ``ctx.get("lines_overloaded")`` — silently falling through to the
+# vectorised obs-based path and re-emitting grid2op's synthetic
+# ``line_<i>`` names instead of the pypowsybl-style friendly
+# identifiers step1 had already resolved. The frontend's
+# ``displayName`` resolver has no mapping for the synthetic strings,
+# so manual-sim action cards displayed e.g. ``line_0: 90.7 %``
+# instead of ``BEON L31CPVAN: 90.7 %``.
+def test_simulate_manual_uses_lines_overloaded_names_from_step1_context(recommender):
+    # rho_before / rho_after are indexed against the ctx-resolved
+    # overload list (lines_overloaded_ids in
+    # ``compute_action_metrics``). Picking a single-overload ctx
+    # against a two-line ``name_line`` lets us assert on the array
+    # cardinality: prior to the fix the consumer fell through to
+    # vectorised recomputation and emitted a TWO-line rho_before
+    # (both lines on rho ≥ 1.0), proving the wrong code path ran.
+    name_line = ["BEON L31CPVAN", "DARCEL61VIELM"]
+    _wire_manual_action_mocks(
+        recommender, name_line,
+        base_rho=[0.10, 0.10], n1_rho=[1.20, 1.15], after_rho=[0.90, 1.10],
+    )
+    # Step1 shape — the resolved friendly identifiers go under
+    # ``lines_overloaded_names``, NOT ``lines_overloaded``.
+    recommender._analysis_context = {
+        "lines_overloaded_names": ["BEON L31CPVAN"],
+        "lines_we_care_about": set(name_line),
+    }
+
+    result = recommender.simulate_manual_action("act_solo", "P.SAOL31RONCI")
+
+    # Single ctx overload → single rho_before / rho_after entry.
+    # Pre-fix this came back with two entries because the consumer
+    # silently fell through to obs-based recomputation, which
+    # masked both 1.20- and 1.15-loaded lines on the N-1 state.
+    assert len(result["rho_before"]) == 1, (
+        "post-step1 manual sims must reuse the step1 overload set, "
+        "not fall through to obs-based recomputation"
+    )
+    assert len(result["rho_after"]) == 1
+
+
+# Session-reload writes the same field under the legacy
+# ``lines_overloaded`` key (see
+# ``RecommenderService.restore_analysis_context``). The dual-key
+# read MUST keep that path working — otherwise a reloaded session
+# would lose its overload set on the next manual simulation.
+def test_simulate_manual_uses_lines_overloaded_from_session_reload_context(recommender):
+    name_line = ["BEON L31CPVAN", "DARCEL61VIELM"]
+    _wire_manual_action_mocks(
+        recommender, name_line,
+        base_rho=[0.10, 0.10], n1_rho=[1.20, 1.15], after_rho=[0.90, 1.10],
+    )
+    # Session-reload shape — the legacy key.
+    recommender._analysis_context = {
+        "lines_overloaded": ["BEON L31CPVAN"],
+        "lines_we_care_about": set(name_line),
+    }
+
+    result = recommender.simulate_manual_action("act_solo", "P.SAOL31RONCI")
+
+    assert len(result["rho_before"]) == 1
+    assert len(result["rho_after"]) == 1
+
+
+# ``lines_overloaded_names`` takes priority over ``lines_overloaded``
+# when both keys are present — matches the ordering compute_superposition
+# already used.
+def test_simulate_manual_lines_overloaded_names_wins_over_legacy_key(recommender):
+    name_line = ["A", "B", "C"]
+    _wire_manual_action_mocks(
+        recommender, name_line,
+        base_rho=[0.10, 0.10, 0.10], n1_rho=[1.20, 1.10, 1.05],
+        after_rho=[0.90, 0.85, 0.80],
+    )
+    # Stale legacy key spans two lines; the live names-key has a
+    # single entry. The dual-key resolver MUST honour the
+    # names-key — proven by the single-entry rho_before length.
+    recommender._analysis_context = {
+        "lines_overloaded_names": ["A"],
+        "lines_overloaded": ["A", "B"],
+        "lines_we_care_about": set(name_line),
+    }
+
+    result = recommender.simulate_manual_action("act_solo", "ctg")
+
+    assert len(result["rho_before"]) == 1
+
+
+# Without analysis context AND without a caller-supplied list the
+# resolver falls through to obs-based recomputation — same path as
+# before the fix. Pins the regression boundary so a future change
+# can't accidentally start treating the empty-ctx case as a step1
+# context.
+def test_simulate_manual_falls_back_to_obs_when_ctx_empty(recommender):
+    name_line = ["A", "B"]
+    _wire_manual_action_mocks(
+        recommender, name_line,
+        base_rho=[0.10, 0.10], n1_rho=[1.20, 1.15], after_rho=[0.90, 1.10],
+    )
+    recommender._analysis_context = None
+
+    result = recommender.simulate_manual_action("act_solo", "ctg")
+
+    # Both N-1 rho values cross the 1.0 threshold and neither
+    # pre-existed in N — the vectorised path picks them both up.
+    assert len(result["rho_before"]) == 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/frontend/src/App.contingency.test.tsx
+++ b/frontend/src/App.contingency.test.tsx
@@ -538,10 +538,14 @@ describe('N-1 overload state is populated before action analysis', () => {
       expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '2');
     });
 
-    // No analysis was run, so the ActionFeed sees zero result-side
-    // overloads. The N-1 highlight pipeline must therefore use the
-    // n1Diagram fallback (covered by the unit tests on the helper).
-    expect(screen.getByTestId('action-feed')).toHaveAttribute('data-ol-count', '0');
+    // No analysis was run, so ``result.lines_overloaded`` is empty —
+    // but the ActionFeed falls back to the N-1 diagram's authoritative
+    // overload list so manual-simulation action cards display the
+    // friendly pypowsybl identifiers (e.g. ``BEON L31CPVAN``) instead
+    // of grid2op's synthetic ``line_<i>`` strings the backend emits
+    // when no ``_analysis_context`` is set yet. See the App.tsx wiring
+    // on the ``ActionFeed.linesOverloaded`` prop.
+    expect(screen.getByTestId('action-feed')).toHaveAttribute('data-ol-count', '2');
   });
 
   it('replaces the overload selection when switching contingencies without running analysis', async () => {

--- a/frontend/src/App.contingency.test.tsx
+++ b/frontend/src/App.contingency.test.tsx
@@ -56,6 +56,7 @@ vi.mock('./components/ActionFeed', () => ({
     <div
       data-testid="action-feed"
       data-ol-count={props.linesOverloaded?.length || 0}
+      data-ol-names={(props.linesOverloaded ?? []).join('|')}
       data-pending={!!props.pendingAnalysisResult}
       data-loading={!!props.analysisLoading}
     >
@@ -546,6 +547,56 @@ describe('N-1 overload state is populated before action analysis', () => {
     // when no ``_analysis_context`` is set yet. See the App.tsx wiring
     // on the ``ActionFeed.linesOverloaded`` prop.
     expect(screen.getByTestId('action-feed')).toHaveAttribute('data-ol-count', '2');
+    // The fallback delivers the exact friendly-name list — same
+    // identifiers the OverloadPanel above is wired to — so the
+    // ``ActionCard.linesOverloaded[i]`` lookup in the "Overload
+    // loading after" row resolves through ``displayName`` cleanly.
+    expect(screen.getByTestId('action-feed')).toHaveAttribute(
+      'data-ol-names',
+      'LINE_OL_A|LINE_OL_B',
+    );
+  });
+
+  // Companion to the test above: once an analysis result is present,
+  // ``result.lines_overloaded`` MUST win over the ``n1Diagram``
+  // fallback — the step2 stream reports the resolved-and-filtered set
+  // (post monitoring deselect / additional-lines etc), and that
+  // authority beats the raw N-1 diagram scan. Pins both directions of
+  // the App.tsx ternary on the ``ActionFeed.linesOverloaded`` prop.
+  it('prefers result.lines_overloaded over the n1Diagram fallback once analysis has populated it', async () => {
+    mockApi.getContingencyDiagram.mockResolvedValueOnce({
+      svg: '<svg></svg>',
+      metadata: null,
+      // Raw n1Diagram overload scan — what the fallback would surface
+      // if the analysis result were empty. TWO entries.
+      lines_overloaded: ['LINE_OL_A', 'LINE_OL_B'],
+    });
+    // Step1 filters the set down to a single resolved overload.
+    mockApi.runAnalysisStep1.mockResolvedValue({
+      can_proceed: true,
+      lines_overloaded: ['LINE_OL_A'],
+    });
+
+    await renderAndLoadStudy();
+    await selectBranch('BRANCH_A');
+    // Confirm the fallback fires pre-analysis (n1Diagram count = 2).
+    await waitFor(() => {
+      expect(screen.getByTestId('action-feed')).toHaveAttribute('data-ol-count', '2');
+    });
+
+    // Drive the full step1 → step2 stream → display-prioritized
+    // path so ``result.lines_overloaded`` becomes non-empty.
+    await runAnalysis();
+
+    // The analysis-result list wins — single ``LINE_OL1`` from the
+    // stream mock above, not the two-entry n1Diagram fallback.
+    await waitFor(() => {
+      expect(screen.getByTestId('action-feed')).toHaveAttribute('data-ol-count', '1');
+      expect(screen.getByTestId('action-feed')).toHaveAttribute(
+        'data-ol-names',
+        'LINE_OL1',
+      );
+    });
   });
 
   it('replaces the overload selection when switching contingencies without running analysis', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1390,7 +1390,20 @@ function App() {
           <ActionFeed
             actions={result?.actions || {}}
             actionScores={result?.action_scores}
-            linesOverloaded={result?.lines_overloaded || []}
+            // Prefer the analysis-result overload list when it carries
+            // entries (step1 / session reload populate it with the
+            // pypowsybl-style friendly identifiers the rest of the UI
+            // is wired against), and fall back to the N-1 diagram's
+            // authoritative list otherwise. The fallback matters for
+            // the pre-analysis manual-simulation flow: without it the
+            // card stack inherits ``simulate_manual_action``'s
+            // vectorised obs-based names — grid2op's synthetic
+            // ``line_<i>`` strings that ``displayName`` cannot resolve.
+            linesOverloaded={
+              result?.lines_overloaded && result.lines_overloaded.length > 0
+                ? result.lines_overloaded
+                : (n1Diagram?.lines_overloaded || [])
+            }
             selectedActionId={selectedActionId}
             scrollTarget={scrollTarget}
             selectedActionIds={selectedActionIds}

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -464,6 +464,33 @@ describe('ActionFeed', () => {
         expect(goodIndex).toBeLessThan(badIndex);
     });
 
+    // Backend regression guard: ``compute_action_metrics`` zeroes
+    // ``max_rho`` on a non-convergent simulation (see
+    // ``expert_backend/services/simulation_helpers.py`` —
+    // ``"max_rho": 0.0`` is the default before the convergence
+    // check). Sorting by ``max_rho`` alone would float the
+    // divergent card to the top of the stack ahead of legitimate
+    // solving actions — this test pins ``non_convergence`` as the
+    // dominant ordering key in that situation.
+    it('ranks divergent actions (max_rho=0) at the bottom, not the top', () => {
+        const props = {
+            ...defaultProps,
+            actions: {
+                act_solving: { description_unitaire: 'Solving Action', rho_before: [1.0], rho_after: [0.9], max_rho: 0.9, max_rho_line: 'A', is_rho_reduction: true, action_topology: emptyTopo },
+                act_divergent: { description_unitaire: 'Divergent Action', rho_before: [1.0], rho_after: null, max_rho: 0, max_rho_line: 'N/A', is_rho_reduction: false, non_convergence: 'LoadFlow failure', action_topology: emptyTopo },
+            },
+            selectedActionIds: new Set(['act_solving', 'act_divergent']),
+        };
+        render(<ActionFeed {...props} />);
+
+        const cards = screen.getAllByTestId(/^action-card-(act_solving|act_divergent)$/);
+        const cardIds = cards.map(el => el.getAttribute('data-testid'));
+
+        expect(cardIds.indexOf('action-card-act_solving')).toBeLessThan(
+            cardIds.indexOf('action-card-act_divergent'),
+        );
+    });
+
     it('shows only PST actions in dropdown after clicking the PST chip', async () => {
         const pstAction = { id: 'pst_tap_up', description: 'PST action', type: 'pst_tap_change' };
         const regularAction = { id: 'line_reco_1', description: 'Regular action', type: 'line_reconnection' };

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -1896,7 +1896,10 @@ describe('ActionFeed', () => {
             // Get all td cells in the row
             const cells = actionRow!.querySelectorAll('td');
             // Second cell is Tap Start (first is Action name)
-            const tapStartCell = cells[1];
+            // Score sits in column 2 since the manual-selection score
+            // table was reorganised so the ranking is visible right
+            // after the action name. Tap Start now lives in column 3.
+            const tapStartCell = cells[2];
             expect(tapStartCell).toBeDefined();
             // The textContent of the Tap Start cell should start with 27
             expect(tapStartCell.textContent).toMatch(/^27/);
@@ -1919,7 +1922,10 @@ describe('ActionFeed', () => {
             const rows = screen.getAllByRole('row');
             const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
             const cells = actionRow!.querySelectorAll('td');
-            const tapStartCell = cells[1];
+            // Score sits in column 2 since the manual-selection score
+            // table was reorganised so the ranking is visible right
+            // after the action name. Tap Start now lives in column 3.
+            const tapStartCell = cells[2];
             expect(tapStartCell.textContent).toMatch(/^27/);
         });
 
@@ -2053,7 +2059,10 @@ describe('ActionFeed', () => {
             const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
             expect(actionRow).toBeDefined();
             const cells = actionRow!.querySelectorAll('td');
-            const tapStartCell = cells[1];
+            // Score sits in column 2 since the manual-selection score
+            // table was reorganised so the ranking is visible right
+            // after the action name. Tap Start now lives in column 3.
+            const tapStartCell = cells[2];
             expect(tapStartCell.textContent).toMatch(/^27/);
         });
 
@@ -2075,7 +2084,10 @@ describe('ActionFeed', () => {
             const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
             expect(actionRow).toBeDefined();
             const cells = actionRow!.querySelectorAll('td');
-            const tapStartCell = cells[1];
+            // Score sits in column 2 since the manual-selection score
+            // table was reorganised so the ranking is visible right
+            // after the action name. Tap Start now lives in column 3.
+            const tapStartCell = cells[2];
             expect(tapStartCell.textContent).toMatch(/^27/);
         });
 
@@ -2147,7 +2159,10 @@ describe('ActionFeed', () => {
             const rows = screen.getAllByRole('row');
             const actionRow = rows.find(r => r.textContent?.includes(pstActionId));
             const cells = actionRow!.querySelectorAll('td');
-            const tapStartCell = cells[1];
+            // Score sits in column 2 since the manual-selection score
+            // table was reorganised so the ranking is visible right
+            // after the action name. Tap Start now lives in column 3.
+            const tapStartCell = cells[2];
             expect(tapStartCell.textContent).toMatch(/^27/);
 
             // Target Tap input should show 29

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study. 
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { interactionLogger } from '../utils/interactionLogger';
@@ -606,6 +606,114 @@ describe('ActionFeed', () => {
             undefined,
             undefined,
         );
+    });
+
+    // Operator-requested addition: chain several manual simulations
+    // from the wide score-table modal without it auto-closing each
+    // round. Mirrors the Combine Actions modal's contract — the
+    // operator typically wants to compare a handful of candidate
+    // remedies before committing. The narrow no-score search still
+    // auto-dismisses (one-shot "type an ID, hit enter" flow).
+    describe('manual-selection modal lifecycle (multi-simulation flow)', () => {
+        // ``defaultProps.onManualActionAdded`` (and the api module
+        // mocks) are shared ``vi.fn()`` references at the describe-block
+        // scope, so a successful simulation in this group would
+        // otherwise carry call history into the unrelated
+        // race-condition guard below ("awaits simulation before
+        // calling onManualActionAdded …"). Clear before each test in
+        // this group AND after the group finishes so the surrounding
+        // suite sees a clean slate.
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+        afterEach(() => {
+            vi.clearAllMocks();
+        });
+
+        const buildScoredProps = () => ({
+            ...defaultProps,
+            actionScores: {
+                line_reconnection: {
+                    scores: { reco_A: 5, reco_B: 4 },
+                    params: {},
+                },
+            } as Record<string, Record<string, unknown>>,
+            actions: {} as Record<string, ActionDetail>,
+        });
+
+        const mockSimulateOk = (actionId: string) => {
+            vi.mocked(api.simulateManualAction).mockResolvedValueOnce({
+                action_id: actionId,
+                description_unitaire: 'simulated',
+                rho_before: [1.05],
+                rho_after: [0.85],
+                max_rho: 0.85,
+                max_rho_line: 'LINE_1',
+                is_rho_reduction: true,
+                is_islanded: false,
+                n_components: 1,
+                disconnected_mw: 0,
+                non_convergence: null,
+                lines_overloaded: ['LINE_1'],
+                lines_overloaded_after: [],
+                load_shedding_details: [],
+                curtailment_details: [],
+                pst_details: [],
+                action_topology: emptyTopo,
+                is_estimated: false,
+            } as Awaited<ReturnType<typeof api.simulateManualAction>>);
+        };
+
+        it('keeps the wide score-table modal open after a successful manual simulation', async () => {
+            const props = buildScoredProps();
+            render(<ActionFeed {...props} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+
+            // Wide layout active — scored actions visible.
+            expect(screen.getByTestId('manual-selection-wide')).toBeInTheDocument();
+            expect(screen.queryByTestId('manual-selection-dropdown')).not.toBeInTheDocument();
+
+            // Wait for the available-actions fetch to settle before the
+            // ScoreTable renders the row links.
+            await waitFor(() => {
+                expect(screen.queryByText('Loading actions...')).not.toBeInTheDocument();
+            });
+
+            mockSimulateOk('reco_A');
+            fireEvent.click(screen.getByText('reco_A'));
+
+            await waitFor(() => {
+                expect(api.simulateManualAction).toHaveBeenCalledTimes(1);
+            });
+            // The wide overlay must still be mounted — pre-fix it
+            // unmounted on every simulation, forcing the operator
+            // to reopen + re-scroll for the next candidate.
+            expect(screen.getByTestId('manual-selection-wide')).toBeInTheDocument();
+            // The score list is preserved so the next row is one
+            // click away (no need to re-filter / re-search).
+            expect(screen.getByText('reco_B')).toBeInTheDocument();
+        });
+
+        it('still closes the narrow no-score dropdown after a manual ID is simulated', async () => {
+            // No actionScores → narrow layout, traditional one-shot
+            // flow. Closing on success is the expected UX.
+            render(<ActionFeed {...defaultProps} />);
+            fireEvent.click(screen.getByText('+ Manual Selection'));
+            expect(screen.getByTestId('manual-selection-dropdown')).toBeInTheDocument();
+
+            const searchInput = screen.getByPlaceholderText(/Search action/);
+            fireEvent.change(searchInput, { target: { value: 'custom_42' } });
+            await waitFor(() => {
+                expect(screen.queryByText('Loading actions...')).not.toBeInTheDocument();
+            });
+
+            mockSimulateOk('custom_42');
+            fireEvent.click(screen.getByText(/Simulate manual ID:/));
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('manual-selection-dropdown')).not.toBeInTheDocument();
+            });
+        });
     });
 
     it('hides actions that classify as disco even when their score type is pst, when filter is "pst"', async () => {

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -556,9 +556,14 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 return true;
             })
             .sort(([, a], [, b]) => {
-                const aIslanded = !!a.is_islanded;
-                const bIslanded = !!b.is_islanded;
-                if (aIslanded !== bIslanded) return aIslanded ? 1 : -1;
+                // Sink load-flow faults (divergent / islanded) to the bottom of
+                // the stack regardless of their reported max_rho. The backend
+                // emits ``max_rho = 0`` (not ``null``) for non-convergent
+                // simulations — sorting by max_rho alone would float those
+                // cards to the top, ahead of legitimate solving actions.
+                const aFault = !!(a.is_islanded || a.non_convergence);
+                const bFault = !!(b.is_islanded || b.non_convergence);
+                if (aFault !== bFault) return aFault ? 1 : -1;
                 return (a.max_rho ?? 999) - (b.max_rho ?? 999);
             });
     }, [actions, overviewFilters, monitoringFactor]);

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -358,8 +358,19 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
 
             };
             onManualActionAdded(trimmedId, detail, result.lines_overloaded || []);
-            setSearchOpen(false);
-            setSearchQuery('');
+            // Keep the wide score-table modal open after a successful
+            // simulation so the operator can chain several manual
+            // simulations in a row (same UX contract as
+            // ``CombinedActionsModal.handleSimulate``). Closing was
+            // forcing a re-open + re-scroll for every row the
+            // operator wanted to compare. The narrow no-score search
+            // dropdown still auto-dismisses since that mode is
+            // typically a one-shot "type an ID, hit enter" flow.
+            const wide = scoredActionsList.length > 0;
+            if (!wide) {
+                setSearchOpen(false);
+                setSearchQuery('');
+            }
         } catch (e: unknown) {
             console.error('Simulation failed:', e);
             const err = e as { response?: { data?: { detail?: string } } };
@@ -808,6 +819,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                         onAddAction={handleAddAction}
                         onResimulate={handleResimulate}
                         onResimulateTap={handleResimulateTap}
+                        monitoringFactor={monitoringFactor}
                         onShowTooltip={showTooltip}
                         onHideTooltip={hideTooltip}
                         wide={scoredActionsList.length > 0}

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -820,6 +820,8 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                         onResimulate={handleResimulate}
                         onResimulateTap={handleResimulateTap}
                         monitoringFactor={monitoringFactor}
+                        displayName={displayName}
+                        onClose={() => { setSearchOpen(false); setSearchQuery(''); }}
                         onShowTooltip={showTooltip}
                         onHideTooltip={hideTooltip}
                         wide={scoredActionsList.length > 0}

--- a/frontend/src/components/ActionSearchDropdown.test.tsx
+++ b/frontend/src/components/ActionSearchDropdown.test.tsx
@@ -37,6 +37,7 @@ describe('ActionSearchDropdown', () => {
         onResimulateTap: vi.fn(),
         onShowTooltip: vi.fn(),
         onHideTooltip: vi.fn(),
+        monitoringFactor: 0.95,
     };
 
     it('renders search input with placeholder', () => {
@@ -457,6 +458,175 @@ describe('ActionSearchDropdown', () => {
                 />,
             );
             expect(screen.queryByTestId('no-relevant-action-warning')).not.toBeInTheDocument();
+        });
+    });
+
+    // Operator-requested addition: a "Simulated Max ρ" column in the
+    // score table so the user can compare action effectiveness from
+    // inside the manual-selection modal without bouncing back to the
+    // action card stack. Pending rows render an em-dash; simulated
+    // rows show the max-ρ percentage with the same green / orange /
+    // red severity colouring the ActionCard uses, and divergent /
+    // islanded simulations render the matching warning label.
+    describe('Simulated Max ρ column', () => {
+        const baseScored = [
+            { type: 'line_reconnection', actionId: 'reco_1', score: 5, mwStart: null },
+        ];
+        const baseScores = {
+            line_reconnection: { scores: { reco_1: 5 }, params: {} },
+        };
+
+        it('renders the column header in the score table', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                />,
+            );
+            expect(screen.getByText(/Simulated Max/i)).toBeInTheDocument();
+        });
+
+        it('renders an em-dash for an unsimulated row', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                />,
+            );
+            const cell = screen.getByTestId('sim-max-rho-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('pending');
+            expect(cell.textContent).toBe('—');
+        });
+
+        it('renders the green-severity max ρ once the action has been simulated below the monitoring band', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: [1.05],
+                    rho_after: [0.5],
+                    max_rho: 0.5,
+                    max_rho_line: 'LINE_A',
+                    is_rho_reduction: true,
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            const cell = screen.getByTestId('sim-max-rho-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('green');
+            expect(cell.textContent).toBe('50.0%');
+            expect(cell.getAttribute('title')).toBe('Max ρ on LINE_A');
+        });
+
+        it('renders orange severity when max_rho is in the (mf - 0.05, mf] band', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: [1.05],
+                    rho_after: [0.92],
+                    // monitoringFactor = 0.95 (default). 0.92 is in
+                    // (mf - 0.05, mf] → orange.
+                    max_rho: 0.92,
+                    max_rho_line: 'LINE_A',
+                    is_rho_reduction: true,
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            expect(screen.getByTestId('sim-max-rho-reco_1').getAttribute('data-state')).toBe('orange');
+        });
+
+        it('renders red severity when max_rho is above the monitoring factor', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: [1.05],
+                    rho_after: [1.02],
+                    max_rho: 1.02,
+                    max_rho_line: 'LINE_A',
+                    is_rho_reduction: false,
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            const cell = screen.getByTestId('sim-max-rho-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('red');
+            expect(cell.textContent).toBe('102.0%');
+        });
+
+        it('renders a "divergent" label for a non-convergent simulation', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: null,
+                    rho_after: null,
+                    // Backend writes max_rho = 0 on non-convergence — the
+                    // numeric value must NOT leak as "0.0%". The
+                    // non_convergence flag wins.
+                    max_rho: 0,
+                    max_rho_line: 'N/A',
+                    is_rho_reduction: false,
+                    non_convergence: 'LoadFlow failure: foo',
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            const cell = screen.getByTestId('sim-max-rho-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('divergent');
+            expect(cell.textContent).toBe('divergent');
+            expect(cell.getAttribute('title')).toContain('LoadFlow failure');
+        });
+
+        it('renders an "islanded" label for an islanded simulation', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: null,
+                    rho_after: null,
+                    max_rho: 0.4,
+                    max_rho_line: 'LINE_A',
+                    is_rho_reduction: false,
+                    is_islanded: true,
+                    disconnected_mw: 42.5,
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            const cell = screen.getByTestId('sim-max-rho-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('islanded');
+            expect(cell.textContent).toBe('islanded');
+            expect(cell.getAttribute('title')).toContain('42.5 MW');
         });
     });
 });

--- a/frontend/src/components/ActionSearchDropdown.test.tsx
+++ b/frontend/src/components/ActionSearchDropdown.test.tsx
@@ -629,4 +629,230 @@ describe('ActionSearchDropdown', () => {
             expect(cell.getAttribute('title')).toContain('42.5 MW');
         });
     });
+
+    // Mirrors the ``Simulated Line`` column in
+    // ``ComputedPairsTable`` — surfaces the branch carrying max ρ on
+    // the post-action observation, resolved through ``displayName``
+    // so the operator sees the friendly pypowsybl substation pair
+    // (e.g. ``BEON L31CPVAN``) instead of the raw element ID. Pending
+    // rows and faulted simulations (divergent / islanded) render an
+    // em-dash because the post-action max-ρ branch is not meaningful
+    // in those cases.
+    describe('Simulated Line column', () => {
+        const baseScored = [
+            { type: 'line_reconnection', actionId: 'reco_1', score: 5, mwStart: null },
+        ];
+        const baseScores = {
+            line_reconnection: { scores: { reco_1: 5 }, params: {} },
+        };
+
+        it('renders the column header in the score table', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                />,
+            );
+            expect(screen.getByText('Simulated Line')).toBeInTheDocument();
+        });
+
+        it('renders an em-dash for an unsimulated row', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                />,
+            );
+            const cell = screen.getByTestId('sim-line-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('pending');
+            expect(cell.textContent).toBe('—');
+        });
+
+        it('renders displayName(max_rho_line) once the action has been simulated', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: [1.05],
+                    rho_after: [0.85],
+                    max_rho: 0.85,
+                    max_rho_line: 'BRANCH_ID_42',
+                    is_rho_reduction: true,
+                },
+            };
+            const displayName = (id: string) => id === 'BRANCH_ID_42' ? 'BEON L31CPVAN' : id;
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                    displayName={displayName}
+                />,
+            );
+            const cell = screen.getByTestId('sim-line-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('resolved');
+            expect(cell.textContent).toBe('BEON L31CPVAN');
+            // Raw ID still on the title so the operator can copy it
+            // if they need to debug at the data layer.
+            expect(cell.getAttribute('title')).toBe('BRANCH_ID_42');
+        });
+
+        it('falls back to the raw id when displayName has no mapping', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: [1.05],
+                    rho_after: [0.85],
+                    max_rho: 0.85,
+                    max_rho_line: 'UNMAPPED_LINE',
+                    is_rho_reduction: true,
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            expect(screen.getByTestId('sim-line-reco_1').textContent).toBe('UNMAPPED_LINE');
+        });
+
+        it('renders an em-dash for a divergent simulation', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: null,
+                    rho_after: null,
+                    max_rho: 0,
+                    max_rho_line: 'N/A',
+                    is_rho_reduction: false,
+                    non_convergence: 'LoadFlow failure',
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            const cell = screen.getByTestId('sim-line-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('unavailable');
+            expect(cell.textContent).toBe('—');
+        });
+
+        it('renders an em-dash for an islanded simulation', () => {
+            const actions: Record<string, ActionDetail> = {
+                reco_1: {
+                    description_unitaire: 'r1',
+                    rho_before: null,
+                    rho_after: null,
+                    max_rho: 0.4,
+                    max_rho_line: 'LINE_A',
+                    is_rho_reduction: false,
+                    is_islanded: true,
+                    disconnected_mw: 12,
+                },
+            };
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                    actions={actions}
+                />,
+            );
+            const cell = screen.getByTestId('sim-line-reco_1');
+            expect(cell.getAttribute('data-state')).toBe('unavailable');
+            expect(cell.textContent).toBe('—');
+        });
+    });
+
+    // Score column moved to position 2 (right after the Action
+    // name) so the ranking is visible without the operator's eye
+    // having to scan past the per-row MW / tap inputs. Pin both the
+    // header order AND the row cell order so a future drag-resize
+    // or re-shuffle can't silently regress it.
+    describe('Score column position', () => {
+        const baseScored = [
+            { type: 'line_reconnection', actionId: 'reco_1', score: 7.25, mwStart: null },
+        ];
+        const baseScores = {
+            line_reconnection: { scores: { reco_1: 7.25 }, params: {} },
+        };
+
+        it('renders the Score header in the second column (right after Action)', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                />,
+            );
+            const headers = screen.getAllByRole('columnheader');
+            expect(headers[0].textContent).toBe('Action');
+            expect(headers[1].textContent).toBe('Score');
+        });
+
+        it('renders the score value cell in the second column of the data row', () => {
+            render(
+                <ActionSearchDropdown
+                    {...defaultProps}
+                    scoredActionsList={baseScored}
+                    actionScores={baseScores}
+                />,
+            );
+            const actionRow = screen.getAllByRole('row').find(r => r.textContent?.includes('reco_1'));
+            const cells = actionRow!.querySelectorAll('td');
+            // Column 0 = action name; column 1 = score (newly moved).
+            expect(cells[0].textContent).toContain('reco_1');
+            expect(cells[1].textContent).toBe('7.25');
+            expect(screen.getByTestId('score-reco_1').textContent).toBe('7.25');
+        });
+    });
+
+    // Operator-requested addition: the wide modal now stays mounted
+    // across multiple simulations (see
+    // ``ActionFeed.handleAddAction``), so it needs an explicit
+    // dismiss affordance. Matches the Combine Actions modal close
+    // button (``CombinedActionsModal.tsx:391``). The narrow inline
+    // dropdown does not get a header — it relies on outside-click
+    // dismissal as before.
+    describe('Close button (wide mode)', () => {
+        it('renders the close button only when wide AND onClose is wired', () => {
+            const onClose = vi.fn();
+            render(<ActionSearchDropdown {...defaultProps} wide onClose={onClose} />);
+            expect(screen.getByTestId('manual-selection-close')).toBeInTheDocument();
+        });
+
+        it('does not render the close button in narrow mode', () => {
+            const onClose = vi.fn();
+            render(<ActionSearchDropdown {...defaultProps} onClose={onClose} />);
+            expect(screen.queryByTestId('manual-selection-close')).not.toBeInTheDocument();
+        });
+
+        it('does not render the close button when onClose is omitted', () => {
+            render(<ActionSearchDropdown {...defaultProps} wide />);
+            expect(screen.queryByTestId('manual-selection-close')).not.toBeInTheDocument();
+        });
+
+        it('invokes onClose when the close button is clicked', () => {
+            const onClose = vi.fn();
+            render(<ActionSearchDropdown {...defaultProps} wide onClose={onClose} />);
+            fireEvent.click(screen.getByTestId('manual-selection-close'));
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('uses the multiplication-sign glyph (×) so it matches the Combine modal', () => {
+            const onClose = vi.fn();
+            render(<ActionSearchDropdown {...defaultProps} wide onClose={onClose} />);
+            // &times; → ×
+            expect(screen.getByTestId('manual-selection-close').textContent).toBe('×');
+        });
+    });
 });

--- a/frontend/src/components/ActionSearchDropdown.tsx
+++ b/frontend/src/components/ActionSearchDropdown.tsx
@@ -41,6 +41,10 @@ interface ActionSearchDropdownProps {
     onResimulateTap: (actionId: string, newTap: number) => void;
     onShowTooltip: (e: React.MouseEvent, content: React.ReactNode) => void;
     onHideTooltip: () => void;
+    /** Same threshold the action cards use to colour their max-ρ
+     *  severity (green / orange / red). Plumbed through so the new
+     *  "Simulated Max ρ" column matches the rest of the UI. */
+    monitoringFactor: number;
     /** When true, render as a wide centered overlay (mirroring the
      *  Combine Actions modal layout) so the score table has room for
      *  its action ID, MW Start and Score columns. Used when scoring
@@ -72,6 +76,7 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
     onResimulateTap,
     onShowTooltip,
     onHideTooltip,
+    monitoringFactor,
     wide = false,
 }) => {
     const dropdownStyle: React.CSSProperties = wide
@@ -184,6 +189,7 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                                 onResimulateTap={onResimulateTap}
                                 onShowTooltip={onShowTooltip}
                                 onHideTooltip={onHideTooltip}
+                                monitoringFactor={monitoringFactor}
                             />
                         )}
 
@@ -298,6 +304,7 @@ interface ScoreTableProps {
     onResimulateTap: (actionId: string, newTap: number) => void;
     onShowTooltip: (e: React.MouseEvent, content: React.ReactNode) => void;
     onHideTooltip: () => void;
+    monitoringFactor: number;
 }
 
 const ScoreTable: React.FC<ScoreTableProps> = ({
@@ -315,6 +322,7 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
     onResimulateTap,
     onShowTooltip,
     onHideTooltip,
+    monitoringFactor,
 }) => {
     return (
         <div style={{ padding: '0 8px', marginBottom: '8px' }}>
@@ -360,11 +368,15 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                         <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', border: `1px solid ${colors.border}`, borderTop: 'none' }}>
                             <thead>
                                 <tr style={{ background: colors.surfaceMuted, borderBottom: `1px solid ${colors.border}` }}>
-                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '40%' : '55%' }}>Action</th>
-                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '15%' }}>{isPstType ? 'Tap Start' : 'MW Start'}</th>
-                                    {isLsOrRcType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}>Target MW</th>}
-                                    {isPstType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}>Target Tap</th>}
-                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: hasEditableColumn ? '15%' : '25%' }}>Score</th>
+                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '32%' : '45%' }}>Action</th>
+                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '12%' }}>{isPstType ? 'Tap Start' : 'MW Start'}</th>
+                                    {isLsOrRcType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '14%' }}>Target MW</th>}
+                                    {isPstType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '14%' }}>Target Tap</th>}
+                                    <th
+                                        style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}
+                                        title="Max ρ on the contingency's overloads after this action has been simulated (dash when not yet simulated)."
+                                    >Simulated Max ρ</th>
+                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: hasEditableColumn ? '12%' : '20%' }}>Score</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -537,6 +549,11 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                     />
                                                 </td>
                                             )}
+                                            <SimulatedMaxRhoCell
+                                                actionId={item.actionId}
+                                                detail={isComputed ? actions[item.actionId] : null}
+                                                monitoringFactor={monitoringFactor}
+                                            />
                                             <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace' }}>
                                                 {item.score.toFixed(2)}
                                             </td>
@@ -549,6 +566,84 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                 );
             })}
         </div>
+    );
+};
+
+// --- SimulatedMaxRhoCell ---
+//
+// Renders the "Simulated Max ρ" column for a single score-table row.
+// Once the action has been simulated (``detail`` non-null), shows the
+// max-ρ percentage colour-coded against ``monitoringFactor`` with the
+// same green / orange / red severity rule the ActionCard severity
+// stripe uses (see ``components/ActionCard.tsx``: > mf → red, > mf
+// - 0.05 → orange, otherwise → green). Surfaces ``max_rho_line`` as
+// a native title tooltip so the operator can identify which line
+// drove the loading without leaving the modal. Non-convergent and
+// islanded simulations render the matching warning glyph instead of
+// a numeric value.
+
+interface SimulatedMaxRhoCellProps {
+    actionId: string;
+    detail: ActionDetail | null;
+    monitoringFactor: number;
+}
+
+const SimulatedMaxRhoCell: React.FC<SimulatedMaxRhoCellProps> = ({ actionId, detail, monitoringFactor }) => {
+    if (!detail) {
+        return (
+            <td
+                data-testid={`sim-max-rho-${actionId}`}
+                data-state="pending"
+                style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: colors.textTertiary }}
+            >—</td>
+        );
+    }
+    if (detail.non_convergence) {
+        return (
+            <td
+                data-testid={`sim-max-rho-${actionId}`}
+                data-state="divergent"
+                title={detail.non_convergence || undefined}
+                style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: colors.danger, fontWeight: 600 }}
+            >divergent</td>
+        );
+    }
+    if (detail.is_islanded) {
+        return (
+            <td
+                data-testid={`sim-max-rho-${actionId}`}
+                data-state="islanded"
+                title={detail.disconnected_mw != null ? `Islanded — ${detail.disconnected_mw.toFixed(1)} MW disconnected` : 'Islanded'}
+                style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: colors.danger, fontWeight: 600 }}
+            >islanded</td>
+        );
+    }
+    const maxRho = detail.max_rho;
+    if (maxRho == null) {
+        return (
+            <td
+                data-testid={`sim-max-rho-${actionId}`}
+                data-state="pending"
+                style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: colors.textTertiary }}
+            >—</td>
+        );
+    }
+    const severity =
+        maxRho > monitoringFactor ? 'red'
+            : maxRho > monitoringFactor - 0.05 ? 'orange'
+                : 'green';
+    const severityColor = severity === 'red' ? colors.danger
+        : severity === 'orange' ? colors.warningStrong
+            : colors.success;
+    return (
+        <td
+            data-testid={`sim-max-rho-${actionId}`}
+            data-state={severity}
+            title={detail.max_rho_line ? `Max ρ on ${detail.max_rho_line}` : undefined}
+            style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: severityColor, fontWeight: 600 }}
+        >
+            {(maxRho * 100).toFixed(1)}%
+        </td>
     );
 };
 

--- a/frontend/src/components/ActionSearchDropdown.tsx
+++ b/frontend/src/components/ActionSearchDropdown.tsx
@@ -45,11 +45,22 @@ interface ActionSearchDropdownProps {
      *  severity (green / orange / red). Plumbed through so the new
      *  "Simulated Max ρ" column matches the rest of the UI. */
     monitoringFactor: number;
+    /** Resolve a pypowsybl element ID to its human-readable display
+     *  name. Used by the "Simulated Line" column so the operator
+     *  sees the friendly substation pair (e.g. ``BEON L31CPVAN``)
+     *  instead of the raw element identifier. Falls back to the ID. */
+    displayName?: (id: string) => string;
     /** When true, render as a wide centered overlay (mirroring the
      *  Combine Actions modal layout) so the score table has room for
      *  its action ID, MW Start and Score columns. Used when scoring
      *  data is available after running an analysis. */
     wide?: boolean;
+    /** Optional dismiss handler. When provided AND ``wide`` is on,
+     *  the modal renders a header row with a "Manual Selection"
+     *  title + ✕ close button — matching the Combine Actions modal
+     *  layout. Required for the multi-simulation flow where the
+     *  modal is no longer auto-dismissed on each row click. */
+    onClose?: () => void;
 }
 
 const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
@@ -77,7 +88,9 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
     onShowTooltip,
     onHideTooltip,
     monitoringFactor,
+    displayName = (id: string) => id,
     wide = false,
+    onClose,
 }) => {
     const dropdownStyle: React.CSSProperties = wide
         ? {
@@ -131,6 +144,30 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                 data-testid={wide ? 'manual-selection-wide' : 'manual-selection-dropdown'}
                 style={dropdownStyle}
             >
+            {wide && onClose && (
+                <div style={{
+                    padding: '15px 24px',
+                    borderBottom: `1px solid ${colors.borderSubtle}`,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    background: colors.surfaceRaised,
+                }}>
+                    <h2 style={{ margin: 0, fontSize: '1.25rem' }}>Manual Selection</h2>
+                    <button
+                        data-testid="manual-selection-close"
+                        onClick={onClose}
+                        style={{
+                            border: 'none',
+                            background: 'none',
+                            fontSize: '24px',
+                            cursor: 'pointer',
+                            color: colors.textTertiary,
+                        }}
+                        aria-label="Close manual selection"
+                    >&times;</button>
+                </div>
+            )}
             <div style={{ padding: '8px' }}>
                 <input
                     ref={searchInputRef}
@@ -190,6 +227,7 @@ const ActionSearchDropdown: React.FC<ActionSearchDropdownProps> = ({
                                 onShowTooltip={onShowTooltip}
                                 onHideTooltip={onHideTooltip}
                                 monitoringFactor={monitoringFactor}
+                                displayName={displayName}
                             />
                         )}
 
@@ -305,6 +343,7 @@ interface ScoreTableProps {
     onShowTooltip: (e: React.MouseEvent, content: React.ReactNode) => void;
     onHideTooltip: () => void;
     monitoringFactor: number;
+    displayName: (id: string) => string;
 }
 
 const ScoreTable: React.FC<ScoreTableProps> = ({
@@ -323,6 +362,7 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
     onShowTooltip,
     onHideTooltip,
     monitoringFactor,
+    displayName,
 }) => {
     return (
         <div style={{ padding: '0 8px', marginBottom: '8px' }}>
@@ -368,15 +408,22 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                         <table style={{ width: '100%', fontSize: '11px', borderCollapse: 'collapse', border: `1px solid ${colors.border}`, borderTop: 'none' }}>
                             <thead>
                                 <tr style={{ background: colors.surfaceMuted, borderBottom: `1px solid ${colors.border}` }}>
-                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '32%' : '45%' }}>Action</th>
-                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '12%' }}>{isPstType ? 'Tap Start' : 'MW Start'}</th>
-                                    {isLsOrRcType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '14%' }}>Target MW</th>}
-                                    {isPstType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '14%' }}>Target Tap</th>}
+                                    <th style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '24%' : '34%' }}>Action</th>
+                                    {/* Score sits in column 2 so the operator's eye reaches the
+                                        ranking before any of the per-row inputs / simulation
+                                        outputs — mirrors the prioritised-actions card layout. */}
+                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '10%' }}>Score</th>
+                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: '10%' }}>{isPstType ? 'Tap Start' : 'MW Start'}</th>
+                                    {isLsOrRcType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '12%' }}>Target MW</th>}
+                                    {isPstType && <th style={{ textAlign: 'right', padding: '4px 6px', width: '12%' }}>Target Tap</th>}
                                     <th
-                                        style={{ textAlign: 'right', padding: '4px 6px', width: '20%' }}
+                                        style={{ textAlign: 'right', padding: '4px 6px', width: '16%' }}
                                         title="Max ρ on the contingency's overloads after this action has been simulated (dash when not yet simulated)."
                                     >Simulated Max ρ</th>
-                                    <th style={{ textAlign: 'right', padding: '4px 6px', width: hasEditableColumn ? '12%' : '20%' }}>Score</th>
+                                    <th
+                                        style={{ textAlign: 'left', padding: '4px 6px', width: hasEditableColumn ? '28%' : '30%' }}
+                                        title="Branch carrying Max ρ in the post-action state — friendly pypowsybl name when available."
+                                    >Simulated Line</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -493,6 +540,12 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                     >i</span>
                                                 )}
                                             </td>
+                                            <td
+                                                data-testid={`score-${item.actionId}`}
+                                                style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace' }}
+                                            >
+                                                {item.score.toFixed(2)}
+                                            </td>
                                             <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: (isPstType ? tapInfo == null : item.mwStart == null) ? colors.textTertiary : colors.textPrimary }}>
                                                 {isPstType
                                                     ? (tapInfo != null ? `${tapInfo.tap}` : 'N/A')
@@ -554,9 +607,11 @@ const ScoreTable: React.FC<ScoreTableProps> = ({
                                                 detail={isComputed ? actions[item.actionId] : null}
                                                 monitoringFactor={monitoringFactor}
                                             />
-                                            <td style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace' }}>
-                                                {item.score.toFixed(2)}
-                                            </td>
+                                            <SimulatedLineCell
+                                                actionId={item.actionId}
+                                                detail={isComputed ? actions[item.actionId] : null}
+                                                displayName={displayName}
+                                            />
                                         </tr>
                                     );
                                 })}
@@ -643,6 +698,69 @@ const SimulatedMaxRhoCell: React.FC<SimulatedMaxRhoCellProps> = ({ actionId, det
             style={{ padding: '4px 6px', textAlign: 'right', fontFamily: 'monospace', color: severityColor, fontWeight: 600 }}
         >
             {(maxRho * 100).toFixed(1)}%
+        </td>
+    );
+};
+
+// --- SimulatedLineCell ---
+//
+// Renders the "Simulated Line" column — the branch carrying max ρ on
+// the post-action observation. Mirrors the ``ComputedPairsTable``
+// column of the same name so the manual-selection modal carries the
+// same vocabulary the operator already learned in the Combined
+// Actions modal. Resolved through ``displayName`` so the friendly
+// pypowsybl substation-pair label appears whenever the ID is keyed
+// in the name map. Renders a dash for pending / divergent /
+// islanded rows where the post-action max-ρ branch is not
+// meaningful (the load-flow either didn't converge or the action
+// disconnected part of the grid).
+
+interface SimulatedLineCellProps {
+    actionId: string;
+    detail: ActionDetail | null;
+    displayName: (id: string) => string;
+}
+
+const SimulatedLineCell: React.FC<SimulatedLineCellProps> = ({ actionId, detail, displayName }) => {
+    const placeholderStyle: React.CSSProperties = {
+        padding: '4px 6px',
+        textAlign: 'left',
+        color: colors.textTertiary,
+        fontStyle: 'italic',
+    };
+    if (!detail) {
+        return (
+            <td data-testid={`sim-line-${actionId}`} data-state="pending" style={placeholderStyle}>—</td>
+        );
+    }
+    if (detail.non_convergence || detail.is_islanded) {
+        return (
+            <td data-testid={`sim-line-${actionId}`} data-state="unavailable" style={placeholderStyle}>—</td>
+        );
+    }
+    const line = detail.max_rho_line;
+    if (!line || line === 'N/A') {
+        return (
+            <td data-testid={`sim-line-${actionId}`} data-state="pending" style={placeholderStyle}>—</td>
+        );
+    }
+    return (
+        <td
+            data-testid={`sim-line-${actionId}`}
+            data-state="resolved"
+            title={line}
+            style={{
+                padding: '4px 6px',
+                textAlign: 'left',
+                fontWeight: 600,
+                color: colors.textPrimary,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                maxWidth: 0,
+            }}
+        >
+            {displayName(line)}
         </td>
     );
 };

--- a/frontend/src/hooks/useActions.test.ts
+++ b/frontend/src/hooks/useActions.test.ts
@@ -240,4 +240,121 @@ describe('useActions — interaction logging', () => {
             expect(log.some(e => e.type === 'pst_tap_resimulated' && e.details.action_id === 'act_7')).toBe(false);
         });
     });
+
+    // Regression for the manual-sim overload-name fix. The backend's
+    // ``simulate_manual_action`` returns ``lines_overloaded`` populated
+    // from ``obs.name_line`` — grid2op's synthetic ``line_<i>`` strings
+    // when no ``_analysis_context`` is set yet, which the frontend's
+    // ``displayName`` resolver has no mapping for. The hook used to
+    // promote that array into ``result.lines_overloaded`` whenever the
+    // prev value was empty, poisoning the ActionCard's "Overload
+    // loading after" row. Now App.tsx falls back to
+    // ``n1Diagram.lines_overloaded`` (authoritative pypowsybl-style
+    // identifiers) and the hook leaves ``lines_overloaded`` empty so
+    // the fallback can take effect. Only step1 / session reload write
+    // the field.
+    describe('lines_overloaded poisoning regression', () => {
+        const detail: ActionDetail = {
+            description_unitaire: 'test',
+            rho_before: [1.1],
+            rho_after: [0.9],
+            max_rho: 0.9,
+            max_rho_line: 'LINE_X',
+            is_rho_reduction: true,
+        };
+
+        it('handleManualActionAdded does NOT promote response lines_overloaded into result.lines_overloaded (prev is null)', () => {
+            const { result } = renderHook(() => useActions());
+            let captured: AnalysisResult | null = null;
+            const setResult = (updater: unknown) => {
+                if (typeof updater === 'function') {
+                    captured = (updater as (p: AnalysisResult | null) => AnalysisResult | null)(null);
+                }
+            };
+
+            act(() => {
+                result.current.handleManualActionAdded(
+                    'manual_x',
+                    detail,
+                    // Manual-sim response field — grid2op synthetic names.
+                    ['line_0', 'line_1'],
+                    setResult as React.Dispatch<React.SetStateAction<AnalysisResult | null>>,
+                    vi.fn(),
+                );
+            });
+
+            expect(captured).not.toBeNull();
+            // Stays empty — App.tsx will fall back to n1Diagram.
+            expect(captured!.lines_overloaded).toEqual([]);
+            // The action detail still lands in result.actions.
+            expect(captured!.actions.manual_x).toBeDefined();
+            expect(captured!.actions.manual_x.is_manual).toBe(true);
+        });
+
+        it('handleManualActionAdded preserves an existing analysis result lines_overloaded (post-step1)', () => {
+            const { result } = renderHook(() => useActions());
+            let captured: AnalysisResult | null = null;
+            const setResult = (updater: unknown) => {
+                if (typeof updater === 'function') {
+                    captured = (updater as (p: AnalysisResult | null) => AnalysisResult | null)({
+                        pdf_path: null, pdf_url: null, actions: {},
+                        // step1 wrote the friendly pypowsybl-style names.
+                        lines_overloaded: ['BEON L31CPVAN'],
+                        message: '', dc_fallback: false,
+                    });
+                }
+            };
+
+            act(() => {
+                result.current.handleManualActionAdded(
+                    'manual_x',
+                    detail,
+                    // Even when the response would have polluted the field
+                    // with grid2op synthetic names, the existing step1
+                    // value must survive.
+                    ['line_0'],
+                    setResult as React.Dispatch<React.SetStateAction<AnalysisResult | null>>,
+                    vi.fn(),
+                );
+            });
+
+            expect(captured!.lines_overloaded).toEqual(['BEON L31CPVAN']);
+        });
+
+        it('handleActionResimulated does NOT promote response lines_overloaded into result.lines_overloaded', () => {
+            const { result } = renderHook(() => useActions());
+            let captured: AnalysisResult | null = null;
+            const setResult = (updater: unknown) => {
+                if (typeof updater === 'function') {
+                    captured = (updater as (p: AnalysisResult | null) => AnalysisResult | null)({
+                        pdf_path: null, pdf_url: null,
+                        actions: {
+                            existing: {
+                                description_unitaire: 'before',
+                                rho_before: [1.1], rho_after: [1.0],
+                                max_rho: 1.0, max_rho_line: 'A',
+                                is_rho_reduction: false, is_manual: false,
+                            },
+                        },
+                        // Pre-existing analysis-result list — must stay.
+                        lines_overloaded: ['BEON L31CPVAN'],
+                        message: '', dc_fallback: false,
+                    });
+                }
+            };
+
+            act(() => {
+                result.current.handleActionResimulated(
+                    'existing',
+                    detail,
+                    ['line_0', 'line_1'],
+                    setResult as React.Dispatch<React.SetStateAction<AnalysisResult | null>>,
+                    vi.fn(),
+                );
+            });
+
+            expect(captured!.lines_overloaded).toEqual(['BEON L31CPVAN']);
+            expect(captured!.actions.existing.rho_after).toEqual([0.9]);
+        });
+    });
 });

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -90,7 +90,7 @@ export function useActions(): ActionsState {
   const handleManualActionAdded = useCallback((
     actionId: string,
     detail: ActionDetail,
-    linesOverloaded: string[],
+    _linesOverloaded: string[],
     setResult: React.Dispatch<React.SetStateAction<AnalysisResult | null>>,
     onSelectAction: (actionId: string) => void,
   ) => {
@@ -104,9 +104,17 @@ export function useActions(): ActionsState {
         message: '',
         dc_fallback: false,
       };
+      // ``_linesOverloaded`` is the manual-simulation backend response's
+      // ``lines_overloaded`` field. It carries grid2op's synthetic
+      // ``line_<i>`` names when the user hits "+ Manual Selection"
+      // before running analysis (no ``_analysis_context``; backend
+      // falls through to the vectorised obs-based path). Keeping
+      // ``lines_overloaded`` empty in that case lets ``App.tsx`` fall
+      // back to ``n1Diagram.lines_overloaded`` — the authoritative
+      // pypowsybl-style identifier list — for the card display.
+      // Step1 / session reload set it on their own setResult paths.
       return {
         ...base,
-        lines_overloaded: base.lines_overloaded.length > 0 ? base.lines_overloaded : linesOverloaded,
         actions: {
           ...base.actions,
           [actionId]: { ...detail, is_manual: true },
@@ -128,7 +136,7 @@ export function useActions(): ActionsState {
   const handleActionResimulated = useCallback((
     actionId: string,
     detail: ActionDetail,
-    linesOverloaded: string[],
+    _linesOverloaded: string[],
     setResult: React.Dispatch<React.SetStateAction<AnalysisResult | null>>,
     onSelectAction: (actionId: string) => void,
   ) => {
@@ -139,12 +147,17 @@ export function useActions(): ActionsState {
     // 'manual_action_simulated' which conflated the two flows
     // and made replay impossible — the log entry now lives next
     // to the actual button click instead.
+    //
+    // ``_linesOverloaded`` (the manual-sim response array) is
+    // intentionally NOT promoted to ``prev.lines_overloaded`` —
+    // see ``handleManualActionAdded`` for the rationale (the
+    // backend emits grid2op's synthetic ``line_<i>`` names when
+    // no analysis context has been set yet).
     setResult(prev => {
       if (!prev) return prev;
       const existing = prev.actions[actionId];
       return {
         ...prev,
-        lines_overloaded: prev.lines_overloaded.length > 0 ? prev.lines_overloaded : linesOverloaded,
         actions: {
           ...prev.actions,
           // Preserve the is_manual flag from the existing entry so a


### PR DESCRIPTION
## Summary
This PR enhances the manual action selection modal with new simulation result columns and improves the multi-simulation workflow by keeping the wide modal open across multiple simulations.

## Key Changes

### Frontend UI Enhancements
- **New "Simulated Max ρ" column**: Displays the maximum rho percentage with severity coloring (green/orange/red) matching ActionCard styling. Shows em-dash for pending rows, and special labels for divergent/islanded simulations.
- **New "Simulated Line" column**: Shows the friendly pypowsybl branch name (e.g., "BEON L31CPVAN") carrying the max ρ, resolved via a `displayName` prop. Falls back to raw ID when no mapping exists.
- **Reordered Score column**: Moved to position 2 (right after Action name) so ranking is visible without scanning past per-row inputs.
- **Modal header with close button**: Wide mode now renders a "Manual Selection" header with a close button (✕) when `onClose` is provided, matching the Combine Actions modal layout.

### Modal Lifecycle Improvements
- **Multi-simulation flow**: The wide score-table modal now stays mounted after a successful simulation, allowing operators to chain multiple manual simulations without re-opening the modal each time.
- **Narrow mode unchanged**: The narrow no-score dropdown still auto-dismisses on simulation (one-shot "type an ID, hit enter" flow).

### Backend Fixes
- **Fixed overload name resolution**: `simulate_manual_action` now correctly reads `lines_overloaded_names` from step1 context (or legacy `lines_overloaded` from session reload) instead of falling through to grid2op's synthetic `line_<i>` names. This ensures the frontend's `displayName` resolver can map to friendly identifiers.
- **Dual-key context reading**: Supports both `lines_overloaded_names` (step1) and `lines_overloaded` (session reload) with proper priority ordering.

### Frontend Data Flow
- **ActionFeed fallback logic**: When no analysis result is available, `ActionFeed` falls back to the N-1 diagram's authoritative overload list so manual-simulation action cards display friendly names instead of synthetic strings.
- **Hook cleanup**: `useActions.handleManualActionAdded` no longer promotes the backend's synthetic `lines_overloaded` response into the result, allowing the fallback mechanism to work correctly.

### New Props
- `monitoringFactor`: Threshold for severity coloring (green/orange/red) in the Simulated Max ρ column
- `displayName`: Optional resolver function to map element IDs to friendly names
- `onClose`: Optional dismiss handler for the wide modal

### Test Coverage
- Comprehensive test suite for both new columns covering pending, resolved, divergent, and islanded states
- Regression tests for the overload name resolution fix in both step1 and session reload contexts
- Multi-simulation modal lifecycle tests ensuring the wide modal persists across simulations
- Divergent action ranking regression guard

https://claude.ai/code/session_018krbC5yQpMRVkSJu8BUVGT