### PR TITLE
Swap single/double-click behavior for severity filter ring

### DIFF
--- a/frontend/src/components/ActionFilterRings.test.tsx
+++ b/frontend/src/components/ActionFilterRings.test.tsx
@@ -78,7 +78,7 @@ describe('ActionFilterRings', () => {
         }
     });
 
-    it('single-click toggles a severity category off (after the double-click window)', () => {
+    it('single-click solos a severity category — enables only that outcome (after the double-click window)', () => {
         const onFiltersChange = vi.fn();
         render(<ActionFilterRings filters={baseFilters} onFiltersChange={onFiltersChange} />);
         fireEvent.click(screen.getByTestId('sidebar-filter-category-red'));
@@ -87,11 +87,42 @@ describe('ActionFilterRings', () => {
         flushClickDelay();
         expect(onFiltersChange).toHaveBeenCalledWith({
             ...baseFilters,
-            categories: { ...baseFilters.categories, red: false },
+            categories: { green: false, orange: false, red: true, grey: false },
         });
     });
 
-    it('single-click toggles a disabled severity category back on', () => {
+    it('single-click on an already-soloed severity category restores all outcomes', () => {
+        const onFiltersChange = vi.fn();
+        const filters: ActionOverviewFilters = {
+            ...baseFilters,
+            categories: { green: false, orange: false, red: true, grey: false },
+        };
+        render(<ActionFilterRings filters={filters} onFiltersChange={onFiltersChange} />);
+        fireEvent.click(screen.getByTestId('sidebar-filter-category-red'));
+        flushClickDelay();
+        expect(onFiltersChange).toHaveBeenCalledWith({
+            ...filters,
+            categories: { green: true, orange: true, red: true, grey: true },
+        });
+    });
+
+    it('double-click toggles a severity category off', () => {
+        const onFiltersChange = vi.fn();
+        render(<ActionFilterRings filters={baseFilters} onFiltersChange={onFiltersChange} />);
+        const red = screen.getByTestId('sidebar-filter-category-red');
+        fireEvent.click(red);
+        fireEvent.click(red);
+        expect(onFiltersChange).toHaveBeenCalledTimes(1);
+        expect(onFiltersChange).toHaveBeenCalledWith({
+            ...baseFilters,
+            categories: { ...baseFilters.categories, red: false },
+        });
+        // The deferred single-click must NOT also fire after the toggle.
+        flushClickDelay();
+        expect(onFiltersChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('double-click toggles a disabled severity category back on', () => {
         const onFiltersChange = vi.fn();
         const filters: ActionOverviewFilters = {
             ...baseFilters,
@@ -101,42 +132,10 @@ describe('ActionFilterRings', () => {
         const greyToggle = screen.getByTestId('sidebar-filter-category-grey');
         expect(greyToggle).toHaveAttribute('aria-pressed', 'false');
         fireEvent.click(greyToggle);
-        flushClickDelay();
+        fireEvent.click(greyToggle);
         expect(onFiltersChange).toHaveBeenCalledWith({
             ...filters,
             categories: { ...filters.categories, grey: true },
-        });
-    });
-
-    it('double-click solos a severity category — enables only that outcome', () => {
-        const onFiltersChange = vi.fn();
-        render(<ActionFilterRings filters={baseFilters} onFiltersChange={onFiltersChange} />);
-        const red = screen.getByTestId('sidebar-filter-category-red');
-        fireEvent.click(red);
-        fireEvent.click(red);
-        expect(onFiltersChange).toHaveBeenCalledTimes(1);
-        expect(onFiltersChange).toHaveBeenCalledWith({
-            ...baseFilters,
-            categories: { green: false, orange: false, red: true, grey: false },
-        });
-        // The deferred single-click must NOT also fire after the solo.
-        flushClickDelay();
-        expect(onFiltersChange).toHaveBeenCalledTimes(1);
-    });
-
-    it('double-click on an already-soloed severity category restores all outcomes', () => {
-        const onFiltersChange = vi.fn();
-        const filters: ActionOverviewFilters = {
-            ...baseFilters,
-            categories: { green: false, orange: false, red: true, grey: false },
-        };
-        render(<ActionFilterRings filters={filters} onFiltersChange={onFiltersChange} />);
-        const red = screen.getByTestId('sidebar-filter-category-red');
-        fireEvent.click(red);
-        fireEvent.click(red);
-        expect(onFiltersChange).toHaveBeenCalledWith({
-            ...filters,
-            categories: { green: true, orange: true, red: true, grey: true },
         });
     });
 

--- a/frontend/src/components/ActionFilterRings.tsx
+++ b/frontend/src/components/ActionFilterRings.tsx
@@ -18,9 +18,9 @@ import { ActionTypeIcon } from './ActionTypeIcon';
  *
  *  - the SEVERITY ring — colour-coded pictograms (one per outcome
  *    bucket: solved / low-margin / still-overloaded / divergent).
- *    Single-click toggles one bucket on/off; double-click "solos" it
- *    (enables only that bucket) and double-clicking the solo bucket
- *    again restores the full set.
+ *    Single-click "solos" the bucket (enables only that outcome) and
+ *    single-clicking the soloed bucket again restores the full set;
+ *    double-click toggles one bucket on/off without touching the others.
  *  - the ACTION-TYPE ring — uncoloured pictograms (disco / reco /
  *    open / close / ls / rc / pst). Single-select; re-clicking the
  *    active one clears back to `all`.
@@ -118,21 +118,23 @@ const ActionFilterRings: React.FC<ActionFilterRingsProps> = ({ filters, onFilter
         onFiltersChange({ ...f, categories });
     }, [onFiltersChange]);
 
-    // Single-click toggles one bucket, double-click solos it. The
-    // single-click action is deferred by one double-click window so a
-    // double-click does not also fire two stray toggles first.
+    // Single-click solos one bucket (or restores all if it is already
+    // the lone enabled one); double-click toggles the bucket on/off
+    // without touching the others. The single-click action is deferred
+    // by one double-click window so a double-click does not also fire
+    // a stray solo first.
     const handleCategoryClick = useCallback((cat: ActionSeverityCategory) => {
         const timers = clickTimers.current;
         const pending = timers.get(cat);
         if (pending !== undefined) {
             clearTimeout(pending);
             timers.delete(cat);
-            soloCategory(cat);
+            toggleCategory(cat);
             return;
         }
         const timer = setTimeout(() => {
             timers.delete(cat);
-            toggleCategory(cat);
+            soloCategory(cat);
         }, DOUBLE_CLICK_MS);
         timers.set(cat, timer);
     }, [soloCategory, toggleCategory]);
@@ -189,7 +191,7 @@ const ActionFilterRings: React.FC<ActionFilterRingsProps> = ({ filters, onFilter
                             type="button"
                             data-testid={`sidebar-filter-category-${cat}`}
                             aria-pressed={enabled}
-                            title={`${label} — click to ${enabled ? 'hide' : 'show'}, double-click to isolate`}
+                            title={`${label} — click to isolate, double-click to ${enabled ? 'hide' : 'show'}`}
                             onClick={() => handleCategoryClick(cat)}
                             style={{
                                 ...toggleBase,

--- a/frontend/src/components/CombinedActionsModal.test.tsx
+++ b/frontend/src/components/CombinedActionsModal.test.tsx
@@ -154,17 +154,19 @@ describe('CombinedActionsModal', () => {
         expect(discoToggle.getAttribute('aria-pressed')).toBe('true');
     });
 
-    it('the severity ring in the modal header filters Explore-Pairs rows by outcome', () => {
+    it('the severity ring in the modal header filters Explore-Pairs rows by outcome', async () => {
         // act1 / act2 / act3 all simulate to max_rho < 0.95 → green
-        // severity. Double-clicking the red toggle "solos" it, leaving
-        // only red-severity rows — so all three green rows drop out.
+        // severity. A single click on the red toggle "solos" it
+        // (deferred by one double-click window), leaving only
+        // red-severity rows — so all three green rows drop out.
         render(<CombinedActionsModal {...defaultProps} />);
         fireEvent.click(getExploreTab());
         expect(screen.getByText('act1')).toBeInTheDocument();
         const redToggle = screen.getByTestId('sidebar-filter-category-red');
         fireEvent.click(redToggle);
-        fireEvent.click(redToggle);
-        expect(screen.queryByText('act1')).not.toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.queryByText('act1')).not.toBeInTheDocument();
+        });
         expect(screen.queryByText('act2')).not.toBeInTheDocument();
         expect(screen.getByText(/No scored actions available/)).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
Inverts the click interaction model for the severity category filter ring in `ActionFilterRings`. Single-click now "solos" a category (enables only that outcome), while double-click toggles a category on/off without affecting others. This reverses the previous behavior where double-click soloed and single-click toggled.

## Key Changes

- **ActionFilterRings.tsx**
  - Swapped the deferred action logic: single-click now calls `soloCategory()` (after double-click window), double-click immediately calls `toggleCategory()`
  - Updated component documentation to reflect new interaction model
  - Updated button title attribute to describe new behavior: "click to isolate, double-click to show/hide"

- **ActionFilterRings.test.tsx**
  - Renamed and updated test cases to match new behavior:
    - "single-click toggles..." → "single-click solos a severity category"
    - "single-click toggles a disabled..." → "single-click on an already-soloed category restores all outcomes"
    - "double-click solos..." → "double-click toggles a severity category off"
    - "double-click on an already-soloed..." → "double-click toggles a disabled category back on"
  - Updated test assertions to expect solo behavior on single-click and toggle behavior on double-click

- **CombinedActionsModal.test.tsx**
  - Updated test description and implementation to reflect single-click solo behavior
  - Changed from double-click sequence to single-click with `waitFor()` to account for deferred execution
  - Removed redundant second click that was part of the old double-click solo pattern

## Implementation Details

The interaction model now uses a deferred single-click pattern:
- First click on a category starts a timer (DOUBLE_CLICK_MS window)
- If a second click arrives within the window, it's treated as a double-click and immediately toggles the category
- If the timer expires without a second click, the deferred single-click fires and solos the category
- This prevents a solo action from also firing a stray toggle when double-clicking

The change improves discoverability by making the primary action (solo/isolate) the simpler gesture (single-click), while the secondary action (toggle) requires the more deliberate double-click.

https://claude.ai/code/session_01KtM2sMEAGW1ne3f5UPVVFx