### PR TITLE
refactor(ActionCard): severity icon left of title, star/reject top-right

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -601,11 +601,12 @@ input[data-testid="sidebar-filter-threshold-input"]::-webkit-outer-spin-button {
 /* ============================================================
    ActionCard progressive disclosure
    ============================================================
-   The star (⭐) and reject (✕) controls live in a "rail" that
-   fades in on hover, on focus, and whenever the card is the
-   currently-viewed action. This trims the at-rest visual load
-   to five fields (rank, ID, severity, max ρ, primary target)
-   while keeping the controls a single mouse-move away.
+   The star (⭐) and reject (✕) controls live in a "rail" in
+   the top-right of the card header (next to the severity icon
+   + title row). The rail fades in on hover, on focus, and
+   whenever the card is the currently-viewed action. This trims
+   the at-rest visual load while keeping the controls a single
+   mouse-move away.
 
    Implemented in CSS (not React state) so hover doesn't trigger
    a re-render on every card. */

--- a/frontend/src/components/ActionCard.test.tsx
+++ b/frontend/src/components/ActionCard.test.tsx
@@ -145,6 +145,31 @@ describe('ActionCard', () => {
         expect(screen.getByTitle('Reject this action')).toBeInTheDocument();
     });
 
+    it('places severity icon before the title and star/reject rail in the header row', () => {
+        // Structural spec: the header row contains (left to right)
+        // the severity pictogram, then the title, then the hover-
+        // revealed star/reject rail in the top-right corner.
+        const { container } = render(<ActionCard {...defaultProps} />);
+        // The first child of the card is the header flex row
+        const card = container.querySelector('[data-testid="action-card-act_1"]')!;
+        const headerRow = card.children[0] as HTMLElement;
+
+        // Left group: severity icon + title
+        const leftGroup = headerRow.children[0] as HTMLElement;
+        const severity = leftGroup.querySelector('[data-testid="action-card-act_1-severity"]');
+        const title = leftGroup.querySelector('h4');
+        expect(severity).not.toBeNull();
+        expect(title).not.toBeNull();
+        // Severity comes before title in DOM order
+        const children = Array.from(leftGroup.children);
+        expect(children.indexOf(severity!)).toBeLessThan(children.indexOf(title!));
+
+        // Right group: the rail sits as the second child of the header row
+        const rail = headerRow.querySelector('.action-card-rail');
+        expect(rail).not.toBeNull();
+        expect(headerRow.children[1]).toBe(rail);
+    });
+
     it('calls onActionSelect when card is clicked', () => {
         const onActionSelect = vi.fn();
         render(<ActionCard {...defaultProps} onActionSelect={onActionSelect} />);

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -257,51 +257,67 @@ const ActionCard: React.FC<ActionCardProps> = ({
                 position: 'relative',
             }} onClick={() => onActionSelect(id)}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '6px' }}>
-                <h4 style={{
-                    margin: 0,
-                    fontSize: '12px',
-                    color: isViewing ? colors.brandStrong : undefined,
-                    flex: 1,
-                    minWidth: 0,
-                    overflowWrap: 'anywhere',
-                    fontWeight: 700,
-                    lineHeight: 1.35,
-                }}>
-                    #{index + 1} {'—'} {id}
-                </h4>
-                {/* Icon-only severity pictogram — the label text was
-                    redundant with the colour and ate horizontal space the
-                    action-id title needs. The full wording is reachable on
-                    hover (native title tooltip) and to assistive tech. */}
-                <span
-                    data-testid={`action-card-${id}-severity`}
-                    title={sc.label}
-                    aria-label={sc.label}
-                    role="img"
-                    style={{
-                        display: 'inline-flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        padding: '3px',
-                        borderRadius: '50%',
-                        background: sc.badgeBg,
-                        color: sc.badgeText,
-                        flexShrink: 0,
-                        lineHeight: 0,
-                    }}
-                >
-                    <SeverityIcon kind={sc.kind} />
-                </span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '5px', flex: 1, minWidth: 0 }}>
+                    {/* Severity pictogram — placed before the title so the
+                        operator immediately reads the outcome colour. */}
+                    <span
+                        data-testid={`action-card-${id}-severity`}
+                        title={sc.label}
+                        aria-label={sc.label}
+                        role="img"
+                        style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            padding: '3px',
+                            borderRadius: '50%',
+                            background: sc.badgeBg,
+                            color: sc.badgeText,
+                            flexShrink: 0,
+                            lineHeight: 0,
+                        }}
+                    >
+                        <SeverityIcon kind={sc.kind} />
+                    </span>
+                    <h4 style={{
+                        margin: 0,
+                        fontSize: '12px',
+                        color: isViewing ? colors.brandStrong : undefined,
+                        flex: 1,
+                        minWidth: 0,
+                        overflowWrap: 'anywhere',
+                        fontWeight: 700,
+                        lineHeight: 1.35,
+                    }}>
+                        #{index + 1} {'—'} {id}
+                    </h4>
+                </div>
+                {/* Star / reject rail — top-right, revealed on hover via
+                    CSS (.action-card-rail opacity transition). */}
+                <div className="action-card-rail" style={{ display: 'flex', gap: '3px', flexShrink: 0 }}>
+                    {!isSelected && (
+                        <button
+                            data-testid={`favorite-${id}`}
+                            onClick={(e) => { e.stopPropagation(); onActionFavorite(id); }}
+                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '2px 4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                            title="Select this action"
+                        ><span style={{ fontSize: '15px', lineHeight: 1 }}>⭐</span></button>
+                    )}
+                    {!isRejected && (
+                        <button
+                            data-testid={`reject-${id}`}
+                            onClick={(e) => { e.stopPropagation(); onActionReject(id); }}
+                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '2px 4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                            title={isSelected ? "Remove from selected" : "Reject this action"}
+                        ><span style={{ fontSize: '15px', lineHeight: 1 }}>❌</span></button>
+                    )}
+                </div>
             </div>
 
             {/* Compact at-rest body: max loading + target badges. The
-                rail (⭐ / ❌) sits to the right and fades in on
-                hover or when this card is being viewed. The row wraps
-                so multi-VL badge stacks flow to a second line when
-                the title is long or the badges don't fit alongside
-                the loading metric — without that, ``flexShrink:0`` on
-                the badges + rail forces the loading text to collapse
-                into a one-word-per-line vertical strip. */}
+                row wraps so multi-VL badge stacks flow to a second
+                line when the title is long or the badges don't fit
+                alongside the loading metric. */}
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', flexWrap: 'wrap', rowGap: '6px', gap: '8px', marginTop: '6px' }}>
                 <div style={{ flex: '1 1 160px', fontSize: '12px', minWidth: 'min-content' }}>
                     {maxRhoPct != null ? (
@@ -320,24 +336,6 @@ const ActionCard: React.FC<ActionCardProps> = ({
                     )}
                 </div>
                 {renderBadges()}
-                <div className="action-card-rail" style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
-                    {!isSelected && (
-                        <button
-                            data-testid={`favorite-${id}`}
-                            onClick={(e) => { e.stopPropagation(); onActionFavorite(id); }}
-                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                            title="Select this action"
-                        ><span style={{ fontSize: '14px' }}>⭐</span></button>
-                    )}
-                    {!isRejected && (
-                        <button
-                            data-testid={`reject-${id}`}
-                            onClick={(e) => { e.stopPropagation(); onActionReject(id); }}
-                            style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: '4px', cursor: 'pointer', padding: '4px 6px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                            title={isSelected ? "Remove from selected" : "Reject this action"}
-                        ><span style={{ fontSize: '14px' }}>❌</span></button>
-                    )}
-                </div>
             </div>
 
             {/* Fault states (divergent / islanded) are primary signals


### PR DESCRIPTION
## Summary
- Move the severity pictogram (green check / orange warning / red X) to the **left** of the action number + title, on the same header line — operators read the outcome colour first when scanning the feed
- Move the star/reject buttons to the **top-right** of the card header (where the severity icon used to be), revealed on hover via the existing `.action-card-rail` CSS transition
- Slightly larger star/reject emoji (15 px) with tighter padding to fit the header row
- Body row (max loading + asset badges) is simplified — no longer hosts the rail, giving more horizontal space to badges

## Test plan
- [x] All 41 ActionCard unit tests pass (40 existing + 1 new structural test)
- [ ] Visual check on a loaded study: severity icon visible left of title, star/reject appear on hover top-right
- [ ] Verify star/reject buttons still fire `onActionFavorite` / `onActionReject` correctly
- [ ] Verify cards in Selected / Rejected sections hide the appropriate button

🤖 Generated with [Claude Code](https://claude.com/claude-code)