### PR TITLE
Prevent NaN viewBox from blanking action variant diagram

### DIFF
--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -910,15 +910,25 @@ export function useDiagrams(
         }
       }
 
+      // Guard against NaN/Infinity coordinates: pypowsybl strips NaN
+      // SVG elements (services/diagram/nad_render.py:_strip_nan_elements)
+      // but leaves the corresponding metadata entry intact. Accumulating
+      // a non-finite point would propagate NaN through Math.min/max into
+      // the viewBox, yielding `<svg viewBox="NaN … NaN …">` and a blank
+      // diagram on tab switch.
       const addNodePointsBySvgId = (svgId: string) => {
         const n = effectiveIndex.nodesBySvgId.get(svgId);
-        if (n) points.push({ x: n.x, y: n.y });
+        if (n && Number.isFinite(n.x) && Number.isFinite(n.y)) {
+          points.push({ x: n.x, y: n.y });
+        }
         return n;
       };
 
       if (targetNode) {
         if (!usingFallbackIndex) targetSvgId = targetNode.svgId;
-        points.push({ x: targetNode.x, y: targetNode.y });
+        if (Number.isFinite(targetNode.x) && Number.isFinite(targetNode.y)) {
+          points.push({ x: targetNode.x, y: targetNode.y });
+        }
         (effectiveIndex.edgesByNode.get(targetNode.svgId) || []).forEach(e => {
           addNodePointsBySvgId(e.node1);
           addNodePointsBySvgId(e.node2);

--- a/frontend/src/hooks/usePanZoom.ts
+++ b/frontend/src/hooks/usePanZoom.ts
@@ -73,8 +73,25 @@ export const usePanZoom = (
     // Direct DOM update — no React involved
     const applyViewBox = useCallback((vb: ViewBox | null) => {
         const svg = svgElRef.current;
-        if (svg && vb) {
+        // Safety net: a NaN/Infinity in any field would yield e.g.
+        // `viewBox="NaN -2245943 NaN NaN"`, which SVG rejects and
+        // renders as a blank diagram. The upstream callers should
+        // never produce non-finite values, but a missing/malformed
+        // coordinate in grid_layout.json can leak through the
+        // pypowsybl metadata; refuse rather than corrupt the DOM.
+        if (
+            svg && vb &&
+            Number.isFinite(vb.x) && Number.isFinite(vb.y) &&
+            Number.isFinite(vb.w) && Number.isFinite(vb.h)
+        ) {
             svg.setAttribute('viewBox', `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
+        } else if (vb) {
+            // Trace the upstream caller so we can pinpoint which path
+            // (handleZoomToElement, useTabSync, useTiedTabsSync, an
+            // overflow-iframe postMessage handler, …) leaked a NaN /
+            // Infinity field. Stack-trace via Error() — works in every
+            // browser that supports SVG.
+            console.warn('[usePanZoom] rejected non-finite viewBox', vb, new Error().stack);
         }
         // Invalidate CTM cache after viewBox change
         ctmCacheRef.current = null;


### PR DESCRIPTION
## Summary

- Filter out non-finite node coordinates in `handleZoomToElement` (the unguarded `Math.min/max` path that was directly contaminating the viewBox).
- Add a catch-all safety net in `applyViewBox` (`usePanZoom`): refuse to write a viewBox containing any `NaN` / `Infinity` field, and log a `console.warn` with the full stack trace so we can pinpoint the upstream culprit on the next occurrence.

## Context

Selecting a remedial action would intermittently leave the diagram blank: the SVG flashed briefly then disappeared, with the browser logging:

```
<svg> attribute viewBox: Expected number, "NaN -2245943 NaN…".
```

The non-finite values originate from a metadata node with an unfit coordinate. pypowsybl already strips NaN SVG **elements** via `services/diagram/nad_render.py:_strip_nan_elements`, but the matching **metadata** entry survives — so any pipeline that reads `node.x` / `node.y` from the metadata index (handleZoomToElement, inspect-asset, tab-sync, tied-detached sync, …) can leak the NaN into the viewBox. The invalid `setAttribute('viewBox', 'NaN …')` overwrites the previously-valid viewBox, which is what produces the blank-screen symptom.

The intermittence is consistent with this: it depends on which specific assets are touched after the analysis (e.g. an action targeting a VL whose layout entry happened to be malformed). The safety net in `applyViewBox` catches it regardless of which call site produced the NaN.

## Test plan

- [x] `npx tsc -b` passes
- [x] `npx vitest run` → 1438 passed, 2 skipped, 0 fail
- [ ] Manual: with `config_large_grid_20240828T0100Z.json`, trigger contingency `P.SAOL31RONCI`, run analysis, explore overflow graph, then click a suggested action. The Remedial Action diagram must stay displayed (not blank).
- [ ] If the issue recurs, capture the `[usePanZoom] rejected non-finite viewBox` warning + stack trace from the browser console — that identifies the upstream call site that needs an additional guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)