### PR TITLE
Add dark mode theme toggle with design-token-driven styling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ docs/
 | [`actions-topology.md`](features/actions-topology.md) | Action formats + topology algorithms (switch → set_bus, Union-Find cache). |
 | [`curtailment-loadshedding-pst-actions.md`](features/curtailment-loadshedding-pst-actions.md) | Renewable curtailment, load shedding, PST tap actions. |
 | [`frontend-ui-improvements.md`](features/frontend-ui-improvements.md) | Voltage filter, run-button placement, color codes, always-visible tabs. |
+| [`dark-mode.md`](features/dark-mode.md) | Light/dark theme: design-token source of truth, `useTheme` hook + pre-mount script, the "soft-background" trap, NAD/SLD diagram + overflow-viewer theming, tests. |
 
 ## Performance (`performance/`)
 

--- a/docs/features/dark-mode.md
+++ b/docs/features/dark-mode.md
@@ -1,0 +1,155 @@
+# Dark Mode
+
+Co-Study4Grid ships a light/dark theme toggle. The whole UI re-themes
+from a single source of truth — the design-token CSS custom properties
+in `frontend/src/styles/tokens.css` — so a theme switch is one DOM
+attribute flip, not a per-component restyle.
+
+This document is the contract: where the theme lives, how it
+propagates, what the diagram / overflow-viewer special-cases are, and
+which tests guard each piece.
+
+---
+
+## 1. How the theme is selected
+
+| Layer | What it does |
+|-------|--------------|
+| Pre-mount script (`frontend/index.html`) | Reads `localStorage['cs4g-theme']` (or the OS `prefers-color-scheme`) **before React mounts** and sets `<html data-theme="…">` + `colorScheme`. Avoids a flash of light theme on a dark reload. |
+| `useTheme` hook (`frontend/src/hooks/useTheme.ts`) | Owns the React-side theme state. Applies `data-theme` + `color-scheme` to `<html>`, persists to `localStorage`, exposes `theme` / `toggleTheme` / `setTheme`. |
+| `resolveInitialTheme()` | Pure resolver shared in spirit with the inline script: persisted value → OS preference → `light`. Tolerates a missing `localStorage` / `matchMedia`. |
+| Header toggle (`components/Header.tsx`) | Sun/moon button (`data-testid="header-theme-toggle"`) calling `toggleTheme`. `☾` in light mode, `☀` in dark. |
+
+The selected theme is recorded as the interaction event
+`theme_toggled { theme }` (declared in the `InteractionType` union,
+mirrored in `specConformance.test.ts` and
+`scripts/check_standalone_parity.py`).
+
+> **Note on multiple `useTheme()` instances.** The hook keeps local
+> `useState`, so two components calling `useTheme()` do **not** share a
+> re-render. The single source of truth across the app is the
+> `<html data-theme>` attribute. Consumers that need to react to a
+> theme change without owning the toggle (e.g. `useOverflowIframe`)
+> observe that attribute with a `MutationObserver` rather than reading
+> React state.
+
+---
+
+## 2. Tokens are the single source of truth
+
+`frontend/src/styles/tokens.css` defines every colour as a CSS custom
+property under `:root` (light) with a `[data-theme="dark"]` override
+block. `tokens.ts` exposes typed `var(--…)` accessors for inline
+`style` objects. **The code-quality gate enforces zero hex literals
+outside `tokens.css` / `tokens.ts`** — so adding a dark variant means
+editing only the token files, and the whole UI follows.
+
+Dark mode flips the **chrome** tokens (surfaces, borders, text, brand,
+state colours, accent). It deliberately does **not** flip the
+domain-signal tokens (`--signal-*`, the action-pin palette) because
+those encode grid semantics and are rendered onto a diagram backdrop.
+
+### Tokens added for dark mode
+
+| Token | Why |
+|-------|-----|
+| `--color-diagram-surface` | Backdrop behind the pypowsybl NAD/SLD (white in light, near-black `#0c0f13` in dark). The SVG is transparent, so the container *is* the diagram background. |
+| `--color-diagram-veil` | Semi-opaque veil painted over a diagram while a new one loads (translucent white → translucent near-black). |
+| `--color-text-on-bright` | Dark ink that stays dark in **both** themes — for text sitting on a solid bright fill (warning-yellow badge, the load-shedding "Re-simulate" button). The `*-text` tokens are tuned for the matching `*-soft` background and flip light in dark mode, so they can't be used on a bright fill. |
+
+---
+
+## 3. The "soft-background" trap
+
+The recurring dark-mode bug class: a control styled `background: <X>Soft`
++ `color: <X>Text` reads fine in light mode (pale bg, dark text) but in
+dark mode `<X>Soft` becomes dark while `<X>Text` becomes light — so a
+control with a **solid bright** fill (`colors.warning`, `colors.brand`)
+ends up with low-contrast text. Two fixes are used:
+
+- **Solid bright fill** (always bright in both themes) → text =
+  `colors.textOnBright` (badge) or `colors.textOnBrand` (active toggle
+  segments: Flows/Impacts, Hierarchical/Geo, the VL-names button, tabs).
+- **Soft fill** (pale in light, dark in dark) → the `*-text` token is
+  correct, no change needed.
+
+When adding a toggle/badge: if the active background is a solid brand /
+state colour, set the text to `textOnBrand` / `textOnBright`, never to
+`colors.surface` or a `*-text` token.
+
+---
+
+## 4. Diagram (NAD/SLD) legibility
+
+pypowsybl bakes voltage-coded line colours into the SVG via an inline
+`<style>` and renders on a transparent canvas. Dark-mode handling lives
+in `frontend/src/App.css` under `[data-theme="dark"]`:
+
+- **Canvas** — `.svg-container { background: var(--color-diagram-surface) }`
+  goes near-black. Lines keep their semantic colours (they read on dark).
+- **NAD flow values** (`.nad-edge-infos text`) — recoloured light. The
+  white "halo" pypowsybl strokes under each value (via `paint-order`)
+  is repainted in the backdrop colour so light text isn't fringed/fuzzy.
+- **NAD VL labels** — HTML `<div>`s inside `<foreignObject>` (not
+  `<text>`). Given light text + a dark chip.
+- **Action-overview dim rect** — the `.nad-overview-dim-rect` is set to
+  `fill="white"` inline for light mode; a CSS `fill: var(--color-diagram-surface)`
+  rule (a CSS property beats the inline presentation attribute) makes it
+  dim toward near-black, so it no longer leaves a grey square over the
+  dark canvas.
+- **SLD labels** (`[data-testid="sld-overlay"] text`) — recoloured
+  light, **excluding** `sld-delta-text-*` so the flow-delta
+  positive/negative/neutral colouring is preserved.
+
+> **Pin labels are deliberately untouched.** Action-overview pins are
+> `<text>` with their own dark-on-white glyph fills written via
+> `setAttribute`. The NAD text rules are class-scoped (`.nad-edge-infos`,
+> not a blanket `text`) precisely so pin labels stay readable.
+
+---
+
+## 5. Overflow Analysis viewer (iframe)
+
+The Overflow Analysis tab embeds a third-party HTML graph viewer in an
+iframe served from the backend. Theming it requires both sides:
+
+- **Frontend** (`hooks/useOverflowIframe.ts`) — posts a
+  `cs4g:theme { theme }` message to the iframe on overlay-ready and
+  whenever `<html data-theme>` flips (watched via `MutationObserver`).
+- **Backend** (`expert_backend/services/overflow_overlay.py`) — the
+  `inject_overlay()` injector (run at serve time on every
+  `/results/pdf/*.html` request) adds:
+  - a `cs4g:theme` message handler that sets `<html data-cs4g-theme>`,
+  - a dark stylesheet keyed off `html[data-cs4g-theme="dark"]`:
+    body / `#sidebar` / `#stage` surfaces, the white graphviz canvas
+    polygon repainted dark, and **edge** fixes scoped to `g.edge`:
+    flow-value labels lightened, grey "null redispatch" edges →
+    near-white, black "overload" edges → red (`#ef4444`). Node
+    ellipses and their labels are never touched.
+
+> Because the dark CSS + handler are injected **server-side**, a change
+> to `overflow_overlay.py` requires a **backend restart** to take
+> effect — the long-running uvicorn process serves the old injection
+> until then.
+
+---
+
+## 6. Tests
+
+| Spec | Test |
+|------|------|
+| Theme resolution / persistence / `<html>` apply / toggle / `theme_toggled` log | `frontend/src/hooks/useTheme.test.ts` |
+| Header toggle glyph + aria-label + document flip | `frontend/src/components/Header.test.tsx` (`dark-mode toggle`) |
+| Overflow viewer: `cs4g:theme` handler, dark chrome surfaces, canvas repaint, edge label/colour retargets, `g.edge` scoping | `expert_backend/tests/test_overflow_overlay.py` (`TestDarkTheme`) |
+
+---
+
+## 7. Adding a dark variant for a new colour
+
+1. Add the token to `:root` in `tokens.css`, and its dark value in the
+   `[data-theme="dark"]` block.
+2. Add the typed accessor to `tokens.ts`.
+3. Use `colors.<name>` (inline styles) or `var(--…)` (CSS). Never inline
+   a hex — the gate (`scripts/check_code_quality.py`) fails on it.
+4. If it's text on a **solid bright** fill, use `textOnBright` /
+   `textOnBrand` instead of a `*-text` token (see §3).

