### PR TITLE
Sidebar readability refresh: collapsible feed, banner Clear, overload info bubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and the project (informally) follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Sidebar readability refresh — collapsible feed, banner Clear, overload info bubble
+
+- **Sidebar visibility gate** — the "Select Contingency" picker card
+  and the "Remedial Actions" feed (renamed from "Simulated Actions")
+  now flip together at the moment a contingency is committed. The
+  picker folds away and the feed mounts, so the sidebar shows only
+  the affordance relevant to the current stage of the workflow.
+- **Sticky-banner Clear shortcut** — `SidebarSummary` grows a red
+  `Clear` button next to the contingency label that routes through
+  the existing "Change Contingency?" confirmation dialog when
+  analysis state would otherwise be lost (clears directly otherwise),
+  then makes the picker reappear. Emits a new
+  `contingency_clear_requested { had_analysis_state }` interaction
+  event.
+- **Overload info bubble** — a `?` icon next to the Overloads label
+  opens a hover popover listing N-state pre-existing overloads,
+  hosting the per-N-1 monitoring checkboxes, the
+  `monitor deselected` switch, and the monitoring-coverage hint.
+  Together with the restored double-click-to-toggle gesture on the
+  banner overload links themselves, the popover replaces the
+  inline `OverloadPanel` card (the component file is kept on disk
+  for unit-test backwards-compat but is no longer rendered).
+- **Collapsible sidebar** — `AppSidebar` accepts a `collapsed` prop
+  that shrinks the shell to a 32-px strip with an expand caret,
+  giving the visualization panel the freed width. When collapsed,
+  the `ActionFilterRings` strip rides along in the
+  `VisualizationPanel` tab row on the left (testid
+  `viz-panel-overview-filters`) so the overview filter remains
+  reachable without re-expanding the sidebar. Emits a new
+  `sidebar_collapsed_toggled { collapsed }` interaction event.
+- **Test coverage** — new `AppSidebar.test.tsx`, extended
+  `SidebarSummary.test.tsx` (Clear button, double-click toggle,
+  info-bubble popover) and `VisualizationPanel.test.tsx` (inline
+  filter strip gating). App-level integration tests in
+  `App.contingency.test.tsx` rewired to the Clear-driven flow.
+
 ### Execution-time breakdown for the "Suggestions produced by …" line
 
 - **Per-stage timing** for every two-step analysis run. The backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,14 @@ Co-Study4Grid/
 │       │                          # toggles, postMessage bridge, pin overlay payload)
 │       ├── components/            # Header, ActionFeed, ActionCard, ActionCardPopover,
 │       │                          # ActionSearchDropdown, ActionTypeFilterChips,
-│       │                          # ActionOverviewDiagram, AppSidebar, SidebarSummary,
-│       │                          # StatusToasts, VisualizationPanel, OverloadPanel,
+│       │                          # ActionOverviewDiagram, AppSidebar (collapsible
+│       │                          # shell — readability-feed PR), SidebarSummary
+│       │                          # (sticky strip — hosts Clear button + overload
+│       │                          # info bubble that absorbed the legacy
+│       │                          # OverloadPanel affordances),
+│       │                          # StatusToasts, VisualizationPanel, OverloadPanel
+│       │                          # (kept on disk for unit-test backwards-compat;
+│       │                          # no longer rendered from App.tsx),
 │       │                          # CombinedActionsModal, ComputedPairsTable,
 │       │                          # ExplorePairsTab, SldOverlay, DetachableTabHost,
 │       │                          # MemoizedSvgContainer, ErrorBoundary, NoticesPanel

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -80,9 +80,20 @@ frontend/
     │   ├── DetachableTabHost.tsx, ErrorBoundary.tsx, ExplorePairsTab.tsx,
     │   ├── MemoizedSvgContainer.tsx, SldOverlay.tsx,
     │   ├── AppSidebar.tsx          # Sidebar layout shell (summary +
-    │   │                           # contingency selector + children)
+    │   │                           # contingency picker + children).
+    │   │                           # Collapsible to a 32-px strip via
+    │   │                           # the `collapsed` / `onToggleCollapsed`
+    │   │                           # props; hides the picker when
+    │   │                           # `hideContingencyPicker` is on
+    │   │                           # (readability-feed PR).
     │   ├── SidebarSummary.tsx      # Sticky top strip — contingency
-    │   │                           # zoom shortcut + N-1 overload jumps
+    │   │                           # zoom shortcut + Clear button +
+    │   │                           # N-1 overload jumps (double-click
+    │   │                           # to toggle monitoring) + overload
+    │   │                           # info bubble (popover hosts N-state
+    │   │                           # overloads, per-N-1 monitoring
+    │   │                           # checkboxes, monitor-deselected
+    │   │                           # switch, monitoring-coverage hint).
     │   ├── StatusToasts.tsx        # Fixed-position error/info banners
     │   └── modals/
     │       ├── SettingsModal.tsx          # 3-tab settings dialog
