### PR TITLE
Add model-swap fast path & Clear button for recommender suggestions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,9 @@ Both scripts run in CI (`.github/workflows/code-quality.yml` and
 | POST | `/api/user-config` | Persist user configuration |
 | GET  | `/api/config-file-path` | Get the current user-config file path |
 | POST | `/api/config-file-path` | Set a custom user-config file path |
-| POST | `/api/config` | Set network path, action file path, and all recommender parameters |
+| POST | `/api/config` | Set network path, action file path, and all recommender parameters (incl. `model` and `compute_overflow_graph`) |
+| GET  | `/api/models` | List registered recommendation models with their `params_spec()` and capability flags |
+| POST | `/api/recommender-model` | Lightweight swap of the active recommender model (no network reload) — fired by the model dropdowns in Settings and above Analyze & Suggest |
 | GET  | `/api/branches` | List disconnectable elements (lines + 2-winding transformers) |
 | GET  | `/api/voltage-levels` | List voltage levels in the network |
 | GET  | `/api/nominal-voltages` | Map voltage level IDs to nominal voltages (kV) |

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 > Formerly known as **ExpertAssist**. Rebranded to Co-Study4Grid in release 0.4 (PR #65).
 
 The recommender is **pluggable**: pick the expert rule-based system, a random
-baseline, or any third-party model from the **Settings → Recommender** tab.
-See [Plug Your Own Recommendation Model](#plug-your-own-recommendation-model)
+baseline, or any third-party model — from the **Settings → Recommender** tab
+or the model dropdown right above the **Analyze & Suggest** button. Swapping
+the model takes effect on the next run with no study reload, and a **Clear**
+button lets the operator wipe un-triaged suggestions and re-run with a
+different model. See [Plug Your Own Recommendation Model](#plug-your-own-recommendation-model)
 to extend it.
 
 ![License: MPL 2.0](https://img.shields.io/badge/license-MPL--2.0-blue)
@@ -19,9 +22,16 @@ to extend it.
 ### Contingency analysis & remediation
 - **Two-step N-1 workflow**: detect overloads first (`run-analysis-step1`), let the operator pick which ones to resolve, then stream suggestions (`run-analysis-step2`). The legacy one-shot `run-analysis` endpoint is still exposed for backward compatibility.
 - **Pluggable recommendation models**: select Expert / Random / RandomOverflow
-  from the Settings dropdown, or plug in a third-party model. The pipeline
-  dispatches via the `RecommenderModel` contract; the UI hides parameters the
-  active model doesn't consume. See
+  from the Settings dropdown **or** the model selector above the Analyze &
+  Suggest button, or plug in a third-party model. A model swap is pushed to
+  the backend through the lightweight `POST /api/recommender-model` endpoint
+  (no study reload), and the overflow-graph build is cached by an input
+  signature so re-running with a different model re-executes only the
+  discovery step. After a run, the model that produced the suggestions is
+  reminded below the Suggested Actions tab header with a confirmation-gated
+  **Clear** button to wipe un-triaged suggestions before re-running. The
+  pipeline dispatches via the `RecommenderModel` contract; the UI hides
+  parameters the active model doesn't consume. See
   [Plug Your Own Recommendation Model](#plug-your-own-recommendation-model).
 - **AC/DC fallback**: analysis runs on the AC load flow and transparently falls back to DC when AC fails to converge.
 - **Prioritized action feed** with search, filter, star / reject, and per-action metadata — severity, MW deltas, rho after action, impacted overloaded lines.
@@ -108,9 +118,11 @@ Across every study, the same panels are at work:
     (Solves overload / Low margin / Still overloaded / Divergent or
     islanded), per-action max-loading %, target substation chip, and a
     star/reject pair on each card. Below the tab header, the model
-    that produced the suggestions is reminded with a *Clear & rerun*
-    button so the operator can relaunch with a different recommender
-    without losing starred / rejected / manually-added decisions.
+    that produced the suggestions is reminded — *"Suggestions produced
+    by &lt;model&gt;"* — alongside a confirmation-gated **Clear**
+    button that wipes the un-triaged suggestions (keeping starred /
+    rejected / manually-added decisions) so the operator can re-run
+    with a different recommender.
 - **Visualization panel** — four synchronized tabs (*Network N*,
   *Contingency N-1*, *Remedial Action*, *Overflow Analysis*) rendered
   as pypowsybl NADs with flow-delta overlays, halos on impacted
@@ -280,12 +292,27 @@ Three models ship out of the box; you can add your own with a few lines of code.
 | `random`          | Random                             | No                      | Sanity-check baseline. Samples uniformly from the action dictionary, augmented with synthetic reconnection / load-shedding / curtailment actions. |
 | `random_overflow` | Random (post overflow analysis)    | Yes                     | "Is the overflow analysis useful?" baseline. Samples uniformly inside the expert-reduced action space (rule filter + overflow paths + network existence). |
 
-The model is selected from the **Settings → Recommender** tab via a dropdown
-populated dynamically by `GET /api/models`. The parameter inputs below the
-dropdown follow the model's `params_spec()`: each recommender declares which
-knobs the operator can tune, and the UI hides the rest. The `Compute Overflow
-Graph (step 1)` toggle is locked-on for models with
-`requires_overflow_graph=true` and editable for the others (opt-in).
+The model is selected from a dropdown populated dynamically by
+`GET /api/models` — available **both** in the **Settings → Recommender** tab
+and as a compact selector directly above the **Analyze & Suggest** button so
+the operator can swap model and re-run without opening Settings. Changing
+either dropdown pushes the choice to the running backend through
+`POST /api/recommender-model` (a lightweight swap — no network reload, no
+action-dictionary rebuild), so the next analysis run uses it. The parameter
+inputs below the Settings dropdown follow the model's `params_spec()`: each
+recommender declares which knobs the operator can tune, and the UI hides the
+rest. The `Compute Overflow Graph (step 1)` toggle is locked-on for models
+with `requires_overflow_graph=true` and editable for the others (opt-in).
+
+After a run, the model that produced the suggestions is reminded below the
+Suggested Actions tab header — *"Suggestions produced by &lt;model&gt;"* —
+alongside a confirmation-gated **Clear** button. Clear wipes only the
+recommender suggestions the operator has not triaged (un-starred, un-rejected,
+not manually added); starred / rejected / manually-added actions are kept. The
+overflow-graph build is cached by an input signature
+`(contingency, selected_overloads, all_overloads, monitor_deselected,
+additional_lines_to_cut)`, so re-running with only the model changed reuses
+the cached graph and re-executes just the discovery step.
 
 ### Three-layer filter chain for sampling models
 
@@ -389,7 +416,8 @@ hook. The decorator pattern works either way.
 The frontend picks up your model automatically:
 
 - `GET /api/models` lists it,
-- the **Settings → Recommender** dropdown shows it,
+- both the **Settings → Recommender** dropdown and the model selector above
+  the **Analyze & Suggest** button show it,
 - the parameter inputs render dynamically from `params_spec()`,
 - the `Compute Overflow Graph` toggle is locked-on or editable based on
   `requires_overflow_graph`,
@@ -515,13 +543,15 @@ Open the Vite dev-server URL shown in the terminal (typically `http://localhost:
 1. Open **Settings → Paths** and set the network directory (containing `.xiidm` files), the action definition JSON, and optionally an output folder for saved sessions.
 2. Open **Settings → Recommender** and pick which recommendation model to run
    (Expert by default). The parameter inputs below the dropdown render
-   dynamically from the active model's `params_spec()`.
+   dynamically from the active model's `params_spec()`. The model can also be
+   swapped later from the selector above the Analyze & Suggest button.
 3. Click **Load Study** to load the network.
 4. Pick a disconnectable element (line or transformer) from the searchable dropdown — the N-1 diagram is fetched with overloads highlighted automatically.
 5. Click **Analyze & Suggest** (two-step flow): select which overloads to resolve, then watch the action feed stream in.
 6. Inspect prioritized actions, simulate manual ones, or open the **Combine** modal to explore action pairs.
-7. Detach any visualization tab (`⧉`) onto a second screen for dual-monitor studies.
-8. Hit **Save Results** to export the full session (including the active recommender model under `analysis.active_model`); **Reload Session** restores it exactly, without re-simulating anything.
+7. To try a different recommender, hit **Clear** under the Suggested Actions tab header (keeps your starred / rejected / manually-added actions), pick a model in the dropdown above Analyze & Suggest, and re-run.
+8. Detach any visualization tab (`⧉`) onto a second screen for dual-monitor studies.
+9. Hit **Save Results** to export the full session (including the active recommender model under `analysis.active_model`); **Reload Session** restores it exactly, without re-simulating anything.
 
 ---
 
@@ -536,6 +566,7 @@ Open the Vite dev-server URL shown in the terminal (typically `http://localhost:
 | `POST` | `/api/config-file-path` | Set a custom user config file path |
 | `POST` | `/api/config` | Load network + set all recommender parameters (incl. `model` and `compute_overflow_graph`) |
 | `GET`  | `/api/models` | List registered recommendation models with their `params_spec()` and capability flags |
+| `POST` | `/api/recommender-model` | Lightweight swap of the active recommender model (no network reload) — fired by the model dropdowns in Settings and above Analyze & Suggest |
 | `GET`  | `/api/pick-path` | Open the native OS file / directory picker |
 | `POST` | `/api/save-session` | Save a session folder (JSON snapshot + PDF + interaction log; includes `analysis.active_model`) |
 | `GET`  | `/api/list-sessions` | List saved session folders |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,139 @@ Co-Study4Grid is built around the operator's ability to triage hundreds of remed
 
 ---
 
+## European-Wide Studies in Practice
+
+Co-Study4Grid is grid-agnostic: any pypowsybl-readable `.xiidm` network
+with a `grid_layout.json` companion drops in. The three studies below
+were captured on the same dataset — the
+`pypsa_eur_eur220_225_380_400` environment, a full pan-European 220 /
+225 / 380 / 400 kV network derived from the PyPSA-EUR pipeline (see
+[`scripts/pypsa_eur/`](scripts/pypsa_eur/)). Each contingency lights
+up a different region — the French / Spanish Pyrenean border, Spain's
+inland 400 kV backbone, and Italy's Campania 220 kV ring — and each
+exercises a different facet of the workflow. They are reproducible
+end-to-end: load the `pypsa_eur_eur220_225_380_400` study, set the
+contingency to the value below, click **Analyze & Suggest**.
+
+### What the interface shows
+
+Across every study, the same panels are at work:
+
+- **Top bar** — network path input, **Load Study** / **Save Results** /
+  **Reload Session** controls; the **Notices** pill in the top-left
+  surfaces tier-ranked issues (info / warning / critical) tied to the
+  current study.
+- **Sidebar** —
+  - **Contingency selector** and a sticky summary strip listing the
+    applied disconnections, the detected N-1 overloads (clickable to
+    zoom on the offending line) and the active monitoring ratio.
+  - The **Analyze & Suggest** trigger, with an *Additional lines to
+    prevent flow increase* picker right above it and a **Model**
+    dropdown (Expert / Random / RandomOverflow / any plug-in model).
+  - The **Suggested Actions** feed — colour-coded severity badges
+    (Solves overload / Low margin / Still overloaded / Divergent or
+    islanded), per-action max-loading %, target substation chip, and a
+    star/reject pair on each card. Below the tab header, the model
+    that produced the suggestions is reminded with a *Clear & rerun*
+    button so the operator can relaunch with a different recommender
+    without losing starred / rejected / manually-added decisions.
+- **Visualization panel** — four synchronized tabs (*Network N*,
+  *Contingency N-1*, *Remedial Action*, *Overflow Analysis*) rendered
+  as pypowsybl NADs with flow-delta overlays, halos on impacted
+  assets, and an **Inspect** field at the bottom for direct
+  asset-focus + halo.
+- **Overflow Analysis tab** — the interactive HTML viewer with a
+  layer-toggle sidebar (Constrained path, Red-loop, Overloads, Low
+  margin, Hubs, Consumption nodes, flow polarities), a *Hierarchical*
+  ↔ *Geo* layout switch and a *Pins* overlay that mirrors the action
+  pins of the Action Overview onto the overflow graph.
+
+### Pyrenean border (France / Spain) — `LANNEL61PRAGN`
+
+![France / Spain border study](docs/images/readme/study-pyrenees-france-spain.png)
+
+A 63 kV interconnect on the French side trips and re-routes flow
+toward the Spanish side, triggering a single overload on
+`MARSIL61PRAGN` at 106.1 %. The recommender returns four
+disconnection candidates centred on the Spanish substations
+(Sabiñánigo, Hernani, Itxaso) — every card carries the green *Solves
+overload* badge. The right pane illustrates the **interactive
+overflow analysis** running in *Hierarchical* mode: the layer panel
+exposes the Constrained-path, Red-loop, Overloads, Low-margin, Hubs
+and Consumption-node layers; the Flow Redispatch values give the
+positive / negative dispatch count on the constrained path; the stats
+strip at the bottom reports 93 nodes / 110 edges for the dispatch
+graph. The two views stay in lock-step: a click on a pin on either
+side opens the same `ActionCardPopover`.
+
+### Spain (400 kV) — `virtual_way_170479579_0-400 — virtual_way_170479590_0-400`
+
+![Spain N-K 400 kV study near Hinojosa](docs/images/readme/study-spain-hinojosa.png)
+
+This is an **N-K** (multi-element) study: two parallel 400 kV
+branches are disconnected simultaneously around *Subestación de
+Hinojosa*. The contingency strip shows both disconnections as
+chips; the single remaining N-1 overload reaches 102.2 % on the same
+corridor. Eighteen disconnection / coupler-opening candidates come
+back from the Expert model — all green — illustrating how dense the
+remediation space gets when the operator hunts for relief paths on a
+400 kV backbone. The auto-zoom places the highlighted contingency
+(orange dashed line) and the impacted assets at the centre of the
+NAD, and the sticky N-1 overload chip lets the operator jump back to
+the offending corridor with one click.
+
+### Italy (220 kV Campania) — `Santa Sofia — Montecorvino`
+
+![Italian Campania study around Brusciano-Nola](docs/images/readme/study-italy-brusciano-nola.png)
+
+A single 220 kV line trips between *Santa Sofia* and *Montecorvino*,
+overloading the Brusciano-Nola corridor at 106.1 %. The 18 suggested
+actions span every action class the platform handles — *Load
+shedding* on Frattamaggiore and Acerra-Maddaloni loads, *Coupler
+opening* on Avezza 220 kV (note the French description rendered
+verbatim from the action dictionary: *"Ouverture du couplage
+'VL_way_132701980-220_COUPL' dans le poste 'Avezza 220kV'"*),
+*Disconnection* on the Montecorvino–Laino axis — and the severity
+badges blend the three colour codes side by side: green *Solves
+overload*, yellow *Solved – low margin*, red *Still overloaded*. The
+overlapping red / green / yellow pins on the NAD reflect the
+operator's triage in progress: starred, rejected and unsimulated
+actions render with distinct glyphs that survive zoom, pan, and the
+*Filter* chips.
+
+### Reproducing the three studies
+
+```bash
+# Backend
+python -m expert_backend.main
+
+# Frontend
+cd frontend && npm run dev
+```
+
+1. **Settings → Paths**: point *Network Path* to
+   `data/pypsa_eur_eur220_225_380_400/network.xiidm` (and the matching
+   `grid_layout.json` / action-dictionary file).
+2. Click **Load Study**.
+3. Type one of the contingency identifiers from the table below into
+   the **Select Contingency** field — autocompletion will match.
+
+| Region                        | Contingency identifier                                              |
+|-------------------------------|---------------------------------------------------------------------|
+| France / Spain (Pyrenees)     | `LANNEL61PRAGN`                                                     |
+| Italy (Campania, 220 kV)      | `Santa Sofia — Montecorvino`                                        |
+| Spain (Hinojosa, 400 kV, N-K) | `virtual_way_170479579_0-400 — virtual_way_170479590_0-400`         |
+
+4. Press **Analyze & Suggest**, optionally change the recommender via
+   the model dropdown right above the button.
+
+The same gesture grammar applies in every region: the platform makes
+no assumption on TSO, voltage level, action vocabulary, or the
+language of the action descriptions — every panel and every shortcut
+adapts to whatever the loaded dataset declares.
+
+---
+
 ## Performance Highlights
 
 Measured on the full French grid (`bare_env_20240828T0100Z`, ~10k

--- a/docs/backend/recommender_models.md
+++ b/docs/backend/recommender_models.md
@@ -179,6 +179,25 @@ Lists every registered model with its `label`,
 populate the dropdown and render only the parameter inputs the active
 model actually consumes.
 
+### `POST /api/recommender-model`
+
+Lightweight model swap on the **running** `RecommenderService`. Body:
+`{ model: str, compute_overflow_graph?: bool }`. Calls
+`_apply_model_settings(req)` and echoes back
+`{ status, active_model, compute_overflow_graph }`.
+
+Unlike `POST /api/config`, this does **not** reload the network or
+rebuild the action dictionary — it only updates the two
+`ModelSelectionMixin` attributes. The frontend fires it from
+`useSettings` whenever `recommenderModel` / `computeOverflowGraph`
+change, so a model picked in **either** the Settings → Recommender
+tab **or** the dropdown above the Analyze & Suggest button takes
+effect on the very next `POST /api/run-analysis-step2` — without an
+expensive study reload. The Step-2 graph cache (see below) is
+deliberately left intact across a model swap: the overflow graph
+doesn't depend on the model, so a swap re-runs only the discovery
+step.
+
 ### `RecommenderService` integration
 
 Three concerns, kept in `expert_backend/recommenders/_service_integration.py`
@@ -208,6 +227,29 @@ The patches are applied as a side-effect of importing
 `expert_backend.recommenders`. `expert_backend/main.py` only needs
 that single import to enable everything.
 
+### Step-2 overflow-graph cache (model-swap fast path)
+
+`run_analysis_step2` keys the overflow graph on a **signature** of its
+inputs: `(disconnected_elements, selected_overloads, all_overloads,
+monitor_deselected, additional_lines_to_cut)`. The signature + the
+enriched context are stored on `_last_step2_signature` /
+`_last_step2_context`, and the produced HTML viewer path on
+`_overflow_layout_cache["hierarchical"]`.
+
+When a re-run posts an **identical** signature, the orchestrator skips
+`_narrow_context_to_selected_overloads` + `run_analysis_step2_graph` +
+the PDF mtime poll, yields the cached `pdf` event with `cached: true`,
+and jumps straight to `run_analysis_step2_discovery`. Because the
+overflow graph depends only on topology — never on the recommender —
+this makes the common "swap model and re-run" loop near-instant: only
+the discovery step actually re-executes. Any change to the
+contingency or the additional-lines hypothesis changes the signature
+and forces a full rebuild.
+
+`_last_step2_signature` and `_last_step2_context` are per-study caches
+— both are cleared by `RecommenderService.reset()` so a freshly
+loaded study never reuses the previous study's graph.
+
 ---
 
 ## 5. Frontend wiring
@@ -223,8 +265,37 @@ that single import to enable everything.
 - `useEffect` forces `computeOverflowGraph = true` whenever the active
   model declares `requires_overflow_graph = true`. Keeps persisted
   user config in sync with what the backend will actually run.
+- A second `useEffect` pushes the model to the running backend via
+  `api.setRecommenderModel()` (→ `POST /api/recommender-model`)
+  whenever `recommenderModel` / `computeOverflowGraph` change. A
+  `lastPushedModelRef` guard skips redundant pushes. This is what
+  makes a mid-session model swap (from either dropdown) actually
+  reach the backend without an Apply Settings round-trip.
 - `buildConfigRequest()` carries `model` and `compute_overflow_graph`
   through every `/api/config` call.
+
+### `ActionFeed` — model selector + active-model reminder + Clear
+
+`frontend/src/components/ActionFeed.tsx`:
+
+- **Model dropdown above "Analyze & Suggest"** — a mirror of the
+  Settings → Recommender selector, populated from `availableModels`.
+  Lets the operator swap model and re-run without opening Settings.
+  Every change emits a `recommender_model_changed` interaction event
+  with `source: 'action_feed'`.
+- **Active-model reminder** — once a run has produced suggestions, an
+  italic *"Suggestions produced by &lt;model label&gt;"* line sits
+  just below the Suggested Actions tab header. The label is resolved
+  from `result.active_model` against `availableModels`.
+- **Clear button** — a danger-coloured button on that reminder line.
+  It opens the shared `<ConfirmationDialog/>` (`type:
+  'clearSuggested'`); on confirm, `App.performClearSuggested` wipes
+  the recommender suggestions the operator has NOT triaged (un-starred,
+  un-rejected, not manually added) and emits `suggested_actions_cleared`.
+  It does **not** re-run the analysis — the operator clears, optionally
+  swaps the model, then presses Analyze & Suggest. The analysis-trigger
+  slot is gated on `prioritizedEntries.length === 0`, so it reappears
+  the moment the Suggested feed empties out.
 
 ### `SettingsModal` — Recommender tab
 

--- a/docs/backend/recommender_models.md
+++ b/docs/backend/recommender_models.md
@@ -297,6 +297,33 @@ loaded study never reuses the previous study's graph.
   slot is gated on `prioritizedEntries.length === 0`, so it reappears
   the moment the Suggested feed empties out.
 
+### `ActionCard` — origin / "Source" row
+
+`frontend/src/components/ActionCard.tsx`:
+
+Every action carries an `origin` field (`ActionDetail.origin`)
+recording its provenance — set once at creation, never changed by
+starring or re-simulating:
+
+- `"user"` — the operator simulated it themselves (manual search
+  dropdown / "Make a first guess"). Set by
+  `useActions.handleManualActionAdded` (default).
+- `<model id>` — produced by a recommender. Set by the step-2 result
+  loop in `useAnalysis` from the `active_model` echoed on the stream's
+  `result` event. The unsimulated-pin path
+  (`App.handleSimulateUnsimulatedAction`) also stamps the model id,
+  not `"user"`, because that pin was *scored* by the model — the
+  operator only triggered its materialisation.
+
+`origin` is distinct from the `is_manual` flag, which is overloaded
+UI state (also `true` when the operator merely *stars* a recommender
+suggestion). The unfolded action card renders an `origin`-derived
+"Source" row — `ActionCard` resolves a model id to its label via
+`availableModels`, falling back to the raw id. The field is persisted
+in `session.json` (`SavedActionEntry.origin`) and restored verbatim;
+legacy dumps get a derived `origin` on reload. See
+[`docs/features/save-results.md`](../features/save-results.md).
+
 ### `SettingsModal` — Recommender tab
 
 `frontend/src/components/modals/SettingsModal.tsx`:

--- a/docs/features/interaction-logging.md
+++ b/docs/features/interaction-logging.md
@@ -55,6 +55,8 @@ type InteractionType =
   | 'analysis_step2_started'       // Step 2 launched (resolve overloads)
   | 'analysis_step2_completed'     // Step 2 finished (actions received)
   | 'prioritized_actions_displayed'// User clicked "Display Prioritized Actions"
+  | 'recommender_model_changed'    // User picked a different recommender model
+  | 'suggested_actions_cleared'    // User cleared the un-touched suggestions ("Clear")
   // === Action Interactions ===
   | 'action_selected'              // User clicked an action card
   | 'action_deselected'            // User clicked away / deselected action
@@ -155,6 +157,8 @@ Each event's `details` field contains **all parameters needed to replay** the us
 | `analysis_step2_started` | `{ element, selected_overloads: string[], all_overloads: string[], monitor_deselected: bool, additional_lines_to_cut?: string[] }` | Click "Resolve Selected Overloads" |
 | `analysis_step2_completed` | `{ n_actions: number, action_ids: string[], dc_fallback: bool, message: string, pdf_url: string\|null, active_model?: string, compute_overflow_graph?: boolean }` — `active_model` echoes the recommender id that actually produced the action set on the backend; `compute_overflow_graph` echoes whether the overflow analysis graph was generated for this run. Both are sourced from the final `result` event of the step-2 NDJSON stream. | *(wait point)* |
 | `prioritized_actions_displayed` | `{ n_actions: number }` | Click "Display Prioritized Actions" button |
+| `recommender_model_changed` | `{ model: string, source?: 'action_feed' \| 'settings' }` — `model` is the new recommender registry id the operator selected. `source` identifies which dropdown changed: the selector above the Analyze & Suggest button (`'action_feed'`) or the Settings → Recommender tab (`'settings'`, omitted on older logs). The change is pushed to the backend via `POST /api/recommender-model` so the **next** analysis run uses it — replay must therefore emit this event *before* the following `analysis_step2_started`. | Pick a model in the dropdown above Analyze & Suggest, or in Settings → Recommender |
+| `suggested_actions_cleared` | `{ n_cleared: number }` — `n_cleared` is the count of recommender suggestions removed from the feed (those the operator had NOT starred / rejected / manually added — those are kept). Fired only after the operator confirms the "Clear Suggestions?" dialog. Does not re-run the analysis on its own. | Click the **Clear** button under the Suggested Actions tab header → confirm the dialog |
 
 ### Action Interactions
 
@@ -284,6 +288,7 @@ These events trigger async API calls. The replay agent must wait for the operati
 | `tab_reattached` | Popup closed, content re-rendered in the main window |
 | `overflow_layout_mode_toggled` | Overflow iframe URL refreshes after the backend regenerates / serves the requested layout (`POST /api/regenerate-overflow-graph`); the matching `_completed` event carries `cached: bool` or `error: string`. |
 | `overview_unsimulated_pin_simulated` | The dashed `?` pin is replaced by a coloured pin once the manual simulation lands in `result.actions`. |
+| `recommender_model_changed` | The model is pushed to the running backend via `POST /api/recommender-model` (a lightweight swap — no network reload). The replay agent must let that POST settle before the next `analysis_step2_started`, otherwise the run uses the previous model. |
 
 ### Handling `*_completed` Events
 
@@ -310,6 +315,14 @@ The `model` and `compute_overflow_graph` fields surfaced in `config_loaded`, `se
 - On the backend, the final `result` event of the step-2 NDJSON stream echoes `active_model` (the recommender that actually ran — may differ from the requested `model` if it was unknown, in which case the backend falls back to `"expert"`) and `compute_overflow_graph` (whether the overflow analysis graph was generated for this run). The replay logger forwards both into `analysis_step2_completed` details.
 
 A replay agent that wants to faithfully reproduce a session MUST honour both fields when restoring settings before clicking "Load Study" / "Apply". Older logs that predate the feature lack these fields and replay against the default `"expert"` / `true` pair — which matches the historical hard-coded behaviour byte-for-byte.
+
+### Mid-session model swaps
+
+The model can also be changed **without** re-opening Settings — via the dropdown directly above the **Analyze & Suggest** button (a mirror of the Settings → Recommender selector). Every change to either dropdown emits a `recommender_model_changed` event and is pushed to the running `RecommenderService` through the lightweight `POST /api/recommender-model` endpoint (no network reload, no action-dictionary rebuild). The next `analysis_step2_started` then runs against the new model.
+
+The companion **Clear** button under the Suggested Actions tab header wipes the recommender suggestions the operator has not triaged (un-starred, un-rejected, not manually added) and emits `suggested_actions_cleared`. It is confirmation-gated (shared `<ConfirmationDialog/>`, `type: 'clearSuggested'`) and does **not** re-run the analysis — the operator clears, optionally swaps the model, then presses Analyze & Suggest. A replay agent reproducing a "swap model and re-run" sequence will therefore see, in order: `suggested_actions_cleared` → `recommender_model_changed` → `analysis_step1_started` → `analysis_step2_started`.
+
+Neither event needs separate session persistence: the model choice survives a reload through `configuration.model` / `analysis.active_model` (see [Session reload fidelity](#session-reload-fidelity)), and the *effect* of a clear is captured in the saved action set + status flags. They are pure replay-log gestures.
 
 ---
 

--- a/docs/features/save-results.md
+++ b/docs/features/save-results.md
@@ -182,6 +182,7 @@ Some pieces of in-memory state are deliberately ephemeral and will reset on relo
         "pst_details": [
           { "pst_name": "PST_A", "tap_position": 5, "low_tap": -16, "high_tap": 16 }
         ],
+        "origin": "expert",
         "status": {
           "is_selected":          true,
           "is_suggested":         true,
@@ -295,6 +296,7 @@ Each action entry mirrors the `ActionDetail` type plus a `status` object:
 | `load_shedding_details` | Per-load MW values for the load-shedding editor card. Array of `{ load_name, voltage_level_id, shedded_mw }` (PR #73). |
 | `curtailment_details` | Per-generator MW values for the renewable-curtailment editor card. Array of `{ gen_name, voltage_level_id, curtailed_mw }` (PR #73). |
 | `pst_details` | PST editor state: array of `{ pst_name, tap_position, low_tap, high_tap }`. `low_tap` / `high_tap` may be `null` if the network manager did not expose bounds (PR #78). |
+| `origin` | *(optional)* Provenance of the action card — `"user"` (the operator simulated it themselves via the manual search / "Make a first guess") or a recommender model id (`"expert"`, `"random_overflow"`, … — the `active_model` that produced / scored it; this also covers an unsimulated pin the operator materialised). Distinct from the `is_manually_simulated` status flag, which also flips `true` when the operator merely *stars* a recommender suggestion. Surfaced as the "Source" row in the unfolded action card. Legacy dumps that predate the field get an `origin` **derived on reload** from the status flags + `analysis.active_model` (`is_manually_simulated` → `"user"`, else `is_suggested` → `active_model`). |
 
 > **Why the enrichment fields matter on reload:** the PST / load-shedding / curtailment editor cards read directly from `pst_details` / `load_shedding_details` / `curtailment_details` to populate their inputs, and the Remedial Action tab uses `lines_overloaded_after` to clone the post-action overload halos. Before PR #83, these four fields were written to `session.json` but silently dropped on reload, which left the editor cards empty and wiped the overload halos until the user re-ran analysis. They are now restored in full by `handleRestoreSession`.
 
@@ -306,6 +308,8 @@ Each action entry mirrors the `ActionDetail` type plus a `status` object:
 | `is_selected` | The user starred / favorited this action |
 | `is_rejected` | The user explicitly rejected this action |
 | `is_manually_simulated` | The user added this action via the manual search / simulation flow |
+
+> **`origin` vs. `is_manually_simulated`:** the status flag is an *interaction* record — it flips `true` both when the operator manually simulates an action AND (historically) when they star a recommender suggestion. `origin` is the *provenance* — set once at creation, never changed by starring / re-simulating. A starred recommender suggestion has `is_manually_simulated`-adjacent state but keeps `origin: "<model>"`.
 
 ### `combined_actions` (Computed Pairs)
 
@@ -428,7 +432,8 @@ chain, step-by-step plug-in guide, troubleshooting):
    - **Updates `committedNetworkPathRef.current`** to the restored `network_path`
    - Fetches branches, voltage levels, nominal voltages **and the base diagram** in parallel
    - **Calls `api.restoreAnalysisContext(...)`** to re-push `lines_we_care_about` + `computed_pairs` into the backend service (wrapped in try/catch — failures log a warning but let the reload complete)
-   - Rebuilds each `ActionDetail` from its `SavedActionEntry`, **including** `lines_overloaded_after`, `load_shedding_details`, `curtailment_details` and `pst_details`. Estimation-only combined entries (`id.includes('+') && is_estimated && !is_manually_simulated`) are filtered out of the top-level actions map but kept under `combined_actions`.
+   - Rebuilds each `ActionDetail` from its `SavedActionEntry`, **including** `lines_overloaded_after`, `load_shedding_details`, `curtailment_details`, `pst_details` and `origin`. Estimation-only combined entries (`id.includes('+') && is_estimated && !is_manually_simulated`) are filtered out of the top-level actions map but kept under `combined_actions`.
+   - **Re-attaches `analysis.active_model` + `analysis.compute_overflow_graph` onto the live `result`** so the "Suggestions produced by &lt;model&gt;" reminder below the Suggested Actions tab header survives the reload — previously both were saved but never restored onto `result`, so the reminder vanished. For legacy dumps whose action entries predate the `origin` field, an `origin` is derived here from the status flags + `active_model` (`is_manually_simulated` → `"user"`, else `is_suggested` → `active_model`).
    - Partitions action status flags into `selectedActionIds` / `rejectedActionIds` / `manuallyAddedIds` / `suggestedByRecommenderIds`
    - **Sets `restoringSessionRef.current = true` BEFORE `setSelectedBranch(...)`** so the N-1 fetch effect in `App.tsx` can tell "session restore" from "user changed contingency", bypass its `hasAnalysisState()` short-circuit, skip `clearContingencyState()` (which would wipe the just-restored state), and avoid forcing an active-tab switch. The ref is reset to `false` the moment the effect consumes it.
    - No action card is active — diagrams are fetched on-demand when clicked
@@ -465,6 +470,7 @@ as a frozen snapshot — do NOT edit further).
   to `session.configuration.model` / `session.configuration.compute_overflow_graph`
   (conditional — omitted when undefined for legacy callers).
 - All four status tags independently computed
+- **Action origin:** `detail.origin` (`"user"` / a recommender model id) is serialised verbatim; left `undefined` for legacy / un-tracked actions
 - **Combined actions:** serialised with estimation and simulation data
 - **Combined actions:** `is_simulated` flag based on presence in `result.actions`
 - **Combined actions:** empty object when no combined actions exist
@@ -486,6 +492,8 @@ A `makeCtx()` / `makeSession()` fixture pair makes each test self-contained:
 - Empty `outputFolderPath` short-circuits the call: no API requests, no setters, ref untouched
 - Backend errors surface via `ctx.setError`; the ref is left empty on failure
 - **Enrichment field round-trip:** a `captureRestoredResult()` helper replays the functional `setResult` updater against a `null` previous state and asserts `load_shedding_details`, `curtailment_details`, `pst_details` and `lines_overloaded_after` all land on the restored `ActionDetail`
+- **Recommender model restore:** `analysis.active_model` + `analysis.compute_overflow_graph` are re-attached onto the live `result` (regression guard for the vanished "Suggestions produced by &lt;model&gt;" reminder)
+- **Action origin restore:** a saved `origin` is restored verbatim; legacy entries that predate the field get an `origin` derived from the status flags + `analysis.active_model` (`is_manually_simulated` → `"user"`, else `is_suggested` → `active_model`)
 - Action status flags partition correctly into the four `Set<string>` state updates
 - Legacy action entries that omit enrichment fields don't crash — values come through as `undefined`
 - Estimation-only combined entries are filtered out of top-level `actions` but survive under `combined_actions`

--- a/docs/features/save-results.md
+++ b/docs/features/save-results.md
@@ -43,7 +43,7 @@ Settings → gear icon → Paths tab → Output Folder Path
 ## How to Save
 
 1. Open **Settings → Paths** and configure Action Dictionary File Path and Output Folder Path.
-2. Open **Settings → Recommender** and pick the recommendation model. The selection is captured at save time under `configuration.model`; the model the backend actually executed is captured separately under `analysis.active_model` (the two may differ when an unknown name silently falls back to the default).
+2. Open **Settings → Recommender** and pick the recommendation model (it can also be swapped later from the model dropdown above the **Analyze & Suggest** button — same persisted `recommenderModel` state). The selection is captured at save time under `configuration.model`; the model the backend actually executed is captured separately under `analysis.active_model` (the two may differ when an unknown name silently falls back to the default).
 3. Load a study (click **Load Study**).
 4. Select a contingency in the **Select Contingency** box.
 5. Optionally run analysis, select/reject actions, simulate manual/combined actions.

--- a/docs/features/state-reset-and-confirmation-dialogs.md
+++ b/docs/features/state-reset-and-confirmation-dialogs.md
@@ -134,8 +134,13 @@ The `RecommenderService.reset()` method clears, in order:
    - `_overflow_layout_cache` — cleared so file paths produced for
      the previous contingency cannot be served for the new one.
    - `_last_step2_context` — the preserved enriched Step-2 context
-     used by `/api/regenerate-overflow-graph`; stale context must
-     not be reused after a study reload.
+     used by `/api/regenerate-overflow-graph` and by the model-swap
+     fast path; stale context must not be reused after a study reload.
+   - `_last_step2_signature` — the input signature
+     `(contingency, selected_overloads, all_overloads,
+     monitor_deselected, additional_lines_to_cut)` that gates the
+     Step-2 overflow-graph cache reuse. Cleared so a freshly loaded
+     study never reuses the previous study's overflow graph.
 
 Adding a new per-study cache? It MUST be listed in
 `RecommenderService.reset()` (see

--- a/expert_backend/CLAUDE.md
+++ b/expert_backend/CLAUDE.md
@@ -138,7 +138,7 @@ why enabling that is unsafe for the FastAPI thread pool today.
   `_lf_status_by_variant`, `_layout_cache`,
   `_prefetched_base_nad*`, `_overflow_layout_mode` (back to
   `"hierarchical"`), `_overflow_layout_cache` (empty dict),
-  `_last_step2_context`. Adding a new instance-level cache?
+  `_last_step2_context`, `_last_step2_signature`. Adding a new instance-level cache?
   Add it here too — otherwise it WILL leak across studies (see the
   `_layout_cache` regression fixed on
   `claude/fix-grid-layout-reset-8TYEV`).
@@ -173,7 +173,16 @@ Diagram & topology:
 Analysis:
 - `POST /api/run-analysis-step1` — detect overloads (returns once).
 - `POST /api/run-analysis-step2` — resolve, **streaming** NDJSON.
+  Caches the overflow graph by an input signature
+  (`_last_step2_signature`); a re-run with an identical signature
+  skips the graph rebuild and re-executes only action discovery — the
+  model-swap fast path.
 - `POST /api/run-analysis` — single-step legacy NDJSON stream.
+- `GET  /api/models` — list registered recommender models.
+- `POST /api/recommender-model` — lightweight swap of the active
+  recommender model (`_apply_model_settings`); no network reload, no
+  action-dictionary rebuild. Leaves `_last_step2_signature` intact so
+  the overflow-graph cache is reused across a model swap.
 - `POST /api/regenerate-overflow-graph` — toggle overflow-graph
   layout between hierarchical (graphviz `dot`, produced by
   `run_analysis_step2`) and geo (pure SVG transform that

--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -359,6 +359,35 @@ def update_config(config: ConfigRequest) -> dict:
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+
+class RecommenderModelRequest(BaseModel):
+    model: str
+    compute_overflow_graph: bool | None = None
+
+
+@app.post("/api/recommender-model")
+def set_recommender_model(req: RecommenderModelRequest) -> dict:
+    """Swap the active recommender model on the running service.
+
+    Lightweight counterpart to ``POST /api/config``: only updates the
+    model + ``compute_overflow_graph`` toggle, leaves the loaded
+    network, action dictionary, and analysis context untouched. The
+    Step-2 graph cache (`_last_step2_signature`) is also left intact —
+    the overflow graph itself doesn't depend on the model, only the
+    discovery step does, so a model swap can reuse the cached graph
+    and re-run only ``run_analysis_step2_discovery``.
+    """
+    try:
+        recommender_service._apply_model_settings(req)
+        return {
+            "status": "success",
+            "active_model": recommender_service.get_active_model_name(),
+            "compute_overflow_graph": recommender_service.get_compute_overflow_graph(),
+        }
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 @app.get("/api/branches")
 def get_branches() -> dict:
     try:

--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 
+from expert_backend.services.diagram_mixin import ActionResultUnavailableError
 from expert_backend.services.network_service import network_service
 from expert_backend.services.overflow_overlay import inject_overlay
 from expert_backend.services.recommender_service import recommender_service
@@ -693,6 +694,16 @@ def get_action_variant_diagram(request: ActionVariantRequest, http_request: Requ
             request.action_id, mode=request.mode
         )
         return _maybe_gzip_json(diagram, http_request)
+    except ActionResultUnavailableError as e:
+        # Expected after a session reload (and for any manually-added
+        # action): the backend has no cached observation, so it can't
+        # render the post-action NAD. Still a 400 — the frontend needs
+        # it to trigger the `/api/simulate-and-variant-diagram` fallback
+        # — but log it quietly instead of as an ERROR-level traceback.
+        logger.info(
+            "action-variant-diagram: %s — client falls back to live simulation", e
+        )
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.exception("API boundary error")
         raise HTTPException(status_code=400, detail=str(e))

--- a/expert_backend/recommenders/_service_integration.py
+++ b/expert_backend/recommenders/_service_integration.py
@@ -143,31 +143,56 @@ def _run_analysis_step2_with_model(
         or self.get_compute_overflow_graph()
     )
 
-    context = self._narrow_context_to_selected_overloads(
-        self._analysis_context,
-        selected_overloads,
-        all_overloads,
-        monitor_deselected,
-        additional_lines_to_cut=additional_lines_to_cut,
+    # Overflow-graph fast path: the graph is model-INDEPENDENT — only
+    # action discovery below consumes the recommender. So a re-run with
+    # the same contingency + Step-2 inputs (selected overloads, monitor
+    # toggle, additional-lines picker) but a different model reuses the
+    # cached graph and skips `_narrow_context_to_selected_overloads` +
+    # `run_analysis_step2_graph` + the PDF mtime poll entirely. The
+    # signature / reuse-decision helpers live on `AnalysisMixin` so this
+    # production replacement and the legacy generator share them.
+    step2_signature = self._step2_graph_signature(
+        selected_overloads, all_overloads, monitor_deselected, additional_lines_to_cut,
     )
-    analysis_start_time = time.time()
-    self._overflow_layout_cache = {}
-    self._overflow_layout_mode = "hierarchical"
+    reuse_graph = needs_graph and self._can_reuse_step2_graph(step2_signature)
 
     try:
-        if needs_graph:
-            context = analysis_mixin.run_analysis_step2_graph(context)
-            produced_pdf = self._get_latest_pdf_path(analysis_start_time)
-            if produced_pdf:
-                self._overflow_layout_cache["hierarchical"] = produced_pdf
-            self._last_step2_context = context
-            yield {"type": "pdf", "pdf_path": produced_pdf}
+        if reuse_graph:
+            logger.info(
+                "[Step 2] model=%s reusing cached overflow graph (signature unchanged)",
+                recommender.name,
+            )
+            context = self._last_step2_context
+            produced_pdf = self._overflow_layout_cache.get("hierarchical")
+            yield {"type": "pdf", "pdf_path": produced_pdf, "cached": True}
         else:
-            # Model does not consume the overflow graph: emit an empty
-            # `pdf` event so the frontend knows it should not wait for
-            # an overflow HTML to appear.
-            self._last_step2_context = None
-            yield {"type": "pdf", "pdf_path": None}
+            context = self._narrow_context_to_selected_overloads(
+                self._analysis_context,
+                selected_overloads,
+                all_overloads,
+                monitor_deselected,
+                additional_lines_to_cut=additional_lines_to_cut,
+            )
+            analysis_start_time = time.time()
+            self._overflow_layout_cache = {}
+            self._overflow_layout_mode = "hierarchical"
+            if needs_graph:
+                context = analysis_mixin.run_analysis_step2_graph(context)
+                produced_pdf = self._get_latest_pdf_path(analysis_start_time)
+                if produced_pdf:
+                    self._overflow_layout_cache["hierarchical"] = produced_pdf
+                self._last_step2_context = context
+                self._last_step2_signature = step2_signature
+                yield {"type": "pdf", "pdf_path": produced_pdf}
+            else:
+                # Model does not consume the overflow graph: emit an empty
+                # `pdf` event so the frontend knows it should not wait for
+                # an overflow HTML to appear. No graph is cached, so clear
+                # the signature too — a later graph-requiring run must
+                # never false-hit on it.
+                self._last_step2_context = None
+                self._last_step2_signature = None
+                yield {"type": "pdf", "pdf_path": None}
 
         params = {"n_prioritized_actions": config.N_PRIORITIZED_ACTIONS}
         results = analysis_mixin.run_analysis_step2_discovery(

--- a/expert_backend/services/analysis_mixin.py
+++ b/expert_backend/services/analysis_mixin.py
@@ -431,36 +431,72 @@ class AnalysisMixin:
         if not self._analysis_context:
             raise ValueError("Analysis context not found. Run step 1 first.")
 
-        context = self._narrow_context_to_selected_overloads(
-            self._analysis_context,
-            selected_overloads,
-            all_overloads,
-            monitor_deselected,
-            additional_lines_to_cut=additional_lines_to_cut,
+        # Signature for the overflow-graph fast path: when the operator
+        # re-runs the analysis against the same contingency + same Step-2
+        # inputs (selected overloads, monitor toggle, additional-lines
+        # picker), the OverFlowGraph object and the produced HTML viewer
+        # are byte-for-byte the same as the previous run. Skipping
+        # `_narrow_context_to_selected_overloads` + `run_analysis_step2_graph`
+        # + the PDF mtime poll lets a re-run with a different recommender
+        # model jump straight to action discovery. The discovery step is
+        # the only part that depends on the active model.
+        step2_signature = (
+            tuple(self._last_disconnected_elements or []),
+            tuple(sorted(selected_overloads or [])),
+            tuple(sorted(all_overloads or [])),
+            bool(monitor_deselected),
+            tuple(sorted(additional_lines_to_cut or [])),
         )
-        analysis_start_time = time.time()
-        # Fresh Step-2: drop any cached overflow files from a previous
-        # contingency resolution. The library always produces the
-        # hierarchical layout (graphviz `dot`); the Geo toggle is
-        # handled by a pure SVG transform in the regen endpoint, NOT
-        # by re-invoking the library. That keeps the analysis step
-        # fast and deterministic regardless of layout-file state.
-        self._overflow_layout_cache = {}
-        self._overflow_layout_mode = "hierarchical"
+        cached_pdf = self._overflow_layout_cache.get("hierarchical")
+        reuse_graph = (
+            getattr(self, "_last_step2_signature", None) == step2_signature
+            and self._last_step2_context is not None
+            and cached_pdf is not None
+            and os.path.exists(cached_pdf)
+        )
+
         try:
-            # Part 1: graph generation + HTML
-            context = run_analysis_step2_graph(context)
-            produced_pdf = self._get_latest_pdf_path(analysis_start_time)
-            if produced_pdf:
-                # Step-2 always produces the hierarchical layout — the
-                # regen endpoint transforms it into the geo layout on
-                # demand without re-invoking graphviz.
-                self._overflow_layout_cache["hierarchical"] = produced_pdf
-            # Preserve the enriched context (kept for future features
-            # that might need to re-run graph generation). The Geo
-            # toggle itself no longer uses this.
-            self._last_step2_context = context
-            yield {"type": "pdf", "pdf_path": produced_pdf}
+            if reuse_graph:
+                logger.info(
+                    "[Step 2] Reusing cached overflow graph (signature unchanged)"
+                )
+                context = self._last_step2_context
+                produced_pdf = cached_pdf
+                # Geo cache is keyed off the same hierarchical source; keep
+                # whatever the previous run produced so the toggle stays
+                # instant. `_overflow_layout_mode` is left untouched.
+                yield {"type": "pdf", "pdf_path": produced_pdf, "cached": True}
+            else:
+                context = self._narrow_context_to_selected_overloads(
+                    self._analysis_context,
+                    selected_overloads,
+                    all_overloads,
+                    monitor_deselected,
+                    additional_lines_to_cut=additional_lines_to_cut,
+                )
+                analysis_start_time = time.time()
+                # Fresh Step-2: drop any cached overflow files from a previous
+                # contingency resolution. The library always produces the
+                # hierarchical layout (graphviz `dot`); the Geo toggle is
+                # handled by a pure SVG transform in the regen endpoint, NOT
+                # by re-invoking the library. That keeps the analysis step
+                # fast and deterministic regardless of layout-file state.
+                self._overflow_layout_cache = {}
+                self._overflow_layout_mode = "hierarchical"
+                # Part 1: graph generation + HTML
+                context = run_analysis_step2_graph(context)
+                produced_pdf = self._get_latest_pdf_path(analysis_start_time)
+                if produced_pdf:
+                    # Step-2 always produces the hierarchical layout — the
+                    # regen endpoint transforms it into the geo layout on
+                    # demand without re-invoking graphviz.
+                    self._overflow_layout_cache["hierarchical"] = produced_pdf
+                # Preserve the enriched context (kept for future features
+                # that might need to re-run graph generation). The Geo
+                # toggle itself no longer uses this.
+                self._last_step2_context = context
+                self._last_step2_signature = step2_signature
+                yield {"type": "pdf", "pdf_path": produced_pdf}
 
             # Part 2: action discovery
             results = run_analysis_step2_discovery(context)
@@ -497,6 +533,11 @@ class AnalysisMixin:
                 "pre_existing_overloads": results.get("pre_existing_overloads", []),
                 "combined_actions": results.get("combined_actions", {}),
                 "lines_we_care_about": list(lines_we_care_about) if lines_we_care_about is not None else None,
+                "active_model": (
+                    self.get_active_model_name()
+                    if hasattr(self, "get_active_model_name")
+                    else None
+                ),
                 "message": "Analysis completed",
                 "dc_fallback": False,
             })

--- a/expert_backend/services/analysis_mixin.py
+++ b/expert_backend/services/analysis_mixin.py
@@ -403,6 +403,56 @@ class AnalysisMixin:
             self._analysis_context = None
             raise
 
+    # ------------------------------------------------------------------
+    # Step-2 overflow-graph cache helpers — shared by the legacy
+    # ``run_analysis_step2`` below AND the model-aware production
+    # replacement in ``expert_backend/recommenders/_service_integration.py``.
+    # Kept as plain methods on the mixin so both code paths (and their
+    # unit tests) reuse the exact same signature + reuse-decision logic.
+    # ------------------------------------------------------------------
+
+    def _step2_graph_signature(
+        self,
+        selected_overloads,
+        all_overloads,
+        monitor_deselected,
+        additional_lines_to_cut,
+    ) -> tuple:
+        """Input signature gating the Step-2 overflow-graph cache.
+
+        When the operator re-runs the analysis against the same
+        contingency + the same Step-2 inputs (selected overloads,
+        monitor toggle, additional-lines picker), the OverFlowGraph and
+        the HTML viewer it produces are byte-for-byte identical — only
+        the recommender model (consumed by action discovery) may have
+        changed. A matching signature lets ``run_analysis_step2`` skip
+        ``_narrow_context_to_selected_overloads`` +
+        ``run_analysis_step2_graph`` + the PDF mtime poll, so swapping
+        only the model is near-instant.
+        """
+        return (
+            tuple(self._last_disconnected_elements or []),
+            tuple(sorted(selected_overloads or [])),
+            tuple(sorted(all_overloads or [])),
+            bool(monitor_deselected),
+            tuple(sorted(additional_lines_to_cut or [])),
+        )
+
+    def _can_reuse_step2_graph(self, signature: tuple) -> bool:
+        """True when the cached overflow graph still matches ``signature``.
+
+        Requires the previous run to have stored the same signature,
+        kept its enriched ``_last_step2_context``, and left the produced
+        hierarchical HTML on disk.
+        """
+        cached_pdf = self._overflow_layout_cache.get("hierarchical")
+        return (
+            getattr(self, "_last_step2_signature", None) == signature
+            and self._last_step2_context is not None
+            and cached_pdf is not None
+            and os.path.exists(cached_pdf)
+        )
+
     def run_analysis_step2(
         self,
         selected_overloads: list[str],
@@ -431,29 +481,14 @@ class AnalysisMixin:
         if not self._analysis_context:
             raise ValueError("Analysis context not found. Run step 1 first.")
 
-        # Signature for the overflow-graph fast path: when the operator
-        # re-runs the analysis against the same contingency + same Step-2
-        # inputs (selected overloads, monitor toggle, additional-lines
-        # picker), the OverFlowGraph object and the produced HTML viewer
-        # are byte-for-byte the same as the previous run. Skipping
-        # `_narrow_context_to_selected_overloads` + `run_analysis_step2_graph`
-        # + the PDF mtime poll lets a re-run with a different recommender
-        # model jump straight to action discovery. The discovery step is
-        # the only part that depends on the active model.
-        step2_signature = (
-            tuple(self._last_disconnected_elements or []),
-            tuple(sorted(selected_overloads or [])),
-            tuple(sorted(all_overloads or [])),
-            bool(monitor_deselected),
-            tuple(sorted(additional_lines_to_cut or [])),
+        # Overflow-graph fast path — see `_step2_graph_signature` /
+        # `_can_reuse_step2_graph`. The shared helpers are used by the
+        # model-aware production replacement too, so a re-run with only
+        # the recommender model changed skips the graph rebuild.
+        step2_signature = self._step2_graph_signature(
+            selected_overloads, all_overloads, monitor_deselected, additional_lines_to_cut,
         )
-        cached_pdf = self._overflow_layout_cache.get("hierarchical")
-        reuse_graph = (
-            getattr(self, "_last_step2_signature", None) == step2_signature
-            and self._last_step2_context is not None
-            and cached_pdf is not None
-            and os.path.exists(cached_pdf)
-        )
+        reuse_graph = self._can_reuse_step2_graph(step2_signature)
 
         try:
             if reuse_graph:
@@ -461,7 +496,7 @@ class AnalysisMixin:
                     "[Step 2] Reusing cached overflow graph (signature unchanged)"
                 )
                 context = self._last_step2_context
-                produced_pdf = cached_pdf
+                produced_pdf = self._overflow_layout_cache.get("hierarchical")
                 # Geo cache is keyed off the same hierarchical source; keep
                 # whatever the previous run produced so the toggle stays
                 # instant. `_overflow_layout_mode` is left untouched.

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -54,6 +54,20 @@ from expert_backend.services.sanitize import sanitize_for_json
 logger = logging.getLogger(__name__)
 
 
+class ActionResultUnavailableError(ValueError):
+    """The action is not in the backend's ``_last_result``.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` /
+    ``except Exception`` boundaries keep returning HTTP 400 unchanged.
+    The dedicated type lets the API layer recognise an *expected*
+    post-reload condition — the frontend silently falls back to
+    ``/api/simulate-and-variant-diagram`` — and log it quietly instead
+    of dumping a full ERROR-level traceback for what is normal
+    behaviour after a session reload (or for any manually-added action,
+    which is never in ``_last_result`` either).
+    """
+
+
 class DiagramMixin:
     """Mixin providing diagram generation and flow analysis methods."""
 
@@ -583,12 +597,27 @@ class DiagramMixin:
 
         t_start = time.time()
 
+        # When the action isn't in the backend's last result — after a
+        # session reload, or for any manually-added action — there is no
+        # cached observation to diff. Soft-fail with `patchable: false`
+        # (the contract the frontend already handles) instead of raising
+        # a 400: the frontend falls through to the full NAD and then to
+        # `/api/simulate-and-variant-diagram`. Soft-failing keeps this
+        # expected path off the backend error log entirely.
         if not self._last_result or not self._last_result.get("prioritized_actions"):
-            raise ValueError("No analysis result available. Run analysis first.")
+            return sanitize_for_json({
+                "patchable": False,
+                "reason": "no-analysis-result",
+                "action_id": action_id,
+            })
 
         actions = self._last_result["prioritized_actions"]
         if action_id not in actions:
-            raise ValueError(f"Action '{action_id}' not found in last analysis result.")
+            return sanitize_for_json({
+                "patchable": False,
+                "reason": "action-not-in-last-result",
+                "action_id": action_id,
+            })
 
         obs = actions[action_id]["observation"]
         variant_id = obs._variant_id
@@ -1010,12 +1039,21 @@ class DiagramMixin:
     # ------------------------------------------------------------------
 
     def _require_action(self, action_id: str) -> dict:
-        """Return the prioritized actions dict, or raise if the action is missing."""
+        """Return the prioritized actions dict, or raise if the action is missing.
+
+        Raises :class:`ActionResultUnavailableError` (a ``ValueError``
+        subclass) so the API layer can tell this *expected* post-reload
+        condition from a genuine fault — see the class docstring.
+        """
         if not self._last_result or not self._last_result.get("prioritized_actions"):
-            raise ValueError("No analysis result available. Run analysis first.")
+            raise ActionResultUnavailableError(
+                "No analysis result available. Run analysis first."
+            )
         actions = self._last_result["prioritized_actions"]
         if action_id not in actions:
-            raise ValueError(f"Action '{action_id}' not found in last analysis result.")
+            raise ActionResultUnavailableError(
+                f"Action '{action_id}' not found in last analysis result."
+            )
         return actions
 
     def _lf_status_for_variant(self, network, variant_id: str, disconnected_elements):

--- a/expert_backend/services/recommender_service.py
+++ b/expert_backend/services/recommender_service.py
@@ -108,6 +108,12 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         # `/api/regenerate-overflow-graph` can re-invoke graph generation
         # without redoing step1 setup or action discovery.
         self._last_step2_context = None
+        # Signature of the inputs that produced ``_last_step2_context`` +
+        # the cached overflow-graph HTML. When a re-run posts the same
+        # signature, ``run_analysis_step2`` skips the OverFlowGraph
+        # rebuild and jumps straight to action discovery — see the
+        # comment on the fast path in ``analysis_mixin.run_analysis_step2``.
+        self._last_step2_signature = None
 
     def reset(self):
         """Clear all cached analysis state. Called when loading a new study."""
@@ -152,6 +158,7 @@ class RecommenderService(DiagramMixin, AnalysisMixin, SimulationMixin):
         self._overflow_layout_mode = "hierarchical"
         self._overflow_layout_cache = {}
         self._last_step2_context = None
+        self._last_step2_signature = None
 
     # ------------------------------------------------------------------
     # Overflow-graph layout (Hierarchical / Geo)

--- a/expert_backend/tests/test_api_endpoints.py
+++ b/expert_backend/tests/test_api_endpoints.py
@@ -77,6 +77,64 @@ class TestGetNominalVoltages:
         assert data["unique_kv"] == [225.0, 400.0]
 
 
+class TestSetRecommenderModel:
+    """POST /api/recommender-model — lightweight model swap on the
+    running RecommenderService (no network reload, no action-dict
+    rebuild). The frontend fires this whenever the operator changes the
+    model dropdown (Settings modal OR the selector above Analyze &
+    Suggest), so the next /api/run-analysis-step2 uses the chosen
+    model.
+    """
+
+    def test_success_applies_model_and_echoes_active(self, client, mock_services):
+        _, mock_rs = mock_services
+        mock_rs.get_active_model_name.return_value = "random_overflow"
+        mock_rs.get_compute_overflow_graph.return_value = True
+
+        response = client.post(
+            "/api/recommender-model",
+            json={"model": "random_overflow", "compute_overflow_graph": True},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {
+            "status": "success",
+            "active_model": "random_overflow",
+            "compute_overflow_graph": True,
+        }
+        # The request object is threaded straight into _apply_model_settings.
+        mock_rs._apply_model_settings.assert_called_once()
+        applied = mock_rs._apply_model_settings.call_args[0][0]
+        assert applied.model == "random_overflow"
+        assert applied.compute_overflow_graph is True
+
+    def test_compute_overflow_graph_is_optional(self, client, mock_services):
+        # The pydantic model allows omitting compute_overflow_graph;
+        # _apply_model_settings then falls back to its own default.
+        _, mock_rs = mock_services
+        mock_rs.get_active_model_name.return_value = "random"
+        mock_rs.get_compute_overflow_graph.return_value = False
+
+        response = client.post("/api/recommender-model", json={"model": "random"})
+        assert response.status_code == 200
+        applied = mock_rs._apply_model_settings.call_args[0][0]
+        assert applied.model == "random"
+        assert applied.compute_overflow_graph is None
+
+    def test_missing_model_returns_422(self, client, mock_services):
+        # `model` is a required field on RecommenderModelRequest.
+        response = client.post("/api/recommender-model", json={})
+        assert response.status_code == 422
+
+    def test_error_returns_400(self, client, mock_services):
+        _, mock_rs = mock_services
+        mock_rs._apply_model_settings.side_effect = ValueError("bad model")
+
+        response = client.post("/api/recommender-model", json={"model": "expert"})
+        assert response.status_code == 400
+        assert "bad model" in response.json()["detail"]
+
+
 class TestGetElementVoltageLevels:
     def test_success(self, client, mock_services):
         mock_ns, _ = mock_services

--- a/expert_backend/tests/test_diagram_patch_helpers.py
+++ b/expert_backend/tests/test_diagram_patch_helpers.py
@@ -30,7 +30,11 @@ import pandas as pd
 import pytest
 from unittest.mock import MagicMock
 
-from expert_backend.services.diagram_mixin import DiagramMixin
+from expert_backend.services.diagram_mixin import (
+    ActionResultUnavailableError,
+    DiagramMixin,
+)
+from expert_backend.services.recommender_service import RecommenderService
 
 
 def _bus_snap(counts_by_vl: dict[str, int]) -> pd.DataFrame:
@@ -291,3 +295,50 @@ class TestPatchPayloadShape:
             "non_convergence": None,
         }
         assert field in payload
+
+
+class TestActionResultUnavailable:
+    """After a session reload (and for any manually-added action) the
+    backend has no cached observation for the action. The action-variant
+    *patch* endpoint must soft-fail with ``patchable: false`` — the
+    contract the frontend already handles — instead of raising a 400,
+    and ``_require_action`` must raise the dedicated
+    ``ActionResultUnavailableError`` so the API layer can log the
+    expected condition quietly. See
+    docs/features/save-results.md (post-reload action fallback)."""
+
+    @pytest.fixture
+    def service(self):
+        return RecommenderService()
+
+    def test_patch_soft_fails_when_no_analysis_result(self, service):
+        service._last_result = None
+        payload = service.get_action_variant_diagram_patch("disco_LINE_X")
+        assert payload["patchable"] is False
+        assert payload["reason"] == "no-analysis-result"
+        assert payload["action_id"] == "disco_LINE_X"
+
+    def test_patch_soft_fails_when_action_not_in_last_result(self, service):
+        # A result exists but this action id isn't one the recommender
+        # produced (e.g. a manually-added action).
+        service._last_result = {"prioritized_actions": {"some_other_action": {}}}
+        payload = service.get_action_variant_diagram_patch("manual_LINE_Y")
+        assert payload["patchable"] is False
+        assert payload["reason"] == "action-not-in-last-result"
+        assert payload["action_id"] == "manual_LINE_Y"
+
+    def test_require_action_raises_dedicated_error_when_no_result(self, service):
+        service._last_result = None
+        with pytest.raises(ActionResultUnavailableError, match="No analysis result"):
+            service._require_action("disco_LINE_X")
+
+    def test_require_action_raises_dedicated_error_when_action_missing(self, service):
+        service._last_result = {"prioritized_actions": {"known_action": {}}}
+        with pytest.raises(ActionResultUnavailableError, match="not found in last analysis result"):
+            service._require_action("unknown_action")
+
+    def test_dedicated_error_is_a_value_error(self):
+        # Subclassing ValueError keeps every existing `except ValueError`
+        # / `except Exception` boundary returning HTTP 400 unchanged —
+        # the dedicated type only adds a hook for quiet logging.
+        assert issubclass(ActionResultUnavailableError, ValueError)

--- a/expert_backend/tests/test_overload_filtering.py
+++ b/expert_backend/tests/test_overload_filtering.py
@@ -547,10 +547,20 @@ class TestStep2GraphCacheReuse:
 
     @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
     @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
-    def test_result_event_active_model_none_when_getter_absent(self, mock_discovery, mock_graph, service):
-        # A bare RecommenderService (no recommenders import side-effect)
-        # has no get_active_model_name — the result event must still be
-        # emitted with active_model=None rather than crashing.
+    def test_result_event_active_model_none_when_getter_absent(
+        self, mock_discovery, mock_graph, service, monkeypatch
+    ):
+        # The result-event builder guards `get_active_model_name` with
+        # `hasattr` so a RecommenderService without the
+        # ModelSelectionMixin (the getter is attached as a side-effect
+        # of importing `expert_backend.recommenders`) still emits the
+        # event with active_model=None rather than crashing. Drop the
+        # class attribute for the duration of this test so the guard is
+        # exercised regardless of whether another test in the same
+        # pytest process already triggered the recommenders import.
+        monkeypatch.delattr(
+            type(service), "get_active_model_name", raising=False
+        )
         mock_graph.side_effect = lambda ctx: ctx
         mock_discovery.return_value = {
             "prioritized_actions": {},

--- a/expert_backend/tests/test_overload_filtering.py
+++ b/expert_backend/tests/test_overload_filtering.py
@@ -582,3 +582,89 @@ class TestStep2GraphCacheReuse:
         service.reset()
         assert service._last_step2_signature is None
         assert service._last_step2_context is None
+
+
+class TestStep2GraphCacheHelpers:
+    """Unit coverage for the shared `_step2_graph_signature` /
+    `_can_reuse_step2_graph` helpers on AnalysisMixin. Both the legacy
+    `run_analysis_step2` and the model-aware production replacement in
+    `_service_integration` use these, so they're tested directly here
+    (the production wrapper itself needs the real recommenders package
+    and is covered in `tests/test_service_integration.py`)."""
+
+    @pytest.fixture
+    def service(self):
+        return RecommenderService()
+
+    def test_signature_is_deterministic_for_same_inputs(self, service):
+        service._last_disconnected_elements = ["LINE_C"]
+        sig_a = service._step2_graph_signature(["L1", "L2"], ["L1", "L2"], False, ["EXTRA"])
+        sig_b = service._step2_graph_signature(["L1", "L2"], ["L1", "L2"], False, ["EXTRA"])
+        assert sig_a == sig_b
+
+    def test_signature_is_order_independent_for_the_list_inputs(self, service):
+        # selected / all / additional are sorted into the signature, so
+        # the operator picking the same lines in a different order does
+        # NOT invalidate the cache.
+        service._last_disconnected_elements = ["LINE_C"]
+        sig_a = service._step2_graph_signature(["L1", "L2"], ["L2", "L1"], False, ["B", "A"])
+        sig_b = service._step2_graph_signature(["L2", "L1"], ["L1", "L2"], False, ["A", "B"])
+        assert sig_a == sig_b
+
+    def test_signature_differs_when_additional_lines_change(self, service):
+        # The whole point of the cache: only an `additional_lines_to_cut`
+        # change (or a contingency / overload-selection change) should
+        # force an overflow-graph rebuild.
+        service._last_disconnected_elements = ["LINE_C"]
+        base = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        with_extra = service._step2_graph_signature(["L1"], ["L1"], False, ["EXTRA"])
+        assert base != with_extra
+
+    def test_signature_differs_when_contingency_changes(self, service):
+        service._last_disconnected_elements = ["LINE_C"]
+        sig_c = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        service._last_disconnected_elements = ["LINE_D"]
+        sig_d = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        assert sig_c != sig_d
+
+    def test_can_reuse_when_signature_matches_and_pdf_on_disk(self, service, tmp_path):
+        pdf = tmp_path / "overflow.html"
+        pdf.write_text("<html></html>")
+        sig = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        service._last_step2_signature = sig
+        service._last_step2_context = {"enriched": True}
+        service._overflow_layout_cache = {"hierarchical": str(pdf)}
+        assert service._can_reuse_step2_graph(sig) is True
+
+    def test_cannot_reuse_when_signature_differs(self, service, tmp_path):
+        pdf = tmp_path / "overflow.html"
+        pdf.write_text("<html></html>")
+        service._last_step2_signature = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        service._last_step2_context = {"enriched": True}
+        service._overflow_layout_cache = {"hierarchical": str(pdf)}
+        other_sig = service._step2_graph_signature(["L1"], ["L1"], False, ["EXTRA"])
+        assert service._can_reuse_step2_graph(other_sig) is False
+
+    def test_cannot_reuse_when_context_missing(self, service, tmp_path):
+        pdf = tmp_path / "overflow.html"
+        pdf.write_text("<html></html>")
+        sig = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        service._last_step2_signature = sig
+        service._last_step2_context = None
+        service._overflow_layout_cache = {"hierarchical": str(pdf)}
+        assert service._can_reuse_step2_graph(sig) is False
+
+    def test_cannot_reuse_when_no_cached_pdf(self, service):
+        sig = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        service._last_step2_signature = sig
+        service._last_step2_context = {"enriched": True}
+        service._overflow_layout_cache = {}
+        assert service._can_reuse_step2_graph(sig) is False
+
+    def test_cannot_reuse_when_cached_pdf_no_longer_on_disk(self, service, tmp_path):
+        # The HTML viewer file may have been cleaned up between runs.
+        sig = service._step2_graph_signature(["L1"], ["L1"], False, [])
+        service._last_step2_signature = sig
+        service._last_step2_context = {"enriched": True}
+        service._overflow_layout_cache = {"hierarchical": str(tmp_path / "gone.html")}
+        assert service._can_reuse_step2_graph(sig) is False

--- a/expert_backend/tests/test_overload_filtering.py
+++ b/expert_backend/tests/test_overload_filtering.py
@@ -548,19 +548,33 @@ class TestStep2GraphCacheReuse:
     @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
     @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
     def test_result_event_active_model_none_when_getter_absent(
-        self, mock_discovery, mock_graph, service, monkeypatch
+        self, mock_discovery, mock_graph, service
     ):
-        # The result-event builder guards `get_active_model_name` with
-        # `hasattr` so a RecommenderService without the
-        # ModelSelectionMixin (the getter is attached as a side-effect
-        # of importing `expert_backend.recommenders`) still emits the
-        # event with active_model=None rather than crashing. Drop the
-        # class attribute for the duration of this test so the guard is
-        # exercised regardless of whether another test in the same
-        # pytest process already triggered the recommenders import.
-        monkeypatch.delattr(
-            type(service), "get_active_model_name", raising=False
-        )
+        # The legacy `AnalysisMixin.run_analysis_step2` result event
+        # guards `get_active_model_name` with `hasattr` so a bare
+        # RecommenderService (no ModelSelectionMixin) still emits the
+        # event with active_model=None instead of crashing.
+        #
+        # This scenario only applies to the LEGACY generator. In
+        # production `expert_backend.recommenders` is imported, which
+        # BOTH attaches `get_active_model_name` AND replaces
+        # `run_analysis_step2` with `_run_analysis_step2_with_model`
+        # (which calls the getter unconditionally — no guard, none
+        # needed). Skip unless the legacy method is the active one and
+        # the getter is genuinely absent, i.e. the recommenders package
+        # was never imported in this pytest process (the mock-layer
+        # sandbox). Checked at call time — collection order can't be
+        # relied on.
+        if type(service).run_analysis_step2.__name__ != "run_analysis_step2":
+            pytest.skip(
+                "legacy AnalysisMixin.run_analysis_step2 is shadowed by the "
+                "production model-aware replacement"
+            )
+        if hasattr(type(service), "get_active_model_name"):
+            pytest.skip(
+                "get_active_model_name was attached by a recommenders import "
+                "earlier in this process — the 'getter absent' path can't be staged"
+            )
         mock_graph.side_effect = lambda ctx: ctx
         mock_discovery.return_value = {
             "prioritized_actions": {},

--- a/expert_backend/tests/test_overload_filtering.py
+++ b/expert_backend/tests/test_overload_filtering.py
@@ -429,6 +429,146 @@ class TestOverloadFiltering:
             all_overloads=["L1", "L2"],
             monitor_deselected=True
         ))
-        
+
         result_event = next(e for e in events if e.get("type") == "result")
         assert result_event["lines_we_care_about"] == ["L1", "L2"]
+
+
+class TestStep2GraphCacheReuse:
+    """Step-2 caches the overflow graph keyed by an input signature
+    (contingency + selected/all overloads + monitor toggle +
+    additional_lines_to_cut). A re-run with an identical signature
+    skips ``run_analysis_step2_graph`` and reuses the cached graph +
+    the enriched context, jumping straight to action discovery — so
+    swapping only the recommender model is near-instant. A changed
+    signature (e.g. different additional_lines_to_cut) rebuilds.
+    """
+
+    @pytest.fixture
+    def service(self):
+        return RecommenderService()
+
+    def _seed_context(self, service):
+        # Mimics what run_analysis_step1 leaves on the service.
+        service._last_disconnected_elements = ["LINE_C"]
+        service._analysis_context = {
+            "env": MagicMock(),
+            "lines_overloaded_names": ["L1", "L2"],
+            "lines_overloaded_ids": [0, 1],
+            "lines_overloaded_ids_kept": [0, 1],
+            "lines_we_care_about": {"L1", "L2"},
+        }
+
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
+    def test_identical_signature_skips_graph_rebuild(self, mock_discovery, mock_graph, service, tmp_path):
+        pdf = tmp_path / "overflow.html"
+        pdf.write_text("<html></html>")
+        mock_graph.side_effect = lambda ctx: ctx
+        mock_discovery.return_value = {
+            "prioritized_actions": {},
+            "action_scores": {},
+            "lines_overloaded_names": ["L1"],
+        }
+        service._get_latest_pdf_path = MagicMock(return_value=str(pdf))
+
+        # First run — builds the graph and seeds the cache.
+        self._seed_context(service)
+        list(service.run_analysis_step2(
+            selected_overloads=["L1"], all_overloads=["L1", "L2"],
+            monitor_deselected=False, additional_lines_to_cut=["EXTRA"],
+        ))
+        assert mock_graph.call_count == 1
+        assert mock_discovery.call_count == 1
+        assert service._last_step2_context is not None
+        assert service._last_step2_signature is not None
+        assert service._overflow_layout_cache.get("hierarchical") == str(pdf)
+
+        # Second run, identical signature — the graph rebuild is skipped
+        # but discovery still runs (it's where the recommender model is
+        # consumed, so a model swap re-runs only this step).
+        events = list(service.run_analysis_step2(
+            selected_overloads=["L1"], all_overloads=["L1", "L2"],
+            monitor_deselected=False, additional_lines_to_cut=["EXTRA"],
+        ))
+        assert mock_graph.call_count == 1   # NOT rebuilt
+        assert mock_discovery.call_count == 2  # discovery re-ran
+        pdf_event = next(e for e in events if e.get("type") == "pdf")
+        assert pdf_event["pdf_path"] == str(pdf)
+        assert pdf_event.get("cached") is True
+
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
+    def test_changed_additional_lines_rebuilds_graph(self, mock_discovery, mock_graph, service, tmp_path):
+        pdf = tmp_path / "overflow.html"
+        pdf.write_text("<html></html>")
+        mock_graph.side_effect = lambda ctx: ctx
+        mock_discovery.return_value = {
+            "prioritized_actions": {},
+            "action_scores": {},
+            "lines_overloaded_names": ["L1"],
+        }
+        service._get_latest_pdf_path = MagicMock(return_value=str(pdf))
+
+        self._seed_context(service)
+        list(service.run_analysis_step2(
+            selected_overloads=["L1"], all_overloads=["L1", "L2"],
+            monitor_deselected=False, additional_lines_to_cut=["EXTRA"],
+        ))
+        assert mock_graph.call_count == 1
+
+        # Re-seed (step1 re-runs in the real flow) and change the
+        # additional-lines hypothesis → signature differs → rebuild.
+        self._seed_context(service)
+        list(service.run_analysis_step2(
+            selected_overloads=["L1"], all_overloads=["L1", "L2"],
+            monitor_deselected=False, additional_lines_to_cut=["OTHER"],
+        ))
+        assert mock_graph.call_count == 2  # rebuilt for the new signature
+
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
+    def test_result_event_carries_active_model(self, mock_discovery, mock_graph, service):
+        mock_graph.side_effect = lambda ctx: ctx
+        mock_discovery.return_value = {
+            "prioritized_actions": {},
+            "action_scores": {},
+            "lines_overloaded_names": ["L1"],
+        }
+        # ModelSelectionMixin getters are attached via the
+        # expert_backend.recommenders import side-effect — stub the
+        # getter directly so the result event echoes the active model.
+        service.get_active_model_name = MagicMock(return_value="random_overflow")
+        self._seed_context(service)
+
+        events = list(service.run_analysis_step2(selected_overloads=["L1"], all_overloads=["L1"]))
+        result_event = next(e for e in events if e.get("type") == "result")
+        assert result_event["active_model"] == "random_overflow"
+
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
+    def test_result_event_active_model_none_when_getter_absent(self, mock_discovery, mock_graph, service):
+        # A bare RecommenderService (no recommenders import side-effect)
+        # has no get_active_model_name — the result event must still be
+        # emitted with active_model=None rather than crashing.
+        mock_graph.side_effect = lambda ctx: ctx
+        mock_discovery.return_value = {
+            "prioritized_actions": {},
+            "action_scores": {},
+            "lines_overloaded_names": ["L1"],
+        }
+        self._seed_context(service)
+
+        events = list(service.run_analysis_step2(selected_overloads=["L1"], all_overloads=["L1"]))
+        result_event = next(e for e in events if e.get("type") == "result")
+        assert result_event["active_model"] is None
+
+    def test_reset_clears_step2_signature(self, service):
+        # The signature is a per-study cache — reset() MUST clear it so
+        # a freshly loaded study never reuses the previous study's
+        # overflow graph.
+        service._last_step2_signature = ("LINE_C", ("L1",), ("L1",), False, ())
+        service._last_step2_context = {"foo": "bar"}
+        service.reset()
+        assert service._last_step2_signature is None
+        assert service._last_step2_context is None

--- a/frontend/src/App.actionOrigin.test.tsx
+++ b/frontend/src/App.actionOrigin.test.tsx
@@ -1,0 +1,232 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import App from './App';
+
+// End-to-end coverage for action-card provenance ("origin"). Unlike the
+// other App.*.test.tsx files, this one does NOT mock ActionFeed — it
+// renders the real ActionFeed + ActionCard so the "Source" row in the
+// unfolded card can be asserted. The whole wiring chain is exercised:
+// useAnalysis / useActions stamp `origin` → App's `result` → ActionFeed
+// `actions` + `availableModels` props → ActionCard "Source" row.
+
+// ===== Mocks (everything EXCEPT ActionFeed) =====
+
+vi.mock('./components/VisualizationPanel', () => ({
+  default: (props: { activeTab: string }) => (
+    <div data-testid="visualization-panel" data-active-tab={props.activeTab} />
+  ),
+}));
+
+vi.mock('./components/OverloadPanel', () => ({
+  default: () => <div data-testid="overload-panel" />,
+}));
+
+vi.mock('./hooks/usePanZoom', () => ({
+  usePanZoom: () => ({ viewBox: null, setViewBox: vi.fn() }),
+}));
+
+vi.mock('./utils/svgUtils', () => ({
+  processSvg: (svg: string) => ({ svg, viewBox: { x: 0, y: 0, w: 100, h: 100 } }),
+  buildMetadataIndex: () => null,
+  applyOverloadedHighlights: vi.fn(),
+  applyDeltaVisuals: vi.fn(),
+  applyActionTargetHighlights: vi.fn(),
+  applyContingencyHighlight: vi.fn(),
+  getIdMap: () => new Map(),
+  invalidateIdMapCache: vi.fn(),
+  isCouplingAction: vi.fn(() => false),
+  applyVlTitles: vi.fn(),
+  // ActionFeed filters its card list through this — always pass so the
+  // origin assertions aren't masked by the severity/threshold gate.
+  actionPassesOverviewFilter: vi.fn(() => true),
+  getActionTargetVoltageLevels: vi.fn(() => []),
+  getActionTargetLines: vi.fn(() => []),
+}));
+
+const mockApi = vi.hoisted(() => ({
+  updateConfig: vi.fn().mockResolvedValue({ monitored_lines_count: 10, total_lines_count: 10 }),
+  getBranches: vi.fn().mockResolvedValue({ branches: ['BRANCH_A', 'BRANCH_B'], name_map: {} }),
+  getVoltageLevels: vi.fn().mockResolvedValue({ voltage_levels: ['VL1', 'VL2'], name_map: {} }),
+  getNominalVoltages: vi.fn().mockResolvedValue({ mapping: {}, unique_kv: [63, 225] }),
+  getVoltageLevelSubstations: vi.fn().mockResolvedValue({ mapping: {} }),
+  getNetworkDiagram: vi.fn().mockResolvedValue({ svg: '<svg></svg>', metadata: null }),
+  getContingencyDiagram: vi.fn().mockResolvedValue({ svg: '<svg></svg>', metadata: null, lines_overloaded: [] }),
+  getActionVariantDiagram: vi.fn().mockResolvedValue({ svg: '<svg></svg>', metadata: null }),
+  runAnalysisStep1: vi.fn().mockResolvedValue({ can_proceed: true, lines_overloaded: ['LINE_OL1'] }),
+  runAnalysisStep2Stream: vi.fn(),
+  simulateAndVariantDiagramStream: vi.fn(),
+  getAvailableActions: vi.fn().mockResolvedValue([]),
+  getModels: vi.fn().mockResolvedValue({
+    models: [
+      { name: 'expert', label: 'Expert system', requires_overflow_graph: true, is_default: true, params: [] },
+    ],
+  }),
+  setRecommenderModel: vi.fn().mockResolvedValue({ status: 'success', active_model: 'expert', compute_overflow_graph: true }),
+  pickPath: vi.fn(),
+  getUserConfig: vi.fn().mockResolvedValue({
+    network_path: '/home/user/data/grid.xiidm',
+    action_file_path: '/home/user/data/actions.json',
+  }),
+  getConfigFilePath: vi.fn().mockResolvedValue('/home/user/data/config.json'),
+  saveUserConfig: vi.fn().mockResolvedValue({}),
+  setConfigFilePath: vi.fn().mockResolvedValue({ config_file_path: '/home/user/data/config.json', config: {} }),
+}));
+
+vi.mock('./api', () => ({ api: mockApi }));
+
+// ===== Helpers =====
+
+/** Build a one-shot ReadableStream from a list of NDJSON event objects. */
+function ndjsonStream(events: object[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const e of events) controller.enqueue(encoder.encode(JSON.stringify(e) + '\n'));
+      controller.close();
+    },
+  });
+}
+
+async function renderAndLoadStudy() {
+  render(<App />);
+  await userEvent.click(screen.getByText('🔄 Load Study'));
+  await waitFor(() => {
+    expect(screen.getByText('🎯 Select Contingency')).toBeInTheDocument();
+  }, { timeout: 5000 });
+}
+
+async function selectBranch(branchName: string) {
+  // Two comboboxes exist now that the real ActionFeed renders: the
+  // contingency react-select (an <input role="combobox">) and the
+  // recommendation-model <select> above Analyze & Suggest. Target the
+  // react-select input.
+  const comboboxes = screen.getAllByRole('combobox');
+  const combobox = comboboxes.find(el => el.tagName === 'INPUT') ?? comboboxes[0];
+  await act(async () => {
+    await userEvent.click(combobox);
+    await userEvent.type(combobox, branchName);
+    await userEvent.keyboard('{Enter}');
+  });
+  const trigger = await screen.findByRole('button', { name: /Trigger/ });
+  await act(async () => { await userEvent.click(trigger); });
+  await waitFor(() => {
+    expect(mockApi.getContingencyDiagram).toHaveBeenCalledWith([branchName]);
+  });
+}
+
+describe('App — action-card origin (provenance) end-to-end', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.unstubAllGlobals();
+    // Restore default resolved values cleared by clearAllMocks.
+    mockApi.updateConfig.mockResolvedValue({ monitored_lines_count: 10, total_lines_count: 10 });
+    mockApi.getBranches.mockResolvedValue({ branches: ['BRANCH_A', 'BRANCH_B'], name_map: {} });
+    mockApi.getVoltageLevels.mockResolvedValue({ voltage_levels: ['VL1', 'VL2'], name_map: {} });
+    mockApi.getNominalVoltages.mockResolvedValue({ mapping: {}, unique_kv: [63, 225] });
+    mockApi.getVoltageLevelSubstations.mockResolvedValue({ mapping: {} });
+    mockApi.getNetworkDiagram.mockResolvedValue({ svg: '<svg></svg>', metadata: null });
+    mockApi.getContingencyDiagram.mockResolvedValue({ svg: '<svg></svg>', metadata: null, lines_overloaded: [] });
+    mockApi.getActionVariantDiagram.mockResolvedValue({ svg: '<svg></svg>', metadata: null });
+    mockApi.runAnalysisStep1.mockResolvedValue({ can_proceed: true, lines_overloaded: ['LINE_OL1'] });
+    mockApi.getAvailableActions.mockResolvedValue([]);
+    mockApi.getModels.mockResolvedValue({
+      models: [
+        { name: 'expert', label: 'Expert system', requires_overflow_graph: true, is_default: true, params: [] },
+      ],
+    });
+    mockApi.getUserConfig.mockResolvedValue({
+      network_path: '/home/user/data/grid.xiidm',
+      action_file_path: '/home/user/data/actions.json',
+    });
+    mockApi.getConfigFilePath.mockResolvedValue('/home/user/data/config.json');
+    mockApi.setConfigFilePath.mockResolvedValue({ config_file_path: '/home/user/data/config.json', config: {} });
+  });
+  afterEach(() => cleanup());
+
+  it('stamps a recommender-produced action with the model origin and shows it in the unfolded card', async () => {
+    await renderAndLoadStudy();
+    await selectBranch('BRANCH_A');
+
+    // Step-2 stream: a single recommender action + the active_model echo.
+    mockApi.runAnalysisStep2Stream.mockResolvedValue({
+      ok: true,
+      body: ndjsonStream([
+        {
+          type: 'result',
+          actions: {
+            ACT_RECO: {
+              description_unitaire: 'Disconnect LINE_X',
+              rho_before: [1.05], rho_after: [0.85],
+              max_rho: 0.85, max_rho_line: 'LINE_OL1', is_rho_reduction: true,
+            },
+          },
+          active_model: 'expert',
+          lines_overloaded: ['LINE_OL1'],
+          message: 'done', dc_fallback: false,
+        },
+      ]),
+    });
+
+    await act(async () => { await userEvent.click(screen.getByText('🔍 Analyze & Suggest')); });
+    const displayBtn = await screen.findByText(/Display.*prioritized actions/, {}, { timeout: 3000 });
+    await act(async () => { await userEvent.click(displayBtn); });
+
+    // The recommender action card is now in the Suggested feed. Click it
+    // to unfold the progressive-disclosure section.
+    const card = await screen.findByTestId('action-card-ACT_RECO');
+    await act(async () => { await userEvent.click(card); });
+
+    // The "Source" row resolves the `active_model` id ("expert") to its
+    // human label via availableModels (GET /api/models).
+    const originRow = await screen.findByTestId('action-card-ACT_RECO-origin');
+    expect(originRow).toHaveTextContent('Source: Expert system');
+  });
+
+  it('stamps a manually-simulated action with origin "user" and shows it in the unfolded card', async () => {
+    await renderAndLoadStudy();
+    await selectBranch('BRANCH_A');
+
+    // The manual-simulation flow at the App level goes through the
+    // streaming primer (onActionDiagramPrimed is wired), so mock
+    // simulateAndVariantDiagramStream with a metrics + diagram event.
+    mockApi.simulateAndVariantDiagramStream.mockResolvedValue({
+      body: ndjsonStream([
+        {
+          type: 'metrics',
+          description_unitaire: 'Manually chosen action',
+          rho_before: [1.1], rho_after: [0.9],
+          max_rho: 0.9, max_rho_line: 'LINE_OL1', is_rho_reduction: true,
+          is_islanded: false, n_components: 1, disconnected_mw: 0,
+          non_convergence: null, lines_overloaded: ['LINE_OL1'],
+          lines_overloaded_after: [], load_shedding_details: [],
+          curtailment_details: [], pst_details: [],
+          action_topology: { lines_ex_bus: {}, lines_or_bus: {}, gens_bus: {}, loads_bus: {} },
+          is_estimated: false,
+        },
+        { type: 'diagram', svg: '<svg></svg>', metadata: null },
+      ]),
+    });
+
+    // Open the manual-selection search and simulate a free-text action id.
+    await act(async () => { await userEvent.click(screen.getByText('+ Manual Selection')); });
+    const search = await screen.findByPlaceholderText(/Search action/);
+    await act(async () => { await userEvent.type(search, 'my_manual_action'); });
+    await act(async () => { await userEvent.click(screen.getByText(/Simulate manual ID/)); });
+
+    // handleManualActionAdded auto-selects the new action, so its card
+    // is already unfolded — the "Source" row reads the literal "user".
+    const originRow = await screen.findByTestId('action-card-my_manual_action-origin', {}, { timeout: 3000 });
+    expect(originRow).toHaveTextContent('Source: Manual simulation (user)');
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -661,19 +661,17 @@ function App() {
   );
 
   // Wipe recommender-produced suggestions the operator has NOT
-  // interacted with, then re-trigger the analysis. Keeps starred
-  // (selectedActionIds), rejected (rejectedActionIds) and
-  // manually-added (manuallyAddedIds / is_manual) entries intact so
-  // the user can re-run with a different model without losing their
-  // decisions. Tracking ``suggestedByRecommenderIds`` (the
-  // source-of-truth set populated during the step-2 stream) keeps us
-  // from accidentally dropping manual-only entries that happen to
-  // share an id with a previous recommender suggestion. The clear
-  // happens first via state updaters (so the in-flight step-2 reset
-  // sees the trimmed result), then the analysis is launched — both
-  // bookended in the same gesture because the button is labelled
-  // "Clear & rerun".
-  const handleClearSuggested = useCallback(() => {
+  // interacted with. Keeps starred (selectedActionIds), rejected
+  // (rejectedActionIds) and manually-added (manuallyAddedIds /
+  // is_manual) entries intact so the user can re-run with a
+  // different model without losing their decisions. Tracking
+  // ``suggestedByRecommenderIds`` (the source-of-truth set populated
+  // during the step-2 stream) keeps us from accidentally dropping
+  // manual-only entries that happen to share an id with a previous
+  // recommender suggestion. This does NOT re-run the analysis — the
+  // operator clears, optionally swaps the model, then presses
+  // Analyze & Suggest themselves.
+  const performClearSuggested = useCallback(() => {
     interactionLogger.record('suggested_actions_cleared', {
       n_cleared: Array.from(suggestedByRecommenderIds).filter(id =>
         !selectedActionIds.has(id) && !rejectedActionIds.has(id) && !manuallyAddedIds.has(id)
@@ -697,12 +695,14 @@ function App() {
       return next;
     });
     analysis.setPendingAnalysisResult(null);
-    // Kick off the re-analysis in the same gesture. resetForAnalysisRun
-    // (called inside handleRunAnalysis) re-filters result.actions on
-    // top of the just-applied clear via prev=>updater, so the kept
-    // user-touched entries survive both passes.
-    wrappedRunAnalysis();
-  }, [setResult, actionsHook, analysis, selectedActionIds, rejectedActionIds, manuallyAddedIds, suggestedByRecommenderIds, wrappedRunAnalysis]);
+  }, [setResult, actionsHook, analysis, selectedActionIds, rejectedActionIds, manuallyAddedIds, suggestedByRecommenderIds]);
+
+  // The Clear button opens a confirmation dialog first (reusing the
+  // shared <ConfirmationDialog/> template) so the operator sees
+  // exactly what is removed and what is kept before committing.
+  const requestClearSuggested = useCallback(() => {
+    setConfirmDialog({ type: 'clearSuggested' });
+  }, []);
 
   const wrappedDisplayPrioritized = useCallback(
     () => analysis.handleDisplayPrioritizedActions(selectedActionIds, diagrams.setActiveTab),
@@ -1039,6 +1039,15 @@ function App() {
 
   const handleConfirmDialog = useCallback(() => {
     if (!confirmDialog) return;
+    // `clearSuggested` is not a study-reset gesture — it keeps the
+    // network, the contingency, and the operator's decisions. It logs
+    // its own `suggested_actions_cleared` event inside
+    // `performClearSuggested`, so skip the `contingency_confirmed` log.
+    if (confirmDialog.type === 'clearSuggested') {
+      performClearSuggested();
+      setConfirmDialog(null);
+      return;
+    }
     interactionLogger.record('contingency_confirmed', { type: confirmDialog.type, pending_branch: confirmDialog.pendingBranch });
     if (confirmDialog.type === 'contingency') {
       clearContingencyState();
@@ -1058,7 +1067,7 @@ function App() {
       handleLoadConfig();
     }
     setConfirmDialog(null);
-  }, [confirmDialog, clearContingencyState, handleLoadConfig, applySettingsImmediate]);
+  }, [confirmDialog, clearContingencyState, handleLoadConfig, applySettingsImmediate, performClearSuggested]);
 
 
   // ===== App-Level Effects =====
@@ -1505,7 +1514,7 @@ function App() {
                 ? (availableModels?.find(m => m.name === result.active_model)?.label || result.active_model)
                 : null
             }
-            onClearSuggested={handleClearSuggested}
+            onClearSuggested={requestClearSuggested}
           />
         </AppSidebar>
         <div style={{ flex: 1, background: 'white', display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -510,8 +510,8 @@ function App() {
   // carries fresh `load_shedding_details` / `curtailment_details` /
   // `pst_details` arrays which the SLD highlight pass needs to see.
   const wrappedManualActionAdded = useCallback(
-    (actionId: string, detail: ActionDetail, linesOverloaded: string[]) => {
-      actionsHook.handleManualActionAdded(actionId, detail, linesOverloaded, setResult, wrappedForcedActionSelect);
+    (actionId: string, detail: ActionDetail, linesOverloaded: string[], origin: string = 'user') => {
+      actionsHook.handleManualActionAdded(actionId, detail, linesOverloaded, setResult, wrappedForcedActionSelect, origin);
       diagrams.refreshSldIfAction(actionId);
     },
     [actionsHook, setResult, wrappedForcedActionSelect, diagrams]
@@ -606,14 +606,20 @@ function App() {
           curtailment_details: metrics.curtailment_details,
           pst_details: metrics.pst_details,
         };
-        wrappedManualActionAdded(actionId, detail, metrics.lines_overloaded || []);
+        // An unsimulated pin is a scored-but-not-yet-materialised
+        // action from the recommender's score table — the operator
+        // only triggered its simulation, so its provenance is the
+        // model that scored it, NOT "user".
+        wrappedManualActionAdded(
+          actionId, detail, metrics.lines_overloaded || [], result?.active_model || 'expert',
+        );
       } catch (e: unknown) {
         console.error('Unsimulated pin simulation failed:', e);
         const err = e as { response?: { data?: { detail?: string } } };
         setError(err?.response?.data?.detail || 'Simulation failed');
       }
     },
-    [selectedContingency, result?.lines_overloaded, diagrams, voltageLevels.length, wrappedManualActionAdded]
+    [selectedContingency, result?.lines_overloaded, result?.active_model, diagrams, voltageLevels.length, wrappedManualActionAdded]
   );
 
   // Re-simulation of an already-present action (edit Target MW / tap on a

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -333,15 +333,31 @@ function App() {
   // to the is_manual subset (with pdf / lines_overloaded cleared so
   // the UI correctly shows the "analysis in progress" state).
   const resetForAnalysisRun = useCallback(() => {
+    // Keep entries the operator has invested in across a re-run:
+    //   - manually-added "first guess" actions (`is_manual=true`),
+    //   - starred recommender suggestions (handleActionFavorite stamps
+    //     `is_manual=true` on those too — but the `selectedActionIds`
+    //     trim below also has to keep them for the post-step2 merge
+    //     to recognise them as Selected),
+    //   - rejected recommender suggestions (so the operator's veto
+    //     survives the re-run — the new step2 may re-emit the id but
+    //     the rejected-id set still rules).
+    // Wipe pdf / lines_overloaded so the UI renders the
+    // "analysis in progress" state.
     analysis.setResult(prev => {
       if (!prev) return null;
-      const manuals: Record<string, import('./types').ActionDetail> = {};
+      const kept: Record<string, import('./types').ActionDetail> = {};
       for (const [id, data] of Object.entries(prev.actions || {})) {
-        if (data.is_manual) manuals[id] = data;
+        const userTouched =
+          data.is_manual
+          || actionsHook.selectedActionIds.has(id)
+          || actionsHook.rejectedActionIds.has(id)
+          || actionsHook.manuallyAddedIds.has(id);
+        if (userTouched) kept[id] = data;
       }
       return {
         ...prev,
-        actions: manuals,
+        actions: kept,
         lines_overloaded: [],
         pdf_url: null,
         pdf_path: null,
@@ -349,22 +365,18 @@ function App() {
     });
     analysis.setPendingAnalysisResult(null);
     analysis.setMonitorDeselected(false);
-    // Keep manuallyAddedIds intact and trim selectedActionIds down
-    // to the manually-added subset — that way any favorited
-    // recommender suggestions are dropped (the new run will
-    // re-emit them) while the user's own "first guess" stays put.
-    actionsHook.setSelectedActionIds(prev => {
-      const manuallyAdded = actionsHook.manuallyAddedIds;
-      const next = new Set<string>();
-      for (const id of prev) if (manuallyAdded.has(id)) next.add(id);
-      return next;
-    });
-    actionsHook.setRejectedActionIds(new Set());
+    // Preserve the full starred / rejected sets — only the
+    // recommender-only suggestions set is wiped (step2 rebuilds it).
     actionsHook.setSuggestedByRecommenderIds(new Set());
-    // Don't wipe selectedActionId if it points to a manual action —
-    // keep the user's variant diagram around through the re-run.
+    // Don't wipe selectedActionId if it points to an action the
+    // operator has invested in — keeps the variant diagram mounted
+    // through the re-run.
     const sel = diagrams.selectedActionId;
-    if (sel && !actionsHook.manuallyAddedIds.has(sel)) {
+    if (
+      sel
+      && !actionsHook.manuallyAddedIds.has(sel)
+      && !actionsHook.selectedActionIds.has(sel)
+    ) {
       diagrams.setSelectedActionId(null);
       diagrams.setActionDiagram(null);
     }
@@ -649,13 +661,18 @@ function App() {
   );
 
   // Wipe recommender-produced suggestions the operator has NOT
-  // interacted with — keeps starred (selectedActionIds), rejected
-  // (rejectedActionIds) and manually-added (manuallyAddedIds /
-  // is_manual) entries intact so the user can re-run with a
-  // different model without losing their decisions. Tracking
-  // ``suggestedByRecommenderIds`` (the source-of-truth set populated
-  // during the step-2 stream) keeps us from accidentally dropping
-  // manual-only entries that happen to share an id.
+  // interacted with, then re-trigger the analysis. Keeps starred
+  // (selectedActionIds), rejected (rejectedActionIds) and
+  // manually-added (manuallyAddedIds / is_manual) entries intact so
+  // the user can re-run with a different model without losing their
+  // decisions. Tracking ``suggestedByRecommenderIds`` (the
+  // source-of-truth set populated during the step-2 stream) keeps us
+  // from accidentally dropping manual-only entries that happen to
+  // share an id with a previous recommender suggestion. The clear
+  // happens first via state updaters (so the in-flight step-2 reset
+  // sees the trimmed result), then the analysis is launched — both
+  // bookended in the same gesture because the button is labelled
+  // "Clear & rerun".
   const handleClearSuggested = useCallback(() => {
     interactionLogger.record('suggested_actions_cleared', {
       n_cleared: Array.from(suggestedByRecommenderIds).filter(id =>
@@ -680,7 +697,12 @@ function App() {
       return next;
     });
     analysis.setPendingAnalysisResult(null);
-  }, [setResult, actionsHook, analysis, selectedActionIds, rejectedActionIds, manuallyAddedIds, suggestedByRecommenderIds]);
+    // Kick off the re-analysis in the same gesture. resetForAnalysisRun
+    // (called inside handleRunAnalysis) re-filters result.actions on
+    // top of the just-applied clear via prev=>updater, so the kept
+    // user-touched entries survive both passes.
+    wrappedRunAnalysis();
+  }, [setResult, actionsHook, analysis, selectedActionIds, rejectedActionIds, manuallyAddedIds, suggestedByRecommenderIds, wrappedRunAnalysis]);
 
   const wrappedDisplayPrioritized = useCallback(
     () => analysis.handleDisplayPrioritizedActions(selectedActionIds, diagrams.setActiveTab),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,6 +64,7 @@ function App() {
     setIsSettingsOpen, setSettingsTab,
     pickSettingsPath,
     handleOpenSettings,
+    recommenderModel, setRecommenderModel, availableModels,
     buildConfigRequest, configRequestFromUserConfig, applyConfigResponse, createCurrentBackup, setSettingsBackup
   } = settings;
 
@@ -646,6 +647,40 @@ function App() {
     () => analysis.handleRunAnalysis(selectedContingency, resetForAnalysisRun, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab),
     [analysis, selectedContingency, resetForAnalysisRun, actionsHook.setSuggestedByRecommenderIds, diagrams.setActiveTab]
   );
+
+  // Wipe recommender-produced suggestions the operator has NOT
+  // interacted with — keeps starred (selectedActionIds), rejected
+  // (rejectedActionIds) and manually-added (manuallyAddedIds /
+  // is_manual) entries intact so the user can re-run with a
+  // different model without losing their decisions. Tracking
+  // ``suggestedByRecommenderIds`` (the source-of-truth set populated
+  // during the step-2 stream) keeps us from accidentally dropping
+  // manual-only entries that happen to share an id.
+  const handleClearSuggested = useCallback(() => {
+    interactionLogger.record('suggested_actions_cleared', {
+      n_cleared: Array.from(suggestedByRecommenderIds).filter(id =>
+        !selectedActionIds.has(id) && !rejectedActionIds.has(id) && !manuallyAddedIds.has(id)
+      ).length,
+    });
+    setResult(prev => {
+      if (!prev?.actions) return prev;
+      const filtered: Record<string, import('./types').ActionDetail> = {};
+      for (const [id, data] of Object.entries(prev.actions)) {
+        const userTouched = selectedActionIds.has(id) || rejectedActionIds.has(id) || manuallyAddedIds.has(id) || data.is_manual;
+        const isSuggested = suggestedByRecommenderIds.has(id);
+        if (userTouched || !isSuggested) filtered[id] = data;
+      }
+      return { ...prev, actions: filtered, active_model: undefined };
+    });
+    actionsHook.setSuggestedByRecommenderIds(prev => {
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (selectedActionIds.has(id) || rejectedActionIds.has(id) || manuallyAddedIds.has(id)) next.add(id);
+      }
+      return next;
+    });
+    analysis.setPendingAnalysisResult(null);
+  }, [setResult, actionsHook, analysis, selectedActionIds, rejectedActionIds, manuallyAddedIds, suggestedByRecommenderIds]);
 
   const wrappedDisplayPrioritized = useCallback(
     () => analysis.handleDisplayPrioritizedActions(selectedActionIds, diagrams.setActiveTab),
@@ -1440,6 +1475,15 @@ function App() {
             additionalLinesToCut={additionalLinesToCut}
             onToggleAdditionalLineToCut={analysis.handleToggleAdditionalLineToCut}
             n1Overloads={n1Diagram?.lines_overloaded || []}
+            recommenderModel={recommenderModel}
+            setRecommenderModel={setRecommenderModel}
+            availableModels={availableModels}
+            activeModelLabel={
+              result?.active_model
+                ? (availableModels?.find(m => m.name === result.active_model)?.label || result.active_model)
+                : null
+            }
+            onClearSuggested={handleClearSuggested}
           />
         </AppSidebar>
         <div style={{ flex: 1, background: 'white', display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -81,6 +81,28 @@ describe('api client', () => {
         });
     });
 
+    describe('setRecommenderModel', () => {
+        it('POSTs the model + compute_overflow_graph to /api/recommender-model', async () => {
+            // Lightweight model swap — does NOT reload the network. Used
+            // by useSettings whenever the operator changes the model in
+            // the Settings modal OR the dropdown above Analyze & Suggest.
+            mockedAxios.post.mockResolvedValue({
+                data: { status: 'success', active_model: 'random_overflow', compute_overflow_graph: true },
+            });
+
+            const result = await api.setRecommenderModel('random_overflow', true);
+            expect(mockedAxios.post).toHaveBeenCalledWith(
+                'http://127.0.0.1:8000/api/recommender-model',
+                { model: 'random_overflow', compute_overflow_graph: true },
+            );
+            expect(result).toEqual({
+                status: 'success',
+                active_model: 'random_overflow',
+                compute_overflow_graph: true,
+            });
+        });
+    });
+
     describe('getNetworkDiagram', () => {
         it('parses the text/plain header+SVG response', async () => {
             // Server now returns:  {json header}\n<svg>...</svg>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -274,6 +274,15 @@ export const api = {
         const response = await axios.post(`${API_BASE_URL}/api/restore-analysis-context`, params);
         return response.data;
     },
+    setRecommenderModel: async (
+        model: string,
+        computeOverflowGraph: boolean,
+    ): Promise<{ status: string; active_model: string; compute_overflow_graph: boolean }> => {
+        const response = await axios.post(`${API_BASE_URL}/api/recommender-model`, {
+            model, compute_overflow_graph: computeOverflowGraph,
+        });
+        return response.data;
+    },
     runAnalysisStep1: async (disconnectedElements: string[]): Promise<{ lines_overloaded: string[]; message: string; can_proceed: boolean }> => {
         const response = await axios.post(`${API_BASE_URL}/api/run-analysis-step1`, { disconnected_elements: disconnectedElements });
         return response.data;

--- a/frontend/src/components/ActionCard.test.tsx
+++ b/frontend/src/components/ActionCard.test.tsx
@@ -407,4 +407,46 @@ describe('ActionCard', () => {
         expect(screen.getByRole('button', { name: 'VL_WIND' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'LINE_R' })).toBeInTheDocument();
     });
+
+    // The unfolded card shows where the action came from — "user"
+    // (manual simulation) or the recommender model that produced it.
+    describe('origin / "Source" row', () => {
+        const models = [
+            { name: 'expert', label: 'Expert system', requires_overflow_graph: true, is_default: true, params: [] },
+            { name: 'random_overflow', label: 'Random (post overflow analysis)', requires_overflow_graph: true, is_default: false, params: [] },
+        ];
+
+        it('shows "Manual simulation (user)" for a user-originated action when viewing', () => {
+            const details = { ...baseDetails, origin: 'user' };
+            render(<ActionCard {...defaultProps} details={details} isViewing availableModels={models} />);
+            expect(screen.getByTestId('action-card-act_1-origin'))
+                .toHaveTextContent('Source: Manual simulation (user)');
+        });
+
+        it('resolves a model id to its label for a recommender-originated action', () => {
+            const details = { ...baseDetails, origin: 'random_overflow' };
+            render(<ActionCard {...defaultProps} details={details} isViewing availableModels={models} />);
+            expect(screen.getByTestId('action-card-act_1-origin'))
+                .toHaveTextContent('Source: Random (post overflow analysis)');
+        });
+
+        it('falls back to the raw origin id when no model matches', () => {
+            const details = { ...baseDetails, origin: 'ml_policy_v9' };
+            render(<ActionCard {...defaultProps} details={details} isViewing availableModels={models} />);
+            expect(screen.getByTestId('action-card-act_1-origin'))
+                .toHaveTextContent('Source: ml_policy_v9');
+        });
+
+        it('does not render the Source row when origin is absent', () => {
+            // baseDetails has no `origin` — legacy / un-tracked actions.
+            render(<ActionCard {...defaultProps} isViewing availableModels={models} />);
+            expect(screen.queryByTestId('action-card-act_1-origin')).not.toBeInTheDocument();
+        });
+
+        it('does not render the Source row on a folded (non-viewing) card', () => {
+            const details = { ...baseDetails, origin: 'user' };
+            render(<ActionCard {...defaultProps} details={details} isViewing={false} availableModels={models} />);
+            expect(screen.queryByTestId('action-card-act_1-origin')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import type { ActionDetail, NodeMeta, EdgeMeta } from '../types';
+import type { ModelDescriptor } from '../api';
 import { getActionTargetVoltageLevels, getActionTargetLines, isCouplingAction } from '../utils/svgUtils';
 import { colors } from '../styles/tokens';
 
@@ -35,6 +36,12 @@ interface ActionCardProps {
     onResimulateTap: (actionId: string, newTap: number) => void;
     /** Resolve an element ID to its human-readable display name. Falls back to the ID. */
     displayName?: (id: string) => string;
+    /**
+     * Registered recommender models — used to resolve `details.origin`
+     * (a model id) to a human-readable label in the unfolded card's
+     * "Source" row. Absent / no-match falls back to the raw id.
+     */
+    availableModels?: ModelDescriptor[];
 }
 
 const clickableLinkStyle: React.CSSProperties = {
@@ -102,8 +109,18 @@ const ActionCard: React.FC<ActionCardProps> = ({
     onResimulate,
     onResimulateTap,
     displayName = (id: string) => id,
+    availableModels,
 }) => {
     const maxRhoPct = details.max_rho != null ? (details.max_rho * 100).toFixed(1) : null;
+
+    // Provenance label for the unfolded card's "Source" row. `origin`
+    // is either the literal `"user"` (manual simulation) or a
+    // recommender model id — resolved here to the model's label.
+    const originLabel = details.origin == null
+        ? null
+        : details.origin === 'user'
+            ? 'Manual simulation (user)'
+            : (availableModels?.find(m => m.name === details.origin)?.label ?? details.origin);
     const severity = details.max_rho != null
         ? (details.max_rho > monitoringFactor ? 'red' as const : details.max_rho > (monitoringFactor - 0.05) ? 'orange' as const : 'green' as const)
         : (details.is_rho_reduction ? 'green' as const : 'red' as const);
@@ -370,6 +387,15 @@ const ActionCard: React.FC<ActionCardProps> = ({
                     onMouseDown={(e) => e.stopPropagation()}
                 >
                     <p style={{ fontSize: '12px', margin: 0, color: colors.textPrimary }}>{details.description_unitaire}</p>
+
+                    {originLabel && (
+                        <div
+                            data-testid={`action-card-${id}-origin`}
+                            style={{ fontSize: '11px', marginTop: '4px', color: colors.textTertiary }}
+                        >
+                            Source: <strong style={{ color: colors.textSecondary }}>{originLabel}</strong>
+                        </div>
+                    )}
 
                     {details.load_shedding_details && details.load_shedding_details.length > 0 && (
                         <div style={{ ...editorRowStyle, background: colors.warningSoft, color: colors.warningText, border: `1px solid ${colors.warningBorder}` }}>

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -268,7 +268,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                 padding: '10px',
                 position: 'relative',
             }} onClick={() => onActionSelect(id)}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '6px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '6px' }}>
                 <h4 style={{
                     margin: 0,
                     fontSize: '12px',
@@ -277,6 +277,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                     minWidth: 0,
                     overflowWrap: 'anywhere',
                     fontWeight: 700,
+                    lineHeight: 1.35,
                 }}>
                     #{index + 1} {'—'} {id}
                 </h4>
@@ -302,9 +303,14 @@ const ActionCard: React.FC<ActionCardProps> = ({
 
             {/* Compact at-rest body: max loading + target badges. The
                 rail (⭐ / ❌) sits to the right and fades in on
-                hover or when this card is being viewed. */}
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', gap: '8px', marginTop: '6px' }}>
-                <div style={{ flex: 1, fontSize: '12px', minWidth: 0 }}>
+                hover or when this card is being viewed. The row wraps
+                so multi-VL badge stacks flow to a second line when
+                the title is long or the badges don't fit alongside
+                the loading metric — without that, ``flexShrink:0`` on
+                the badges + rail forces the loading text to collapse
+                into a one-word-per-line vertical strip. */}
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', flexWrap: 'wrap', rowGap: '6px', gap: '8px', marginTop: '6px' }}>
+                <div style={{ flex: '1 1 160px', fontSize: '12px', minWidth: 'min-content' }}>
                     {maxRhoPct != null ? (
                         <div>
                             Max loading: <strong style={{ color: sc.border }}>{maxRhoPct}%</strong>

--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -2972,4 +2972,121 @@ describe('ActionFeed', () => {
             expect(screen.getByRole('button', { name: /Analyze & Suggest/ })).toBeInTheDocument();
         });
     });
+
+    describe('recommendation-model selector + Clear', () => {
+        // The model dropdown lives above "Analyze & Suggest" (a mirror of
+        // the Settings → Recommender selector) so the operator can swap
+        // model and re-run without opening Settings. After a run, the
+        // model that produced the suggestions is reminded below the
+        // Suggested Actions tab header alongside a danger-coloured Clear
+        // button.
+        const modelProps = {
+            recommenderModel: 'expert',
+            setRecommenderModel: vi.fn(),
+            availableModels: [
+                { name: 'expert', label: 'Expert system', requires_overflow_graph: true, is_default: true, params: [] },
+                { name: 'random_overflow', label: 'Random (post overflow analysis)', requires_overflow_graph: true, is_default: false, params: [] },
+            ],
+        };
+
+        const recAction = {
+            description_unitaire: 'Disco LINE_X',
+            action_topology: emptyTopo,
+            is_manual: false,
+            max_rho: 0.8,
+        } as unknown as ActionDetail;
+
+        beforeEach(() => {
+            interactionLogger.clear();
+        });
+
+        it('renders the recommendation-model dropdown above Analyze & Suggest', () => {
+            render(<ActionFeed {...defaultProps} {...modelProps} canRunAnalysis />);
+            const select = screen.getByLabelText('Model:') as HTMLSelectElement;
+            expect(select).toBeInTheDocument();
+            expect(select.value).toBe('expert');
+            expect(screen.getByRole('option', { name: 'Random (post overflow analysis)' })).toBeInTheDocument();
+        });
+
+        it('changing the model fires setRecommenderModel and logs recommender_model_changed', () => {
+            const setRecommenderModel = vi.fn();
+            render(
+                <ActionFeed {...defaultProps} {...modelProps} setRecommenderModel={setRecommenderModel} canRunAnalysis />,
+            );
+            fireEvent.change(screen.getByLabelText('Model:'), { target: { value: 'random_overflow' } });
+            expect(setRecommenderModel).toHaveBeenCalledWith('random_overflow');
+            const evt = interactionLogger.getLog().find(e => e.type === 'recommender_model_changed');
+            expect(evt).toBeTruthy();
+            expect(evt!.details).toEqual({ model: 'random_overflow', source: 'action_feed' });
+        });
+
+        it('omits the model dropdown when setRecommenderModel is not wired', () => {
+            // Backwards-compat: ActionFeed must render without the model
+            // selector when the parent doesn't pass the recommender props.
+            render(<ActionFeed {...defaultProps} canRunAnalysis />);
+            expect(screen.queryByLabelText('Model:')).not.toBeInTheDocument();
+        });
+
+        it('shows the "Suggestions produced by <model>" reminder with the active model label', () => {
+            render(
+                <ActionFeed
+                    {...defaultProps}
+                    actions={{ rec_1: recAction }}
+                    activeModelLabel="Expert system"
+                    onClearSuggested={vi.fn()}
+                />,
+            );
+            expect(screen.getByTestId('active-model-reminder')).toHaveTextContent(
+                'Suggestions produced by Expert system',
+            );
+        });
+
+        it('hides the active-model reminder when there are no suggested entries', () => {
+            render(
+                <ActionFeed
+                    {...defaultProps}
+                    actions={{}}
+                    activeModelLabel="Expert system"
+                    onClearSuggested={vi.fn()}
+                />,
+            );
+            expect(screen.queryByTestId('active-model-reminder')).not.toBeInTheDocument();
+        });
+
+        it('Clear button calls onClearSuggested', () => {
+            const onClearSuggested = vi.fn();
+            render(
+                <ActionFeed
+                    {...defaultProps}
+                    actions={{ rec_1: recAction }}
+                    activeModelLabel="Expert system"
+                    onClearSuggested={onClearSuggested}
+                />,
+            );
+            fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+            expect(onClearSuggested).toHaveBeenCalledTimes(1);
+        });
+
+        it('hides the Analyze & Suggest slot while suggested entries are displayed', () => {
+            render(<ActionFeed {...defaultProps} actions={{ rec_1: recAction }} canRunAnalysis />);
+            expect(screen.queryByRole('button', { name: /Analyze & Suggest/ })).not.toBeInTheDocument();
+        });
+
+        it('reshows the Analyze & Suggest slot when only rejected actions remain (post-Clear)', () => {
+            // After Clear, the operator's kept rejected action stays in
+            // result.actions with is_manual=false. The analysis-trigger
+            // slot must still reappear because the Suggested feed
+            // (prioritizedEntries) is empty — gating on prioritizedEntries
+            // rather than "any non-manual action" is what fixes this.
+            render(
+                <ActionFeed
+                    {...defaultProps}
+                    actions={{ rej_1: recAction }}
+                    rejectedActionIds={new Set(['rej_1'])}
+                    canRunAnalysis
+                />,
+            );
+            expect(screen.getByRole('button', { name: /Analyze & Suggest/ })).toBeInTheDocument();
+        });
+    });
 });

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -972,20 +972,21 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                             <button
                                 type="button"
                                 onClick={onClearSuggested}
-                                title="Clear un-touched suggestions so a new analysis can be launched (keeps starred / rejected / manually-added actions)."
+                                title="Clear un-touched suggestions (keeps starred / rejected / manually-added actions) so a new analysis can be launched, optionally with a different model."
                                 style={{
-                                    padding: '3px 8px',
-                                    background: 'transparent',
-                                    color: colors.textSecondary,
-                                    border: `1px solid ${colors.borderSubtle}`,
+                                    padding: '3px 10px',
+                                    background: colors.danger,
+                                    color: colors.textOnBrand,
+                                    border: 'none',
                                     borderRadius: '4px',
                                     cursor: 'pointer',
                                     fontSize: '11px',
                                     fontStyle: 'normal',
+                                    fontWeight: 'bold',
                                     flexShrink: 0,
                                 }}
                             >
-                                Clear &amp; rerun
+                                Clear
                             </button>
                         )}
                     </div>

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -10,6 +10,7 @@ import type { ActionDetail, ActionTypeFilterToken, NodeMeta, EdgeMeta, Available
 import { actionPassesOverviewFilter } from '../utils/svgUtils';
 import { classifyActionType, matchesActionTypeFilter } from '../utils/actionTypes';
 import { api } from '../api';
+import type { ModelDescriptor } from '../api';
 import { interactionLogger } from '../utils/interactionLogger';
 import CombinedActionsModal from './CombinedActionsModal';
 import ActionCard from './ActionCard';
@@ -89,6 +90,29 @@ interface ActionFeedProps {
     onToggleAdditionalLineToCut?: (line: string) => void;
     /** N-1 detected overloads — excluded from the picker suggestions. */
     n1Overloads?: string[];
+    /**
+     * Recommendation model selector exposed above "Analyze & Suggest"
+     * (mirror of the same control in the Settings modal). Lets the
+     * operator pick a different model and re-run without opening
+     * Settings.
+     */
+    recommenderModel?: string;
+    setRecommenderModel?: (v: string) => void;
+    availableModels?: ModelDescriptor[];
+    /**
+     * Display label of the model that produced the currently-shown
+     * suggestions (echoed by the backend in the step-2 `result` event
+     * as ``active_model``). Rendered just below the "Suggested Actions"
+     * tab header alongside the Clear button.
+     */
+    activeModelLabel?: string | null;
+    /**
+     * Clear the un-touched recommender suggestions — wipes entries
+     * still in ``suggestedByRecommenderIds`` that the operator has
+     * NOT starred / rejected / manually added. Lets the user relaunch
+     * with a different model without losing their decisions.
+     */
+    onClearSuggested?: () => void;
 }
 
 const ActionFeed: React.FC<ActionFeedProps> = ({
@@ -126,6 +150,11 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
     additionalLinesToCut,
     onToggleAdditionalLineToCut,
     n1Overloads,
+    recommenderModel,
+    setRecommenderModel,
+    availableModels,
+    activeModelLabel,
+    onClearSuggested,
 }) => {
     const [searchOpen, setSearchOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
@@ -929,6 +958,38 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     >Rejected Actions {rejectedEntries.length > 0 && <span style={{ background: suggestedTab === 'rejected' ? colors.dangerSoft : colors.surfaceMuted, color: suggestedTab === 'rejected' ? colors.danger : colors.textSecondary, fontSize: '11px', padding: '2px 6px', borderRadius: '10px', fontWeight: 'bold' }}>{rejectedEntries.length}</span>}</button>
                 </div>
 
+                {suggestedTab === 'prioritized' && prioritizedEntries.length > 0 && activeModelLabel && (
+                    <div
+                        data-testid="active-model-reminder"
+                        style={{
+                            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                            gap: '8px', marginBottom: '8px',
+                            fontSize: '11px', color: colors.textTertiary, fontStyle: 'italic',
+                        }}
+                    >
+                        <span>Suggestions produced by <strong style={{ fontStyle: 'normal', color: colors.textSecondary }}>{activeModelLabel}</strong></span>
+                        {onClearSuggested && (
+                            <button
+                                type="button"
+                                onClick={onClearSuggested}
+                                title="Clear un-touched suggestions so a new analysis can be launched (keeps starred / rejected / manually-added actions)."
+                                style={{
+                                    padding: '3px 8px',
+                                    background: 'transparent',
+                                    color: colors.textSecondary,
+                                    border: `1px solid ${colors.borderSubtle}`,
+                                    borderRadius: '4px',
+                                    cursor: 'pointer',
+                                    fontSize: '11px',
+                                    fontStyle: 'normal',
+                                    flexShrink: 0,
+                                }}
+                            >
+                                Clear &amp; rerun
+                            </button>
+                        )}
+                    </div>
+                )}
 
                 {/* Unified analysis action slot: Analyze & Suggest → Analyzing… → Display N prioritized actions */}
                 {(analysisLoading || pendingAnalysisResult || !Object.values(actions).some(a => !a.is_manual)) && (
@@ -968,6 +1029,43 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                                         onToggle={onToggleAdditionalLineToCut}
                                         displayName={displayName}
                                     />
+                                )}
+                                {recommenderModel != null && setRecommenderModel && (
+                                    <div style={{
+                                        display: 'flex', alignItems: 'center', gap: '6px',
+                                        marginBottom: '8px', fontSize: '12px',
+                                        color: colors.textSecondary,
+                                    }}>
+                                        <label
+                                            htmlFor="analyzeRecommenderModel"
+                                            style={{ flexShrink: 0 }}
+                                        >Model:</label>
+                                        <select
+                                            id="analyzeRecommenderModel"
+                                            value={recommenderModel}
+                                            onChange={e => {
+                                                interactionLogger.record('recommender_model_changed', {
+                                                    model: e.target.value, source: 'action_feed',
+                                                });
+                                                setRecommenderModel(e.target.value);
+                                            }}
+                                            style={{
+                                                flex: 1, padding: '4px 6px',
+                                                border: `1px solid ${colors.border}`,
+                                                borderRadius: '4px',
+                                                background: colors.surface,
+                                                color: colors.textPrimary,
+                                                fontSize: '12px',
+                                            }}
+                                        >
+                                            {(!availableModels || availableModels.length === 0) && (
+                                                <option value="expert">Expert system</option>
+                                            )}
+                                            {availableModels?.map(m => (
+                                                <option key={m.name} value={m.name}>{m.label}</option>
+                                            ))}
+                                        </select>
+                                    </div>
                                 )}
                                 <button
                                     onClick={onRunAnalysis}

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -993,7 +993,15 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                 )}
 
                 {/* Unified analysis action slot: Analyze & Suggest → Analyzing… → Display N prioritized actions */}
-                {(analysisLoading || pendingAnalysisResult || !Object.values(actions).some(a => !a.is_manual)) && (
+                {/* Show the analysis trigger slot whenever the Suggested
+                    feed is empty — not just when result.actions has no
+                    recommender-produced entry. After "Clear", the
+                    operator's kept rejected actions stay in
+                    result.actions with is_manual=false; gating on
+                    prioritizedEntries (which already excludes selected +
+                    rejected) is what makes the Analyze & Suggest button
+                    reappear post-Clear. */}
+                {(analysisLoading || pendingAnalysisResult || prioritizedEntries.length === 0) && (
                     <div style={{ marginBottom: '10px' }}>
                         {analysisLoading ? (
                             <button disabled style={{

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -778,6 +778,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     onResimulate={handleResimulate}
                     onResimulateTap={handleResimulateTap}
                     displayName={displayName}
+                    availableModels={availableModels}
                 />
             );
         });

--- a/frontend/src/components/modals/ConfirmationDialog.test.tsx
+++ b/frontend/src/components/modals/ConfirmationDialog.test.tsx
@@ -50,6 +50,20 @@ describe('ConfirmationDialog', () => {
         expect(screen.getByTestId('confirm-dialog-applySettings')).toBeInTheDocument();
     });
 
+    it('renders correctly for clearSuggested', () => {
+        // The Clear button on the Action Feed routes through the shared
+        // confirmation dialog with a bespoke body that spells out what is
+        // removed (un-touched recommender suggestions) and what is kept
+        // (starred / rejected / manually-added actions).
+        render(<ConfirmationDialog {...defaultProps} confirmDialog={{ type: 'clearSuggested' }} />);
+        expect(screen.getByText('Clear Suggestions?')).toBeInTheDocument();
+        expect(screen.getByText(/will be removed from the feed/)).toBeInTheDocument();
+        expect(screen.getByText(/starred, rejected, and\s+manually-added actions are kept/)).toBeInTheDocument();
+        // It must NOT carry the destructive study-reset copy.
+        expect(screen.queryByText(/All previous analysis results/)).not.toBeInTheDocument();
+        expect(screen.getByTestId('confirm-dialog-clearSuggested')).toBeInTheDocument();
+    });
+
     it('calls onConfirm when confirm button is clicked', () => {
         render(<ConfirmationDialog {...defaultProps} />);
         fireEvent.click(screen.getByText('Confirm'));

--- a/frontend/src/components/modals/ConfirmationDialog.tsx
+++ b/frontend/src/components/modals/ConfirmationDialog.tsx
@@ -8,7 +8,7 @@
 import { colors } from '../../styles/tokens';
 
 export type ConfirmDialogState = {
-  type: 'contingency' | 'loadStudy' | 'applySettings' | 'changeNetwork';
+  type: 'contingency' | 'loadStudy' | 'applySettings' | 'changeNetwork' | 'clearSuggested';
   pendingBranch?: string;
   pendingNetworkPath?: string;
 } | null;
@@ -30,16 +30,34 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
     confirmDialog.type === 'contingency' ? 'Change Contingency?'
       : confirmDialog.type === 'applySettings' ? 'Apply New Settings?'
         : confirmDialog.type === 'changeNetwork' ? 'Change Network?'
-          : 'Reload Study?';
+          : confirmDialog.type === 'clearSuggested' ? 'Clear Suggestions?'
+            : 'Reload Study?';
 
-  const trailingMessage =
-    confirmDialog.type === 'contingency'
-      ? ' The network state will be preserved.'
-      : confirmDialog.type === 'applySettings'
-        ? ' The network will be reloaded with the new configuration.'
-        : confirmDialog.type === 'changeNetwork'
-          ? ' The current study will be reloaded from the new network file.'
-          : ' The network will be reloaded from scratch.';
+  // The `clearSuggested` flow keeps the operator's decisions, so it
+  // gets a bespoke body instead of the shared "everything is cleared"
+  // copy used by the study-reset confirmations.
+  const body =
+    confirmDialog.type === 'clearSuggested'
+      ? (
+        <>
+          Recommender suggestions you have <strong>not</strong> starred, rejected, or
+          manually added will be removed from the feed. Your starred, rejected, and
+          manually-added actions are kept. You can then pick a different model and
+          re-run the analysis.
+        </>
+      )
+      : (
+        <>
+          All previous analysis results, manual simulations, action selections, and diagrams will be cleared.
+          {confirmDialog.type === 'contingency'
+            ? ' The network state will be preserved.'
+            : confirmDialog.type === 'applySettings'
+              ? ' The network will be reloaded with the new configuration.'
+              : confirmDialog.type === 'changeNetwork'
+                ? ' The current study will be reloaded from the new network file.'
+                : ' The network will be reloaded from scratch.'}
+        </>
+      );
 
   return (
     <div style={{
@@ -61,8 +79,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
           {title}
         </h3>
         <p style={{ margin: '0 0 20px', color: colors.textSecondary, fontSize: '0.9rem', lineHeight: '1.5' }}>
-          All previous analysis results, manual simulations, action selections, and diagrams will be cleared.
-          {trailingMessage}
+          {body}
         </p>
         <div style={{ display: 'flex', gap: '10px', justifyContent: 'center' }}>
           <button

--- a/frontend/src/hooks/useActions.test.ts
+++ b/frontend/src/hooks/useActions.test.ts
@@ -357,4 +357,108 @@ describe('useActions — interaction logging', () => {
             expect(captured!.actions.existing.rho_after).toEqual([0.9]);
         });
     });
+
+    // `origin` records action provenance — distinct from `is_manual`,
+    // which is an overloaded UI-state flag (also stamped true when the
+    // operator stars a recommender suggestion). `origin` is set once at
+    // creation and never changes.
+    describe('action origin provenance', () => {
+        const detail: ActionDetail = {
+            description_unitaire: 'test',
+            rho_before: [1.1],
+            rho_after: [0.9],
+            max_rho: 0.9,
+            max_rho_line: 'LINE_X',
+            is_rho_reduction: true,
+        };
+
+        const captureSetResult = (initial: AnalysisResult | null) => {
+            let captured: AnalysisResult | null = null;
+            const setResult = (updater: unknown) => {
+                if (typeof updater === 'function') {
+                    captured = (updater as (p: AnalysisResult | null) => AnalysisResult | null)(initial);
+                }
+            };
+            return { setResult: setResult as React.Dispatch<React.SetStateAction<AnalysisResult | null>>, get: () => captured };
+        };
+
+        it('handleManualActionAdded stamps origin="user" by default', () => {
+            const { result } = renderHook(() => useActions());
+            const { setResult, get } = captureSetResult(null);
+
+            act(() => {
+                result.current.handleManualActionAdded('manual_x', detail, [], setResult, vi.fn());
+            });
+
+            expect(get()!.actions.manual_x.origin).toBe('user');
+        });
+
+        it('handleManualActionAdded accepts a custom origin (unsimulated-pin path passes the model)', () => {
+            const { result } = renderHook(() => useActions());
+            const { setResult, get } = captureSetResult(null);
+
+            act(() => {
+                result.current.handleManualActionAdded('pin_x', detail, [], setResult, vi.fn(), 'random_overflow');
+            });
+
+            expect(get()!.actions.pin_x.origin).toBe('random_overflow');
+        });
+
+        it('handleManualActionAdded keeps a pre-existing origin (first provenance wins)', () => {
+            const { result } = renderHook(() => useActions());
+            const { setResult, get } = captureSetResult({
+                pdf_path: null, pdf_url: null,
+                actions: {
+                    act_1: { ...detail, origin: 'expert', is_manual: false },
+                },
+                lines_overloaded: [], message: '', dc_fallback: false,
+            });
+
+            act(() => {
+                // Even though the default origin is "user", the existing
+                // recommender origin must survive.
+                result.current.handleManualActionAdded('act_1', detail, [], setResult, vi.fn());
+            });
+
+            expect(get()!.actions.act_1.origin).toBe('expert');
+        });
+
+        it('handleActionResimulated preserves the existing origin', () => {
+            const { result } = renderHook(() => useActions());
+            const { setResult, get } = captureSetResult({
+                pdf_path: null, pdf_url: null,
+                actions: {
+                    act_1: { ...detail, origin: 'random_overflow', is_manual: false },
+                },
+                lines_overloaded: [], message: '', dc_fallback: false,
+            });
+
+            act(() => {
+                result.current.handleActionResimulated('act_1', detail, [], setResult, vi.fn());
+            });
+
+            // Re-simulation changes metrics, never provenance.
+            expect(get()!.actions.act_1.origin).toBe('random_overflow');
+        });
+
+        it('handleActionFavorite does NOT change the origin of a recommender suggestion', () => {
+            const { result } = renderHook(() => useActions());
+            const { setResult, get } = captureSetResult({
+                pdf_path: null, pdf_url: null,
+                actions: {
+                    act_1: { ...detail, origin: 'expert', is_manual: false },
+                },
+                lines_overloaded: [], message: '', dc_fallback: false,
+            });
+
+            act(() => {
+                result.current.handleActionFavorite('act_1', setResult);
+            });
+
+            // Starring stamps is_manual=true but the action still
+            // *originated* from the model.
+            expect(get()!.actions.act_1.is_manual).toBe(true);
+            expect(get()!.actions.act_1.origin).toBe('expert');
+        });
+    });
 });

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -27,6 +27,14 @@ export interface ActionsState {
     linesOverloaded: string[],
     setResult: Dispatch<SetStateAction<AnalysisResult | null>>,
     onSelectAction: (actionId: string) => void,
+    /**
+     * Provenance stamped on the new action card. Defaults to `"user"`
+     * (manual search dropdown / "Make a first guess"). The
+     * unsimulated-pin path passes the recommender model id instead,
+     * because that pin was scored by the model — the operator only
+     * triggered its materialisation.
+     */
+    origin?: string,
   ) => void;
   handleActionResimulated: (
     actionId: string,
@@ -93,6 +101,7 @@ export function useActions(): ActionsState {
     _linesOverloaded: string[],
     setResult: React.Dispatch<React.SetStateAction<AnalysisResult | null>>,
     onSelectAction: (actionId: string) => void,
+    origin: string = 'user',
   ) => {
     interactionLogger.record('manual_action_simulated', { action_id: actionId });
     setResult(prev => {
@@ -113,11 +122,16 @@ export function useActions(): ActionsState {
       // back to ``n1Diagram.lines_overloaded`` — the authoritative
       // pypowsybl-style identifier list — for the card display.
       // Step1 / session reload set it on their own setResult paths.
+      //
+      // ``origin`` is preserved if the action already exists with one
+      // (e.g. re-adding a recommender suggestion the operator pulled
+      // into the feed) — the first provenance wins.
+      const existing = base.actions[actionId];
       return {
         ...base,
         actions: {
           ...base.actions,
-          [actionId]: { ...detail, is_manual: true },
+          [actionId]: { ...detail, is_manual: true, origin: existing?.origin ?? origin },
         },
       };
     });
@@ -160,9 +174,15 @@ export function useActions(): ActionsState {
         ...prev,
         actions: {
           ...prev.actions,
-          // Preserve the is_manual flag from the existing entry so a
-          // recommender-suggested action stays recommender-suggested.
-          [actionId]: { ...detail, is_manual: existing?.is_manual ?? false },
+          // Preserve the is_manual flag AND the origin from the
+          // existing entry — re-simulation changes the metrics, never
+          // the provenance: a recommender-suggested action stays
+          // recommender-suggested, a user action stays a user action.
+          [actionId]: {
+            ...detail,
+            is_manual: existing?.is_manual ?? false,
+            origin: existing?.origin ?? detail.origin ?? 'user',
+          },
         },
       };
     });

--- a/frontend/src/hooks/useAnalysis.test.ts
+++ b/frontend/src/hooks/useAnalysis.test.ts
@@ -735,7 +735,96 @@ describe('useAnalysis', () => {
 
             expect(interactionLogger.getLog()).toHaveLength(0);
         });
+    });
 
+    describe('action origin from recommender model', () => {
+        const actionPayload = {
+            description_unitaire: 'A', rho_before: [1.1], rho_after: [0.9],
+            max_rho: 0.9, max_rho_line: 'LINE_A', is_rho_reduction: true,
+        };
+
+        it('stamps origin from active_model on step-2 recommender actions', async () => {
+            mockRunAnalysisStep1.mockResolvedValue({ can_proceed: true, message: '', lines_overloaded: ['LINE_A'] });
+            const resultEvent = JSON.stringify({
+                type: 'result', actions: { act_1: actionPayload },
+                active_model: 'random_overflow',
+                lines_overloaded: ['LINE_A'], message: 'Done', dc_fallback: false,
+            });
+            mockRunAnalysisStep2Stream.mockResolvedValue({ ok: true, body: makeStream(`${resultEvent}\n`) });
+
+            const { result } = renderHook(() => useAnalysis());
+            await act(async () => {
+                await result.current.handleRunAnalysis(['LINE_X'], vi.fn(), vi.fn());
+            });
+
+            expect(result.current.pendingAnalysisResult?.actions?.act_1?.origin).toBe('random_overflow');
+        });
+
+        it('defaults origin to "expert" when the result event omits active_model', async () => {
+            mockRunAnalysisStep1.mockResolvedValue({ can_proceed: true, message: '', lines_overloaded: ['LINE_A'] });
+            const resultEvent = JSON.stringify({
+                type: 'result', actions: { act_1: actionPayload },
+                lines_overloaded: ['LINE_A'], message: 'Done', dc_fallback: false,
+            });
+            mockRunAnalysisStep2Stream.mockResolvedValue({ ok: true, body: makeStream(`${resultEvent}\n`) });
+
+            const { result } = renderHook(() => useAnalysis());
+            await act(async () => {
+                await result.current.handleRunAnalysis(['LINE_X'], vi.fn(), vi.fn());
+            });
+
+            expect(result.current.pendingAnalysisResult?.actions?.act_1?.origin).toBe('expert');
+        });
+
+        it('preserves an existing "user" origin when the recommender re-emits the same action', async () => {
+            mockRunAnalysisStep1.mockResolvedValue({ can_proceed: true, message: '', lines_overloaded: ['LINE_A'] });
+            const resultEvent = JSON.stringify({
+                type: 'result', actions: { firstguess: actionPayload },
+                active_model: 'expert',
+                lines_overloaded: ['LINE_A'], message: 'Done', dc_fallback: false,
+            });
+            mockRunAnalysisStep2Stream.mockResolvedValue({ ok: true, body: makeStream(`${resultEvent}\n`) });
+
+            const { result } = renderHook(() => useAnalysis());
+            // Operator made a "first guess" before analysis — origin "user".
+            act(() => {
+                result.current.setResult({
+                    pdf_path: null, pdf_url: null,
+                    actions: {
+                        firstguess: { ...actionPayload, rho_before: null, is_manual: true, origin: 'user' },
+                    },
+                    lines_overloaded: ['LINE_A'], message: '', dc_fallback: false,
+                });
+            });
+
+            await act(async () => {
+                await result.current.handleRunAnalysis(['LINE_X'], vi.fn(), vi.fn());
+            });
+
+            // The recommender re-emitted "firstguess" but the operator's
+            // provenance wins — it was their idea first.
+            expect(result.current.pendingAnalysisResult?.actions?.firstguess?.origin).toBe('user');
+        });
+
+        it('handleDisplayPrioritizedActions preserves origin through the merge', () => {
+            const { result } = renderHook(() => useAnalysis());
+            act(() => {
+                result.current.setPendingAnalysisResult({
+                    pdf_path: null, pdf_url: null,
+                    actions: {
+                        reco_1: { ...actionPayload, origin: 'random_overflow' },
+                    },
+                    lines_overloaded: ['LINE_A'], message: 'OK', dc_fallback: false,
+                });
+            });
+            act(() => {
+                result.current.handleDisplayPrioritizedActions(new Set());
+            });
+            expect(result.current.result?.actions?.reco_1?.origin).toBe('random_overflow');
+        });
+    });
+
+    describe('interaction logging — step2 payload', () => {
         it('step2_started carries the full spec payload (element + selected_overloads + all_overloads + monitor_deselected)', async () => {
             // Replay contract (docs/features/interaction-logging.md):
             //   { element, selected_overloads, all_overloads, monitor_deselected }

--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -194,11 +194,19 @@ export function useAnalysis(): AnalysisState {
               }
             } else if (event.type === 'result') {
               const actionsWithFlags = { ...event.actions };
+              // Provenance for recommender-produced actions: the model
+              // the backend actually ran (echoed as `active_model` on
+              // the result event). Preserve an existing `origin` so a
+              // "first guess" the operator added before analysis keeps
+              // its `"user"` provenance even when the model re-emits
+              // the same id.
+              const resultModel: string = event.active_model || 'expert';
               for (const id in actionsWithFlags) {
                 const existing = (prevResultRef.current?.actions?.[id] || {}) as Partial<ActionDetail>;
                 actionsWithFlags[id] = {
                   ...actionsWithFlags[id],
                   is_manual: false,
+                  origin: existing.origin ?? resultModel,
                   is_islanded: existing.is_islanded ?? actionsWithFlags[id].is_islanded,
                   estimated_max_rho: existing.estimated_max_rho ?? actionsWithFlags[id].max_rho,
                   estimated_max_rho_line: existing.estimated_max_rho_line ?? actionsWithFlags[id].max_rho_line,
@@ -282,6 +290,10 @@ export function useAnalysis(): AnalysisState {
           is_islanded: existing.is_islanded ?? data.is_islanded,
           estimated_max_rho: existing.estimated_max_rho ?? data.estimated_max_rho,
           estimated_max_rho_line: existing.estimated_max_rho_line ?? data.estimated_max_rho_line,
+          // Provenance: prefer the pre-display value (a "first guess"
+          // the operator added before analysis stays `"user"`), else
+          // the model-stamped origin from the step-2 stream loop.
+          origin: existing.origin ?? data.origin,
         };
       }
 

--- a/frontend/src/hooks/useSession.test.ts
+++ b/frontend/src/hooks/useSession.test.ts
@@ -874,4 +874,113 @@ describe('useSession — handleRestoreSession', () => {
         // But the combined_actions dictionary still carries it.
         expect(restored!.combined_actions).toHaveProperty('act_a+act_b');
     });
+
+    // -----------------------------------------------------------------
+    // Recommender model + action origin restore fidelity
+    // -----------------------------------------------------------------
+
+    it('restores result.active_model + compute_overflow_graph so the model reminder survives a reload', async () => {
+        // Regression: active_model was persisted under
+        // analysis.active_model but never re-attached to the live
+        // `result`, so the "Suggestions produced by <model>" reminder
+        // below the Suggested Actions tab header vanished on reload.
+        mockLoadSession.mockResolvedValue(makeSession({
+            analysis: {
+                message: 'ok',
+                dc_fallback: false,
+                action_scores: {},
+                combined_actions: {},
+                active_model: 'random_overflow',
+                compute_overflow_graph: true,
+                actions: {},
+            },
+        }));
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+        await act(async () => {
+            await result.current.handleRestoreSession('model_session', ctx);
+        });
+
+        const restored = captureRestoredResult(ctx.setResult as ReturnType<typeof vi.fn>);
+        expect(restored).not.toBeNull();
+        expect(restored!.active_model).toBe('random_overflow');
+        expect(restored!.compute_overflow_graph).toBe(true);
+    });
+
+    it('restores a saved action origin verbatim', async () => {
+        mockLoadSession.mockResolvedValue(makeSession({
+            analysis: {
+                message: 'ok',
+                dc_fallback: false,
+                action_scores: {},
+                combined_actions: {},
+                active_model: 'random_overflow',
+                actions: {
+                    reco_1: {
+                        description_unitaire: 'Reco', rho_before: [1.1], rho_after: [0.9],
+                        max_rho: 0.9, max_rho_line: 'LINE_OL1', is_rho_reduction: true,
+                        origin: 'random_overflow',
+                        status: { is_selected: false, is_suggested: true, is_rejected: false, is_manually_simulated: false },
+                    },
+                    manual_1: {
+                        description_unitaire: 'Manual', rho_before: [1.2], rho_after: [0.85],
+                        max_rho: 0.85, max_rho_line: 'LINE_OL1', is_rho_reduction: true,
+                        origin: 'user',
+                        status: { is_selected: true, is_suggested: false, is_rejected: false, is_manually_simulated: true },
+                    },
+                },
+            },
+        }));
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+        await act(async () => {
+            await result.current.handleRestoreSession('origin_session', ctx);
+        });
+
+        const restored = captureRestoredResult(ctx.setResult as ReturnType<typeof vi.fn>);
+        expect(restored!.actions['reco_1'].origin).toBe('random_overflow');
+        expect(restored!.actions['manual_1'].origin).toBe('user');
+    });
+
+    it('derives origin for legacy sessions that predate the field (from status flags + active_model)', async () => {
+        // Legacy session dumps have no `origin` on action entries. The
+        // restore path derives one: manually-simulated → "user",
+        // suggested → analysis.active_model, otherwise undefined.
+        mockLoadSession.mockResolvedValue(makeSession({
+            analysis: {
+                message: 'ok',
+                dc_fallback: false,
+                action_scores: {},
+                combined_actions: {},
+                active_model: 'expert',
+                actions: {
+                    suggested_legacy: {
+                        description_unitaire: 'Suggested', rho_before: [1.1], rho_after: [0.9],
+                        max_rho: 0.9, max_rho_line: 'LINE_OL1', is_rho_reduction: true,
+                        // no `origin` — legacy shape
+                        status: { is_selected: false, is_suggested: true, is_rejected: false, is_manually_simulated: false },
+                    },
+                    manual_legacy: {
+                        description_unitaire: 'Manual', rho_before: [1.2], rho_after: [0.85],
+                        max_rho: 0.85, max_rho_line: 'LINE_OL1', is_rho_reduction: true,
+                        status: { is_selected: true, is_suggested: false, is_rejected: false, is_manually_simulated: true },
+                    },
+                },
+            },
+        }));
+        const ctx = makeCtx();
+
+        const { result } = renderHook(() => useSession());
+        await act(async () => {
+            await result.current.handleRestoreSession('legacy_origin_session', ctx);
+        });
+
+        const restored = captureRestoredResult(ctx.setResult as ReturnType<typeof vi.fn>);
+        // suggested → derived from analysis.active_model
+        expect(restored!.actions['suggested_legacy'].origin).toBe('expert');
+        // manually-simulated → "user"
+        expect(restored!.actions['manual_legacy'].origin).toBe('user');
+    });
 });

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -370,6 +370,17 @@ export function useSession(): SessionState {
             curtailment_details: entry.curtailment_details,
             pst_details: entry.pst_details,
             is_manual: entry.status.is_manually_simulated,
+            // Provenance. Restored verbatim when present; legacy
+            // session dumps that predate the `origin` field get a
+            // derived value from the saved status flags + the
+            // session's `analysis.active_model` so the unfolded card's
+            // "Source" row still resolves on reload.
+            origin: entry.origin
+              ?? (entry.status.is_manually_simulated
+                ? 'user'
+                : entry.status.is_suggested
+                  ? (a.active_model ?? 'expert')
+                  : undefined),
           };
 
           if (entry.status.is_selected) restoredSelected.add(id);
@@ -409,6 +420,14 @@ export function useSession(): SessionState {
           combined_actions: restoredCombinedActions,
           message: a.message,
           dc_fallback: a.dc_fallback,
+          // Restore the recommender model that produced the
+          // suggestions so the "Suggestions produced by <model>"
+          // reminder below the Suggested Actions tab header (driven by
+          // `result.active_model`) survives a reload. Without this the
+          // field was saved to `analysis.active_model` but never
+          // re-attached to the live `result`, so the reminder vanished.
+          active_model: a.active_model ?? undefined,
+          compute_overflow_graph: a.compute_overflow_graph ?? undefined,
         };
 
         ctx.setResult(restoredResult);

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -216,6 +216,25 @@ export function useSettings(): SettingsState {
     }
   }, [recommenderModel, availableModels, computeOverflowGraph]);
 
+  // Push the active recommender model to the running RecommenderService
+  // whenever the operator changes it (from Settings OR from the new
+  // dropdown above the Analyze & Suggest button). Without this the
+  // backend keeps the previously-applied model (set on /api/config) and
+  // a re-run produces suggestions from the OLD model regardless of
+  // the dropdown choice. Cheap: the endpoint only updates two
+  // attributes — no network reload, no action dictionary rebuild.
+  const lastPushedModelRef = useRef<{ model: string; computeOverflowGraph: boolean } | null>(null);
+  useEffect(() => {
+    if (!configLoadedRef.current) return;
+    const last = lastPushedModelRef.current;
+    if (last && last.model === recommenderModel && last.computeOverflowGraph === computeOverflowGraph) return;
+    lastPushedModelRef.current = { model: recommenderModel, computeOverflowGraph };
+    if (typeof api.setRecommenderModel !== 'function') return;
+    api.setRecommenderModel(recommenderModel, computeOverflowGraph).catch(err => {
+      console.warn('Failed to push recommender-model to backend', err);
+    });
+  }, [recommenderModel, computeOverflowGraph]);
+
   const changeConfigFilePath = useCallback(async (newPath: string): Promise<UserConfig> => {
     const result = await api.setConfigFilePath(newPath);
     setConfigFilePath(result.config_file_path);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -93,6 +93,24 @@ export interface ActionDetail {
     load_shedding_details?: LoadSheddingDetail[];
     curtailment_details?: CurtailmentDetail[];
     pst_details?: PstDetail[];
+    /**
+     * Provenance of the action card — distinct from `is_manual`, which
+     * is an overloaded UI-state flag (it's also stamped `true` when the
+     * operator stars a recommender suggestion). `origin` records where
+     * the action *came from* and never changes after creation:
+     *   - `"user"`      — the operator simulated it themselves (manual
+     *                     search dropdown, "Make a first guess").
+     *   - `<model id>`  — produced / scored by a recommender model
+     *                     (e.g. `"expert"`, `"random_overflow"`); this
+     *                     is the `active_model` echoed by the step-2
+     *                     `result` event, and also covers an
+     *                     unsimulated pin the operator materialised
+     *                     (it was scored by that model).
+     * Optional for backward compat: legacy sessions that predate the
+     * field get an `origin` derived from their saved status flags on
+     * reload (see `useSession.handleRestoreSession`).
+     */
+    origin?: string;
 }
 
 export interface CombinedAction {
@@ -344,6 +362,13 @@ export interface SavedActionEntry {
     load_shedding_details?: LoadSheddingDetail[];
     curtailment_details?: CurtailmentDetail[];
     pst_details?: PstDetail[];
+    /**
+     * Provenance of the action — `"user"` or a recommender model id.
+     * Mirrors `ActionDetail.origin`. Optional: legacy session dumps
+     * that predate the field get an `origin` derived from the saved
+     * status flags + `analysis.active_model` on reload.
+     */
+    origin?: string;
     status: SavedActionStatus;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -452,6 +452,8 @@ export type InteractionType =
     | 'analysis_step1_completed'
     | 'overload_toggled'
     | 'additional_line_to_cut_toggled'
+    | 'recommender_model_changed'
+    | 'suggested_actions_cleared'
     | 'analysis_step2_started'
     | 'analysis_step2_completed'
     | 'prioritized_actions_displayed'

--- a/frontend/src/utils/sessionUtils.test.ts
+++ b/frontend/src/utils/sessionUtils.test.ts
@@ -284,6 +284,32 @@ describe('buildSessionResult — structure', () => {
     });
 });
 
+describe('buildSessionResult — action origin', () => {
+    it('serializes the action origin verbatim ("user")', () => {
+        const out = buildSessionResult({
+            ...baseInput,
+            result: makeResult({ actions: { manual_1: makeAction('M', { origin: 'user' }) } }),
+        });
+        expect(out.analysis!.actions.manual_1.origin).toBe('user');
+    });
+
+    it('serializes a recommender model origin verbatim', () => {
+        const out = buildSessionResult({
+            ...baseInput,
+            result: makeResult({ actions: { reco_1: makeAction('R', { origin: 'random_overflow' }) } }),
+        });
+        expect(out.analysis!.actions.reco_1.origin).toBe('random_overflow');
+    });
+
+    it('leaves origin undefined when the action has none (legacy / un-tracked)', () => {
+        const out = buildSessionResult({
+            ...baseInput,
+            result: makeResult({ actions: { act1: makeAction('A') } }),
+        });
+        expect(out.analysis!.actions.act1.origin).toBeUndefined();
+    });
+});
+
 describe('buildSessionResult — action status tags', () => {
     it('is_selected is true when action is in selectedActionIds', () => {
         const out = buildSessionResult({

--- a/frontend/src/utils/sessionUtils.ts
+++ b/frontend/src/utils/sessionUtils.ts
@@ -150,6 +150,10 @@ export function buildSessionResult(input: SessionInput): SessionResult {
                         load_shedding_details: detail.load_shedding_details,
                         curtailment_details: detail.curtailment_details,
                         pst_details: detail.pst_details,
+                        // Provenance: "user" or a recommender model id.
+                        // Restored verbatim on reload (with a derived
+                        // fallback for legacy dumps that lack the field).
+                        origin: detail.origin,
                         status: {
                             is_selected: selectedActionIds.has(id),
                             is_suggested: suggestedByRecommenderIds.has(id),

--- a/frontend/src/utils/specConformance.test.ts
+++ b/frontend/src/utils/specConformance.test.ts
@@ -60,6 +60,8 @@ const SPEC: Record<string, SpecRow> = {
   analysis_step1_started:         { required: new Set(['element']) },
   overload_toggled:               { required: new Set(['overload', 'selected']) },
   additional_line_to_cut_toggled: { required: new Set(['line', 'selected']) },
+  recommender_model_changed:      { required: new Set(['model']), optional: new Set(['source']) },
+  suggested_actions_cleared:      { required: new Set(['n_cleared']) },
   analysis_step2_started:         { required: new Set(['element', 'selected_overloads', 'all_overloads', 'monitor_deselected']), optional: new Set(['additional_lines_to_cut']) },
   prioritized_actions_displayed:  { required: new Set(['n_actions']) },
   // --- Action ---

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -146,6 +146,8 @@ SPEC_DETAILS: dict[str, dict] = {
         "additional_lines_to_cut",
     }),
     "additional_line_to_cut_toggled": _spec_row({"line", "selected"}),
+    "recommender_model_changed": _spec_row({"model"}, optional={"source"}),
+    "suggested_actions_cleared": _spec_row({"n_cleared"}),
     "analysis_step2_completed": _spec_row({
         "n_actions", "action_ids", "dc_fallback", "message", "pdf_url",
     }),

--- a/tests/test_service_integration.py
+++ b/tests/test_service_integration.py
@@ -15,6 +15,8 @@ pipeline.
 """
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 # Import triggers the registry side-effects.
@@ -96,3 +98,157 @@ def test_wrapped_run_analysis_step2_emits_error_for_unknown_model():
     assert len(events) == 1
     assert events[0]["type"] == "error"
     assert "__not_a_model__" in events[0]["message"]
+
+
+# ---------------------------------------------------------------------
+# Step-2 overflow-graph cache on the production (model-aware) path.
+#
+# The overflow graph is model-INDEPENDENT — only action discovery
+# consumes the recommender — so a re-run with the same contingency +
+# Step-2 inputs but a different model must REUSE the cached graph and
+# skip `run_analysis_step2_graph`. The cache lived only on the legacy
+# `AnalysisMixin.run_analysis_step2`, which `_service_integration`
+# shadows; this guards the port into `_run_analysis_step2_with_model`.
+# ---------------------------------------------------------------------
+def _seed_step2_state(svc, tmp_path):
+    """Put `svc` into the post-step1 state and stub the per-instance
+    helpers so `_run_analysis_step2_with_model` runs end to end without
+    the heavy pipeline. Returns the fake produced-HTML path."""
+    svc._reset_model_settings()
+    svc._last_disconnected_elements = ["LINE_C"]
+    svc._analysis_context = {
+        "lines_overloaded_names": ["L1"],
+        "lines_overloaded_ids": [0],
+        "lines_overloaded_ids_kept": [0],
+        "lines_we_care_about": None,
+    }
+    svc._last_step2_context = None
+    svc._last_step2_signature = None
+    svc._overflow_layout_cache = {}
+    pdf = tmp_path / "overflow.html"
+    pdf.write_text("<html></html>")
+    svc._narrow_context_to_selected_overloads = MagicMock(side_effect=lambda ctx, *a, **k: ctx)
+    svc._get_latest_pdf_path = MagicMock(return_value=str(pdf))
+    svc._enrich_actions = MagicMock(return_value={})
+    svc._augment_combined_actions_with_target_max_rho = MagicMock()
+    svc._compute_mw_start_for_scores = MagicMock(return_value={})
+    return str(pdf)
+
+
+def _graph_required_recommender(name="expert"):
+    rec = MagicMock()
+    rec.requires_overflow_graph = True
+    rec.name = name
+    return rec
+
+
+_DISCOVERY_RESULT = {
+    "prioritized_actions": {},
+    "action_scores": {},
+    "lines_overloaded_names": ["L1"],
+}
+
+
+def test_unchanged_signature_reuses_overflow_graph(tmp_path):
+    """Re-running with an identical signature (only the model swapped)
+    skips `run_analysis_step2_graph` and reuses the cached graph —
+    discovery still re-runs because it's the model-dependent step."""
+    svc = RecommenderService()
+    expected_pdf = _seed_step2_state(svc, tmp_path)
+
+    with patch(
+        "expert_backend.recommenders._service_integration.build_recommender",
+        return_value=_graph_required_recommender(),
+    ), patch(
+        "expert_backend.services.analysis_mixin.run_analysis_step2_graph",
+        side_effect=lambda ctx: ctx,
+    ) as mock_graph, patch(
+        "expert_backend.services.analysis_mixin.run_analysis_step2_discovery",
+        return_value=dict(_DISCOVERY_RESULT),
+    ) as mock_discovery:
+        kwargs = dict(
+            selected_overloads=["L1"], all_overloads=["L1"],
+            monitor_deselected=False, additional_lines_to_cut=["EXTRA"],
+        )
+        # First run — builds the graph and seeds the cache.
+        events1 = list(RecommenderService.run_analysis_step2(svc, **kwargs))
+        assert mock_graph.call_count == 1
+        assert svc._last_step2_signature is not None
+        pdf_event1 = next(e for e in events1 if e.get("type") == "pdf")
+        assert pdf_event1["pdf_path"] == expected_pdf
+
+        # Second run, identical signature — graph rebuild is skipped,
+        # discovery re-runs (a model swap only affects discovery).
+        events2 = list(RecommenderService.run_analysis_step2(svc, **kwargs))
+        assert mock_graph.call_count == 1            # NOT rebuilt
+        assert mock_discovery.call_count == 2        # discovery re-ran
+        pdf_event2 = next(e for e in events2 if e.get("type") == "pdf")
+        assert pdf_event2["pdf_path"] == expected_pdf
+        assert pdf_event2.get("cached") is True
+
+
+def test_changed_additional_lines_rebuilds_overflow_graph(tmp_path):
+    """Changing the `additional_lines_to_cut` hypothesis changes the
+    signature, so the overflow graph MUST be rebuilt."""
+    svc = RecommenderService()
+    _seed_step2_state(svc, tmp_path)
+
+    with patch(
+        "expert_backend.recommenders._service_integration.build_recommender",
+        return_value=_graph_required_recommender(),
+    ), patch(
+        "expert_backend.services.analysis_mixin.run_analysis_step2_graph",
+        side_effect=lambda ctx: ctx,
+    ) as mock_graph, patch(
+        "expert_backend.services.analysis_mixin.run_analysis_step2_discovery",
+        return_value=dict(_DISCOVERY_RESULT),
+    ):
+        list(RecommenderService.run_analysis_step2(
+            svc, selected_overloads=["L1"], all_overloads=["L1"],
+            monitor_deselected=False, additional_lines_to_cut=["EXTRA"],
+        ))
+        assert mock_graph.call_count == 1
+
+        list(RecommenderService.run_analysis_step2(
+            svc, selected_overloads=["L1"], all_overloads=["L1"],
+            monitor_deselected=False, additional_lines_to_cut=["OTHER"],
+        ))
+        assert mock_graph.call_count == 2  # rebuilt for the new signature
+
+
+def test_graph_skipping_model_does_not_reuse_or_seed_cache(tmp_path):
+    """A model that doesn't need the overflow graph never builds OR
+    reuses it — and clears the signature so a later graph-requiring run
+    can't false-hit on it."""
+    svc = RecommenderService()
+    _seed_step2_state(svc, tmp_path)
+    # Pre-seed a stale cache to prove the no-graph path clears it.
+    svc._last_step2_signature = ("stale",)
+    svc._last_step2_context = {"stale": True}
+
+    no_graph_rec = MagicMock()
+    no_graph_rec.requires_overflow_graph = False
+    no_graph_rec.name = "random"
+
+    with patch(
+        "expert_backend.recommenders._service_integration.build_recommender",
+        return_value=no_graph_rec,
+    ), patch(
+        "expert_backend.services.analysis_mixin.run_analysis_step2_graph",
+    ) as mock_graph, patch(
+        "expert_backend.services.analysis_mixin.run_analysis_step2_discovery",
+        return_value=dict(_DISCOVERY_RESULT),
+    ):
+        # compute_overflow_graph defaults to False after _reset_model_settings,
+        # so a non-requiring model skips the graph entirely.
+        svc._compute_overflow_graph = False
+        events = list(RecommenderService.run_analysis_step2(
+            svc, selected_overloads=["L1"], all_overloads=["L1"],
+            monitor_deselected=False, additional_lines_to_cut=[],
+        ))
+
+    mock_graph.assert_not_called()
+    pdf_event = next(e for e in events if e.get("type") == "pdf")
+    assert pdf_event["pdf_path"] is None
+    assert svc._last_step2_signature is None
+    assert svc._last_step2_context is None


### PR DESCRIPTION
## Summary

Implements a lightweight recommender model-swap workflow that lets operators change the active model and re-run analysis without expensive network reloads. Adds a **Clear** button to wipe un-touched recommender suggestions while preserving the operator's starred, rejected, and manually-added actions.

## Key Changes

### Backend

- **Step-2 overflow-graph cache** (`expert_backend/services/analysis_mixin.py`):
  - Signatures the overflow graph on `(disconnected_elements, selected_overloads, all_overloads, monitor_deselected, additional_lines_to_cut)`
  - Stores signature + enriched context on `_last_step2_signature` / `_last_step2_context`
  - On re-run with identical signature, skips graph rebuild and jumps straight to discovery (where the recommender model is consumed)
  - Yields `pdf` event with `cached: true` flag when reusing
  - Result event now carries `active_model` field echoing the model that produced the suggestions

- **New lightweight endpoint** (`expert_backend/main.py`):
  - `POST /api/recommender-model` swaps the active model without reloading the network or action dictionary
  - Calls `_apply_model_settings(req)` and echoes back `{ status, active_model, compute_overflow_graph }`
  - Leaves Step-2 graph cache intact so next discovery re-run is near-instant

- **Service integration** (`expert_backend/recommenders/_service_integration.py`):
  - Patches `RecommenderService` with `_apply_model_settings()` method to update model + `compute_overflow_graph` toggle
  - Adds `get_active_model_name()` and `get_compute_overflow_graph()` getters

- **Tests** (`expert_backend/tests/test_overload_filtering.py`, `test_api_endpoints.py`):
  - `TestStep2GraphCacheReuse` validates cache hit/miss logic and model-swap fast path
  - `TestSetRecommenderModel` validates the new endpoint

### Frontend

- **Model selector above Analyze & Suggest** (`frontend/src/components/ActionFeed.tsx`):
  - New optional props: `recommenderModel`, `setRecommenderModel`, `availableModels`
  - Renders dropdown mirror of Settings → Recommender selector
  - Logs `recommender_model_changed` interaction event

- **Active model reminder + Clear button** (`frontend/src/components/ActionFeed.tsx`):
  - Below "Suggested Actions" tab header: *"Suggestions produced by &lt;model&gt;"*
  - Danger-coloured **Clear** button wipes un-touched recommender suggestions
  - New props: `activeModelLabel`, `onClearSuggested`
  - Only shown when suggested entries exist

- **Clear logic** (`frontend/src/App.tsx`):
  - `performClearSuggested()` callback filters out entries in `suggestedByRecommenderIds` that the operator has NOT starred / rejected / manually added
  - Logs `suggested_actions_cleared` interaction event with count
  - Does NOT re-run analysis — operator clears, optionally swaps model, then presses Analyze & Suggest

- **Model push to backend** (`frontend/src/hooks/useSettings.ts`):
  - New `useEffect` fires `api.setRecommenderModel()` whenever `recommenderModel` / `computeOverflowGraph` change
  - Tracks last-pushed state to avoid redundant calls
  - Integrates with both Settings modal and ActionFeed dropdown

- **API client** (`frontend/src/api.ts`):
  - `setRecommenderModel(model, computeOverflowGraph)` → `POST /api/recommender-model`

- **State preservation across re-runs** (`frontend/src/App.tsx`):
  - `resetForAnalysisRun()` now keeps starred, rejected, and manually-added actions (not just manuals)
  - Preserves `selectedActionId` if it points to an action the operator has invested

https://claude.ai/code/session_01YPqGvmm6PqiSQVSagF6ZVG