### PR TITLE
Suppress Analyze & Suggest button when overview filter hides all actions

### DIFF
--- a/frontend/src/components/ActionFeed.test.tsx
+++ b/frontend/src/components/ActionFeed.test.tsx
@@ -3055,6 +3055,60 @@ describe('ActionFeed', () => {
             expect(screen.queryByTestId('action-card-reco_GEN.PY762')).not.toBeInTheDocument();
             expect(screen.getByTestId('overview-filter-hint')).toBeInTheDocument();
         });
+
+        it('suppresses the Analyze & Suggest button and shows the no-match notice when the filter hides every action', () => {
+            // Product rule (PR — fix-empty-filter-message): when the
+            // overview filter hides every otherwise-eligible action,
+            // the Analyze & Suggest button must NOT reappear — only
+            // clearing the filter (or pressing Clear) should bring it
+            // back. The notice tells the operator why their feed
+            // is empty.
+            render(
+                <ActionFeed
+                    {...defaultProps}
+                    actions={{ 'reco_GEN.PY762': recoDetail }}
+                    actionScores={{ line_reconnection: { scores: { 'reco_GEN.PY762': 0.04 } } }}
+                    overviewFilters={{ ...DEFAULT_FILTERS, actionType: 'disco' }}
+                    onOverviewFiltersChange={vi.fn()}
+                    canRunAnalysis
+                />,
+            );
+            expect(screen.queryByRole('button', { name: /Analyze & Suggest/ })).not.toBeInTheDocument();
+            expect(screen.getByTestId('no-actions-match-filter')).toBeInTheDocument();
+            expect(screen.getByText(/No actions match the active filter/)).toBeInTheDocument();
+        });
+
+        it('reshows the Analyze & Suggest button once the filter is cleared', () => {
+            // Same fixture as above but with `actionType: 'all'` —
+            // the action matches the filter, so the feed renders the
+            // card AND the Analyze & Suggest slot stays hidden because
+            // prioritizedEntries is non-empty. Clearing the type
+            // filter alone is enough to restore the slot when no card
+            // is left visible (verified by removing the action below).
+            const { rerender } = render(
+                <ActionFeed
+                    {...defaultProps}
+                    actions={{ 'reco_GEN.PY762': recoDetail }}
+                    actionScores={{ line_reconnection: { scores: { 'reco_GEN.PY762': 0.04 } } }}
+                    overviewFilters={{ ...DEFAULT_FILTERS, actionType: 'disco' }}
+                    onOverviewFiltersChange={vi.fn()}
+                    canRunAnalysis
+                />,
+            );
+            expect(screen.queryByRole('button', { name: /Analyze & Suggest/ })).not.toBeInTheDocument();
+            rerender(
+                <ActionFeed
+                    {...defaultProps}
+                    actions={{}}
+                    actionScores={{}}
+                    overviewFilters={{ ...DEFAULT_FILTERS, actionType: 'all' }}
+                    onOverviewFiltersChange={vi.fn()}
+                    canRunAnalysis
+                />,
+            );
+            expect(screen.getByRole('button', { name: /Analyze & Suggest/ })).toBeInTheDocument();
+            expect(screen.queryByTestId('no-actions-match-filter')).not.toBeInTheDocument();
+        });
     });
 
     describe('recommendation-model selector + Clear', () => {

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -1129,8 +1129,14 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     result.actions with is_manual=false; gating on
                     prioritizedEntries (which already excludes selected +
                     rejected) is what makes the Analyze & Suggest button
-                    reappear post-Clear. */}
-                {(analysisLoading || pendingAnalysisResult || prioritizedEntries.length === 0) && (
+                    reappear post-Clear.
+
+                    When the overview filter hides every otherwise-
+                    eligible action, suppress the Analyze & Suggest
+                    button and surface a "no actions match the filter"
+                    notice instead — the operator should clear the
+                    filter before re-running an analysis. */}
+                {(analysisLoading || pendingAnalysisResult || (prioritizedEntries.length === 0 && overviewFilteredOutCount === 0)) && (
                     <div style={{ marginBottom: '10px' }}>
                         {analysisLoading ? (
                             <button disabled style={{
@@ -1233,8 +1239,13 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
                     prioritizedEntries.length > 0 ? renderActionList(prioritizedEntries) : (
                         !analysisLoading ? (
                             <div style={{ textAlign: 'center' }}>
-                                <p style={{ color: colors.textTertiary, fontStyle: 'italic', fontSize: '13px', margin: '5px 0' }}>
-                                    {!pendingAnalysisResult ? 'Click \u201cAnalyze & Suggest\u201d above to get action suggestions.' : 'No suggested actions available.'}
+                                <p
+                                    data-testid={overviewFilteredOutCount > 0 && !pendingAnalysisResult ? 'no-actions-match-filter' : undefined}
+                                    style={{ color: colors.textTertiary, fontStyle: 'italic', fontSize: '13px', margin: '5px 0' }}
+                                >
+                                    {overviewFilteredOutCount > 0 && !pendingAnalysisResult
+                                        ? 'No actions match the active filter. Clear the filter to see suggestions.'
+                                        : (!pendingAnalysisResult ? 'Click \u201cAnalyze & Suggest\u201d above to get action suggestions.' : 'No suggested actions available.')}
                                 </p>
                                 {/* Recommender thresholds banner moved into NoticesPanel
                                     (tier-warning-system PR — see `docs/proposals/ui-design-critique.md`


### PR DESCRIPTION
## Summary
When the overview filter hides every otherwise-eligible action, the Analyze & Suggest button is now suppressed and replaced with a "no actions match the filter" notice. This prevents operators from running analysis on an empty feed and guides them to clear the filter first.

## Changes
- **ActionFeed.tsx**: Updated the condition for showing the Analyze & Suggest button to check `overviewFilteredOutCount === 0` in addition to `prioritizedEntries.length === 0`. When the filter hides all actions, the button is hidden and a contextual message is shown instead.
  - Modified the empty-state message to display "No actions match the active filter. Clear the filter to see suggestions." when `overviewFilteredOutCount > 0` and no analysis is pending
  - Added `data-testid='no-actions-match-filter'` to the message paragraph for test targeting

- **ActionFeed.test.tsx**: Added two new test cases to verify the behavior:
  - Test that suppresses the Analyze & Suggest button and shows the no-match notice when a filter hides every action
  - Test that reshows the Analyze & Suggest button once the filter is cleared (via rerender)

## Implementation Details
The fix leverages the existing `overviewFilteredOutCount` prop to distinguish between "no actions exist" (show Analyze & Suggest) and "actions exist but are filtered out" (show notice). This aligns with the product rule (PR — fix-empty-filter-message) that the button must not reappear until the filter is explicitly cleared.

https://claude.ai/code/session_018RFo4B2wwSsVCM1XhiNg7S