@@ -194,9 +205,43 @@ AND make sure the backend mixin clears whatever cache shadows it.
 
 Confirmation dialog flow lives in `App.tsx`:
 - `confirmDialog` state: `{ type: 'contingency' | 'loadStudy' |
-  'applySettings', pendingBranch?: string } | null`.
-- `<ConfirmationDialog />` is the shared modal — used for all three
-  contingency-loss-warning gestures.
+  'applySettings' | 'changeNetwork' | 'clearSuggested', pendingBranch?:
+  string, pendingNetworkPath?: string } | null`.
+- `<ConfirmationDialog />` is the shared modal — used for all
+  contingency-loss-warning gestures (picker-driven *and* the new
+  sticky-banner Clear shortcut, see below).
+
+## Sidebar visibility & banner Clear shortcut
+
+`App.tsx` flips two visibility gates the moment the operator commits
+a contingency (`selectedContingency.length > 0`):
+- `hideContingencyPicker` is passed to `AppSidebar` so the "Select
+  Contingency" card folds away — the sticky banner already echoes
+  the contingency label and the `Clear` button (see below) replaces
+  the picker's affordance.
+- The `ActionFeed` is rendered only inside the same gate. Pre-trigger
+  the sidebar shows only the picker; post-trigger it shows the feed.
+
+The sticky banner (`SidebarSummary`) hosts:
+- a `Clear` button (`requestClearContingency`) that routes through
+  `<ConfirmationDialog type="contingency">` when `hasAnalysisState()`
+  would otherwise be lost, and clears in place otherwise;
+- a `?` info bubble next to the Overloads label whose popover lists
+  N-state pre-existing overloads, hosts the per-N-1 monitoring
+  checkboxes (`onToggleOverload`), the `monitorDeselected` switch,
+  and the monitoring-coverage hint — i.e. every affordance that
+  used to live in the now-retired `OverloadPanel` card.
+
+`AppSidebar` accepts a `collapsed` flag; when set, the shell shrinks
+to a 32-px strip with an expand caret. The `VisualizationPanel`
+mirrors this by hosting an inline copy of `ActionFilterRings` on the
+left of its tab row (testid `viz-panel-overview-filters`) so the
+filter remains reachable without re-expanding the sidebar.
+
+Interaction-log events emitted by this flow:
+`sidebar_collapsed_toggled { collapsed }`,
+`contingency_clear_requested { had_analysis_state }`. Both are
+mirrored in `scripts/check_standalone_parity.py`'s `SPEC_DETAILS`.
 
 ## SVG handling
 

--- a/frontend/src/App.contingency.test.tsx
+++ b/frontend/src/App.contingency.test.tsx
@@ -165,9 +165,23 @@ async function renderAndLoadStudy() {
 
 // Helper: add ``branchName`` to the pending contingency by typing it
 // into the react-select multi-select and pressing Enter to confirm
-// the highlighted option.
+// the highlighted option. After a contingency has already been
+// committed the picker card is hidden behind the sticky banner Clear
+// shortcut, so transparently click Clear (and confirm the dialog when
+// analysis state would be lost) to reveal the picker again.
 async function pickBranch(branchName: string) {
-  const combobox = screen.getByRole('combobox');
+  let combobox = screen.queryByRole('combobox');
+  if (!combobox) {
+    const clearBtn = screen.queryByTestId('sidebar-summary-clear');
+    if (clearBtn) {
+      await act(async () => { await userEvent.click(clearBtn); });
+      const confirmDialog = screen.queryByText('Change Contingency?');
+      if (confirmDialog) {
+        await act(async () => { await userEvent.click(screen.getByText('Confirm')); });
+      }
+    }
+    combobox = screen.getByRole('combobox');
+  }
   await act(async () => {
     await userEvent.click(combobox);
     await userEvent.type(combobox, branchName);
@@ -231,32 +245,35 @@ describe('Contingency Change Confirmation', () => {
     vi.unstubAllGlobals();
   });
 
-  it('does NOT show confirmation dialog when no analysis state exists', async () => {
+  it('does NOT show confirmation dialog when clearing without analysis state', async () => {
     await renderAndLoadStudy();
     await selectBranch('BRANCH_A');
 
-    // Now switch to BRANCH_B — no analysis has been run, so no dialog
+    // Clear from the sticky banner. No analysis state has been built
+    // up yet, so the Clear shortcut bypasses the confirmation dialog
+    // and the picker reappears immediately.
     mockApi.getContingencyDiagram.mockClear();
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('sidebar-summary-clear'));
+    });
+    expect(screen.queryByText('Change Contingency?')).not.toBeInTheDocument();
+
+    // Pick a fresh contingency through the now-visible picker.
     await pickBranch('BRANCH_B');
     await triggerContingency();
-
     await waitFor(() => {
-      expect(mockApi.getContingencyDiagram).toHaveBeenCalledWith(['BRANCH_A', 'BRANCH_B']);
+      expect(mockApi.getContingencyDiagram).toHaveBeenCalledWith(['BRANCH_B']);
     });
-
-    // No dialog should appear
-    expect(screen.queryByText('Change Contingency?')).not.toBeInTheDocument();
   });
 
-  it('shows confirmation dialog when switching branch after running analysis', async () => {
+  it('shows confirmation dialog when clearing after running analysis', async () => {
     await renderAndLoadStudy();
     await selectBranch('BRANCH_A');
     await runAnalysis();
 
-    // Now switch to BRANCH_B — should trigger dialog
-    await pickBranch('BRANCH_B');
-    await triggerContingency();
-
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('sidebar-summary-clear'));
+    });
     await waitFor(() => {
       expect(screen.getByText('Change Contingency?')).toBeInTheDocument();
     }, { timeout: 3000 });
@@ -267,53 +284,46 @@ describe('Contingency Change Confirmation', () => {
     await selectBranch('BRANCH_A');
     await runAnalysis();
 
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('sidebar-summary-clear'));
+    });
+    await screen.findByText('Change Contingency?');
+    await userEvent.click(screen.getByText('Confirm'));
+
+    mockApi.getContingencyDiagram.mockClear();
     await pickBranch('BRANCH_B');
     await triggerContingency();
-
-    await screen.findByText('Change Contingency?');
-    const confirmBtn = screen.getByText('Confirm');
-    await userEvent.click(confirmBtn);
-
     await waitFor(() => {
-      expect(mockApi.getContingencyDiagram).toHaveBeenCalledWith(['BRANCH_A', 'BRANCH_B']);
+      expect(mockApi.getContingencyDiagram).toHaveBeenCalledWith(['BRANCH_B']);
     });
     expect(screen.queryByText('Change Contingency?')).not.toBeInTheDocument();
   });
 
-  it('cancels contingency change on dismissal', async () => {
+  it('cancels contingency clear on dismissal', async () => {
     await renderAndLoadStudy();
     await selectBranch('BRANCH_A');
     await runAnalysis();
 
-    await pickBranch('BRANCH_B');
-    await triggerContingency();
-
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('sidebar-summary-clear'));
+    });
     await screen.findByText('Change Contingency?');
-    const cancelBtn = screen.getByText('Cancel');
-    await userEvent.click(cancelBtn);
+    await userEvent.click(screen.getByText('Cancel'));
 
-    // Should NOT have called the diagram fetch with the new pair
-    expect(mockApi.getContingencyDiagram).not.toHaveBeenCalledWith(['BRANCH_A', 'BRANCH_B']);
-    // The applied contingency stays at BRANCH_A — its chip is still
-    // visible in the multi-select. (Use getAllByText since the chip
-    // and the sidebar-summary link both surface the name.)
+    // BRANCH_A stays applied; its name still surfaces in the sticky
+    // banner. (Use getAllByText since both the banner link and the
+    // action-card data attribute may surface the name.)
     expect(screen.getAllByText('BRANCH_A').length).toBeGreaterThan(0);
   });
 
-  it('does not trigger dialog for partial/invalid branch text', async () => {
+  it('does not trigger a clear dialog for partial/invalid branch text', async () => {
     await renderAndLoadStudy();
-    await selectBranch('BRANCH_A');
-    await runAnalysis();
-
-    // Type something that doesn't match a full branch and DON'T press
-    // Enter — react-select keeps it as raw input text; no chip is added.
+    // The contingency picker stays visible until the operator
+    // triggers a contingency, so partial input via the multi-select
+    // never affects the banner / Clear flow.
     const combobox = screen.getByRole('combobox');
     await userEvent.click(combobox);
     await userEvent.type(combobox, 'INVALID_NAME');
-
-    // No dialog should appear for partial / invalid names — nothing
-    // is committed to the pending list until a real option is picked
-    // and the Trigger button is clicked.
     expect(screen.queryByText('Change Contingency?')).not.toBeInTheDocument();
   });
 });
@@ -351,20 +361,22 @@ describe('Overload Clearing Logic', () => {
     await pickBranch('BRANCH_A');
     await triggerContingency();
 
+    // The banner echoes both overloads as soon as the N-1 diagram
+    // fetch resolves (sticky strip rendered by SidebarSummary).
     await waitFor(() => {
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '2');
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '2');
+      const banner = screen.getByTestId('sidebar-summary-overloads');
+      expect(banner.textContent).toMatch(/OL_1/);
+      expect(banner.textContent).toMatch(/OL_2/);
     }, { timeout: 3000 });
 
     // Run analysis to create state
     await runAnalysis();
 
-    // 2. Select BRANCH_B (triggers confirmation dialog because the
-    // applied contingency now changes from [BRANCH_A] to
-    // [BRANCH_A, BRANCH_B] while analysis state still exists).
-    await pickBranch('BRANCH_B');
-    await triggerContingency();
-
+    // 2. Click the banner Clear shortcut — the confirmation dialog
+    // appears because analysis state would otherwise be lost.
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('sidebar-summary-clear'));
+    });
     await waitFor(() => {
       expect(screen.getByText('Change Contingency?')).toBeInTheDocument();
     }, { timeout: 3000 });
@@ -372,10 +384,11 @@ describe('Overload Clearing Logic', () => {
     // 3. Confirm change
     fireEvent.click(screen.getByText('Confirm'));
 
-    // 4. VERIFY IMMEDIATE CLEAR
+    // 4. VERIFY IMMEDIATE CLEAR — banner falls back to the empty
+    // state (no contingency, no overloads), and the picker reappears.
     await waitFor(() => {
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '0');
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '0');
+      expect(screen.queryByTestId('sidebar-summary-overloads')).not.toBeInTheDocument();
+      expect(screen.getByText('⚡ Select Contingency')).toBeInTheDocument();
     });
   });
 
@@ -426,6 +439,7 @@ describe('Overload Clearing Logic', () => {
   });
   it('pins contingency + overloads while only the action feed scrolls', async () => {
     await renderAndLoadStudy();
+    await selectBranch('BRANCH_A');
 
     // The sidebar itself no longer scrolls — it hosts a non-scrolling
     // sticky header (contingency + overloads) and a scrolling body
@@ -436,7 +450,8 @@ describe('Overload Clearing Logic', () => {
     expect(sidebar).toHaveStyle({ overflow: 'hidden' });
 
     // The ActionFeed is inside a scrolling wrapper that takes the
-    // remaining sidebar height.
+    // remaining sidebar height. It only mounts after a contingency
+    // has been committed, mirroring the new sidebar visibility gate.
     const sidebarActionsHeader = await within(sidebar).findByTestId('action-feed-header');
     const scrollWrapper = sidebarActionsHeader.closest('div[style*="overflow-y: auto"]');
     expect(scrollWrapper).toBeInTheDocument();
@@ -538,13 +553,15 @@ describe('N-1 overload state is populated before action analysis', () => {
     await renderAndLoadStudy();
     await selectBranch('BRANCH_A');
 
-    // The OverloadPanel reflects the two overloads from the N-1
-    // diagram fetch — and they are auto-selected so the
+    // The sticky banner reflects the two overloads from the N-1
+    // diagram fetch — and they are auto-selected (rendered as blue
+    // dotted-underlined links, the SidebarSummary convention) so the
     // computeN1OverloadHighlights helper will return them as the
     // highlight set on the very next render of the N-1 tab.
     await waitFor(() => {
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '2');
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '2');
+      const banner = screen.getByTestId('sidebar-summary-overloads');
+      expect(banner.textContent).toMatch(/LINE_OL_A/);
+      expect(banner.textContent).toMatch(/LINE_OL_B/);
     });
 
     // No analysis was run, so ``result.lines_overloaded`` is empty —
@@ -613,7 +630,7 @@ describe('N-1 overload state is populated before action analysis', () => {
   // set, so every user toggle retriggered the effect and re-added the
   // overload that was just removed ("blinks but does not switch to
   // unselected"). Lock in the fix: deselecting an overload must persist.
-  it('preserves user-deselected overloads across re-renders (double-click unselect)', async () => {
+  it('preserves user-deselected overloads across re-renders (info bubble unselect)', async () => {
     mockApi.getContingencyDiagram.mockResolvedValueOnce({
       svg: '<svg></svg>',
       metadata: null,
@@ -623,27 +640,44 @@ describe('N-1 overload state is populated before action analysis', () => {
     await renderAndLoadStudy();
     await selectBranch('BRANCH_A');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '2');
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '2');
-    });
-
+    // Open the info bubble next to the Overloads banner label —
+    // the popover hosts the per-overload monitoring toggles. Both
+    // overloads start checked (auto-selected) so both checkboxes
+    // are initially ticked.
+    await waitFor(() => screen.getByTestId('sidebar-summary-overloads-bubble'));
     await act(async () => {
-      screen.getByTestId('toggle-overload-LINE_OL_A').click();
+      screen.getByTestId('sidebar-summary-overloads-bubble').click();
     });
+    const popover = await screen.findByTestId('overload-info-popover');
+    const toggleA = within(popover).getByTestId('overload-info-toggle-LINE_OL_A')
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const toggleB = within(popover).getByTestId('overload-info-toggle-LINE_OL_B')
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(toggleA.checked).toBe(true);
+    expect(toggleB.checked).toBe(true);
 
+    await act(async () => { toggleA.click(); });
     await waitFor(() => {
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '1');
+      expect((within(screen.getByTestId('overload-info-popover'))
+        .getByTestId('overload-info-toggle-LINE_OL_A')
+        .querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(false);
     });
 
     // Force an additional render cycle — the buggy effect retriggered on
     // every analysis-memo refresh and re-added the deselected overload.
     await act(async () => {
-      screen.getByTestId('toggle-overload-LINE_OL_B').click();
+      (within(screen.getByTestId('overload-info-popover'))
+        .getByTestId('overload-info-toggle-LINE_OL_B')
+        .querySelector('input[type="checkbox"]') as HTMLInputElement).click();
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '0');
+      expect((within(screen.getByTestId('overload-info-popover'))
+        .getByTestId('overload-info-toggle-LINE_OL_A')
+        .querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(false);
+      expect((within(screen.getByTestId('overload-info-popover'))
+        .getByTestId('overload-info-toggle-LINE_OL_B')
+        .querySelector('input[type="checkbox"]') as HTMLInputElement).checked).toBe(false);
     });
   });
 
@@ -658,7 +692,9 @@ describe('N-1 overload state is populated before action analysis', () => {
     await selectBranch('BRANCH_A');
 
     await waitFor(() => {
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '2');
+      const banner = screen.getByTestId('sidebar-summary-overloads');
+      expect(banner.textContent).toMatch(/LINE_OL_A/);
+      expect(banner.textContent).toMatch(/LINE_OL_B/);
     });
 
     mockApi.getContingencyDiagram.mockResolvedValueOnce({
@@ -667,15 +703,18 @@ describe('N-1 overload state is populated before action analysis', () => {
       lines_overloaded: ['LINE_OL_C'],
     });
 
+    // pickBranch automatically routes through the Clear shortcut
+    // (no analysis state → no confirmation), so the new contingency
+    // is the lone BRANCH_B rather than the legacy ['A', 'B'] append.
     await pickBranch('BRANCH_B');
     await triggerContingency();
 
     await waitFor(() => {
-      // Multi-element contingency now applies, so the diagram fetch
-      // carries both branches in the order the user added them.
-      expect(mockApi.getContingencyDiagram).toHaveBeenCalledWith(['BRANCH_A', 'BRANCH_B']);
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-n1-ol-count', '1');
-      expect(screen.getByTestId('overload-panel')).toHaveAttribute('data-sel-ol-count', '1');
+      expect(mockApi.getContingencyDiagram).toHaveBeenCalledWith(['BRANCH_B']);
+      const banner = screen.getByTestId('sidebar-summary-overloads');
+      expect(banner.textContent).toMatch(/LINE_OL_C/);
+      expect(banner.textContent).not.toMatch(/LINE_OL_A/);
+      expect(banner.textContent).not.toMatch(/LINE_OL_B/);
     });
   });
 });

--- a/frontend/src/App.contingency.test.tsx
+++ b/frontend/src/App.contingency.test.tsx
@@ -61,7 +61,7 @@ vi.mock('./components/ActionFeed', () => ({
       data-loading={!!props.analysisLoading}
     >
       <div>
-        <h3 data-testid="action-feed-header">Simulated Actions</h3>
+        <h3 data-testid="action-feed-header">Remedial Actions</h3>
       </div>
       {props.analysisLoading ? (
         <button disabled>⚙️ Analyzing…</button>

--- a/frontend/src/App.session.test.tsx
+++ b/frontend/src/App.session.test.tsx
@@ -304,7 +304,7 @@ describe('Full State Reset on Load Study', () => {
     await renderAndLoadStudy();
     await selectBranch('BRANCH_A');
 
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')?.textContent).toBe('BRANCH_A');
+    expect(screen.getByTestId('sidebar-summary-contingency').textContent).toContain('BRANCH_A');
 
     mockApi.updateConfig.mockClear();
     mockApi.getBranches.mockClear();
@@ -325,7 +325,7 @@ describe('Full State Reset on Load Study', () => {
     });
 
     // Branch input should be cleared
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')).toBeNull();
+    expect(screen.queryByTestId('sidebar-summary-contingency')).toBeNull();
   });
 
   it('clears branch selection after confirming Load Study with analysis state', async () => {
@@ -333,7 +333,7 @@ describe('Full State Reset on Load Study', () => {
     await selectBranch('BRANCH_A');
     await runAnalysis();
 
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')?.textContent).toBe('BRANCH_A');
+    expect(screen.getByTestId('sidebar-summary-contingency').textContent).toContain('BRANCH_A');
 
     mockApi.updateConfig.mockClear();
     mockApi.getBranches.mockClear();
@@ -361,7 +361,7 @@ describe('Full State Reset on Load Study', () => {
     });
 
     // Branch input must be cleared after reset
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')).toBeNull();
+    expect(screen.queryByTestId('sidebar-summary-contingency')).toBeNull();
   });
 
   it('re-fetches branches after Load Study reset', async () => {
@@ -441,7 +441,7 @@ describe('Full State Reset on Apply Settings', () => {
     await renderAndLoadStudy();
     await selectBranch('BRANCH_A');
 
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')?.textContent).toBe('BRANCH_A');
+    expect(screen.getByTestId('sidebar-summary-contingency').textContent).toContain('BRANCH_A');
 
     mockApi.updateConfig.mockClear();
 
@@ -452,7 +452,7 @@ describe('Full State Reset on Apply Settings', () => {
       expect(mockApi.updateConfig).toHaveBeenCalled();
     });
 
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')).toBeNull();
+    expect(screen.queryByTestId('sidebar-summary-contingency')).toBeNull();
     expect(screen.queryByText('Apply')).not.toBeInTheDocument();
   });
 
@@ -461,7 +461,7 @@ describe('Full State Reset on Apply Settings', () => {
     await selectBranch('BRANCH_A');
     await runAnalysis();
 
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')?.textContent).toBe('BRANCH_A');
+    expect(screen.getByTestId('sidebar-summary-contingency').textContent).toContain('BRANCH_A');
 
     mockApi.updateConfig.mockClear();
 
@@ -472,7 +472,7 @@ describe('Full State Reset on Apply Settings', () => {
       expect(mockApi.updateConfig).toHaveBeenCalled();
     });
 
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')).toBeNull();
+    expect(screen.queryByTestId('sidebar-summary-contingency')).toBeNull();
     expect(screen.queryByText('Apply')).not.toBeInTheDocument();
   });
 
@@ -677,7 +677,7 @@ describe('Apply Settings Confirmation', () => {
     expect(mockApi.updateConfig).not.toHaveBeenCalled();
     expect(screen.getByText('Apply')).toBeInTheDocument();
     // The contingency selection must also still be intact.
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')?.textContent).toBe('BRANCH_A');
+    expect(screen.getByTestId('sidebar-summary-contingency').textContent).toContain('BRANCH_A');
   });
 });
 
@@ -901,7 +901,7 @@ describe('Session reload — different contingency than current', () => {
     await runAnalysis();
 
     // Verify pre-state: BRANCH_A committed and analysis result present.
-    expect(document.querySelector('.cs4g-contingency__multi-value__label')?.textContent).toBe('BRANCH_A');
+    expect(screen.getByTestId('sidebar-summary-contingency').textContent).toContain('BRANCH_A');
 
     // 2. Open the Reload Session modal and pick the BRANCH_B session.
     const reloadBtn = screen.getByText('Reload Session');

--- a/frontend/src/App.stateManagement.test.tsx
+++ b/frontend/src/App.stateManagement.test.tsx
@@ -170,13 +170,27 @@ async function clearContingencyChips() {
 // tests keep their semantics; pass ``{ append: true }`` to grow a
 // multi-element contingency on top of the existing chips.
 async function selectBranch(branchName: string, opts: { append?: boolean } = {}) {
-  if (!opts.append) {
+  // The picker card hides once a contingency has been committed —
+  // the sticky banner Clear shortcut brings it back. Route through
+  // Clear when the combobox is missing so the helper keeps a
+  // legacy-feel "switch branch" API for the existing test suite.
+  let combobox = screen.queryByRole('combobox');
+  if (!combobox) {
+    const clearBtn = screen.queryByTestId('sidebar-summary-clear');
+    if (clearBtn) {
+      await act(async () => { await userEvent.click(clearBtn); });
+      const confirmDialog = screen.queryByText('Change Contingency?');
+      if (confirmDialog) {
+        await act(async () => { await userEvent.click(screen.getByText('Confirm')); });
+      }
+    }
+    combobox = screen.getByRole('combobox');
+  } else if (!opts.append) {
     await clearContingencyChips();
   }
-  const combobox = screen.getByRole('combobox');
   await act(async () => {
-    await userEvent.click(combobox);
-    await userEvent.type(combobox, branchName);
+    await userEvent.click(combobox!);
+    await userEvent.type(combobox!, branchName);
     await userEvent.keyboard('{Enter}');
   });
   const trigger = await screen.findByRole('button', { name: /Trigger/ });
@@ -230,6 +244,9 @@ describe('Phase 2: State Management Optimization', () => {
 
     it('does NOT pass individual recommender settings as separate props', async () => {
       await renderAndLoadStudy();
+      // ActionFeed mounts only after a contingency is committed
+      // (sidebar visibility gate from the readability-feed PR).
+      await selectBranch('BRANCH_A');
 
       const lastRender = actionFeedRenderLog[actionFeedRenderLog.length - 1];
       // These should NOT exist as individual props since they're now grouped
@@ -265,6 +282,8 @@ describe('Phase 2: State Management Optimization', () => {
 
     it('provides stable onActionFavorite callback to ActionFeed', async () => {
       await renderAndLoadStudy();
+      // ActionFeed only mounts post-contingency.
+      await selectBranch('BRANCH_A');
 
       const lastRender = actionFeedRenderLog[actionFeedRenderLog.length - 1];
       expect(typeof lastRender.onActionFavorite).toBe('function');
@@ -275,13 +294,12 @@ describe('Phase 2: State Management Optimization', () => {
       expect(typeof lastRender.onManualActionAdded).toBe('function');
     });
 
-    it('provides stable toggle callbacks to OverloadPanel', async () => {
-      // tier-warning-system PR retired the inline yellow monitoring banner —
-      // OverloadPanel now receives a one-line `monitoringHint` string
-      // and the dismiss/openSettings affordances live in NoticesPanel.
-      // What remains stable here are the overload-toggle callbacks.
+    it.skip('provides stable toggle callbacks to OverloadPanel', async () => {
+      // readability-feed PR retired the inline OverloadPanel — the
+      // overload-toggle callbacks now route through the sticky
+      // banner info-bubble popover (SidebarSummary). The component
+      // is no longer mounted, so this assertion is dead weight.
       await renderAndLoadStudy();
-
       const lastRender = overloadPanelRenderLog[overloadPanelRenderLog.length - 1];
       expect(typeof lastRender.onToggleOverload).toBe('function');
       expect(typeof lastRender.onToggleMonitorDeselected).toBe('function');
@@ -340,12 +358,15 @@ describe('Phase 2: State Management Optimization', () => {
       expect(actionFeed).toHaveAttribute('data-has-recommender-config', 'true');
     });
 
-    it('renders all three memoized panels', async () => {
+    it('renders the visualization and action-feed memoized panels after a contingency is committed', async () => {
+      // The OverloadPanel was removed in the readability-feed PR;
+      // its functionality moved to SidebarSummary's info bubble.
+      // ActionFeed mounts only after a contingency is committed.
       await renderAndLoadStudy();
+      await selectBranch('BRANCH_A');
 
       expect(screen.getByTestId('visualization-panel')).toBeInTheDocument();
       expect(screen.getByTestId('action-feed')).toBeInTheDocument();
-      expect(screen.getByTestId('overload-panel')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,6 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import './App.css';
 import VisualizationPanel from './components/VisualizationPanel';
 import ActionFeed from './components/ActionFeed';
-import OverloadPanel from './components/OverloadPanel';
 import Header from './components/Header';
 import AppSidebar from './components/AppSidebar';
 import StatusToasts from './components/StatusToasts';
@@ -153,6 +152,18 @@ function App() {
   // Confirmation dialog state for contingency change / load study /
   // apply settings / change network path.
   const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState>(null);
+
+  // Collapsed mode for the left sidebar. When true the sidebar shrinks
+  // to a thin strip and the visualization panel takes the full width.
+  // Toggleable from the Clear/Collapse caret rendered by `AppSidebar`.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const handleToggleSidebarCollapsed = useCallback(() => {
+    setSidebarCollapsed(c => {
+      const next = !c;
+      interactionLogger.record('sidebar_collapsed_toggled', { collapsed: next });
+      return next;
+    });
+  }, []);
 
   // Path of the network file the currently-loaded study was loaded from.
   // Updated after every successful handleLoadConfig / applySettings, used
@@ -411,6 +422,16 @@ function App() {
     // not survive a fresh reset.
     setConfirmDialog(null);
   }, [clearContingencyState, diagrams, setShowMonitoringWarning]);
+
+  // Sidebar visibility gates. The picker card and the action feed
+  // flip together at the moment the operator has played a contingency.
+  // From that point on the sticky banner echoes the contingency +
+  // overload labels with its own Clear shortcut, so the picker would
+  // just duplicate state — and the feed becomes useful (Analyze &
+  // Suggest, manual selection, …). Pre-trigger states keep the picker
+  // visible and the feed hidden so the sidebar stays focused.
+  const hasCommittedContingency = selectedContingency.length > 0;
+  const sidebarSwitchedToFeed = hasCommittedContingency;
 
   // Pre-compute the pin descriptors posted to the overflow-graph
   // iframe. Memoised so unrelated re-renders don't churn the iframe
@@ -836,6 +857,23 @@ function App() {
   const hasAnalysisState = useCallback(() => {
     return !!(result || pendingAnalysisResult || selectedActionId || actionDiagram || manuallyAddedIds.size > 0 || selectedActionIds.size > 0 || rejectedActionIds.size > 0);
   }, [result, pendingAnalysisResult, selectedActionId, actionDiagram, manuallyAddedIds, selectedActionIds, rejectedActionIds]);
+
+  // Sidebar-banner Clear button: drops the current contingency and
+  // returns to the picker. Routes through the contingency confirmation
+  // dialog when analysis state would otherwise be lost; clears
+  // directly otherwise (mirroring the picker-driven flow's gating).
+  const requestClearContingency = useCallback(() => {
+    interactionLogger.record('contingency_clear_requested', {
+      had_analysis_state: hasAnalysisState(),
+    });
+    if (hasAnalysisState()) {
+      setConfirmDialog({ type: 'contingency', pendingBranch: '' });
+      return;
+    }
+    clearContingencyState();
+    setSelectedContingency([]);
+    setPendingContingency([]);
+  }, [hasAnalysisState, clearContingencyState]);
 
   // Full-fidelity snapshot of every parameter an agent would need to
   // replay a config-loaded / settings-applied gesture. Per the
@@ -1451,35 +1489,31 @@ function App() {
           nameMap={nameMap}
           n1LinesOverloaded={n1Diagram?.lines_overloaded}
           n1LinesOverloadedRho={n1Diagram?.lines_overloaded_rho}
+          nLinesOverloaded={nDiagram?.lines_overloaded}
+          nLinesOverloadedRho={nDiagram?.lines_overloaded_rho}
           selectedOverloads={selectedOverloads}
           onPendingContingencyChange={handlePendingContingencyChange}
           onContingencyApply={handleContingencyApply}
           displayName={displayName}
           onContingencyZoom={handleZoomOnActiveTab}
           onOverloadClick={wrappedAssetClick as (actionId: string, assetName: string, tab: 'n' | 'contingency') => void}
+          onToggleOverload={analysis.handleToggleOverload}
+          monitorDeselected={monitorDeselected}
+          onToggleMonitorDeselected={handleToggleMonitorDeselected}
+          monitoringHint={
+            showMonitoringWarning && totalLinesCount && totalLinesCount > 0
+              ? `${monitoredLinesCount || 0}/${totalLinesCount} lines monitored — see Notices for details.`
+              : null
+          }
+          onClearContingency={requestClearContingency}
+          hideContingencyPicker={sidebarSwitchedToFeed}
+          collapsed={sidebarCollapsed}
+          onToggleCollapsed={handleToggleSidebarCollapsed}
           overviewFilters={overviewFilters}
           onOverviewFiltersChange={setOverviewFilters}
           hasActions={Object.keys(result?.actions || {}).length > 0}
         >
-          <div style={{ flexShrink: 0 }}>
-            <OverloadPanel
-              nOverloads={nDiagram?.lines_overloaded || []}
-              n1Overloads={n1Diagram?.lines_overloaded || []}
-              nOverloadsRho={nDiagram?.lines_overloaded_rho}
-              n1OverloadsRho={n1Diagram?.lines_overloaded_rho}
-              onAssetClick={wrappedAssetClick as (actionId: string, assetName: string, tab?: 'n' | 'contingency') => void}
-              monitoringHint={
-                showMonitoringWarning && totalLinesCount && totalLinesCount > 0
-                  ? `${monitoredLinesCount || 0}/${totalLinesCount} lines monitored — see Notices for details.`
-                  : null
-              }
-              selectedOverloads={selectedOverloads}
-              onToggleOverload={analysis.handleToggleOverload}
-              monitorDeselected={monitorDeselected}
-              onToggleMonitorDeselected={handleToggleMonitorDeselected}
-              displayName={displayName}
-            />
-          </div>
+          {sidebarSwitchedToFeed && (
           <ActionFeed
             actions={result?.actions || {}}
             actionScores={result?.action_scores}
@@ -1545,6 +1579,7 @@ function App() {
             wallClockTime={result?.wall_clock_time ?? null}
             onClearSuggested={requestClearSuggested}
           />
+          )}
         </AppSidebar>
         <div style={{ flex: 1, background: 'white', display: 'flex', flexDirection: 'column' }}>
           <VisualizationPanel

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1644,6 +1644,8 @@ function App() {
             displayName={displayName}
             overviewFilters={overviewFilters}
             onOverviewFiltersChange={setOverviewFilters}
+            sidebarCollapsed={sidebarCollapsed}
+            hasActions={Object.keys(result?.actions || {}).length > 0}
             unsimulatedActionIds={unsimulatedActionIds}
             unsimulatedActionInfo={unsimulatedActionInfo}
             onSimulateUnsimulatedAction={handleSimulateUnsimulatedAction}

--- a/frontend/src/components/ActionFeed.tsx
+++ b/frontend/src/components/ActionFeed.tsx
@@ -849,7 +849,7 @@ const ActionFeed: React.FC<ActionFeedProps> = ({
         <div style={{ padding: '15px' }}>
             {/* Header with search */}
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px', position: 'relative' }}>
-                <h3 data-testid="action-feed-header" style={{ margin: 0, flex: 1 }}>Simulated Actions</h3>
+                <h3 data-testid="action-feed-header" style={{ margin: 0, flex: 1 }}>Remedial Actions</h3>
                 <button
                     onClick={handleOpenSearch}
                     style={{

--- a/frontend/src/components/AppSidebar.test.tsx
+++ b/frontend/src/components/AppSidebar.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+// This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import AppSidebar from './AppSidebar';
+
+describe('AppSidebar', () => {
+    const baseProps = {
+        selectedContingency: [] as string[],
+        pendingContingency: [] as string[],
+        branches: ['BRANCH_A', 'BRANCH_B'],
+        nameMap: {} as Record<string, string>,
+        n1LinesOverloaded: undefined as string[] | undefined,
+        n1LinesOverloadedRho: undefined as number[] | undefined,
+        selectedOverloads: undefined as Set<string> | null | undefined,
+        onPendingContingencyChange: vi.fn(),
+        onContingencyApply: vi.fn(),
+        displayName: (id: string) => id,
+        onContingencyZoom: vi.fn(),
+        onOverloadClick: vi.fn(),
+        children: <div data-testid="sidebar-children">FEED</div>,
+    };
+
+    it('renders the picker card by default and includes the children slot', () => {
+        render(<AppSidebar {...baseProps} />);
+        expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+        expect(screen.getByText('⚡ Select Contingency')).toBeInTheDocument();
+        expect(screen.getByTestId('sidebar-children')).toBeInTheDocument();
+    });
+
+    it('hides the picker card when hideContingencyPicker is true', () => {
+        render(
+            <AppSidebar
+                {...baseProps}
+                selectedContingency={['BRANCH_A']}
+                pendingContingency={['BRANCH_A']}
+                hideContingencyPicker
+            />,
+        );
+        expect(screen.queryByText('⚡ Select Contingency')).not.toBeInTheDocument();
+        expect(screen.getByTestId('sidebar-children')).toBeInTheDocument();
+    });
+
+    it('omits the picker card when no branches are loaded yet', () => {
+        render(<AppSidebar {...baseProps} branches={[]} />);
+        expect(screen.queryByText('⚡ Select Contingency')).not.toBeInTheDocument();
+    });
+
+    describe('Collapse mode', () => {
+        it('renders a thin strip with an expand button when collapsed=true', () => {
+            const onToggleCollapsed = vi.fn();
+            render(
+                <AppSidebar
+                    {...baseProps}
+                    collapsed
+                    onToggleCollapsed={onToggleCollapsed}
+                />,
+            );
+            const sidebar = screen.getByTestId('sidebar');
+            expect(sidebar).toHaveAttribute('data-collapsed', 'true');
+            expect(screen.getByTestId('sidebar-expand-button')).toBeInTheDocument();
+            // The picker card and the children-slot (feed) are NOT
+            // rendered in collapsed mode — the strip is intentionally
+            // bare so the visualization panel takes the freed width.
+            expect(screen.queryByText('⚡ Select Contingency')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('sidebar-children')).not.toBeInTheDocument();
+        });
+
+        it('fires onToggleCollapsed when the expand button is clicked', () => {
+            const onToggleCollapsed = vi.fn();
+            render(
+                <AppSidebar
+                    {...baseProps}
+                    collapsed
+                    onToggleCollapsed={onToggleCollapsed}
+                />,
+            );
+            fireEvent.click(screen.getByTestId('sidebar-expand-button'));
+            expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+        });
+
+        it('renders the collapse caret in the expanded shell when onToggleCollapsed is wired', () => {
+            const onToggleCollapsed = vi.fn();
+            render(
+                <AppSidebar
+                    {...baseProps}
+                    onToggleCollapsed={onToggleCollapsed}
+                />,
+            );
+            const caret = screen.getByTestId('sidebar-collapse-button');
+            expect(caret).toBeInTheDocument();
+            fireEvent.click(caret);
+            expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+        });
+
+        it('omits the collapse caret when no toggle handler is provided', () => {
+            render(<AppSidebar {...baseProps} />);
+            expect(screen.queryByTestId('sidebar-collapse-button')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('Forwarding to SidebarSummary', () => {
+        it('passes the Clear handler and overload toggles through to the sticky banner', () => {
+            const onClearContingency = vi.fn();
+            const onToggleOverload = vi.fn();
+            render(
+                <AppSidebar
+                    {...baseProps}
+                    selectedContingency={['BRANCH_A']}
+                    pendingContingency={['BRANCH_A']}
+                    n1LinesOverloaded={['LINE_X']}
+                    n1LinesOverloadedRho={[1.05]}
+                    onClearContingency={onClearContingency}
+                    onToggleOverload={onToggleOverload}
+                />,
+            );
+            fireEvent.click(screen.getByTestId('sidebar-summary-clear'));
+            expect(onClearContingency).toHaveBeenCalledTimes(1);
+            fireEvent.doubleClick(screen.getByRole('button', { name: 'LINE_X' }));
+            expect(onToggleOverload).toHaveBeenCalledWith('LINE_X');
+        });
+    });
+});

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -25,6 +25,9 @@ interface AppSidebarProps {
   nameMap: Record<string, string>;
   n1LinesOverloaded: string[] | undefined;
   n1LinesOverloadedRho: number[] | undefined;
+  /** N-state pre-existing overloads, surfaced in the SidebarSummary info bubble. */
+  nLinesOverloaded?: string[];
+  nLinesOverloadedRho?: number[];
   selectedOverloads: Set<string> | null | undefined;
   /** Replace the pending list with the user's current selection. */
   onPendingContingencyChange: (next: string[]) => void;
@@ -33,6 +36,23 @@ interface AppSidebarProps {
   displayName: (id: string) => string;
   onContingencyZoom: (assetName: string) => void;
   onOverloadClick: (actionId: string, assetName: string, tab: 'n' | 'contingency') => void;
+  /** Toggle an N-1 overload's inclusion in the analysis monitoring set.
+   *  Forwarded to SidebarSummary's info bubble. */
+  onToggleOverload?: (overload: string) => void;
+  monitorDeselected?: boolean;
+  onToggleMonitorDeselected?: () => void;
+  monitoringHint?: string | null;
+  /** Drop the current contingency to investigate a new one. Triggers
+   *  the confirmation dialog at the call site. */
+  onClearContingency?: () => void;
+  /** Hide the "Select Contingency" card. Used after a contingency has
+   *  been committed AND its overloads detected, since the sticky banner
+   *  then carries the same info plus a Clear shortcut. */
+  hideContingencyPicker?: boolean;
+  /** Collapsed mode: the sidebar shrinks to a thin strip so the
+   *  visualization panel can take the full width. */
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
   /** Shared severity + action-type filters; forwarded to
    *  SidebarSummary so the persistent strip can host the filter
    *  rings alongside the contingency / overload lines. */
@@ -49,19 +69,16 @@ interface AppSidebarProps {
  * - A COMPACT sticky strip at the top (<SidebarSummary>) keeps only
  *   the clickable fields of interest visible while scrolling
  *   (selected contingency → zoom active tab; contingency overloads →
- *   jump to the contingency tab + zoom).
- * - Everything else — the full Select Contingency card with the
- *   multi-select picker + Apply button, the Overloads panel with its
- *   warnings and N / contingency breakdown, and the ActionFeed —
- *   scrolls together in a single column below (rendered as
- *   ``children``), saving vertical space.
+ *   jump to the contingency tab + zoom). The strip also hosts the
+ *   Clear-contingency shortcut and the overload-info bubble.
+ * - The Select Contingency card with the multi-select picker + Trigger
+ *   button shows below the strip — but only as long as no contingency
+ *   has been committed (after that, the strip carries the same info
+ *   and the picker would be redundant).
+ * - The ActionFeed (rendered as ``children``) sits below.
  *
- * The Select Contingency card supports N-1 AND N-K studies: the user
- * picks elements one-by-one from the searchable multi-select (chips
- * appear inline; ✕ removes a chip) and confirms the full list with
- * the Apply button. Pressing Apply commits the pending list to the
- * actual ``selectedContingency`` which then drives the diagram fetch
- * and analysis.
+ * The shell can be collapsed to a thin strip when the operator wants
+ * to expand the visualization panel.
  */
 export default function AppSidebar({
   selectedContingency,
@@ -70,19 +87,29 @@ export default function AppSidebar({
   nameMap,
   n1LinesOverloaded,
   n1LinesOverloadedRho,
+  nLinesOverloaded,
+  nLinesOverloadedRho,
   selectedOverloads,
   onPendingContingencyChange,
   onContingencyApply,
   displayName,
   onContingencyZoom,
   onOverloadClick,
+  onToggleOverload,
+  monitorDeselected,
+  onToggleMonitorDeselected,
+  monitoringHint,
+  onClearContingency,
+  hideContingencyPicker,
+  collapsed,
+  onToggleCollapsed,
   overviewFilters,
   onOverviewFiltersChange,
   hasActions,
   children,
 }: AppSidebarProps) {
   // Pending differs from applied → user has unconfirmed edits to the
-  // contingency that won't take effect until they hit Apply.
+  // contingency that won't take effect until they hit Trigger.
   const samePendingApplied =
     pendingContingency.length === selectedContingency.length &&
     pendingContingency.every((e, i) => e === selectedContingency[i]);
@@ -107,22 +134,97 @@ export default function AppSidebar({
     [pendingContingency, optionByValue, nameMap],
   );
 
+  if (collapsed) {
+    return (
+      <div
+        data-testid="sidebar"
+        data-collapsed="true"
+        style={{
+          width: '32px',
+          background: colors.borderSubtle,
+          borderRight: `1px solid ${colors.border}`,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: `${space[2]} 0`,
+        }}
+      >
+        <button
+          data-testid="sidebar-expand-button"
+          onClick={onToggleCollapsed}
+          title="Expand sidebar"
+          style={{
+            background: colors.surface,
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.sm,
+            cursor: 'pointer',
+            width: '24px',
+            height: '24px',
+            fontSize: '12px',
+            color: colors.textSecondary,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 0,
+          }}
+        >
+          ›
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div data-testid="sidebar" style={{ width: '25%', background: colors.borderSubtle, borderRight: `1px solid ${colors.border}`, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <div data-testid="sidebar" style={{ width: '25%', background: colors.borderSubtle, borderRight: `1px solid ${colors.border}`, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      {onToggleCollapsed && (
+        <button
+          data-testid="sidebar-collapse-button"
+          onClick={onToggleCollapsed}
+          title="Collapse sidebar to widen the visualization panel"
+          style={{
+            position: 'absolute',
+            top: '4px',
+            right: '4px',
+            zIndex: 5,
+            background: colors.surface,
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.sm,
+            cursor: 'pointer',
+            width: '20px',
+            height: '20px',
+            fontSize: '11px',
+            color: colors.textSecondary,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 0,
+            lineHeight: 1,
+          }}
+        >
+          ‹
+        </button>
+      )}
       <SidebarSummary
         selectedContingency={selectedContingency}
         n1LinesOverloaded={n1LinesOverloaded}
         n1LinesOverloadedRho={n1LinesOverloadedRho}
+        nLinesOverloaded={nLinesOverloaded}
+        nLinesOverloadedRho={nLinesOverloadedRho}
         selectedOverloads={selectedOverloads}
         displayName={displayName}
         onContingencyZoom={onContingencyZoom}
         onOverloadClick={onOverloadClick}
+        onToggleOverload={onToggleOverload}
+        monitorDeselected={monitorDeselected}
+        onToggleMonitorDeselected={onToggleMonitorDeselected}
+        monitoringHint={monitoringHint}
+        onClearContingency={onClearContingency}
         overviewFilters={overviewFilters}
         onOverviewFiltersChange={onOverviewFiltersChange}
         hasActions={hasActions}
       />
       <div style={{ flex: 1, overflowY: 'auto', padding: space[4], minHeight: 0, display: 'flex', flexDirection: 'column', gap: space[4] }}>
-        {branches.length > 0 && (
+        {branches.length > 0 && !hideContingencyPicker && (
           <div style={{ flexShrink: 0, padding: `${space[3]} ${space[4]}`, background: colors.surface, borderRadius: radius.lg, border: `1px solid ${colors.border}`, boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: space[2], marginBottom: '5px' }}>
               <label style={{ fontSize: '0.8rem', fontWeight: 'bold' }}>⚡ Select Contingency</label>

--- a/frontend/src/components/SidebarSummary.test.tsx
+++ b/frontend/src/components/SidebarSummary.test.tsx
@@ -6,7 +6,7 @@
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import SidebarSummary from './SidebarSummary';
 import { DEFAULT_ACTION_OVERVIEW_FILTERS } from '../utils/actionTypes';
@@ -138,5 +138,206 @@ describe('SidebarSummary', () => {
         );
         expect(screen.getByTestId('sticky-feed-summary')).toBeInTheDocument();
         expect(screen.getByTestId('sidebar-action-filters')).toBeInTheDocument();
+    });
+
+    // ===== readability-feed PR: Clear button =====
+    describe('Clear contingency shortcut', () => {
+        it('renders the Clear button next to the contingency label when a handler is wired', () => {
+            render(
+                <SidebarSummary
+                    {...baseProps}
+                    selectedContingency={['LINE_A']}
+                    onClearContingency={vi.fn()}
+                />,
+            );
+            const clearBtn = screen.getByTestId('sidebar-summary-clear');
+            expect(clearBtn).toBeInTheDocument();
+            expect(clearBtn.textContent).toMatch(/Clear/);
+        });
+
+        it('fires onClearContingency when the Clear button is clicked', () => {
+            const onClearContingency = vi.fn();
+            render(
+                <SidebarSummary
+                    {...baseProps}
+                    selectedContingency={['LINE_A']}
+                    onClearContingency={onClearContingency}
+                />,
+            );
+            fireEvent.click(screen.getByTestId('sidebar-summary-clear'));
+            expect(onClearContingency).toHaveBeenCalledTimes(1);
+        });
+
+        it('omits the Clear button when no handler is provided', () => {
+            render(
+                <SidebarSummary
+                    {...baseProps}
+                    selectedContingency={['LINE_A']}
+                />,
+            );
+            expect(screen.queryByTestId('sidebar-summary-clear')).not.toBeInTheDocument();
+        });
+
+        it('omits the Clear button when there is no contingency to clear', () => {
+            render(
+                <SidebarSummary
+                    {...baseProps}
+                    n1LinesOverloaded={['LINE_X']}
+                    n1LinesOverloadedRho={[1.05]}
+                    onClearContingency={vi.fn()}
+                />,
+            );
+            expect(screen.queryByTestId('sidebar-summary-clear')).not.toBeInTheDocument();
+        });
+    });
+
+    // ===== readability-feed PR: double-click overload toggle =====
+    describe('Overload double-click toggle', () => {
+        it('toggles the overload via onToggleOverload on double-click', () => {
+            const onToggleOverload = vi.fn();
+            render(
+                <SidebarSummary
+                    {...baseProps}
+                    selectedContingency={['LINE_A']}
+                    n1LinesOverloaded={['LINE_X', 'LINE_Y']}
+                    n1LinesOverloadedRho={[1.05, 1.02]}
+                    onToggleOverload={onToggleOverload}
+                />,
+            );
+            fireEvent.doubleClick(screen.getByRole('button', { name: 'LINE_X' }));
+            expect(onToggleOverload).toHaveBeenCalledWith('LINE_X');
+        });
+
+        it('single-click still routes to onOverloadClick (zoom shortcut) regardless of toggle wiring', () => {
+            const onOverloadClick = vi.fn();
+            render(
+                <SidebarSummary
+                    {...baseProps}
+                    selectedContingency={['LINE_A']}
+                    n1LinesOverloaded={['LINE_X']}
+                    n1LinesOverloadedRho={[1.05]}
+                    onOverloadClick={onOverloadClick}
+                    onToggleOverload={vi.fn()}
+                />,
+            );
+            fireEvent.click(screen.getByRole('button', { name: 'LINE_X' }));
+            expect(onOverloadClick).toHaveBeenCalledWith('', 'LINE_X', 'contingency');
+        });
+
+        it('does nothing on double-click when no toggle handler is wired', () => {
+            // The double-click branch is gated on `onToggleOverload` —
+            // without it the dbl-click is a no-op (the existing single-
+            // click zoom semantics are preserved by the click handler).
+            const onToggleOverload = vi.fn();
+            render(
+                <SidebarSummary
+                    {...baseProps}
+                    selectedContingency={['LINE_A']}
+                    n1LinesOverloaded={['LINE_X']}
+                    n1LinesOverloadedRho={[1.05]}
+                    // onToggleOverload intentionally omitted
+                />,
+            );
+            fireEvent.doubleClick(screen.getByRole('button', { name: 'LINE_X' }));
+            expect(onToggleOverload).not.toHaveBeenCalled();
+        });
+
+        it('shows the deselected style when an overload is not in selectedOverloads', () => {
+            const selectedOverloads = new Set<string>();
+            const { container } = render(
+                <SidebarSummary
+                    {...baseProps}
+                    selectedContingency={['LINE_A']}
+                    n1LinesOverloaded={['LINE_X']}
+                    n1LinesOverloadedRho={[1.05]}
+                    selectedOverloads={selectedOverloads}
+                />,
+            );
+            const link = screen.getByRole('button', { name: 'LINE_X' });
+            // Deselected links carry weight 400 and no underline (vs 600
+            // + underline-dotted for selected) — matches the OverloadPanel
+            // contract preserved by the readability-feed PR.
+            const style = link.getAttribute('style') || '';
+            expect(style).toMatch(/font-weight:\s*400/);
+            expect(style).not.toMatch(/underline/);
+            expect(container).toBeInTheDocument();
+        });
+    });
+
+    // ===== readability-feed PR: overload info bubble =====
+    describe('Overload info bubble', () => {
+        const overloadProps = {
+            ...baseProps,
+            selectedContingency: ['LINE_A'],
+            n1LinesOverloaded: ['LINE_X', 'LINE_Y'],
+            n1LinesOverloadedRho: [1.05, 1.02],
+        };
+
+        it('renders the bubble icon when overloads are present', () => {
+            render(<SidebarSummary {...overloadProps} />);
+            expect(screen.getByTestId('sidebar-summary-overloads-bubble')).toBeInTheDocument();
+        });
+
+        it('opens the popover on click and shows N-overloads + N-1 toggles + monitor-deselected', () => {
+            const onToggleOverload = vi.fn();
+            const onToggleMonitorDeselected = vi.fn();
+            render(
+                <SidebarSummary
+                    {...overloadProps}
+                    nLinesOverloaded={['LINE_N_PRE']}
+                    nLinesOverloadedRho={[1.10]}
+                    selectedOverloads={new Set(['LINE_X'])} // LINE_Y deselected → monitor-deselected toggle shows
+                    onToggleOverload={onToggleOverload}
+                    onToggleMonitorDeselected={onToggleMonitorDeselected}
+                    monitorDeselected={false}
+                    monitoringHint="100/200 lines monitored — see Notices for details."
+                />,
+            );
+            fireEvent.click(screen.getByTestId('sidebar-summary-overloads-bubble'));
+
+            const popover = screen.getByTestId('overload-info-popover');
+            expect(popover).toBeInTheDocument();
+            expect(popover.textContent).toMatch(/100\/200 lines monitored/);
+            expect(within(popover).getByText('LINE_N_PRE')).toBeInTheDocument();
+            expect(within(popover).getByTestId('overload-info-toggle-LINE_X')).toBeInTheDocument();
+            expect(within(popover).getByTestId('overload-info-toggle-LINE_Y')).toBeInTheDocument();
+            expect(within(popover).getByTestId('overload-info-monitor-deselected')).toBeInTheDocument();
+        });
+
+        it('toggles the overload from the popover checkbox', () => {
+            const onToggleOverload = vi.fn();
+            render(
+                <SidebarSummary
+                    {...overloadProps}
+                    selectedOverloads={new Set(['LINE_X', 'LINE_Y'])}
+                    onToggleOverload={onToggleOverload}
+                />,
+            );
+            fireEvent.click(screen.getByTestId('sidebar-summary-overloads-bubble'));
+            const popover = screen.getByTestId('overload-info-popover');
+            const checkbox = within(popover).getByTestId('overload-info-toggle-LINE_X')
+                .querySelector('input[type="checkbox"]') as HTMLInputElement;
+            fireEvent.click(checkbox);
+            expect(onToggleOverload).toHaveBeenCalledWith('LINE_X');
+        });
+
+        it('hides the monitor-deselected toggle when every overload is selected', () => {
+            render(
+                <SidebarSummary
+                    {...overloadProps}
+                    selectedOverloads={new Set(['LINE_X', 'LINE_Y'])}
+                    onToggleMonitorDeselected={vi.fn()}
+                />,
+            );
+            fireEvent.click(screen.getByTestId('sidebar-summary-overloads-bubble'));
+            expect(screen.queryByTestId('overload-info-monitor-deselected')).not.toBeInTheDocument();
+        });
+
+        it('falls back to "None" for N-overloads when the list is empty', () => {
+            render(<SidebarSummary {...overloadProps} />);
+            fireEvent.click(screen.getByTestId('sidebar-summary-overloads-bubble'));
+            const popover = screen.getByTestId('overload-info-popover');
+            expect(popover.textContent).toMatch(/N Overloads:\s*None/);
+        });
     });
 });

--- a/frontend/src/components/SidebarSummary.tsx
+++ b/frontend/src/components/SidebarSummary.tsx
@@ -153,24 +153,25 @@ export default function SidebarSummary({
           ))}
           {onClearContingency && (
             <button
+              type="button"
               data-testid="sidebar-summary-clear"
               onClick={(e) => { e.stopPropagation(); onClearContingency(); }}
               title="Clear the current contingency and pick a new one"
               style={{
-                marginLeft: 'auto',
-                background: 'none',
-                border: `1px solid ${colors.border}`,
+                padding: '3px 10px',
+                background: colors.danger,
+                color: colors.textOnBrand,
+                border: 'none',
                 borderRadius: radius.sm,
-                padding: `0 ${space[1]}`,
                 cursor: 'pointer',
-                fontSize: '10px',
-                color: colors.textSecondary,
-                fontWeight: 600,
-                lineHeight: 1.5,
+                fontSize: '11px',
+                fontWeight: 'bold',
+                flexShrink: 0,
+                marginLeft: space[1],
                 whiteSpace: 'nowrap',
               }}
             >
-              ✕ Clear
+              Clear
             </button>
           )}
         </div>
@@ -191,7 +192,17 @@ export default function SidebarSummary({
                   {i > 0 && ', '}
                   <button
                     onClick={(e) => { e.stopPropagation(); onOverloadClick('', name, 'contingency'); }}
-                    title={`Open Contingency tab and zoom to ${name}`}
+                    onDoubleClick={(e) => {
+                      if (onToggleOverload) {
+                        e.stopPropagation();
+                        onToggleOverload(name);
+                      }
+                    }}
+                    title={onToggleOverload
+                      ? (isSelected
+                        ? `Zoom to ${name} (Double-click to unselect)`
+                        : `Zoom to ${name} (Double-click to select)`)
+                      : `Open Contingency tab and zoom to ${name}`}
                     style={{
                       background: 'none',
                       border: 'none',

--- a/frontend/src/components/SidebarSummary.tsx
+++ b/frontend/src/components/SidebarSummary.tsx
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
-import React from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import type { ActionOverviewFilters } from '../types';
-import { colors, space, text } from '../styles/tokens';
+import { colors, radius, space, text } from '../styles/tokens';
 import ActionFilterRings from './ActionFilterRings';
 
 interface SidebarSummaryProps {
@@ -15,18 +15,31 @@ interface SidebarSummaryProps {
   selectedContingency: string[];
   n1LinesOverloaded: string[] | undefined;
   n1LinesOverloadedRho: number[] | undefined;
+  /** N-state pre-existing overloads. Surfaced via the info bubble next to
+   *  the Overloads label, since they are no longer shown in a dedicated
+   *  OverloadPanel card. */
+  nLinesOverloaded?: string[];
+  nLinesOverloadedRho?: number[];
   selectedOverloads: Set<string> | null | undefined;
   displayName: (id: string) => string;
   onContingencyZoom: (assetName: string) => void;
   onOverloadClick: (actionId: string, assetName: string, tab: 'n' | 'contingency') => void;
-  /** Shared severity + action-type filters driving the action feed.
-   *  When set together with `hasActions`, the persistent strip grows
-   *  a compact two-ring icon filter below the contingency / overload
-   *  rows. */
+  /** Toggle an N-1 overload's inclusion in the analysis monitoring set. */
+  onToggleOverload?: (overload: string) => void;
+  /** Whether deselected overloads are still kept in the monitoring scope. */
+  monitorDeselected?: boolean;
+  onToggleMonitorDeselected?: () => void;
+  /** Optional one-line monitoring coverage hint (replaces the legacy
+   *  OverloadPanel hint when present). */
+  monitoringHint?: string | null;
+  /** Drop the current contingency and return to the contingency picker.
+   *  Triggers the confirmation dialog at the call site. */
+  onClearContingency?: () => void;
+  /** Shared severity + action-type filters; forwarded to the inline
+   *  ActionFilterRings row. */
   overviewFilters?: ActionOverviewFilters;
   onOverviewFiltersChange?: (next: ActionOverviewFilters) => void;
-  /** Whether the action feed currently holds any card to filter —
-   *  the filter rings stay hidden until there is something to act on. */
+  /** Whether the action feed has any card to filter right now. */
   hasActions?: boolean;
 }
 
@@ -37,15 +50,33 @@ interface SidebarSummaryProps {
  * and the contingency-state overloaded lines (with per-line
  * navigation + rho percentages). Rendered only when at least one of
  * those pieces of state is present.
+ *
+ * Hosts:
+ * - a Clear button next to the Contingency label so the operator
+ *   can drop the current contingency and go investigate another
+ *   one (confirmation dialog handled by the parent);
+ * - an info bubble next to the Overloads label that opens a small
+ *   popover listing N-state pre-existing overloads, letting the
+ *   operator deselect N-1 overloads (toggling their inclusion in
+ *   the analysis monitoring set) and flip the "monitor deselected"
+ *   switch — the former OverloadPanel functionality folded into
+ *   the sticky banner.
  */
 export default function SidebarSummary({
   selectedContingency,
   n1LinesOverloaded,
   n1LinesOverloadedRho,
+  nLinesOverloaded,
+  nLinesOverloadedRho,
   selectedOverloads,
   displayName,
   onContingencyZoom,
   onOverloadClick,
+  onToggleOverload,
+  monitorDeselected = false,
+  onToggleMonitorDeselected,
+  monitoringHint,
+  onClearContingency,
   overviewFilters,
   onOverviewFiltersChange,
   hasActions,
@@ -53,7 +84,24 @@ export default function SidebarSummary({
   const hasOverloads = (n1LinesOverloaded?.length ?? 0) > 0;
   const hasContingency = selectedContingency.length > 0;
   const hasFilters = !!hasActions && !!overviewFilters && !!onOverviewFiltersChange;
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const hideTimerRef = useRef<number | null>(null);
+
+  const cancelHide = useCallback(() => {
+    if (hideTimerRef.current != null) {
+      window.clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+  const scheduleHide = useCallback(() => {
+    cancelHide();
+    hideTimerRef.current = window.setTimeout(() => setPopoverOpen(false), 180);
+  }, [cancelHide]);
+
   if (!hasContingency && !hasOverloads && !hasFilters) return null;
+
+  const hasNOverloads = (nLinesOverloaded?.length ?? 0) > 0;
+  const overloadsBubbleEnabled = hasOverloads || hasNOverloads || !!monitoringHint;
 
   return (
     <div
@@ -75,7 +123,7 @@ export default function SidebarSummary({
       {hasContingency && (
         <div
           data-testid="sidebar-summary-contingency"
-          style={{ display: 'flex', alignItems: 'baseline', gap: space[1], flexWrap: 'wrap' }}
+          style={{ display: 'flex', alignItems: 'baseline', gap: space[1], flexWrap: 'wrap', width: '100%' }}
         >
           <span style={{ color: colors.textSecondary, fontWeight: 600, whiteSpace: 'nowrap' }}>
             ⚡ Contingency{selectedContingency.length > 1 ? ` (N-${selectedContingency.length})` : ''}:
@@ -103,12 +151,34 @@ export default function SidebarSummary({
               </button>
             </React.Fragment>
           ))}
+          {onClearContingency && (
+            <button
+              data-testid="sidebar-summary-clear"
+              onClick={(e) => { e.stopPropagation(); onClearContingency(); }}
+              title="Clear the current contingency and pick a new one"
+              style={{
+                marginLeft: 'auto',
+                background: 'none',
+                border: `1px solid ${colors.border}`,
+                borderRadius: radius.sm,
+                padding: `0 ${space[1]}`,
+                cursor: 'pointer',
+                fontSize: '10px',
+                color: colors.textSecondary,
+                fontWeight: 600,
+                lineHeight: 1.5,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              ✕ Clear
+            </button>
+          )}
         </div>
       )}
       {hasOverloads && (
         <div
           data-testid="sidebar-summary-overloads"
-          style={{ display: 'flex', alignItems: 'baseline', gap: space[1] }}
+          style={{ display: 'flex', alignItems: 'baseline', gap: space[1], position: 'relative' }}
         >
           <span style={{ color: colors.dangerStrong, fontWeight: 600, whiteSpace: 'nowrap' }}>⚠️ Overloads:</span>
           <span style={{ wordBreak: 'break-word' }}>
@@ -144,6 +214,54 @@ export default function SidebarSummary({
               );
             })}
           </span>
+          {overloadsBubbleEnabled && (
+            <span
+              data-testid="sidebar-summary-overloads-bubble-wrap"
+              style={{ position: 'relative', display: 'inline-flex', alignItems: 'center' }}
+              onMouseEnter={() => { cancelHide(); setPopoverOpen(true); }}
+              onMouseLeave={scheduleHide}
+            >
+              <button
+                data-testid="sidebar-summary-overloads-bubble"
+                onClick={(e) => { e.stopPropagation(); setPopoverOpen(o => !o); }}
+                aria-label="Overload details"
+                title="Show N-state overloads, toggle N-1 overload selection, and monitor-deselected"
+                style={{
+                  background: colors.chromeSoft,
+                  color: colors.textOnBrand,
+                  border: 'none',
+                  borderRadius: '50%',
+                  width: '14px',
+                  height: '14px',
+                  fontSize: '10px',
+                  lineHeight: 1,
+                  cursor: 'pointer',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  padding: 0,
+                  marginLeft: space[1],
+                }}
+              >
+                ?
+              </button>
+              {popoverOpen && (
+                <OverloadInfoPopover
+                  nLinesOverloaded={nLinesOverloaded ?? []}
+                  nLinesOverloadedRho={nLinesOverloadedRho}
+                  n1LinesOverloaded={n1LinesOverloaded ?? []}
+                  n1LinesOverloadedRho={n1LinesOverloadedRho}
+                  selectedOverloads={selectedOverloads}
+                  onToggleOverload={onToggleOverload}
+                  monitorDeselected={monitorDeselected}
+                  onToggleMonitorDeselected={onToggleMonitorDeselected}
+                  monitoringHint={monitoringHint}
+                  onAssetClick={onOverloadClick}
+                  displayName={displayName}
+                />
+              )}
+            </span>
+          )}
         </div>
       )}
       {hasFilters && (
@@ -152,6 +270,191 @@ export default function SidebarSummary({
           onFiltersChange={onOverviewFiltersChange!}
         />
       )}
+    </div>
+  );
+}
+
+interface OverloadInfoPopoverProps {
+  nLinesOverloaded: string[];
+  nLinesOverloadedRho?: number[];
+  n1LinesOverloaded: string[];
+  n1LinesOverloadedRho?: number[];
+  selectedOverloads: Set<string> | null | undefined;
+  onToggleOverload?: (overload: string) => void;
+  monitorDeselected: boolean;
+  onToggleMonitorDeselected?: () => void;
+  monitoringHint?: string | null;
+  onAssetClick: (actionId: string, assetName: string, tab: 'n' | 'contingency') => void;
+  displayName: (id: string) => string;
+}
+
+function OverloadInfoPopover({
+  nLinesOverloaded,
+  nLinesOverloadedRho,
+  n1LinesOverloaded,
+  n1LinesOverloadedRho,
+  selectedOverloads,
+  onToggleOverload,
+  monitorDeselected,
+  onToggleMonitorDeselected,
+  monitoringHint,
+  onAssetClick,
+  displayName,
+}: OverloadInfoPopoverProps) {
+  const formatRho = (v: number | undefined) =>
+    v == null || Number.isNaN(v) ? null : `${(v * 100).toFixed(1)}%`;
+  const hasDeselected = n1LinesOverloaded.some(name => !(selectedOverloads?.has(name) ?? true));
+
+  return (
+    <div
+      data-testid="overload-info-popover"
+      role="dialog"
+      style={{
+        position: 'absolute',
+        top: '100%',
+        left: 0,
+        marginTop: space[1],
+        zIndex: 50,
+        background: colors.surface,
+        border: `1px solid ${colors.border}`,
+        borderRadius: radius.md,
+        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+        padding: `${space[2]} ${space[3]}`,
+        minWidth: '240px',
+        maxWidth: '320px',
+        fontSize: text.xs,
+        color: colors.textPrimary,
+        lineHeight: 1.5,
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {monitoringHint && (
+        <div
+          data-testid="overload-info-monitoring-hint"
+          style={{
+            marginBottom: space[1],
+            fontSize: '11px',
+            color: colors.textTertiary,
+            fontStyle: 'italic',
+          }}
+        >
+          {monitoringHint}
+        </div>
+      )}
+      <div style={{ marginBottom: space[1] }}>
+        <strong style={{ color: colors.textSecondary }}>N Overloads:</strong>{' '}
+        {nLinesOverloaded.length > 0 ? (
+          <span style={{ wordBreak: 'break-word' }}>
+            {nLinesOverloaded.map((name, i) => {
+              const rhoPct = formatRho(nLinesOverloadedRho?.[i]);
+              return (
+                <React.Fragment key={name}>
+                  {i > 0 && ', '}
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onAssetClick('', name, 'n'); }}
+                    title={`Open N tab and zoom to ${name}`}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      padding: 0,
+                      fontSize: 'inherit',
+                      color: colors.brand,
+                      fontWeight: 600,
+                      textDecoration: 'underline dotted',
+                    }}
+                  >
+                    {displayName(name)}
+                  </button>
+                  {rhoPct && <span style={{ marginLeft: space.half }}>({rhoPct})</span>}
+                </React.Fragment>
+              );
+            })}
+          </span>
+        ) : (
+          <span style={{ color: colors.textTertiary, fontStyle: 'italic' }}>None</span>
+        )}
+      </div>
+      <div>
+        <strong style={{ color: colors.textSecondary }}>N-1 Overloads:</strong>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', marginTop: space.half }}>
+          {n1LinesOverloaded.map((name, i) => {
+            const rhoPct = formatRho(n1LinesOverloadedRho?.[i]);
+            const isSelected = selectedOverloads?.has(name) ?? true;
+            return (
+              <label
+                key={name}
+                data-testid={`overload-info-toggle-${name}`}
+                title={isSelected
+                  ? `Uncheck to exclude ${displayName(name)} from monitoring`
+                  : `Check to include ${displayName(name)} in monitoring`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: space[1],
+                  cursor: onToggleOverload ? 'pointer' : 'default',
+                  color: isSelected ? colors.textPrimary : colors.borderStrong,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  disabled={!onToggleOverload}
+                  onChange={() => onToggleOverload?.(name)}
+                  onClick={(e) => e.stopPropagation()}
+                  style={{ margin: 0, cursor: onToggleOverload ? 'pointer' : 'default' }}
+                />
+                <button
+                  onClick={(e) => { e.stopPropagation(); onAssetClick('', name, 'contingency'); }}
+                  title={`Open Contingency tab and zoom to ${name}`}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: 0,
+                    fontSize: 'inherit',
+                    color: isSelected ? colors.brand : colors.borderStrong,
+                    fontWeight: isSelected ? 600 : 400,
+                    textDecoration: isSelected ? 'underline dotted' : 'none',
+                  }}
+                >
+                  {displayName(name)}
+                </button>
+                {rhoPct && (
+                  <span style={{ color: isSelected ? colors.textPrimary : colors.borderStrong }}>
+                    ({rhoPct})
+                  </span>
+                )}
+              </label>
+            );
+          })}
+        </div>
+        {hasDeselected && onToggleMonitorDeselected && (
+          <label
+            data-testid="overload-info-monitor-deselected"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '4px',
+              cursor: 'pointer',
+              fontSize: '11px',
+              color: monitorDeselected ? colors.brandStrong : colors.textSecondary,
+              fontWeight: monitorDeselected ? 600 : 400,
+              marginTop: space[1],
+            }}
+            title="When checked, deselected overloads are still included in the analysis monitoring scope"
+          >
+            <input
+              type="checkbox"
+              checked={monitorDeselected}
+              onChange={onToggleMonitorDeselected}
+              onClick={(e) => e.stopPropagation()}
+              style={{ margin: 0, cursor: 'pointer' }}
+            />
+            monitor deselected
+          </label>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/VisualizationPanel.test.tsx
+++ b/frontend/src/components/VisualizationPanel.test.tsx
@@ -11,7 +11,8 @@ import '@testing-library/jest-dom/vitest';
 import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import VisualizationPanel from './VisualizationPanel';
-import type { DiagramData, AnalysisResult, TabId } from '../types';
+import type { DiagramData, AnalysisResult, TabId, ActionOverviewFilters } from '../types';
+import { DEFAULT_ACTION_OVERVIEW_FILTERS } from '../utils/actionTypes';
 
 const createDefaultProps = (overrides: Record<string, unknown> = {}) => ({
     activeTab: 'n' as TabId,
@@ -1047,6 +1048,40 @@ describe('VisualizationPanel', () => {
             await openFilter();
             const [low, high] = sliders();
             expect(parseInt(low.style.zIndex, 10)).toBeLessThan(parseInt(high.style.zIndex, 10));
+        });
+    });
+
+    // ===== readability-feed PR: ActionFilterRings ride along when the
+    // sidebar is collapsed. The strip moves into the tab row on the
+    // left so the operator can still tune the overview filter without
+    // re-expanding the sidebar.
+    describe('Overview filter strip when the sidebar is collapsed', () => {
+        const filterProps = (overrides: Record<string, unknown> = {}) => createDefaultProps({
+            overviewFilters: DEFAULT_ACTION_OVERVIEW_FILTERS as ActionOverviewFilters,
+            onOverviewFiltersChange: vi.fn(),
+            hasActions: true,
+            sidebarCollapsed: true,
+            ...overrides,
+        });
+
+        it('renders the inline filter strip when sidebar is collapsed and actions exist', () => {
+            render(<VisualizationPanel {...filterProps()} />);
+            expect(screen.getByTestId('viz-panel-overview-filters')).toBeInTheDocument();
+        });
+
+        it('hides the inline filter strip when the sidebar is expanded', () => {
+            render(<VisualizationPanel {...filterProps({ sidebarCollapsed: false })} />);
+            expect(screen.queryByTestId('viz-panel-overview-filters')).not.toBeInTheDocument();
+        });
+
+        it('hides the inline filter strip when there are no actions to filter', () => {
+            render(<VisualizationPanel {...filterProps({ hasActions: false })} />);
+            expect(screen.queryByTestId('viz-panel-overview-filters')).not.toBeInTheDocument();
+        });
+
+        it('hides the inline filter strip when no filter state is wired', () => {
+            render(<VisualizationPanel {...filterProps({ overviewFilters: undefined, onOverviewFiltersChange: undefined })} />);
+            expect(screen.queryByTestId('viz-panel-overview-filters')).not.toBeInTheDocument();
         });
     });
 });

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -15,6 +15,7 @@ import ActionCardPopover from './ActionCardPopover';
 import DiagramLegend from './DiagramLegend';
 import InspectSearchField from './InspectSearchField';
 import DetachedPlaceholder from './DetachedPlaceholder';
+import ActionFilterRings from './ActionFilterRings';
 import type { DetachedTabsMap } from '../hooks/useDetachedTabs';
 import type { PZInstance } from '../hooks/useTiedTabsSync';
 import { useOverflowIframe } from '../hooks/useOverflowIframe';
@@ -164,6 +165,15 @@ interface VisualizationPanelProps {
     overviewFilters?: ActionOverviewFilters;
     /** Setter for the shared overview filter state (owned by App.tsx). */
     onOverviewFiltersChange?: (next: ActionOverviewFilters) => void;
+    /** When true, the sidebar is collapsed and its ActionFilterRings
+     *  row is unreachable. Surface a copy of the strip on the left
+     *  side of this panel's tab row so the filter remains accessible
+     *  even with the sidebar folded away. */
+    sidebarCollapsed?: boolean;
+    /** Whether the action feed currently holds any card to filter —
+     *  the inline filter strip stays hidden until there is something
+     *  to act on, mirroring the sidebar's gating. */
+    hasActions?: boolean;
     /** Ids of scored-but-not-simulated actions to render as dimmed pins. */
     unsimulatedActionIds?: readonly string[];
     /** Per-id score metadata used to enrich the un-simulated pin tooltip. */
@@ -255,6 +265,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     displayName,
     overviewFilters,
     onOverviewFiltersChange,
+    sidebarCollapsed,
+    hasActions,
     unsimulatedActionIds,
     unsimulatedActionInfo,
     onSimulateUnsimulatedAction,
@@ -614,8 +626,22 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
         <>
             {/* Tab bar — all 4 tabs always visible; unavailable ones show placeholder.
                 Each tab exposes a small detach/reattach button so the user can move
-                its content into a secondary browser window and back. */}
-            <div style={{ display: 'flex', borderBottom: `1px solid ${colors.border}`, flexShrink: 0 }}>
+                its content into a secondary browser window and back. When the
+                sidebar is collapsed, the action-filter rings move into the same
+                row on the left so the operator can still tune the overview filter
+                without re-expanding the sidebar. */}
+            <div style={{ display: 'flex', alignItems: 'center', borderBottom: `1px solid ${colors.border}`, flexShrink: 0 }}>
+                {sidebarCollapsed && hasActions && overviewFilters && onOverviewFiltersChange && (
+                    <div
+                        data-testid="viz-panel-overview-filters"
+                        style={{ flexShrink: 0, padding: '4px 8px', borderRight: `1px solid ${colors.border}` }}
+                    >
+                        <ActionFilterRings
+                            filters={overviewFilters}
+                            onFiltersChange={onOverviewFiltersChange}
+                        />
+                    </div>
+                )}
                 {(
                     [
                         { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: colors.brand, dimColor: colors.chromeSoft, placeholder: 'Configure a network path in Settings to load the base-case diagram.' },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -564,7 +564,9 @@ export type InteractionType =
     | 'overview_unsimulated_pin_simulated'
     | 'session_saved'
     | 'session_reload_modal_opened'
-    | 'session_reloaded';
+    | 'session_reloaded'
+    | 'sidebar_collapsed_toggled'
+    | 'contingency_clear_requested';
 
 export interface InteractionLogEntry {
     seq: number;

--- a/frontend/src/utils/specConformance.test.ts
+++ b/frontend/src/utils/specConformance.test.ts
@@ -136,6 +136,9 @@ const SPEC: Record<string, SpecRow> = {
   session_saved:                  { required: new Set(['output_folder']) },
   session_reload_modal_opened:    { required: new Set() },
   session_reloaded:               { required: new Set(['session_name']) },
+  // --- Sidebar layout / contingency clear ---
+  sidebar_collapsed_toggled:      { required: new Set(['collapsed']) },
+  contingency_clear_requested:    { required: new Set(['had_analysis_state']) },
 };
 
 // ---------------------------------------------------------------------

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -219,6 +219,9 @@ SPEC_DETAILS: dict[str, dict] = {
     "session_saved":            _spec_row({"output_folder"}),
     "session_reload_modal_opened": _spec_row(set()),
     "session_reloaded":         _spec_row({"session_name"}),
+    # --- Sidebar layout / contingency clear ---
+    "sidebar_collapsed_toggled": _spec_row({"collapsed"}),
+    "contingency_clear_requested": _spec_row({"had_analysis_state"}),
 }
 
 # Event types whose details argument is a bare identifier or a


### PR DESCRIPTION
## Summary

This PR refactors the sidebar layout and contingency workflow to improve readability and reduce redundancy. The "Select Contingency" picker and "Remedial Actions" feed now flip visibility together when a contingency is committed, the sticky banner gains a Clear shortcut button, and overload management moves into an info-bubble popover next to the Overloads label.

## Key Changes

### Sidebar Visibility Gate
- **Picker card** and **action feed** now toggle together: the picker hides once a contingency is committed, and the feed mounts in its place
- New props on `AppSidebar`: `hideContingencyPicker` (boolean) and `sidebarCollapsed` / `onToggleCollapsed` (collapse mode)
- Sidebar can collapse to a 32px strip to expand the visualization panel; expand button appears in collapsed mode
- Updated test helpers (`selectBranch`, `pickBranch`) to route through the Clear button when the picker is hidden

### Sticky Banner Clear Shortcut
- `SidebarSummary` now renders a red **Clear** button next to the contingency label (when `onClearContingency` is wired)
- Clicking Clear routes through the existing "Change Contingency?" confirmation dialog if analysis state exists; clears directly otherwise
- New interaction event: `contingency_clear_requested { had_analysis_state }`
- Contingency row now spans full width to accommodate the button

### Overload Info Bubble & Double-Click Toggle
- New `?` icon next to the Overloads label opens a hover popover (`OverloadInfoPopover` component)
- Popover displays:
  - N-state pre-existing overloads (new props: `nLinesOverloaded`, `nLinesOverloadedRho`)
  - Per-N-1 overload monitoring checkboxes (double-click on banner links to toggle; requires `onToggleOverload`)
  - "Monitor deselected" switch (new props: `monitorDeselected`, `onToggleMonitorDeselected`)
  - Monitoring-coverage hint (new prop: `monitoringHint`)
- Popover uses mouse-enter/leave with a 180ms hide delay for smooth interaction
- Overload links show deselected styling (font-weight 400, no underline) when not in `selectedOverloads`

### Component Updates
- **SidebarSummary**: Added state for popover visibility, new props for N-overloads and monitoring controls, new `OverloadInfoPopover` subcomponent
- **AppSidebar**: Forwarded new props to `SidebarSummary`, added collapsed-mode rendering, added collapse-toggle caret
- **VisualizationPanel**: Added `sidebarCollapsed` prop; surfaces `ActionFilterRings` in the tab row when sidebar is collapsed so filters remain accessible
- **App.tsx**: Added `sidebarCollapsed` state and toggle handler, wired Clear button callback, updated sidebar visibility gates

### Test Coverage
- New `AppSidebar.test.tsx` with tests for picker visibility, collapse mode, and expand/collapse buttons
- Extended `SidebarSummary.test.tsx` with tests for Clear button, double-click toggle, and info-bubble popover
- Updated integration tests (`App.contingency.test.tsx`, `App.stateManagement.test.tsx`, `App.session.test.tsx`) to use the new Clear flow and sticky-banner selectors
- Updated `VisualizationPanel.test.tsx` with filter-strip collapse-mode tests

### Documentation & Metadata
- Updated `CLAUDE.md` with sidebar architecture notes (collapsible mode, picker visibility, Clear button, info bubble)
- Updated `CHANGELOG.md` with feature summary
- Added new interaction types: `sidebar_collapsed_toggled`, `contingency_clear_requested`
- Updated interaction spec conformance checks

### Renamed Label
- "Simulated Actions" → "Remedial Actions" in the action feed header (reflects the actual remedial-action nature of the feed)

## Implementation Details

- **Popover placement**: Positioned absolutely below the bubble icon; uses `position: relative` on the

https://claude.ai/code/session_017S5DCS1DGp89wcWYczRCtn