--- a/expert_backend/services/overflow_overlay.py
+++ b/expert_backend/services/overflow_overlay.py
@@ -198,6 +198,45 @@ def _build_overlay_block() -> str:
   html[data-cs4g-theme="dark"] #cs4g-overflow-meta strong {{
     color: #e6e8eb !important;
   }}
+
+  /* --- Graphviz edge legibility on the dark canvas ---
+     Edges live in <g class="edge"> (path = the line, polygon = the
+     arrowhead, text = the flow-value label). Scope every rule to
+     `g.edge` so node ellipses / their labels are never touched. */
+  /* Flow-value labels → light ink (their white background <polygon>
+     is already repainted dark by the white-polygon rule above). */
+  html[data-cs4g-theme="dark"] #stage svg g.edge text {{
+    fill: #e6e8eb !important;
+  }}
+  /* "Null redispatch" grey edges are near-invisible on dark → lighten
+     the line + its arrowhead toward white. */
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="grey"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="gray"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="#808080"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="#999999"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="#cccccc"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="#c0c0c0"] {{
+    stroke: #e6e8eb !important;
+  }}
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="grey"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="gray"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="#808080"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="#999999"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="#cccccc"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="#c0c0c0"] {{
+    fill: #e6e8eb !important;
+    stroke: #e6e8eb !important;
+  }}
+  /* "Overload" edges are drawn black → invisible on dark; repaint red. */
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="black"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge path[stroke="#000000"] {{
+    stroke: #ef4444 !important;
+  }}
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="black"],
+  html[data-cs4g-theme="dark"] #stage svg g.edge polygon[fill="#000000"] {{
+    fill: #ef4444 !important;
+    stroke: #ef4444 !important;
+  }}
 </style>
 <script id="cs4g-overlay-script">
 (function() {{

--- a/expert_backend/services/overflow_overlay.py
+++ b/expert_backend/services/overflow_overlay.py
@@ -153,6 +153,51 @@ def _build_overlay_block() -> str:
     font-style: normal; font-weight: 600;
     color: #111;
   }}
+
+  /* ===== Dark theme =====
+     Engaged when the React parent posts a ``cs4g:theme`` message and
+     the overlay script sets ``<html data-cs4g-theme="dark">``. The
+     upstream alphaDeesp viewer drives its palette through CSS custom
+     properties (``--border`` / ``--muted`` / …) with light fallbacks,
+     so we mostly redefine those + flip the structural surfaces. The
+     graphviz canvas is a white background <polygon> — repaint it dark
+     so the colour-coded nodes / edges pop. Node/edge label text stays
+     as-authored (it sits on light node fills). */
+  html[data-cs4g-theme="dark"] {{
+    --bg: #0c0f13; --panel: #1b1f24; --border: #3a4049;
+    --muted: #9aa1ab; --text: #e6e8eb;
+    background: #0c0f13;
+    color-scheme: dark;
+  }}
+  html[data-cs4g-theme="dark"] body {{
+    background: #0c0f13 !important;
+    color: #e6e8eb !important;
+  }}
+  html[data-cs4g-theme="dark"] #sidebar {{
+    background: #1b1f24 !important;
+    color: #e6e8eb !important;
+    border-color: #3a4049 !important;
+  }}
+  html[data-cs4g-theme="dark"] #stage {{
+    background: #0c0f13 !important;
+  }}
+  /* Graphviz emits the canvas as a white background polygon — recolour
+     just that one (transparent-stroked, white-filled) shape. */
+  html[data-cs4g-theme="dark"] #stage svg > g > polygon:first-of-type,
+  html[data-cs4g-theme="dark"] #stage svg polygon[fill="#ffffff"],
+  html[data-cs4g-theme="dark"] #stage svg polygon[fill="white"] {{
+    fill: #0c0f13 !important;
+  }}
+  html[data-cs4g-theme="dark"] a {{ color: #60a5fa !important; }}
+  html[data-cs4g-theme="dark"] input,
+  html[data-cs4g-theme="dark"] select {{
+    background: #232830 !important; color: #e6e8eb !important;
+    border-color: #3a4049 !important;
+  }}
+  html[data-cs4g-theme="dark"] #cs4g-filters .filters-counter,
+  html[data-cs4g-theme="dark"] #cs4g-overflow-meta strong {{
+    color: #e6e8eb !important;
+  }}
 </style>
 <script id="cs4g-overlay-script">
 (function() {{
@@ -869,6 +914,13 @@ def _build_overlay_block() -> str:
     }}
     if (msg.type === 'cs4g:overflow-meta') {{
       renderOverflowMeta(msg.overflowGraphTime);
+      return;
+    }}
+    if (msg.type === 'cs4g:theme') {{
+      // Parent broadcasts its light/dark theme. Flip a data attribute
+      // on <html>; the dark CSS in the injected <style> keys off it.
+      const t = msg.theme === 'dark' ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-cs4g-theme', t);
       return;
     }}
     if (msg.type !== 'cs4g:pins') return;

--- a/expert_backend/services/overflow_overlay.py
+++ b/expert_backend/services/overflow_overlay.py
@@ -181,16 +181,36 @@ def _build_overlay_block() -> str:
   html[data-cs4g-theme="dark"] #stage {{
     background: #0c0f13 !important;
   }}
-  /* Graphviz emits the canvas as a white background polygon — recolour
-     just that one (transparent-stroked, white-filled) shape. */
+  /* Graphviz emits the canvas (and edge-label backgrounds, e.g. a flow
+     "%…" chip) as white-filled shapes. Repaint them dark. Attribute
+     matching is case-insensitive (`i`) because graphviz may emit
+     `#FFFFFF` / `WHITE` / `#fff`, and covers both <polygon> and <rect>. */
   html[data-cs4g-theme="dark"] #stage svg > g > polygon:first-of-type,
-  html[data-cs4g-theme="dark"] #stage svg polygon[fill="#ffffff"],
-  html[data-cs4g-theme="dark"] #stage svg polygon[fill="white"] {{
+  html[data-cs4g-theme="dark"] #stage svg polygon[fill="#ffffff" i],
+  html[data-cs4g-theme="dark"] #stage svg polygon[fill="#fff" i],
+  html[data-cs4g-theme="dark"] #stage svg polygon[fill="white" i],
+  html[data-cs4g-theme="dark"] #stage svg rect[fill="#ffffff" i],
+  html[data-cs4g-theme="dark"] #stage svg rect[fill="#fff" i],
+  html[data-cs4g-theme="dark"] #stage svg rect[fill="white" i] {{
     fill: #0c0f13 !important;
   }}
   html[data-cs4g-theme="dark"] a {{ color: #60a5fa !important; }}
   html[data-cs4g-theme="dark"] input,
-  html[data-cs4g-theme="dark"] select {{
+  html[data-cs4g-theme="dark"] select,
+  html[data-cs4g-theme="dark"] textarea {{
+    background: #232830 !important; color: #e6e8eb !important;
+    border-color: #3a4049 !important;
+  }}
+  /* The sidebar "SELECTION" info box (and any similar white panel)
+     renders on a hard white background that flashes on the dark UI.
+     Darken it. Best-effort selectors — the upstream viewer's exact id
+     varies, so we cover the common shapes (pre/textarea + any element
+     whose id/class mentions "selection"/"info"). */
+  html[data-cs4g-theme="dark"] #sidebar pre,
+  html[data-cs4g-theme="dark"] #sidebar [id*="selection" i],
+  html[data-cs4g-theme="dark"] #sidebar [class*="selection" i],
+  html[data-cs4g-theme="dark"] #sidebar [id*="info" i],
+  html[data-cs4g-theme="dark"] #sidebar [class*="info" i] {{
     background: #232830 !important; color: #e6e8eb !important;
     border-color: #3a4049 !important;
   }}

--- a/expert_backend/tests/test_overflow_overlay.py
+++ b/expert_backend/tests/test_overflow_overlay.py
@@ -51,6 +51,61 @@ class TestInjectOverlay:
         assert "cs4g:pin-clicked" in out
         assert "cs4g:overlay-ready" in out
 
+
+class TestDarkTheme:
+    """The overlay carries the dark-theme contract: a ``cs4g:theme``
+    message handler that flips ``<html data-cs4g-theme>`` plus the CSS
+    that keys off it (chrome surfaces + graphviz edge legibility)."""
+
+    def test_theme_message_handler_sets_data_attribute(self) -> None:
+        out = inject_overlay(_BASE_HTML)
+        assert "cs4g:theme" in out
+        # The handler must set the data attribute the dark CSS keys off.
+        assert "data-cs4g-theme" in out
+        assert "setAttribute('data-cs4g-theme'" in out
+
+    def test_dark_chrome_surfaces_are_styled(self) -> None:
+        out = inject_overlay(_BASE_HTML)
+        # Body / sidebar / stage all get a dark surface under the theme.
+        assert 'html[data-cs4g-theme="dark"] body' in out
+        assert 'html[data-cs4g-theme="dark"] #sidebar' in out
+        assert 'html[data-cs4g-theme="dark"] #stage' in out
+
+    def test_white_graphviz_canvas_polygon_is_repainted_dark(self) -> None:
+        out = inject_overlay(_BASE_HTML)
+        assert 'polygon[fill="white"]' in out
+        assert 'polygon[fill="#ffffff"]' in out
+
+    def test_edge_flow_value_labels_are_lightened(self) -> None:
+        out = inject_overlay(_BASE_HTML)
+        assert 'html[data-cs4g-theme="dark"] #stage svg g.edge text' in out
+
+    def test_grey_null_edges_are_lightened(self) -> None:
+        out = inject_overlay(_BASE_HTML)
+        # Both the line stroke and the arrowhead fill are retargeted.
+        assert 'g.edge path[stroke="grey"]' in out
+        assert 'g.edge polygon[fill="grey"]' in out
+
+    def test_black_overload_edges_become_red(self) -> None:
+        out = inject_overlay(_BASE_HTML)
+        assert 'g.edge path[stroke="black"]' in out
+        assert 'g.edge path[stroke="#000000"]' in out
+        # The retarget colour is the danger red.
+        assert "#ef4444" in out
+
+    def test_edge_rules_are_scoped_to_edges_not_nodes(self) -> None:
+        """Node ellipses must keep their authored colours — every edge
+        recolour rule must be qualified by ``g.edge`` so a black node
+        border or a white node fill is never caught."""
+        out = inject_overlay(_BASE_HTML)
+        for needle in ('path[stroke="black"]', 'polygon[fill="grey"]',
+                       'g.edge text'):
+            idx = out.find(needle)
+            assert idx != -1
+            # The selector segment leading up to the needle includes g.edge.
+            seg_start = out.rfind('html[data-cs4g-theme="dark"]', 0, idx)
+            assert 'g.edge' in out[seg_start:idx + len(needle)]
+
     def test_single_click_is_debounced_against_double_click(self) -> None:
         """The pin's click handler must defer firing
         ``cs4g:pin-clicked`` via a setTimeout so that a follow-up

--- a/expert_backend/tests/test_overflow_overlay.py
+++ b/expert_backend/tests/test_overflow_overlay.py
@@ -73,8 +73,17 @@ class TestDarkTheme:
 
     def test_white_graphviz_canvas_polygon_is_repainted_dark(self) -> None:
         out = inject_overlay(_BASE_HTML)
-        assert 'polygon[fill="white"]' in out
-        assert 'polygon[fill="#ffffff"]' in out
+        assert 'polygon[fill="white" i]' in out
+        assert 'polygon[fill="#ffffff" i]' in out
+        # Case-insensitive + <rect> coverage so #FFFFFF / WHITE / a flow
+        # "%…" label chip drawn as a <rect> are caught too.
+        assert 'rect[fill="white" i]' in out
+
+    def test_sidebar_selection_box_is_darkened(self) -> None:
+        out = inject_overlay(_BASE_HTML)
+        # The white "SELECTION" info panel must be retargeted dark.
+        assert 'html[data-cs4g-theme="dark"] #sidebar [id*="selection" i]' in out
+        assert 'html[data-cs4g-theme="dark"] #sidebar pre' in out
 
     def test_edge_flow_value_labels_are_lightened(self) -> None:
         out = inject_overlay(_BASE_HTML)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,21 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Co-Study4Grid</title>
+    <script>
+      // Apply persisted theme before React mounts to avoid a flash of
+      // light theme on dark-mode reloads. Mirrors resolveInitialTheme()
+      // in src/hooks/useTheme.ts — keep the two in sync.
+      (function () {
+        try {
+          var stored = localStorage.getItem('cs4g-theme');
+          var theme = (stored === 'light' || stored === 'dark')
+            ? stored
+            : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+          document.documentElement.setAttribute('data-theme', theme);
+          document.documentElement.style.colorScheme = theme;
+        } catch (e) { /* localStorage unavailable */ }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -34,6 +34,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
    class. `!important` beats pypowsybl's appended inline <style>. */
 [data-theme="dark"] .svg-container .nad-edge-infos text {
     fill: var(--color-text-primary) !important;
+    /* pypowsybl paints a white stroke "halo" under each flow value so it
+       reads over the coloured line. On the near-black backdrop that white
+       halo turns the light text fuzzy — repaint the halo in the backdrop
+       colour (still legible over lines, no white fringe). */
+    stroke: var(--color-diagram-surface) !important;
+    paint-order: stroke fill !important;
 }
 
 [data-theme="dark"] .svg-container foreignObject.nad-text-nodes div,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13,9 +13,37 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
     width: 100%;
     height: 100%;
     overflow: hidden;
+    /* The pypowsybl SVG is transparent, so the container provides the
+       diagram backdrop. Tokenised so dark mode flips it to near-black. */
+    background: var(--color-diagram-surface);
     /* CSS containment: tells the browser this subtree's layout/paint is
        independent of the rest of the page, reducing work during viewBox changes */
     contain: layout style paint;
+}
+
+/* ===== Dark-mode diagram legibility =====
+   pypowsybl bakes voltage-coded line colours into the SVG via an inline
+   <style> block; those read fine on the near-black backdrop. The text
+   does NOT: VL label boxes and edge-info flow values are emitted as
+   dark text on (assumed) white. On the dark backdrop they vanish, so we
+   recolour them to a light ink. `!important` beats pypowsybl's appended
+   inline <style>. Scoped to [data-theme="dark"] so light mode is
+   untouched. */
+[data-theme="dark"] .svg-container .nad-edge-infos text,
+[data-theme="dark"] .svg-container .nad-vl-nodes text,
+[data-theme="dark"] .svg-container .nad-label-nodes text,
+[data-theme="dark"] .svg-container .nad-branch-edges text,
+[data-theme="dark"] .svg-container .nad-3wt-edges text {
+    fill: var(--color-text-primary) !important;
+}
+
+/* VL label boxes are HTML inside <foreignObject>. Give them a dark,
+   semi-opaque chip so the (light, recoloured) label text sits on a
+   readable backing instead of floating on the dark canvas. */
+[data-theme="dark"] .svg-container .nad-label-box,
+[data-theme="dark"] .svg-container foreignObject.nad-text-nodes div {
+    color: var(--color-text-primary) !important;
+    background: rgba(27, 31, 36, 0.82) !important;
 }
 
 .svg-container svg {
@@ -453,7 +481,7 @@ circle.nad-highlight {
     right: 0;
     bottom: 0;
     width: 62px;
-    background: rgba(244, 244, 244, 0.92);
+    background: var(--color-surface-muted);
     border-left: 1px solid var(--color-border);
     display: flex;
     flex-direction: column;
@@ -581,7 +609,7 @@ input[data-testid="sidebar-filter-threshold-input"]::-webkit-outer-spin-button {
     right: 0;
     bottom: 0;
     width: 24px;
-    background: rgba(244, 244, 244, 0.85);
+    background: var(--color-surface-muted);
     border: none;
     border-left: 1px solid var(--color-border);
     cursor: pointer;
@@ -595,7 +623,7 @@ input[data-testid="sidebar-filter-threshold-input"]::-webkit-outer-spin-button {
 }
 
 .voltage-sidebar-toggle:hover {
-    background: rgba(220, 220, 220, 0.95);
+    background: var(--color-surface-raised);
     color: var(--color-text-primary);
 }
 /* ============================================================

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -24,26 +24,34 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
 /* ===== Dark-mode diagram legibility =====
    pypowsybl bakes voltage-coded line colours into the SVG via an inline
    <style> block; those read fine on the near-black backdrop. The text
-   does NOT: VL label boxes and edge-info flow values are emitted as
-   dark text on (assumed) white. On the dark backdrop they vanish, so we
-   recolour them to a light ink. `!important` beats pypowsybl's appended
-   inline <style>. Scoped to [data-theme="dark"] so light mode is
-   untouched. */
-[data-theme="dark"] .svg-container .nad-edge-infos text,
-[data-theme="dark"] .svg-container .nad-vl-nodes text,
-[data-theme="dark"] .svg-container .nad-label-nodes text,
-[data-theme="dark"] .svg-container .nad-branch-edges text,
-[data-theme="dark"] .svg-container .nad-3wt-edges text {
+   does NOT. Two distinct cases:
+     - edge-info flow values are SVG <text> (dark fill) → recolour light.
+     - VL labels are HTML <div>s inside <foreignObject> (dark text, no
+       backing) → give them a light text + dark chip.
+   We deliberately do NOT blanket-recolour every <text> in the SVG: the
+   action-overview pin labels are <text> with their own fills (dark text
+   on a white pin glyph) and must stay dark. So edge-info is targeted by
+   class. `!important` beats pypowsybl's appended inline <style>. */
+[data-theme="dark"] .svg-container .nad-edge-infos text {
     fill: var(--color-text-primary) !important;
 }
 
-/* VL label boxes are HTML inside <foreignObject>. Give them a dark,
-   semi-opaque chip so the (light, recoloured) label text sits on a
-   readable backing instead of floating on the dark canvas. */
-[data-theme="dark"] .svg-container .nad-label-box,
-[data-theme="dark"] .svg-container foreignObject.nad-text-nodes div {
+[data-theme="dark"] .svg-container foreignObject.nad-text-nodes div,
+[data-theme="dark"] .svg-container .nad-vl-nodes foreignObject div,
+[data-theme="dark"] .svg-container .nad-label-nodes foreignObject div,
+[data-theme="dark"] .svg-container .nad-label-box {
     color: var(--color-text-primary) !important;
-    background: rgba(27, 31, 36, 0.82) !important;
+    background-color: rgba(27, 31, 36, 0.85) !important;
+    border-color: var(--color-border) !important;
+}
+
+/* Action-overview "dim the network" rect — set to fill='white' inline
+   for light mode. Drive its colour from the diagram-surface token (a
+   CSS `fill` property beats the inline presentation attribute), so in
+   dark mode it dims toward near-black instead of leaving a grey square
+   over the dark backdrop. */
+.svg-container .nad-overview-dim-rect {
+    fill: var(--color-diagram-surface);
 }
 
 .svg-container svg {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -54,6 +54,17 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
     fill: var(--color-diagram-surface);
 }
 
+/* ===== Dark-mode SLD legibility =====
+   The Single-Line-Diagram overlay injects pypowsybl `sld-*` markup onto
+   a dark panel. Feeder / power-value labels (`.sld-label`) and graph
+   labels are dark <text> → recolour them to light. We exclude the
+   flow-delta text classes (`sld-delta-text-*`) because those carry a
+   meaningful positive / negative / neutral colour applied by
+   SldOverlay. Scoped to the overlay root so nothing else is touched. */
+[data-theme="dark"] [data-testid="sld-overlay"] text:not([class*="sld-delta-text"]) {
+    fill: var(--color-text-primary) !important;
+}
+
 .svg-container svg {
     width: 100%;
     height: 100%;

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -387,7 +387,7 @@ const ActionCard: React.FC<ActionCardProps> = ({
                                             if (!isNaN(mwVal) && mwVal >= 0) onResimulate(id, mwVal);
                                         }}
                                         disabled={resimulating === id}
-                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: `1px solid ${colors.warningStrong}`, background: colors.warning, color: colors.warningText, cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
+                                        style={{ fontSize: '10px', padding: '2px 8px', borderRadius: '3px', border: `1px solid ${colors.warningStrong}`, background: colors.warning, color: colors.textOnBright, cursor: resimulating === id ? 'wait' : 'pointer', fontWeight: 600, whiteSpace: 'nowrap' }}
                                     >
                                         {resimulating === id ? 'Simulating...' : 'Re-simulate'}
                                     </button>

--- a/frontend/src/components/ActionOverviewDiagram.tsx
+++ b/frontend/src/components/ActionOverviewDiagram.tsx
@@ -829,7 +829,7 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                 inset: 0,
                 display: visible ? 'flex' : 'none',
                 flexDirection: 'column',
-                background: 'white',
+                background: colors.diagramSurface,
                 // Sit above the hidden MemoizedSvgContainer for
                 // actionDiagram (which stays mounted to preserve
                 // zoom state) so clicks land on the overview.
@@ -1004,7 +1004,8 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                                     fontSize: 12,
                                     width: 180,
                                     boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
-                                    background: 'white',
+                                    background: colors.surface,
+                                    color: colors.textPrimary,
                                 }}
                             />
                             {showInspectDropdown && (
@@ -1017,7 +1018,8 @@ const ActionOverviewDiagram: React.FC<ActionOverviewDiagramProps> = ({
                                         width: 220,
                                         maxHeight: 220,
                                         overflowY: 'auto',
-                                        background: 'white',
+                                        background: colors.surface,
+                                        color: colors.textPrimary,
                                         border: `1px solid ${colors.brand}`,
                                         borderRadius: 4,
                                         boxShadow: '0 4px 12px rgba(0,0,0,0.18)',

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -272,8 +272,11 @@ export default function AppSidebar({
                   minHeight: 36,
                   borderRadius: radius.sm,
                   borderColor: colors.border,
+                  background: colors.surface,
                   fontSize: '0.85rem',
                 }),
+                input: (base) => ({ ...base, color: colors.textPrimary }),
+                placeholder: (base) => ({ ...base, color: colors.textTertiary }),
                 multiValue: (base) => ({
                   ...base,
                   background: colors.borderSubtle,
@@ -281,6 +284,7 @@ export default function AppSidebar({
                 }),
                 multiValueLabel: (base) => ({
                   ...base,
+                  color: colors.textPrimary,
                   fontSize: '0.78rem',
                 }),
                 option: (base, state) => ({
@@ -290,7 +294,7 @@ export default function AppSidebar({
                   color: colors.textPrimary,
                   cursor: 'pointer',
                 }),
-                menu: (base) => ({ ...base, zIndex: 30 }),
+                menu: (base) => ({ ...base, zIndex: 30, background: colors.surface }),
               }}
             />
           </div>

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -120,4 +120,40 @@ describe('Header', () => {
         fireEvent.blur(input);
         expect(onCommitNetworkPath).toHaveBeenCalledWith('/new/path.xiidm');
     });
+
+    describe('dark-mode toggle', () => {
+        beforeEach(() => {
+            localStorage.clear();
+            document.documentElement.removeAttribute('data-theme');
+            document.documentElement.style.colorScheme = '';
+            window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+                matches: false, media: query, onchange: null,
+                addEventListener: vi.fn(), removeEventListener: vi.fn(),
+                addListener: vi.fn(), removeListener: vi.fn(), dispatchEvent: vi.fn(),
+            }));
+        });
+
+        it('renders a theme toggle that shows the moon glyph in light mode', () => {
+            render(<Header {...defaultProps} />);
+            const toggle = screen.getByTestId('header-theme-toggle');
+            expect(toggle).toHaveTextContent('☾');
+            expect(toggle).toHaveAttribute('aria-label', 'Switch to dark mode');
+        });
+
+        it('flips the document theme and glyph when clicked', () => {
+            render(<Header {...defaultProps} />);
+            const toggle = screen.getByTestId('header-theme-toggle');
+
+            fireEvent.click(toggle);
+
+            expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+            expect(toggle).toHaveTextContent('☀');
+            expect(toggle).toHaveAttribute('aria-label', 'Switch to light mode');
+
+            fireEvent.click(toggle);
+
+            expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+            expect(toggle).toHaveTextContent('☾');
+        });
+    });
 });

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,6 +8,7 @@
 import type { AnalysisResult } from '../types';
 import { colors, radius, space } from '../styles/tokens';
 import NoticesPanel, { type Notice } from './NoticesPanel';
+import { useTheme } from '../hooks/useTheme';
 
 type SettingsTab = 'paths' | 'recommender' | 'configurations';
 
@@ -52,6 +53,7 @@ const Header: React.FC<HeaderProps> = ({
   notices,
 }) => {
   const saveDisabled = !result && selectedContingency.length === 0;
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <header style={{
@@ -146,6 +148,21 @@ const Header: React.FC<HeaderProps> = ({
         title="Reload a previously saved session"
       >
         {sessionRestoring ? 'Restoring...' : 'Reload Session'}
+      </button>
+
+      <button
+        data-testid="header-theme-toggle"
+        onClick={toggleTheme}
+        style={{
+          background: colors.chromeSoft, display: 'flex', alignItems: 'center',
+          justifyContent: 'center', padding: `${space[2]} ${space[2]}`, fontSize: '1rem',
+          color: colors.textOnBrand, border: 'none', borderRadius: radius.sm,
+          cursor: 'pointer', fontWeight: 'bold', minWidth: '34px'
+        }}
+        title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+      >
+        {theme === 'dark' ? '☀' : '☾'}
       </button>
 
       <button

--- a/frontend/src/components/InspectSearchField.tsx
+++ b/frontend/src/components/InspectSearchField.tsx
@@ -72,7 +72,8 @@ const InspectSearchField: React.FC<{
                     fontSize: '12px',
                     width: '180px',
                     boxShadow: '0 2px 5px rgba(0,0,0,0.15)',
-                    background: 'white',
+                    background: colors.surface,
+                    color: colors.textPrimary,
                 }}
             />
             {showDropdown && (
@@ -85,7 +86,8 @@ const InspectSearchField: React.FC<{
                         width: '220px',
                         maxHeight: '220px',
                         overflowY: 'auto',
-                        background: 'white',
+                        background: colors.surface,
+                        color: colors.textPrimary,
                         border: `1px solid ${colors.brand}`,
                         borderRadius: '4px',
                         boxShadow: '0 4px 12px rgba(0,0,0,0.18)',
@@ -113,7 +115,7 @@ const InspectSearchField: React.FC<{
                                 textOverflow: 'ellipsis',
                             }}
                             onMouseEnter={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.brandSoft; }}
-                            onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = 'white'; }}
+                            onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.backgroundColor = colors.surface; }}
                         >
                             {item}
                         </div>

--- a/frontend/src/components/NoticesPanel.tsx
+++ b/frontend/src/components/NoticesPanel.tsx
@@ -160,7 +160,7 @@ export default function NoticesPanel({ notices }: NoticesPanelProps) {
             height: '18px',
             padding: `0 ${space[1]}`,
             background: colors.warning,
-            color: colors.textPrimary,
+            color: colors.textOnBright,
             borderRadius: '999px',
             fontSize: text.xs,
             fontWeight: 700,

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -560,8 +560,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                         aria-pressed={showVoltageLevelNames}
                                         data-testid="toggle-vl-names"
                                         style={{
-                                            background: showVoltageLevelNames ? colors.brandSoft : colors.surface,
-                                            color: showVoltageLevelNames ? colors.brand : colors.textSecondary,
+                                            background: showVoltageLevelNames ? colors.brand : colors.surface,
+                                            color: showVoltageLevelNames ? colors.textOnBrand : colors.textSecondary,
                                             border: `1px solid ${showVoltageLevelNames ? colors.brand : colors.border}`,
                                             borderRadius: '4px',
                                             padding: '4px 8px',
@@ -644,8 +644,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                 )}
                 {(
                     [
-                        { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: colors.brand, dimColor: colors.textTertiary, placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
-                        { id: 'contingency' as TabId, label: contingencyTabLabel as React.ReactNode, available: !!n1Diagram?.svg, accentColor: colors.danger, dimColor: colors.textTertiary, placeholder: 'Trigger a contingency from the dropdown to view the post-contingency state.' },
+                        { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: colors.brand, dimColor: colors.textSecondary, placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
+                        { id: 'contingency' as TabId, label: contingencyTabLabel as React.ReactNode, available: !!n1Diagram?.svg, accentColor: colors.danger, dimColor: colors.textSecondary, placeholder: 'Trigger a contingency from the dropdown to view the post-contingency state.' },
                         // When no card is selected, the Remedial Action tab hosts the
                         // action-overview view (pins over the N-1 network). It is considered
                         // "available" as soon as the N-1 diagram has loaded, so the tab is no
@@ -743,10 +743,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             ) as React.ReactNode : 'Remedial action: overview' as React.ReactNode,
                             available: !!actionDiagram?.svg || !!n1Diagram?.svg,
                             accentColor: 'var(--signal-action-target)',
-                            dimColor: colors.textTertiary,
+                            dimColor: colors.textSecondary,
                             placeholder: 'Select a contingency and run the analysis to see remedial actions.',
                         },
-                        { id: 'overflow' as TabId, label: 'Overflow Analysis' as React.ReactNode, available: !!result?.pdf_url, accentColor: colors.success, dimColor: colors.textTertiary, placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
+                        { id: 'overflow' as TabId, label: 'Overflow Analysis' as React.ReactNode, available: !!result?.pdf_url, accentColor: colors.success, dimColor: colors.textSecondary, placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
                     ] as const
                 ).map(tab => {
                     const isActive = activeTab === tab.id;

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -353,10 +353,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
         <div style={{
             position: 'absolute', top: 8, left: '50%', transform: 'translateX(-50%)',
             zIndex: 400, display: 'flex', alignItems: 'center', gap: '8px',
-            padding: '4px 10px', background: 'rgba(255,255,255,0.95)',
+            padding: '4px 10px', background: colors.surface,
             border: `1px solid ${accentColor}`, borderRadius: '14px',
             boxShadow: '0 2px 8px rgba(0,0,0,0.15)', fontSize: '12px', fontWeight: 600,
-            color: colors.chrome, pointerEvents: 'auto',
+            color: colors.textPrimary, pointerEvents: 'auto',
         }}>
             <span style={{ color: accentColor }}>●</span>
             <span>{label}</span>
@@ -382,7 +382,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                 onClick={() => reattachTabCb(tabId)}
                 title="Reattach this tab to the main window"
                 style={{
-                    border: `1px solid ${accentColor}`, background: 'white',
+                    border: `1px solid ${accentColor}`, background: colors.surface,
                     color: accentColor, borderRadius: '10px',
                     padding: '2px 10px', fontSize: '11px', fontWeight: 700, cursor: 'pointer',
                 }}
@@ -507,7 +507,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <button
                                 onClick={() => onZoomIn(tabId)}
                                 style={{
-                                    background: 'white', color: colors.textPrimary,
+                                    background: colors.surface, color: colors.textPrimary,
                                     border: `1px solid ${colors.border}`, borderRadius: '4px',
                                     padding: '5px 12px', cursor: 'pointer',
                                     fontSize: '14px', fontWeight: 600,
@@ -520,7 +520,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <button
                                 onClick={() => onResetView(tabId)}
                                 style={{
-                                    background: 'white', color: colors.textPrimary,
+                                    background: colors.surface, color: colors.textPrimary,
                                     border: `1px solid ${colors.border}`, borderRadius: '4px',
                                     padding: '5px 14px', cursor: 'pointer',
                                     fontSize: '12px', fontWeight: 600,
@@ -532,7 +532,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             <button
                                 onClick={() => onZoomOut(tabId)}
                                 style={{
-                                    background: 'white', color: colors.textPrimary,
+                                    background: colors.surface, color: colors.textPrimary,
                                     border: `1px solid ${colors.border}`, borderRadius: '4px',
                                     padding: '5px 12px', cursor: 'pointer',
                                     fontSize: '14px', fontWeight: 600,
@@ -756,7 +756,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             key={tab.id}
                             style={{
                                 flex: 1, display: 'flex', alignItems: 'stretch',
-                                background: isActive && !isDetached ? 'white' : colors.surfaceMuted,
+                                background: isActive && !isDetached ? colors.surfaceRaised : colors.surfaceMuted,
                                 borderBottom: isActive && tab.available && !isDetached ? `3px solid ${tab.accentColor}` : 'none',
                                 minWidth: 0,
                             }}
@@ -1068,12 +1068,12 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         {/* Always mounted — see comment on N-1 container below. */}
                         <MemoizedSvgContainer svg={nDiagram?.svg || ''} containerRef={nSvgContainerRef} display="block" tabId="n" hideVlLabels={!showVoltageLevelNames} />
                         {configLoading && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: colors.diagramVeil, zIndex: 20 }}>
                                 Loading configuration...
                             </div>
                         )}
                         {!configLoading && !nDiagram?.svg && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'white' }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: colors.diagramSurface }}>
                                 Load configuration to see diagram
                             </div>
                         )}
@@ -1121,12 +1121,12 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             viewBox that was applied between the two invocations. */}
                         <MemoizedSvgContainer svg={n1Diagram?.svg || ''} containerRef={n1SvgContainerRef} display="block" tabId="contingency" hideVlLabels={!showVoltageLevelNames} />
                         {n1Loading && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: colors.diagramVeil, zIndex: 20 }}>
                                 Generating N-1 Diagram...
                             </div>
                         )}
                         {!n1Loading && !n1Diagram?.svg && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, fontStyle: 'italic', textAlign: 'center', padding: '40px', background: 'white' }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, fontStyle: 'italic', textAlign: 'center', padding: '40px', background: colors.diagramSurface }}>
                                 Select a contingency element from the dropdown to view the N-1 state.
                             </div>
                         )}
@@ -1209,12 +1209,12 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             onSimulateUnsimulatedAction={onSimulateUnsimulatedAction}
                         />
                         {actionDiagramLoading && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'rgba(255,255,255,0.85)', zIndex: 20 }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: colors.diagramVeil, zIndex: 20 }}>
                                 Generating Action Variant Diagram...
                             </div>
                         )}
                         {!actionDiagramLoading && !actionDiagram?.svg && selectedActionId && (
-                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: 'white' }}>
+                            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: colors.textTertiary, background: colors.diagramSurface }}>
                                 Failed to load diagram for action {selectedActionId}
                             </div>
                         )}

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -445,7 +445,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                 style={{
                                     padding: '4px 12px', border: 'none', cursor: 'pointer',
                                     backgroundColor: tabViewMode === 'network' ? colors.brand : colors.surface,
-                                    color: tabViewMode === 'network' ? colors.surface : colors.textSecondary,
+                                    color: tabViewMode === 'network' ? colors.textOnBrand : colors.textSecondary,
                                     transition: 'all 0.15s ease'
                                 }}
                             >
@@ -456,7 +456,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                 style={{
                                     padding: '4px 12px', border: 'none', borderLeft: `1px solid ${colors.border}`, cursor: 'pointer',
                                     backgroundColor: tabViewMode === 'delta' ? colors.brand : colors.surface,
-                                    color: tabViewMode === 'delta' ? colors.surface : colors.textSecondary,
+                                    color: tabViewMode === 'delta' ? colors.textOnBrand : colors.textSecondary,
                                     transition: 'all 0.15s ease'
                                 }}
                             >
@@ -644,8 +644,8 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                 )}
                 {(
                     [
-                        { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: colors.brand, dimColor: colors.chromeSoft, placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
-                        { id: 'contingency' as TabId, label: contingencyTabLabel as React.ReactNode, available: !!n1Diagram?.svg, accentColor: colors.danger, dimColor: colors.borderStrong, placeholder: 'Trigger a contingency from the dropdown to view the post-contingency state.' },
+                        { id: 'n' as TabId, label: 'Network (N)' as React.ReactNode, available: !!nDiagram?.svg, accentColor: colors.brand, dimColor: colors.textTertiary, placeholder: 'Configure a network path in Settings to load the base-case diagram.' },
+                        { id: 'contingency' as TabId, label: contingencyTabLabel as React.ReactNode, available: !!n1Diagram?.svg, accentColor: colors.danger, dimColor: colors.textTertiary, placeholder: 'Trigger a contingency from the dropdown to view the post-contingency state.' },
                         // When no card is selected, the Remedial Action tab hosts the
                         // action-overview view (pins over the N-1 network). It is considered
                         // "available" as soon as the N-1 diagram has loaded, so the tab is no
@@ -743,10 +743,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                             ) as React.ReactNode : 'Remedial action: overview' as React.ReactNode,
                             available: !!actionDiagram?.svg || !!n1Diagram?.svg,
                             accentColor: 'var(--signal-action-target)',
-                            dimColor: colors.borderStrong,
+                            dimColor: colors.textTertiary,
                             placeholder: 'Select a contingency and run the analysis to see remedial actions.',
                         },
-                        { id: 'overflow' as TabId, label: 'Overflow Analysis' as React.ReactNode, available: !!result?.pdf_url, accentColor: colors.success, dimColor: colors.borderStrong, placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
+                        { id: 'overflow' as TabId, label: 'Overflow Analysis' as React.ReactNode, available: !!result?.pdf_url, accentColor: colors.success, dimColor: colors.textTertiary, placeholder: 'Run \u201cAnalyze & Suggest\u201d to see the overflow graph.' },
                     ] as const
                 ).map(tab => {
                     const isActive = activeTab === tab.id;
@@ -778,7 +778,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                     fontWeight: isActive && tab.available && !isDetached ? 'bold' : 400,
                                     fontStyle: !tab.available || isDetached ? 'italic' : 'normal',
                                     background: 'transparent',
-                                    color: isDetached ? colors.textTertiary : (tab.available ? (isActive ? colors.chrome : tab.dimColor) : colors.borderStrong),
+                                    color: isDetached ? colors.textTertiary : (tab.available ? (isActive ? colors.textPrimary : tab.dimColor) : colors.borderStrong),
                                     fontSize: tab.id === 'action' && selectedActionId ? '0.75rem' : '0.85rem',
                                     // The action tab with a selected card carries its
                                     // own flex label with internal ellipsis on the chip.

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -930,7 +930,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                                 padding: '4px 12px', border: 'none',
                                                 cursor: loading ? 'wait' : 'pointer',
                                                 backgroundColor: mode === 'hierarchical' ? colors.brand : colors.surface,
-                                                color: mode === 'hierarchical' ? colors.surface : colors.textSecondary,
+                                                color: mode === 'hierarchical' ? colors.textOnBrand : colors.textSecondary,
                                                 transition: 'all 0.15s ease',
                                             }}
                                         >
@@ -946,7 +946,7 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                                                 padding: '4px 12px', border: 'none', borderLeft: `1px solid ${colors.border}`,
                                                 cursor: (loading || !hasLayout) ? 'not-allowed' : 'pointer',
                                                 backgroundColor: mode === 'geo' ? colors.brand : colors.surface,
-                                                color: mode === 'geo' ? colors.surface : (hasLayout ? colors.textSecondary : colors.borderStrong),
+                                                color: mode === 'geo' ? colors.textOnBrand : (hasLayout ? colors.textSecondary : colors.borderStrong),
                                                 transition: 'all 0.15s ease',
                                             }}
                                         >

--- a/frontend/src/hooks/useOverflowIframe.ts
+++ b/frontend/src/hooks/useOverflowIframe.ts
@@ -343,6 +343,28 @@ export function useOverflowIframe(args: UseOverflowIframeArgs): OverflowIframeSt
         iframe.contentWindow.postMessage(msg, '*');
     }, [overlayReady, overflowGraphTime]);
 
+    // Mirror the host's light/dark theme into the embedded overflow
+    // viewer. We read `<html data-theme>` directly (rather than the
+    // React theme state, which lives in independent useTheme instances)
+    // and re-broadcast whenever it flips via a MutationObserver — so a
+    // theme toggle anywhere in the app reaches the iframe.
+    React.useEffect(() => {
+        const iframe = overflowIframeRef.current;
+        if (!iframe || !iframe.contentWindow) return;
+        if (!overlayReady) return;
+        const send = () => {
+            const win = overflowIframeRef.current?.contentWindow;
+            if (!win) return;
+            const theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+            const msg: ParentToIframeMessage = { type: 'cs4g:theme', theme };
+            win.postMessage(msg, '*');
+        };
+        send();
+        const observer = new MutationObserver(send);
+        observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+        return () => observer.disconnect();
+    }, [overlayReady]);
+
     return {
         overflowIframeRef,
         overflowPopoverRef,

--- a/frontend/src/hooks/useTheme.test.ts
+++ b/frontend/src/hooks/useTheme.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTheme, resolveInitialTheme } from './useTheme';
+import { interactionLogger } from '../utils/interactionLogger';
+
+vi.mock('../utils/interactionLogger', () => ({
+    interactionLogger: { record: vi.fn() },
+}));
+
+const STORAGE_KEY = 'cs4g-theme';
+
+function mockMatchMedia(prefersDark: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('dark') ? prefersDark : false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+}
+
+describe('resolveInitialTheme', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia(false);
+    });
+
+    it('returns the persisted theme when present', () => {
+        localStorage.setItem(STORAGE_KEY, 'dark');
+        expect(resolveInitialTheme()).toBe('dark');
+        localStorage.setItem(STORAGE_KEY, 'light');
+        expect(resolveInitialTheme()).toBe('light');
+    });
+
+    it('ignores a malformed persisted value and falls back to the OS pref', () => {
+        localStorage.setItem(STORAGE_KEY, 'banana');
+        mockMatchMedia(true);
+        expect(resolveInitialTheme()).toBe('dark');
+    });
+
+    it('falls back to the OS preference when nothing is persisted', () => {
+        mockMatchMedia(true);
+        expect(resolveInitialTheme()).toBe('dark');
+        mockMatchMedia(false);
+        expect(resolveInitialTheme()).toBe('light');
+    });
+
+    it('defaults to light when matchMedia is unavailable', () => {
+        // @ts-expect-error — intentionally remove matchMedia for the test.
+        window.matchMedia = undefined;
+        expect(resolveInitialTheme()).toBe('light');
+    });
+});
+
+describe('useTheme', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia(false);
+        document.documentElement.removeAttribute('data-theme');
+        document.documentElement.style.colorScheme = '';
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        document.documentElement.removeAttribute('data-theme');
+        document.documentElement.style.colorScheme = '';
+    });
+
+    it('initialises from the OS preference and applies it to <html>', () => {
+        mockMatchMedia(true);
+        const { result } = renderHook(() => useTheme());
+        expect(result.current.theme).toBe('dark');
+        expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+        expect(document.documentElement.style.colorScheme).toBe('dark');
+    });
+
+    it('initialises from a persisted value over the OS preference', () => {
+        mockMatchMedia(true);
+        localStorage.setItem(STORAGE_KEY, 'light');
+        const { result } = renderHook(() => useTheme());
+        expect(result.current.theme).toBe('light');
+        expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    });
+
+    it('toggleTheme flips the theme, the <html> attribute and persists it', () => {
+        const { result } = renderHook(() => useTheme());
+        expect(result.current.theme).toBe('light');
+
+        act(() => result.current.toggleTheme());
+
+        expect(result.current.theme).toBe('dark');
+        expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+        expect(document.documentElement.style.colorScheme).toBe('dark');
+        expect(localStorage.getItem(STORAGE_KEY)).toBe('dark');
+
+        act(() => result.current.toggleTheme());
+
+        expect(result.current.theme).toBe('light');
+        expect(localStorage.getItem(STORAGE_KEY)).toBe('light');
+    });
+
+    it('records a theme_toggled interaction event with the new theme', () => {
+        const { result } = renderHook(() => useTheme());
+        act(() => result.current.toggleTheme());
+        expect(interactionLogger.record).toHaveBeenCalledWith('theme_toggled', { theme: 'dark' });
+        act(() => result.current.toggleTheme());
+        expect(interactionLogger.record).toHaveBeenCalledWith('theme_toggled', { theme: 'light' });
+    });
+
+    it('setTheme applies an explicit theme without a toggle', () => {
+        const { result } = renderHook(() => useTheme());
+        act(() => result.current.setTheme('dark'));
+        expect(result.current.theme).toBe('dark');
+        expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+        // setTheme is not a user gesture toggle — it must not log.
+        expect(interactionLogger.record).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import { useCallback, useEffect, useState } from 'react';
+import { interactionLogger } from '../utils/interactionLogger';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'cs4g-theme';
+
+// Read the persisted choice, falling back to the OS preference. Kept
+// pure (no DOM writes) so the same logic can run from the pre-mount
+// inline script in index.html and from React without diverging.
+export function resolveInitialTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // localStorage unavailable (private mode, SSR-like envs) — fall through.
+  }
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+function applyThemeToDocument(theme: Theme): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.style.colorScheme = theme;
+}
+
+export interface ThemeState {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (t: Theme) => void;
+}
+
+export function useTheme(): ThemeState {
+  const [theme, setThemeState] = useState<Theme>(() => resolveInitialTheme());
+
+  useEffect(() => {
+    applyThemeToDocument(theme);
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // ignore — same fallback as resolveInitialTheme.
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => setThemeState(t), []);
+  const toggleTheme = useCallback(() => {
+    setThemeState(prev => {
+      const next: Theme = prev === 'dark' ? 'light' : 'dark';
+      interactionLogger.record('theme_toggled', { theme: next });
+      return next;
+    });
+  }, []);
+
+  return { theme, toggleTheme, setTheme };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,9 +12,12 @@ This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface t
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: var(--color-surface-dark);
+  /* Theme is selected by `<html data-theme="light|dark">` (set by the
+     pre-mount script in index.html and by useTheme). color-scheme
+     follows the same flip via a style attribute set in JS. */
+  color-scheme: light;
+  color: var(--color-text-primary);
+  background-color: var(--color-surface);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -27,19 +30,12 @@ body {
   min-width: 320px;
   min-height: 100vh;
   background-color: var(--color-surface);
+  color: var(--color-text-primary);
 }
 
 #root {
   width: 100%;
   height: 100vh;
-}
-
-/* Light mode overrides for this specific app style */
-@media (prefers-color-scheme: light) {
-  :root {
-    color: var(--color-text-primary);
-    background-color: var(--color-surface);
-  }
 }
 
 /* Standalone Style Alignments */

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -29,6 +29,14 @@ remaining hex-literal count after each migration.
   --color-surface-muted: #f8f9fa;
   --color-surface-raised: #fcfcfc;
 
+  /* Backdrop behind the pypowsybl NAD/SLD diagram. White in light
+     mode; flipped dark by [data-theme="dark"] below. The diagram SVG
+     itself is transparent, so this token IS the diagram background. */
+  --color-diagram-surface: #ffffff;
+  /* Semi-opaque veil painted over the diagram while a new one loads
+     (dims the stale diagram). Translucent so the old SVG shows through. */
+  --color-diagram-veil: rgba(255, 255, 255, 0.85);
+
   /* ----- Color: borders ----- */
   --color-border: #cccccc;
   --color-border-subtle: #eeeeee;
@@ -165,10 +173,13 @@ remaining hex-literal count after each migration.
    keeps `colors.surface` here = light grey-blue so flow arrows /
    delta colors keep their meaning. */
 [data-theme="dark"] {
-  /* Surfaces — diagram canvases stay near-white, app shell is dark. */
+  /* Surfaces — app shell is dark; the diagram backdrop goes near-black
+     (see --color-diagram-surface) so voltage-coded lines pop. */
   --color-surface: #1b1f24;            /* base app background */
   --color-surface-muted: #232830;      /* sidebar / cards */
   --color-surface-raised: #2a3038;     /* hover / raised tiles */
+  --color-diagram-surface: #0c0f13;    /* near-black diagram backdrop */
+  --color-diagram-veil: rgba(12, 15, 19, 0.78);
 
   /* Borders */
   --color-border: #3a4049;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -155,3 +155,66 @@ remaining hex-literal count after each migration.
      Kept as a token so the dark-mode initial-paint color has a name. */
   --color-surface-dark: #242424;
 }
+
+/* ===== Dark theme =====
+   Engaged via `<html data-theme="dark">`, set by useTheme + the
+   pre-mount script in index.html. Only chrome tokens flip — domain
+   signals (overload / contingency / action-target / pin palette)
+   stay identical because pypowsybl SVGs render on a light backdrop
+   and the colors encode semantic state. The diagram <svg> container
+   keeps `colors.surface` here = light grey-blue so flow arrows /
+   delta colors keep their meaning. */
+[data-theme="dark"] {
+  /* Surfaces — diagram canvases stay near-white, app shell is dark. */
+  --color-surface: #1b1f24;            /* base app background */
+  --color-surface-muted: #232830;      /* sidebar / cards */
+  --color-surface-raised: #2a3038;     /* hover / raised tiles */
+
+  /* Borders */
+  --color-border: #3a4049;
+  --color-border-subtle: #2d333b;
+  --color-border-strong: #555c66;
+
+  /* Text — high-contrast on the dark surfaces above. */
+  --color-text-primary: #e6e8eb;
+  --color-text-secondary: #b5bac1;
+  --color-text-tertiary: #8b9098;
+  --color-text-on-brand: #ffffff;
+
+  /* Brand — lift the Tailwind blue one step so it stays vivid on dark. */
+  --color-brand: #3b82f6;              /* blue-500 — primary CTAs */
+  --color-brand-strong: #60a5fa;       /* blue-400 — hover */
+  --color-brand-soft: #1e3a8a;         /* blue-900 — selection bg */
+  --color-brand-mid: #60a5fa;          /* slider / range fills */
+
+  /* Success / Warning / Danger / Info — keep hue, deepen the soft
+     backgrounds so badge text stays readable on dark cards. */
+  --color-success: #22c55e;
+  --color-success-strong: #16a34a;
+  --color-success-soft: #14532d;
+  --color-success-text: #bbf7d0;
+
+  --color-warning: #facc15;
+  --color-warning-strong: #eab308;
+  --color-warning-soft: #422006;
+  --color-warning-border: #713f12;
+  --color-warning-text: #fde68a;
+
+  --color-danger: #ef4444;
+  --color-danger-strong: #dc2626;
+  --color-danger-soft: #4c1d1d;
+  --color-danger-text: #fecaca;
+
+  --color-accent: #c084fc;             /* save/secondary action */
+  --color-accent-soft: #3b1f5c;
+  --color-accent-border: #7e22ce;
+  --color-accent-text: #e9d5ff;
+  --color-chrome: #0f1419;             /* header background */
+  --color-chrome-soft: #4a5159;        /* settings cog */
+  --color-disabled: #4b5563;
+
+  --color-info: #38bdf8;
+  --color-info-soft: #0c3445;
+  --color-info-border: #075985;
+  --color-info-text: #bae6fd;
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -47,6 +47,11 @@ remaining hex-literal count after each migration.
   --color-text-secondary: #555555;
   --color-text-tertiary: #888888;
   --color-text-on-brand: #ffffff;
+  /* Dark ink for text sitting on a bright, solid fill (warning yellow,
+     notice badge, etc.). Stays dark in BOTH themes because those fills
+     are bright in both — unlike the *-text tokens which are tuned for
+     the matching *-soft background and flip light in dark mode. */
+  --color-text-on-bright: #1f2937;
 
   /* ----- Color: brand (Tailwind blue ramp) ----- */
   --color-brand: #1e40af;          /* blue-800 — primary links + active CTAs */

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -29,6 +29,7 @@ export const colors = {
   textSecondary: 'var(--color-text-secondary)',
   textTertiary: 'var(--color-text-tertiary)',
   textOnBrand: 'var(--color-text-on-brand)',
+  textOnBright: 'var(--color-text-on-bright)',
 
   brand: 'var(--color-brand)',
   brandStrong: 'var(--color-brand-strong)',

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -18,6 +18,8 @@ export const colors = {
   surface: 'var(--color-surface)',
   surfaceMuted: 'var(--color-surface-muted)',
   surfaceRaised: 'var(--color-surface-raised)',
+  diagramSurface: 'var(--color-diagram-surface)',
+  diagramVeil: 'var(--color-diagram-veil)',
 
   border: 'var(--color-border)',
   borderSubtle: 'var(--color-border-subtle)',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -566,7 +566,8 @@ export type InteractionType =
     | 'session_reload_modal_opened'
     | 'session_reloaded'
     | 'sidebar_collapsed_toggled'
-    | 'contingency_clear_requested';
+    | 'contingency_clear_requested'
+    | 'theme_toggled';
 
 export interface InteractionLogEntry {
     seq: number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -677,4 +677,11 @@ export type ParentToIframeMessage =
         // can see how long the graph took to produce.
         type: 'cs4g:overflow-meta';
         overflowGraphTime: number | null;
+    }
+    | {
+        // Light/dark theme of the host app. Posted on overlay-ready and
+        // whenever the parent's `<html data-theme>` flips, so the
+        // embedded overflow viewer can match the surrounding chrome.
+        type: 'cs4g:theme';
+        theme: 'light' | 'dark';
     };

--- a/frontend/src/utils/specConformance.test.ts
+++ b/frontend/src/utils/specConformance.test.ts
@@ -139,6 +139,8 @@ const SPEC: Record<string, SpecRow> = {
   // --- Sidebar layout / contingency clear ---
   sidebar_collapsed_toggled:      { required: new Set(['collapsed']) },
   contingency_clear_requested:    { required: new Set(['had_analysis_state']) },
+  // --- Theme ---
+  theme_toggled:                  { required: new Set(['theme']) },
 };
 
 // ---------------------------------------------------------------------

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -222,6 +222,8 @@ SPEC_DETAILS: dict[str, dict] = {
     # --- Sidebar layout / contingency clear ---
     "sidebar_collapsed_toggled": _spec_row({"collapsed"}),
     "contingency_clear_requested": _spec_row({"had_analysis_state"}),
+    # --- Theme ---
+    "theme_toggled":            _spec_row({"theme"}),
 }
 
 # Event types whose details argument is a bare identifier or a


### PR DESCRIPTION
## Summary

Implements a complete light/dark theme system for Co-Study4Grid, driven by a single source of truth in design tokens. The theme is selected via a header toggle button, persisted to localStorage, and synchronized across the app (including the embedded overflow-analysis iframe) through a `data-theme` attribute on `<html>`.

## Key Changes

### Frontend Theme Infrastructure
- **`useTheme` hook** (`frontend/src/hooks/useTheme.ts`): Manages theme state, applies `data-theme` + `color-scheme` to the document, persists to localStorage, and logs `theme_toggled` interaction events. Includes `resolveInitialTheme()` resolver (persisted value → OS preference → light).
- **Pre-mount script** (`frontend/index.html`): Reads localStorage and OS preference before React mounts to avoid a flash of light theme on dark-mode reloads.
- **Header toggle** (`frontend/src/components/Header.tsx`): Sun/moon button calling `toggleTheme()`, with aria-labels and glyph flips (☾ in light, ☀ in dark).

### Design Tokens (Single Source of Truth)
- **`tokens.css`**: Added dark-mode overrides in `[data-theme="dark"]` block covering:
  - Chrome surfaces (app background, sidebar, cards)
  - Diagram backdrop (`--color-diagram-surface`: white → near-black `#0c0f13`)
  - Text colors (high-contrast on dark surfaces)
  - Brand, success, warning, danger, accent, info state colors
  - New tokens: `--color-diagram-surface`, `--color-diagram-veil`, `--color-text-on-bright` (dark ink for bright fills in both themes)
- **`tokens.ts`**: Exposed typed accessors for new tokens.

### Diagram Legibility (NAD/SLD)
- **`App.css`**: Dark-mode rules for pypowsybl SVG diagrams:
  - Flow-value labels recolored to light text with dark stroke halos
  - VL labels (HTML `<div>` in `<foreignObject>`) given light text + dark chip background
  - Action-overview dim rect driven by `--color-diagram-surface` token (CSS property beats inline attribute)
  - SLD labels recolored light, excluding flow-delta text to preserve semantic coloring
- **`ActionOverviewDiagram.tsx`**: Diagram container background now uses `colors.diagramSurface` token.

### Overflow Analysis Iframe Theming
- **`useOverflowIframe.ts`**: Posts `cs4g:theme` message to iframe on overlay-ready and whenever `<html data-theme>` flips (via `MutationObserver`).
- **`overflow_overlay.py`**: Injected dark CSS + message handler:
  - Chrome surfaces (body, sidebar, stage) recolored dark
  - Graphviz canvas polygon (white background) repainted near-black
  - Edge flow-value labels lightened
  - Grey "null redispatch" edges → near-white
  - Black "overload" edges → red (`#ef4444`)
  - All edge rules scoped to `g.edge` to preserve node colors

### Interaction Logging & Type Updates
- **`types.ts`**: Added `theme_toggled` to `InteractionType` union; added `cs4g:theme` message type to `ParentToIframeMessage`.
- **`specConformance.test.ts` & `check_standalone_parity.py`**: Updated to include `theme_toggled` spec.

### Component Updates for Dark Mode
- **`VisualizationPanel.tsx`**: Fixed text contrast on active toggle segments (Network/Delta, Hierarchical/Geo) by using `colors.textOnBrand` instead of `colors.surface`.
- **`ActionCard.tsx`**: Re-simulate button text now uses `colors.textOnBright`.
- **`NoticesPanel.tsx`**: Badge text uses `colors.textOnBright`.
- **`AppSidebar.tsx`**: Input backgrounds now use `colors.surface`.
-

https://claude.ai/code/session_01Xf3Nyea3s2Gt4r3JWBvLBc