### PR TITLE
Interactive SLD topology edit → manual action simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and the project (informally) follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Interactive SLD topology edit → manual action card
+
+A new gesture lets the operator build a remedial action by clicking
+switches on a Single Line Diagram, mirroring the `manoeuvre_ihm` tool
+in `expert_op4grid_recommender`:
+
+- **`✎ Manual action`** button in the SLD overlay header (visible on
+  N-1 and post-action SLD tabs). Clicking it enters edit mode.
+- **Target-topology preview** — each staged switch toggle triggers a
+  debounced `POST /api/sld-topology-preview` call (new endpoint).
+  Backend clones a throwaway variant, applies the overrides, and
+  re-renders the SLD with `SldParameters(topological_coloring=True)`
+  (no load flow). The frontend shows the preview in place of the
+  baseline with stale-flow values greyed (`.sld-preview-stale`); the
+  changed breaker keeps its dashed outline so the operator always
+  sees WHERE the topology changed.
+- **Interactive maneuver list** (`SldEditPanel`) — focus a single
+  switch by clicking its row, remove one with `×`, remove a block
+  via checkbox + `Remove selected (N)`, or `Reset` all.
+- **Simulate action** — streams `/api/simulate-and-variant-diagram`
+  (new optional `voltage_level_id` field auto-names switch-only
+  actions: `"Manoeuvre manuelle sur <vl>: SW_A ouvert, SW_B fermé"`),
+  the card lands in the Action Feed and the SLD overlay auto-focuses
+  on its `ACTION` tab.
+- **Combined-action support** — editing on a post-action SLD produces
+  a combined card `<base>+user_topo_<vl>_<ts>`; the backend
+  canonicalises combined ids (`"+"`-sorted) and `_require_action`
+  aliases the raw ordering onto the canonical entry so the frontend
+  fetch keys never desync.
+- **Action-type filter** — `classifyActionTypes` (multi-bucket) is
+  introduced so a single maneuver that opens a coupling AND a line
+  (comma-joined description), or a combined card that opens one
+  coupling AND closes another, passes BOTH the corresponding filters
+  in the Action Feed / Action Overview / Combine modal / overflow
+  pins.
+- **Six new interaction events** declared in both `SPEC`
+  (`specConformance.test.ts`) and `SPEC_DETAILS`
+  (`check_standalone_parity.py`): `sld_edit_mode_toggled`,
+  `sld_switch_toggled`, `sld_maneuver_removed`,
+  `sld_maneuver_focused`, `sld_edit_reset`, `sld_topology_simulated`.
+
+Full contract + test inventory in
+[`docs/features/sld-topology-edit.md`](docs/features/sld-topology-edit.md).
+
 ### Sidebar readability refresh — collapsible feed, banner Clear, overload info bubble
 
 - **Sidebar visibility gate** — the "Select Contingency" picker card

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,7 @@ Both scripts run in CI (`.github/workflows/code-quality.yml` and
 | POST | `/api/n-sld` | Single Line Diagram for voltage level in N state. Response includes `switch_states` (per-switch open/closed map) used by the interactive SLD-edit feature. |
 | POST | `/api/contingency-sld` | Single Line Diagram in N-1 state (with flow deltas + `switch_states`). |
 | POST | `/api/action-variant-sld` | SLD in post-action state (with flow deltas, `changed_switches`, `switch_states`). |
+| POST | `/api/sld-topology-preview` | Target-topology preview SLD for the interactive SLD-edit feature: applies staged switch overrides on a throwaway variant and re-renders with topological colouring (no load flow; `stale_flows: true`). |
 | GET  | `/api/actions` | Return all available action IDs and descriptions |
 | POST | `/api/regenerate-overflow-graph` | Regenerate (or serve from cache) the overflow graph in hierarchical / geo layout — drives the toggle on the Overflow Analysis tab |
 | POST | `/api/simulate-manual-action` | Simulate a specific action against a contingency. Accepts an optional `voltage_level_id` field used to auto-name switch-only user actions (interactive SLD-edit feature). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ Co-Study4Grid/
 | `docs/README.md` | Index of design/feature/perf/architecture/proposal docs. Start here for any `docs/**` lookup. |
 | `docs/features/save-results.md` | Save / reload session contract (JSON schema, reload flow, regression-guard matrix) |
 | `docs/features/interaction-logging.md` | Replay-ready event log contract |
+| `docs/features/sld-topology-edit.md` | Interactive SLD topology edit → manual action card |
 
 ## Tech Stack
 
@@ -259,12 +260,12 @@ Both scripts run in CI (`.github/workflows/code-quality.yml` and
 | POST | `/api/action-variant-diagram-patch` | Per-branch delta + VL-subtree splice for action DOM recycling |
 | POST | `/api/focused-diagram` | Generate NAD sub-diagram focused on a specific element |
 | POST | `/api/action-variant-focused-diagram` | Focused NAD for specific VL in post-action state |
-| POST | `/api/n-sld` | Single Line Diagram for voltage level in N state |
-| POST | `/api/contingency-sld` | Single Line Diagram in N-1 state (with flow deltas) |
-| POST | `/api/action-variant-sld` | SLD in post-action state |
+| POST | `/api/n-sld` | Single Line Diagram for voltage level in N state. Response includes `switch_states` (per-switch open/closed map) used by the interactive SLD-edit feature. |
+| POST | `/api/contingency-sld` | Single Line Diagram in N-1 state (with flow deltas + `switch_states`). |
+| POST | `/api/action-variant-sld` | SLD in post-action state (with flow deltas, `changed_switches`, `switch_states`). |
 | GET  | `/api/actions` | Return all available action IDs and descriptions |
 | POST | `/api/regenerate-overflow-graph` | Regenerate (or serve from cache) the overflow graph in hierarchical / geo layout — drives the toggle on the Overflow Analysis tab |
-| POST | `/api/simulate-manual-action` | Simulate a specific action against a contingency |
+| POST | `/api/simulate-manual-action` | Simulate a specific action against a contingency. Accepts an optional `voltage_level_id` field used to auto-name switch-only user actions (interactive SLD-edit feature). |
 | POST | `/api/simulate-and-variant-diagram` | NDJSON stream: `{type:"metrics"}` then `{type:"diagram"}` so sidebar updates ahead of the SVG |
 | POST | `/api/compute-superposition` | Compute combined effect of two actions (superposition theorem) |
 | POST | `/api/save-session` | Save session folder with JSON snapshot + PDF copy |

--- a/docs/features/sld-topology-edit.md
+++ b/docs/features/sld-topology-edit.md
@@ -1,87 +1,218 @@
 # Interactive SLD topology edit → manual action
 
-## What it does
+This feature lets the operator build a manual remedial action directly
+from the Single Line Diagram by clicking switches. It mirrors the
+`manoeuvre_ihm` tool in `expert_op4grid_recommender/scripts/` —
+target-topology view with topological colouring, an editable maneuver
+list, single / block deletion — adapted to the React + FastAPI stack
+of Co-Study4Grid.
 
-From the SLD overlay opened on an **N-1 (contingency)** or
-**post-action** voltage-level diagram, the operator can:
+## TL;DR — the workflow
 
-1. Click `✎ Manual action` to enter edit mode.
-2. Click any switch on the diagram to stage a toggle. The diagram then
-   re-renders as a **target-topology preview** (see below): the breaker
-   is drawn in its target open/closed state and the busbar / branch
-   connectivity is re-coloured by pypowsybl's topological colouring, so
-   a node split / merge is immediately visible — same affordance as the
-   `manoeuvre_ihm` target-topology view. Flow values are greyed because
-   no load flow has been run yet.
-3. Click `Reset` to drop the staged toggles, or `Simulate action` to
-   send the user-built topology to the backend for a real simulation.
+1. Open the SLD overlay on a voltage level (double-click on the NAD)
+   in the **N-1 (contingency)** tab or the **action-variant** tab of
+   an already-suggested action.
+2. Click the **`✎ Manual action`** button in the SLD header to enter
+   edit mode.
+3. Click any operable switch on the diagram. The diagram is
+   re-rendered as a **target-topology preview** (see below): the
+   breaker is drawn in its target open/closed state, the busbar /
+   branch connectivity is re-coloured by pypowsybl's topological
+   colouring (so a node split / merge is immediately visible), and
+   flow values are greyed because no load flow has been run yet. The
+   changed switch keeps its dashed highlight (magenta = will open,
+   blue = will close) **on top of** the preview, so the operator
+   always sees WHERE the topology changed.
+4. The side panel under the SVG lists every staged maneuver. From
+   there, the operator can:
+   - **Click a row** to focus a single switch (only its outline stays
+     on the diagram — same affordance as `seq_highlights` in
+     `manoeuvre_ihm`).
+   - Click **`×`** on a row to remove that maneuver (`seq_delete`).
+   - **Check** several rows + click **`Remove selected (N)`** to drop
+     a block (`seq_delete_many`).
+   - Click **`Reset`** to drop every staged change.
+5. Click **`Simulate action`**. The backend simulates the user-built
+   topology and emits a manual-action card in the Action Feed; the
+   SLD overlay auto-focuses on the new action's `ACTION` tab so the
+   post-action state is shown immediately (no manual tab switch).
 
-### Target-topology preview
+When the edit was done **on a post-action SLD**, the resulting card
+has a combined id `<base_action_id>+user_topo_<vl>_<ts>` so it appears
+as a combined action (same visual treatment as `ComputedPairs`
+cards).
 
-While toggles are staged, the frontend calls
-`POST /api/sld-topology-preview` (debounced ~280 ms, with a
-sequence guard dropping stale responses). The backend
-(`get_topology_preview_sld` in `diagram_mixin.py`) clones a throwaway
-variant from the contingency (or post-action) state, applies the
-switch overrides, and re-renders the VL SLD with
-`SldParameters(topological_coloring=True)` — **no load flow**. The
-response carries `stale_flows: True`; the frontend renders it in place
-of the baseline with the `sld-preview-stale` class greying every flow
-text / arrow. The throwaway variant is always removed and the working
-variant restored in a `finally`, so the shared Network is never left
-mutated.
+## Target-topology preview
 
-The result lands in the Action Feed as a manual action card. When the
-edit was done on a **post-action SLD**, the card is created with a
-combined id `<base_action_id>+user_topo_<vl>_<ts>` so it appears as a
-combined action (same visual treatment as `ComputedPairs` cards).
+While toggles are staged, the frontend calls **`POST
+/api/sld-topology-preview`** (debounced ~280 ms, with a sequence
+guard dropping stale responses).
 
-This mirrors the `manoeuvre_ihm` IHM in
-`expert_op4grid_recommender/scripts/manoeuvre_ihm.py` — same boolean
-`{switch_id: is_open}` contract — adapted to the React/FastAPI stack.
+The backend (`get_topology_preview_sld` in
+`expert_backend/services/diagram_mixin.py`) :
+
+1. Resolves the source variant — the **contingency variant** by
+   default, or the **post-action variant** when the request carries
+   a `base_action_id` (the SLD was opened from an action card).
+2. **Clones** a throwaway variant from it.
+3. Applies the user's switch overrides via
+   `network.update_switches(id=…, open=…)`.
+4. Re-renders the VL SLD with
+   `SldParameters(use_name=True, topological_coloring=True)`.
+   Topological colouring is what makes a node split / merge visible:
+   opening a coupling splits the busbar into two connected components
+   that pypowsybl paints in distinct colours — the same affordance
+   the `manoeuvre_ihm` target-topology view relies on. Falls back to
+   default parameters if the installed pypowsybl predates
+   `SldParameters`.
+5. Returns `{ svg, sld_metadata, voltage_level_id, switch_states,
+   stale_flows: true }`. **No load flow** runs — the flow values are
+   stale, hence `stale_flows: true`.
+6. **Always** removes the throwaway variant and restores the working
+   variant in a `finally`, so the shared Network is never left
+   mutated even if rendering raises.
+
+The frontend renders the preview SVG in place of the baseline with
+the `sld-preview-stale` CSS class greying every flow `<text>` and
+arrow glyph until the operator commits the simulation.
 
 ## Backend contract
 
-`/api/n-sld`, `/api/contingency-sld`, `/api/action-variant-sld` now
-include a `switch_states: {switch_id: is_open_bool}` field listing
-every **operable** switch on the requested voltage level. Source:
-`extract_vl_switch_states` in
-`expert_backend/services/diagram/sld_render.py`. Fictitious and
-non-existent switches are filtered out, so this map is the source of
-truth for what is editable.
+| Endpoint | Change |
+|---|---|
+| `POST /api/n-sld` | Response gains `switch_states: { switch_id: is_open }` for the requested VL. |
+| `POST /api/contingency-sld` | Same. |
+| `POST /api/action-variant-sld` | Same. The existing `changed_switches` diff is unchanged. |
+| `POST /api/sld-topology-preview` | **NEW.** Body: `{ voltage_level_id, disconnected_elements, switches, base_action_id? }`. Response: `{ svg, sld_metadata, voltage_level_id, switch_states, stale_flows: true }`. |
+| `POST /api/simulate-manual-action` | New optional body field `voltage_level_id` used to auto-name switch-only manual actions (`"Manoeuvre manuelle sur <vl>: SW_A ouvert, SW_B fermé"`). |
+| `POST /api/simulate-and-variant-diagram` | Same `voltage_level_id` plumbing. The NDJSON stream is unchanged (`{type:"metrics"} → {type:"diagram"}`). |
 
-`/api/simulate-manual-action` and `/api/simulate-and-variant-diagram`
-gained an optional `voltage_level_id` field. When supplied alongside
-an `action_content` that only carries a `switches` key, the backend
-auto-generates a human-readable description (`"Manoeuvre manuelle sur
-<vl>: SW_A ouvert, SW_B fermé"`) instead of falling back to the
-synthetic action id.
+**Operable switch filtering** — `extract_vl_switch_states`
+(`expert_backend/services/diagram/sld_render.py`) reads
+`network.get_switches(attributes=["open","voltage_level_id","kind","fictitious","retained"])`,
+keeps only switches on the requested VL, and excludes
+`fictitious=True` rows so internal-bookkeeping switches are not
+editable. The fallback path (`["open","voltage_level_id"]`) handles
+legacy pypowsybl builds that don't accept the extended attribute list.
 
-No new endpoints. Co-Study4Grid runs the pypowsybl backend
-exclusively (`recommender_service._get_simulation_env()` always
-instantiates `SimulationEnvironment` from
-`expert_op4grid_recommender.pypowsybl_backend`), so the switch action
-path is always supported.
+**Combined-action id canonicalisation** —
+`simulate_manual_action` registers a combined id under its
+**canonical** (`"+"`-parts sorted alphabetically) key. The frontend
+mints the raw, unsorted order (`base+user`), so `_require_action`
+aliases the raw key onto the canonical entry before raising — every
+later `get_action_variant_diagram` / `get_action_variant_sld` /
+`get_topology_preview_sld` lookup works regardless of ordering. The
+frontend ALSO adopts the canonical id (taken from `metrics.action_id`)
+when registering the card so subsequent fetches start from the same
+key.
 
 ## Frontend contract
 
-- `hooks/useSldTopologyEdit.ts` owns the pending overrides.
-- `components/SldEditPanel.tsx` renders the side-panel.
-- `components/SldOverlay.tsx` delegates clicks on switch DOM elements
-  via the SLD metadata `equipmentId → SVG id` map (same chain used by
-  the delta and highlight passes — dot/underscore variants handled).
-- The Simulate handler in `App.tsx` (`handleSimulateSldEdit`)
-  streams `/api/simulate-and-variant-diagram`, primes the
-  action-variant diagram, and pushes the new card via
-  `wrappedManualActionAdded(_, _, _, 'user')`.
+| File | Role |
+|---|---|
+| `hooks/useSldTopologyEdit.ts` | Owns the pending overrides, focus state, and the toggle / removeSwitch / removeSwitches / reset / setFocusedSwitch API. Auto-drops stale overrides on baseline identity change. |
+| `components/SldEditPanel.tsx` | Side panel under the SLD body — maneuver list, focus on row click, `×` per row, checkbox + **Remove selected (N)** for blocks, combined-with badge, Reset / Simulate buttons. |
+| `components/SldOverlay.tsx` | Header `✎ Manual action` button, switch-click delegation via SLD metadata `equipmentId → SVG id` map (dot/underscore variants handled), toggle outlines + focused-switch filter — applied **also on the preview** so the highlight persists. |
+| `App.tsx::handleSimulateSldEdit` | Streams `/api/simulate-and-variant-diagram` with `action_content={switches}` + `voltage_level_id`, primes the action-variant diagram under the **backend-canonical** id (`metrics.action_id`), pushes the card via `wrappedManualActionAdded(_, _, _, 'user')`, then `handleVlDoubleClick(id, vl, 'action')` to auto-focus the new action's tab. |
+| `App.tsx::sldPreview` | Debounced fetch of `/api/sld-topology-preview` with sequence guard. |
+| `styles/tokens.css` | `--signal-edit-open` / `--signal-edit-closed` token pair for the toggle outline. |
+| `App.css` | `.sld-user-toggle-{open,closed}` (dashed outline) + `.sld-preview-stale` (grey flow values). |
+
+### Edit-mode invariants
+
+The hook drops every staged toggle when:
+- the operator exits edit mode (`setEditMode(false)`),
+- the baseline `switch_states` map identity changes (new SLD tab, new
+  VL, or new action variant),
+- the simulation succeeds (after the card is pushed).
+
+The hook **silently ignores** taps on switches that aren't in the
+baseline — this is the cheapest way to guarantee a user-built
+`switches` payload only references operable equipment.
+
+### Single-bucket vs multi-bucket type classification
+
+A manual maneuver can toggle several switches in one go
+(comma-joined) and a combined action joins maneuvers with `+`. A
+single card therefore may belong to **multiple** action-type
+buckets (open coupling **and** line disconnection, for example).
+`utils/actionTypes.ts` exposes a multi-bucket
+`classifyActionTypes(): Set<ActionTypeKind>` that handles this; the
+existing singular `classifyActionType` keeps the fast-path for
+non-maneuver cards. `matchesActionTypeFilter` routes through the Set
+so a comma-joined `…COUCH6COUPL… ouvert, …COUCH6CPVAN.1… ouvert`
+maneuver passes BOTH the **open coupling** and **line
+disconnection** filters in the feed / overview / combine modal /
+overflow-pin filters at once.
 
 ## Interaction-log events
 
-| Event | Payload |
-|---|---|
-| `sld_edit_mode_toggled` | `{ enabled }` |
-| `sld_switch_toggled` | `{ equipment_id }` |
-| `sld_edit_reset` | `{}` |
-| `sld_topology_simulated` | `{ voltage_level_id, switches, combined_with }` |
+| Event | Required payload | Optional |
+|---|---|---|
+| `sld_edit_mode_toggled` | `enabled` | |
+| `sld_switch_toggled` | `equipment_id` | |
+| `sld_maneuver_removed` | `equipment_ids` | |
+| `sld_maneuver_focused` | `equipment_id` | |
+| `sld_edit_reset` | — | |
+| `sld_topology_simulated` | `voltage_level_id`, `switches` | `combined_with` |
 
-Declared on the `InteractionType` union in `types.ts`.
+Declared in the `InteractionType` union (`frontend/src/types.ts`),
+mirrored in the conformance contract
+(`frontend/src/utils/specConformance.test.ts` `SPEC` and
+`scripts/check_standalone_parity.py` `SPEC_DETAILS`).
+
+## Test coverage
+
+### Backend (`expert_backend/tests/test_sld_topology_edit.py`)
+
+- `TestExtractVlSwitchStates` — happy path, fictitious-row filter,
+  pypowsybl-failure resilience, extended-attribute fallback.
+- `TestExtractVlSwitchStatesEdgeCases` — corrupt-row skipping, missing
+  VL, missing `fictitious` column.
+- `TestIsSwitchOnlyContent` / `TestBuildSwitchActionDescription` /
+  `TestBuildSwitchActionDescriptionShape` — auto-description contract
+  that the frontend filter parser depends on (the action-type
+  classifier looks for `coupl` + `ouvert`/`fermé` per clause).
+- `TestSimulateManualActionSwitchOnly` — `_inject_action_content_entries`
+  builds a switch-only entry with the right description (with or
+  without VL).
+- `TestTopologyPreviewSld` — clones + applies + removes + restores
+  even on render failure.
+- `TestTopologyPreviewEmptyAndPostAction` — empty-switches no-op +
+  post-action path using the action's network manager.
+- `TestRequireActionCanonicalAlias` / `TestCanonicalAliasSymmetry` —
+  combined-id ordering symmetry (`A+B` and `B+A` resolve identically,
+  canonicalisation is idempotent).
+- `TestSldEndpointSwitchStates` — `switch_states` round-trip on the
+  N-SLD endpoint.
+- `TestSldTopologyPreviewEndpoint` + `TestSimulateManualActionEndpointPlumbsVoltageLevel`
+  — HTTP-boundary tests via FastAPI `TestClient` (skipped in sandboxes
+  that mock `expert_op4grid_recommender.models`).
+
+### Frontend
+
+- `hooks/useSldTopologyEdit.test.ts` — toggle / reset / remove single /
+  remove block / focus / baseline-change pruning / interaction-log
+  emissions.
+- `components/SldEditPanel.test.tsx` — empty state, per-row direction
+  display, focus on row click, `×` removal, block removal, busy
+  state, combined-with badge.
+- `utils/actionTypes.test.ts` — multi-bucket classifier coverage
+  (open/close/disco/reco from manual maneuvers), combined open+close
+  card, comma-joined coupling + line, line-only maneuvers, ligature
+  spelling, regression that singular classifier still returns one
+  bucket for normal cards.
+- `utils/specConformance.test.ts` — `SPEC` rows for the six
+  `sld_*` interaction types.
+
+## Limitation: which backend
+
+Co-Study4Grid runs the **pypowsybl** backend exclusively
+(`recommender_service._get_simulation_env()` always instantiates
+`SimulationEnvironment` from
+`expert_op4grid_recommender.pypowsybl_backend`). Switch-based actions
+are fully supported on that path
+(`pypowsybl_backend.action_space.SwitchAction`). The grid2op native
+backend in `expert_op4grid_recommender` ignores the `switches` content
+key silently — not a concern here, but worth keeping in mind if the
+feature is ever ported to a grid2op-only deployment.

--- a/docs/features/sld-topology-edit.md
+++ b/docs/features/sld-topology-edit.md
@@ -5,13 +5,31 @@
 From the SLD overlay opened on an **N-1 (contingency)** or
 **post-action** voltage-level diagram, the operator can:
 
-1. Click `Edit` to enter topology-edit mode.
-2. Click any switch on the diagram to stage a toggle. The breaker is
-   highlighted with a dashed outline:
-   - magenta = will open (`sld-user-toggle-open`)
-   - blue    = will close (`sld-user-toggle-closed`)
+1. Click `✎ Manual action` to enter edit mode.
+2. Click any switch on the diagram to stage a toggle. The diagram then
+   re-renders as a **target-topology preview** (see below): the breaker
+   is drawn in its target open/closed state and the busbar / branch
+   connectivity is re-coloured by pypowsybl's topological colouring, so
+   a node split / merge is immediately visible — same affordance as the
+   `manoeuvre_ihm` target-topology view. Flow values are greyed because
+   no load flow has been run yet.
 3. Click `Reset` to drop the staged toggles, or `Simulate action` to
-   send the user-built topology to the backend.
+   send the user-built topology to the backend for a real simulation.
+
+### Target-topology preview
+
+While toggles are staged, the frontend calls
+`POST /api/sld-topology-preview` (debounced ~280 ms, with a
+sequence guard dropping stale responses). The backend
+(`get_topology_preview_sld` in `diagram_mixin.py`) clones a throwaway
+variant from the contingency (or post-action) state, applies the
+switch overrides, and re-renders the VL SLD with
+`SldParameters(topological_coloring=True)` — **no load flow**. The
+response carries `stale_flows: True`; the frontend renders it in place
+of the baseline with the `sld-preview-stale` class greying every flow
+text / arrow. The throwaway variant is always removed and the working
+variant restored in a `finally`, so the shared Network is never left
+mutated.
 
 The result lands in the Action Feed as a manual action card. When the
 edit was done on a **post-action SLD**, the card is created with a

--- a/docs/features/sld-topology-edit.md
+++ b/docs/features/sld-topology-edit.md
@@ -1,0 +1,69 @@
+# Interactive SLD topology edit → manual action
+
+## What it does
+
+From the SLD overlay opened on an **N-1 (contingency)** or
+**post-action** voltage-level diagram, the operator can:
+
+1. Click `Edit` to enter topology-edit mode.
+2. Click any switch on the diagram to stage a toggle. The breaker is
+   highlighted with a dashed outline:
+   - magenta = will open (`sld-user-toggle-open`)
+   - blue    = will close (`sld-user-toggle-closed`)
+3. Click `Reset` to drop the staged toggles, or `Simulate action` to
+   send the user-built topology to the backend.
+
+The result lands in the Action Feed as a manual action card. When the
+edit was done on a **post-action SLD**, the card is created with a
+combined id `<base_action_id>+user_topo_<vl>_<ts>` so it appears as a
+combined action (same visual treatment as `ComputedPairs` cards).
+
+This mirrors the `manoeuvre_ihm` IHM in
+`expert_op4grid_recommender/scripts/manoeuvre_ihm.py` — same boolean
+`{switch_id: is_open}` contract — adapted to the React/FastAPI stack.
+
+## Backend contract
+
+`/api/n-sld`, `/api/contingency-sld`, `/api/action-variant-sld` now
+include a `switch_states: {switch_id: is_open_bool}` field listing
+every **operable** switch on the requested voltage level. Source:
+`extract_vl_switch_states` in
+`expert_backend/services/diagram/sld_render.py`. Fictitious and
+non-existent switches are filtered out, so this map is the source of
+truth for what is editable.
+
+`/api/simulate-manual-action` and `/api/simulate-and-variant-diagram`
+gained an optional `voltage_level_id` field. When supplied alongside
+an `action_content` that only carries a `switches` key, the backend
+auto-generates a human-readable description (`"Manoeuvre manuelle sur
+<vl>: SW_A ouvert, SW_B fermé"`) instead of falling back to the
+synthetic action id.
+
+No new endpoints. Co-Study4Grid runs the pypowsybl backend
+exclusively (`recommender_service._get_simulation_env()` always
+instantiates `SimulationEnvironment` from
+`expert_op4grid_recommender.pypowsybl_backend`), so the switch action
+path is always supported.
+
+## Frontend contract
+
+- `hooks/useSldTopologyEdit.ts` owns the pending overrides.
+- `components/SldEditPanel.tsx` renders the side-panel.
+- `components/SldOverlay.tsx` delegates clicks on switch DOM elements
+  via the SLD metadata `equipmentId → SVG id` map (same chain used by
+  the delta and highlight passes — dot/underscore variants handled).
+- The Simulate handler in `App.tsx` (`handleSimulateSldEdit`)
+  streams `/api/simulate-and-variant-diagram`, primes the
+  action-variant diagram, and pushes the new card via
+  `wrappedManualActionAdded(_, _, _, 'user')`.
+
+## Interaction-log events
+
+| Event | Payload |
+|---|---|
+| `sld_edit_mode_toggled` | `{ enabled }` |
+| `sld_switch_toggled` | `{ equipment_id }` |
+| `sld_edit_reset` | `{}` |
+| `sld_topology_simulated` | `{ voltage_level_id, switches, combined_with }` |
+
+Declared on the `InteractionType` union in `types.ts`.

--- a/expert_backend/CLAUDE.md
+++ b/expert_backend/CLAUDE.md
@@ -32,6 +32,10 @@ expert_backend/
 │   │   ├── nad_params.py          # - default NadParameters factory
 │   │   ├── nad_render.py          # - NAD generation + NaN-element stripping
 │   │   ├── sld_render.py          # - SLD SVG + metadata with fallbacks
+│   │   │                          #   + extract_vl_switch_states (per-VL
+│   │   │                          #   operable-switch baseline used by the
+│   │   │                          #   interactive SLD-edit feature, see
+│   │   │                          #   docs/features/sld-topology-edit.md)
 │   │   ├── overloads.py           # - overload filtering, element-currents
 │   │   ├── flows.py               # - branch + asset flow extractors (vectorised)
 │   │   ├── deltas.py              # - terminal-aware flow-delta math (pure)
@@ -186,6 +190,12 @@ Diagram & topology:
   the ~12 MB French NAD. See
   `docs/performance/history/svg-dom-recycling.md`.
 - `POST /api/n-sld` / `/api/contingency-sld` / `/api/action-variant-sld`
+  — each response now carries a `switch_states` map (per-VL
+  operable-switch booleans), driving the interactive SLD-edit baseline.
+- `POST /api/sld-topology-preview` — re-renders the VL SLD with the
+  user's staged switch overrides applied on a throwaway variant
+  (topological-colouring, NO load flow). Response carries
+  `stale_flows: true`. See `docs/features/sld-topology-edit.md`.
 
 Analysis:
 - `POST /api/run-analysis-step1` — detect overloads (returns once).
@@ -212,7 +222,9 @@ Analysis:
   `run_analysis_step2` and on `reset()`. The transform lives in
   `services/analysis/overflow_geo_transform.py` (pure function,
   lxml-based, fully unit-tested).
-- `POST /api/simulate-manual-action` — one-off simulation.
+- `POST /api/simulate-manual-action` — one-off simulation. Optional
+  `voltage_level_id` field used to auto-name switch-only manual actions
+  (`"Manoeuvre manuelle sur <vl>: SW_A ouvert, SW_B fermé"`).
 - `POST /api/simulate-and-variant-diagram` — combined NDJSON stream
   emitting `{type:"metrics"}` then `{type:"diagram"}` so the
   sidebar can update ahead of the SVG.

--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -821,12 +821,34 @@ class ContingencySldRequest(BaseModel):
     disconnected_elements: list[str]
     voltage_level_id: str
 
+class SldTopologyPreviewRequest(BaseModel):
+    voltage_level_id: str
+    disconnected_elements: list[str]
+    switches: dict
+    base_action_id: str | None = None
+
 @app.post("/api/contingency-sld")
 def get_contingency_sld(request: ContingencySldRequest, http_request: Request) -> Response:
     try:
         diagram = recommender_service.get_contingency_sld(
             request.disconnected_elements,
             request.voltage_level_id,
+        )
+        return _maybe_gzip_json(diagram, http_request)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("API boundary error")
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/api/sld-topology-preview")
+def sld_topology_preview(request: SldTopologyPreviewRequest, http_request: Request) -> Response:
+    try:
+        diagram = recommender_service.get_topology_preview_sld(
+            request.disconnected_elements,
+            request.voltage_level_id,
+            request.switches,
+            base_action_id=request.base_action_id,
         )
         return _maybe_gzip_json(diagram, http_request)
     except HTTPException:

--- a/expert_backend/main.py
+++ b/expert_backend/main.py
@@ -273,6 +273,7 @@ class ManualActionRequest(BaseModel):
     lines_overloaded: list[str] | None = None
     target_mw: float | None = None
     target_tap: int | None = None
+    voltage_level_id: str | None = None
 
 class SaveSessionRequest(BaseModel):
     session_name: str
@@ -851,6 +852,7 @@ def simulate_manual_action(request: ManualActionRequest) -> dict:
             lines_overloaded=request.lines_overloaded,
             target_mw=request.target_mw,
             target_tap=request.target_tap,
+            voltage_level_id=request.voltage_level_id,
         )
         return result
     except Exception as e:
@@ -865,6 +867,7 @@ class SimulateAndVariantDiagramRequest(BaseModel):
     lines_overloaded: list[str] | None = None
     target_mw: float | None = None
     target_tap: int | None = None
+    voltage_level_id: str | None = None
     mode: str = "network"
 
 
@@ -878,6 +881,7 @@ async def simulate_and_variant_diagram(request: SimulateAndVariantDiagramRequest
                 lines_overloaded=request.lines_overloaded,
                 target_mw=request.target_mw,
                 target_tap=request.target_tap,
+                voltage_level_id=request.voltage_level_id,
             )
             yield json.dumps({"type": "metrics", **sim_result}) + "\n"
 

--- a/expert_backend/services/diagram/sld_render.py
+++ b/expert_backend/services/diagram/sld_render.py
@@ -13,6 +13,49 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def extract_vl_switch_states(network: Any, voltage_level_id: str) -> dict[str, bool]:
+    """Return ``{switch_id: is_open}`` for every operable switch on a VL.
+
+    Source of truth for the frontend's SLD-edit baseline: the operator
+    can only toggle a switch the user-built action then sends back as
+    ``{"switches": {id: bool}}`` to ``simulate_manual_action``, so the
+    payload here is the contract — any switch missing from this map is
+    not editable. Filters out fictitious / retained switches that
+    pypowsybl exposes for internal bookkeeping (they cannot be
+    manoeuvred). Returns ``{}`` rather than raising on any pypowsybl
+    failure: switch editing is an additive feature, the SLD must still
+    render.
+    """
+    try:
+        df = network.get_switches(
+            attributes=["open", "voltage_level_id", "kind", "fictitious", "retained"]
+        )
+    except Exception as e:
+        logger.debug("get_switches failed for VL %s: %s", voltage_level_id, e)
+        try:
+            df = network.get_switches(attributes=["open", "voltage_level_id"])
+        except Exception as e2:
+            logger.debug("get_switches fallback also failed for VL %s: %s", voltage_level_id, e2)
+            return {}
+
+    try:
+        sub = df[df["voltage_level_id"] == voltage_level_id]
+    except Exception as e:
+        logger.debug("Switch VL filter failed for %s: %s", voltage_level_id, e)
+        return {}
+
+    if "fictitious" in sub.columns:
+        sub = sub[~sub["fictitious"].astype(bool)]
+
+    states: dict[str, bool] = {}
+    for sw_id, row in sub.iterrows():
+        try:
+            states[str(sw_id)] = bool(row["open"])
+        except Exception:
+            continue
+    return states
+
+
 def extract_sld_svg_and_metadata(sld: Any) -> tuple:
     """Extract ``(svg, metadata)`` from a pypowsybl SLD diagram object.
 

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -60,6 +60,7 @@ from expert_backend.services.diagram.sld_render import (
     extract_vl_switch_states,
 )
 from expert_backend.services.sanitize import sanitize_for_json
+from expert_backend.services.simulation_helpers import canonicalize_action_id
 
 logger = logging.getLogger(__name__)
 
@@ -743,9 +744,20 @@ class DiagramMixin:
             )
         actions = self._last_result["prioritized_actions"]
         if action_id not in actions:
-            raise ActionResultUnavailableError(
-                f"Action '{action_id}' not found in last analysis result."
-            )
+            # Combined actions are stored under a CANONICAL key (the
+            # "+"-joined parts sorted alphabetically — see
+            # ``canonicalize_action_id``). A caller using the raw,
+            # unsorted order (e.g. ``base+user_topo`` straight from the
+            # frontend) would otherwise miss it. Alias the raw key onto
+            # the canonical entry so ``actions[action_id]`` works for
+            # either ordering.
+            canon = canonicalize_action_id(action_id)
+            if canon != action_id and canon in actions:
+                actions[action_id] = actions[canon]
+            else:
+                raise ActionResultUnavailableError(
+                    f"Action '{action_id}' not found in last analysis result."
+                )
         return actions
 
     def _lf_status_for_variant(self, network, variant_id: str, disconnected_elements):

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -632,6 +632,80 @@ class DiagramMixin:
 
         return result
 
+    def _render_topological_sld(self, network, voltage_level_id):
+        """Render a VL SLD with topological (per-connected-bus) colouring.
+
+        Topological colouring is what makes a node split / merge visible:
+        opening a coupling splits the busbar into two connected
+        components, which pypowsybl then paints in distinct colours —
+        the same affordance the ``manoeuvre_ihm`` target-topology view
+        relies on. Falls back to the default parameters when the
+        installed pypowsybl predates ``SldParameters`` or rejects the
+        flag.
+        """
+        try:
+            import pypowsybl.network as pn
+            params = pn.SldParameters(use_name=True, topological_coloring=True)
+            return network.get_single_line_diagram(voltage_level_id, parameters=params)
+        except Exception as e:
+            logger.debug("Topological SLD params unavailable, using default: %s", e)
+            return network.get_single_line_diagram(voltage_level_id)
+
+    def get_topology_preview_sld(
+        self, disconnected_elements, voltage_level_id, switches, base_action_id=None
+    ) -> dict:
+        """Render a *target-topology preview* SLD.
+
+        Clones a throwaway variant from the contingency state (or the
+        post-action variant when ``base_action_id`` is given), applies
+        the user's pending switch overrides, and re-renders the VL SLD
+        with topological colouring. NO load flow is run — the flow
+        values shown are stale, so the response carries
+        ``stale_flows: True`` and the frontend greys them out until the
+        operator commits the simulation.
+
+        The throwaway variant is always removed and the working variant
+        restored in a ``finally`` so the shared Network is never left
+        mutated.
+        """
+        norm = self._normalize_contingency_elements(disconnected_elements)
+
+        if base_action_id:
+            actions = self._require_action(base_action_id)
+            obs = actions[base_action_id]["observation"]
+            nm = obs._network_manager
+            network = nm.network
+            base_variant = obs._variant_id
+        else:
+            network = self._get_base_network()
+            base_variant = self._get_contingency_variant(norm)
+
+        original_variant = network.get_working_variant_id()
+        preview_variant = f"sld_preview_{voltage_level_id}_{time.time_ns()}"
+        network.clone_variant(base_variant, preview_variant)
+        try:
+            network.set_working_variant(preview_variant)
+            if switches:
+                ids = [str(k) for k in switches.keys()]
+                opens = [bool(switches[k]) for k in switches.keys()]
+                network.update_switches(id=ids, open=opens)
+            sld = self._render_topological_sld(network, voltage_level_id)
+            svg, sld_metadata = extract_sld_svg_and_metadata(sld)
+            switch_states = extract_vl_switch_states(network, voltage_level_id)
+            return {
+                "svg": svg,
+                "sld_metadata": sld_metadata,
+                "voltage_level_id": voltage_level_id,
+                "switch_states": switch_states,
+                "stale_flows": True,
+            }
+        finally:
+            network.set_working_variant(original_variant)
+            try:
+                network.remove_variant(preview_variant)
+            except Exception as e:
+                logger.debug("Failed to remove preview variant %s: %s", preview_variant, e)
+
     def _diff_action_switches_vs_contingency(self, action_switches_snap, disconnected_elements) -> dict:
         """Diff a pre-captured action-variant switch snapshot against the
         live contingency variant.

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -55,7 +55,10 @@ from expert_backend.services.diagram.overloads import (
     get_element_max_currents,
     get_overloaded_lines,
 )
-from expert_backend.services.diagram.sld_render import extract_sld_svg_and_metadata
+from expert_backend.services.diagram.sld_render import (
+    extract_sld_svg_and_metadata,
+    extract_vl_switch_states,
+)
 from expert_backend.services.sanitize import sanitize_for_json
 
 logger = logging.getLogger(__name__)
@@ -481,12 +484,14 @@ class DiagramMixin:
         try:
             sld = n.get_single_line_diagram(voltage_level_id)
             svg, sld_metadata = extract_sld_svg_and_metadata(sld)
+            switch_states = extract_vl_switch_states(n, voltage_level_id)
         finally:
             n.set_working_variant(original_variant)
         return {
             "svg": svg,
             "sld_metadata": sld_metadata,
             "voltage_level_id": voltage_level_id,
+            "switch_states": switch_states,
         }
 
     def get_contingency_sld(self, disconnected_elements, voltage_level_id: str) -> dict:
@@ -499,11 +504,13 @@ class DiagramMixin:
         try:
             sld = n.get_single_line_diagram(voltage_level_id)
             svg, sld_metadata = extract_sld_svg_and_metadata(sld)
+            switch_states = extract_vl_switch_states(n, voltage_level_id)
             result = {
                 "svg": svg,
                 "sld_metadata": sld_metadata,
                 "voltage_level_id": voltage_level_id,
                 "disconnected_elements": list(norm),
+                "switch_states": switch_states,
             }
             self._attach_flow_deltas_vs_base(result, n, voltage_level_ids=[voltage_level_id])
             return result
@@ -531,12 +538,14 @@ class DiagramMixin:
         network = nm.network
         sld = network.get_single_line_diagram(voltage_level_id)
         svg, sld_metadata = extract_sld_svg_and_metadata(sld)
+        switch_states = extract_vl_switch_states(network, voltage_level_id)
 
         result = {
             "svg": svg,
             "sld_metadata": sld_metadata,
             "action_id": action_id,
             "voltage_level_id": voltage_level_id,
+            "switch_states": switch_states,
         }
         self._attach_convergence_from_obs(result, obs)
 

--- a/expert_backend/services/simulation_helpers.py
+++ b/expert_backend/services/simulation_helpers.py
@@ -55,6 +55,40 @@ def canonicalize_action_id(action_id: str) -> str:
     return "+".join(sorted(p.strip() for p in action_id.split("+")))
 
 
+def is_switch_only_content(content: Any) -> bool:
+    """True if ``content`` carries only a non-empty ``switches`` dict.
+
+    Used by ``simulate_manual_action`` to decide whether to auto-build a
+    human-readable description for user-built SLD-edit actions, instead
+    of falling back to the raw ``action_id`` (which is just a generated
+    placeholder like ``user_topo_<vl>_<ts>``).
+    """
+    if not isinstance(content, dict):
+        return False
+    switches = content.get("switches")
+    if not isinstance(switches, dict) or not switches:
+        return False
+    other_keys = [k for k in content.keys() if k != "switches"]
+    return len(other_keys) == 0
+
+
+def build_switch_action_description(
+    switches: dict[str, bool],
+    voltage_level_id: str | None = None,
+) -> str:
+    """Return ``"Manoeuvre manuelle sur <vl>: A ouvert, B fermé"`` ."""
+    if not switches:
+        return "Manoeuvre manuelle (aucun switch)"
+    parts: list[str] = []
+    for sw_id, is_open in switches.items():
+        verb = "ouvert" if is_open else "fermé"
+        parts.append(f"{sw_id} {verb}")
+    body = ", ".join(parts)
+    if voltage_level_id:
+        return f"Manoeuvre manuelle sur {voltage_level_id}: {body}"
+    return f"Manoeuvre manuelle: {body}"
+
+
 def compute_reduction_setpoint(
     element_name: str,
     element_type: str,

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -26,6 +26,7 @@ from expert_op4grid_recommender.utils.superposition import (
 from expert_backend.services.sanitize import sanitize_for_json
 from expert_backend.services.simulation_helpers import (
     build_combined_description,
+    build_switch_action_description,
     canonicalize_action_id,
     classify_action_content,
     clamp_tap,
@@ -35,6 +36,7 @@ from expert_backend.services.simulation_helpers import (
     compute_target_max_rho,
     extract_action_topology,
     is_pst_action,
+    is_switch_only_content,
     normalise_non_convergence,
     parse_pst_tap_id,
     pst_fallback_line_idxs,
@@ -135,6 +137,7 @@ class SimulationMixin:
         lines_overloaded=None,
         target_mw=None,
         target_tap=None,
+        voltage_level_id=None,
     ):
         """Simulate a single or combined action and return its impact.
 
@@ -165,7 +168,9 @@ class SimulationMixin:
             self._last_result.get("prioritized_actions", {}) if self._last_result else {}
         )
 
-        self._inject_action_content_entries(action_ids, action_content, recent_actions)
+        self._inject_action_content_entries(
+            action_ids, action_content, recent_actions, voltage_level_id=voltage_level_id
+        )
 
         env = self._get_simulation_env()
         nm = env.network_manager
@@ -334,12 +339,22 @@ class SimulationMixin:
     # read/mutate self state (caches, `_dict_action`, `_last_result`).
     # ------------------------------------------------------------------
 
-    def _inject_action_content_entries(self, action_ids, action_content, recent_actions):
+    def _inject_action_content_entries(
+        self, action_ids, action_content, recent_actions, voltage_level_id=None
+    ):
         """Inject caller-provided topology dicts into `_dict_action`.
 
-        Used on session reload: actions restored from a saved JSON may
-        not be in the action dictionary, and we need their content
-        available before `env.action_space(content)` is called.
+        Used on session reload AND on user-built SLD topology edits:
+        actions whose ID was minted at the call site (e.g.
+        ``user_topo_<vl>_<ts>``) aren't in the action dictionary, and
+        their content has to be available before
+        ``env.action_space(content)`` is called.
+
+        When the content is switch-only (the SLD-edit case) and a
+        ``voltage_level_id`` is provided, the placeholder ``Restored
+        action`` description is replaced with a human-readable one so
+        the resulting card in the frontend feed reads "Manoeuvre
+        manuelle sur <vl>: …" instead of the synthetic id.
         """
         if not action_content:
             return
@@ -351,6 +366,13 @@ class SimulationMixin:
             if not topo:
                 continue
             entry = self._build_action_entry_from_topology(aid, topo)
+            content = entry.get("content") or {}
+            if is_switch_only_content(content):
+                desc = build_switch_action_description(
+                    content["switches"], voltage_level_id=voltage_level_id
+                )
+                entry["description_unitaire"] = desc
+                entry["description"] = desc
             self._dict_action[aid] = entry
             logger.info(
                 "[simulate_manual_action] Injected restored action '%s' into dict", aid

--- a/expert_backend/tests/CLAUDE.md
+++ b/expert_backend/tests/CLAUDE.md
@@ -122,6 +122,7 @@ Configuration in `frontend/vite.config.ts` (Vitest plugin).
 | `test_direct_file_loading.py` | Direct file loading configuration |
 | `test_config_persistence.py` | Configuration file persistence |
 | `test_sld_highlight.py` | SLD highlight and switch change computation |
+| `test_sld_topology_edit.py` | Interactive SLD-edit feature — `extract_vl_switch_states` filters, auto-description for switch-only actions, `get_topology_preview_sld` (clones / applies / removes / restores), `_require_action` canonical-id alias, `/api/sld-topology-preview` HTTP-boundary (skipped when `expert_op4grid_recommender.models` is unavailable). See `docs/features/sld-topology-edit.md`. |
 
 ## Frontend Test Structure
 

--- a/expert_backend/tests/test_sld_topology_edit.py
+++ b/expert_backend/tests/test_sld_topology_edit.py
@@ -217,6 +217,35 @@ class TestTopologyPreviewSld:
         assert mock_net.set_working_variant.call_args_list[-1][0][0] == "ContingencyVar"
 
 
+class TestRequireActionCanonicalAlias:
+    """A combined action is registered under a CANONICAL (sorted) key;
+    ``_require_action`` must still resolve it when looked up with the
+    raw, unsorted ordering the frontend sends."""
+
+    def test_resolves_raw_unsorted_combined_id(self):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+        # Registered under the canonical (alphabetically sorted) key.
+        service._last_result = {
+            "prioritized_actions": {
+                "user_topo_BEON+user_topo_COUCHP6": {"observation": object()},
+            }
+        }
+        # Looked up with the raw order (base + new) as minted by the UI.
+        actions = service._require_action("user_topo_COUCHP6+user_topo_BEON")
+        assert "user_topo_COUCHP6+user_topo_BEON" in actions
+
+    def test_still_raises_when_truly_absent(self):
+        from expert_backend.services.recommender_service import RecommenderService
+        from expert_backend.services.diagram_mixin import ActionResultUnavailableError
+
+        service = RecommenderService()
+        service._last_result = {"prioritized_actions": {"some_action": {}}}
+        with pytest.raises(ActionResultUnavailableError):
+            service._require_action("nonexistent+other")
+
+
 class TestSldEndpointSwitchStates:
     """get_*_sld endpoints expose switch_states alongside svg + metadata."""
 

--- a/expert_backend/tests/test_sld_topology_edit.py
+++ b/expert_backend/tests/test_sld_topology_edit.py
@@ -15,15 +15,23 @@ Covers the additive pieces wired in by this feature:
     ``simulate_manual_action`` accepts ``action_content={"switches":
     {...}}`` + ``voltage_level_id`` and stamps a human-readable
     description on the resulting action dict entry.
+  - ``get_topology_preview_sld`` clones a throwaway variant, applies
+    user switch overrides, renders with topological colouring + flags
+    flows as stale, and always restores the working variant.
+  - ``_require_action`` resolves combined-action ids regardless of "+"
+    ordering by aliasing the raw key onto the canonical entry.
+  - HTTP boundary: ``/api/sld-topology-preview`` plumbing.
 """
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from fastapi.testclient import TestClient
 
 from expert_backend.services.diagram.sld_render import extract_vl_switch_states
 from expert_backend.services.simulation_helpers import (
     build_switch_action_description,
+    canonicalize_action_id,
     is_switch_only_content,
 )
 
@@ -277,3 +285,275 @@ class TestSldEndpointSwitchStates:
         result = service.get_n_sld("VL_X")
         assert result["voltage_level_id"] == "VL_X"
         assert result["switch_states"] == {"SW_X": False}
+
+
+class TestExtractVlSwitchStatesEdgeCases:
+    """Additional defensive paths."""
+
+    def test_skips_rows_with_unreadable_open_value(self):
+        # A row where `bool(row["open"])` raises must not abort the
+        # whole VL extraction — it's a corrupt-input recovery path,
+        # critical when partial pypowsybl exports leak NaNs / None.
+        network = MagicMock()
+
+        class _Boom:
+            def __bool__(self):
+                raise ValueError("not a bool")
+
+        network.get_switches.return_value = pd.DataFrame(
+            {
+                "open": [True, _Boom(), False],
+                "voltage_level_id": ["VL_A", "VL_A", "VL_A"],
+                "kind": ["BREAKER", "BREAKER", "DISCONNECTOR"],
+                "fictitious": [False, False, False],
+                "retained": [True, True, True],
+            },
+            index=["SW_OK", "SW_BAD", "SW_OK2"],
+        )
+        states = extract_vl_switch_states(network, "VL_A")
+        assert states == {"SW_OK": True, "SW_OK2": False}
+
+    def test_no_match_on_voltage_level_returns_empty(self):
+        network = MagicMock()
+        network.get_switches.return_value = pd.DataFrame(
+            {"open": [False], "voltage_level_id": ["VL_OTHER"],
+             "kind": ["BREAKER"], "fictitious": [False], "retained": [True]},
+            index=["SW_OTHER"],
+        )
+        assert extract_vl_switch_states(network, "VL_MISSING") == {}
+
+    def test_handles_missing_fictitious_column(self):
+        # ``fictitious`` may be absent on legacy pypowsybl builds — the
+        # extractor must still return states (no row filtering).
+        network = MagicMock()
+        network.get_switches.return_value = pd.DataFrame(
+            {"open": [False, True], "voltage_level_id": ["VL_A", "VL_A"]},
+            index=["SW_1", "SW_2"],
+        )
+        # Force the extractor onto the fallback get_switches call.
+        network.get_switches.side_effect = [
+            TypeError("unsupported"),
+            pd.DataFrame(
+                {"open": [False, True], "voltage_level_id": ["VL_A", "VL_A"]},
+                index=["SW_1", "SW_2"],
+            ),
+        ]
+        assert extract_vl_switch_states(network, "VL_A") == {
+            "SW_1": False, "SW_2": True,
+        }
+
+
+class TestBuildSwitchActionDescriptionShape:
+    """Description format is the contract the frontend filter relies on
+    (`coupl` + ouvert/fermé → open/close, line + ouvert/fermé → disco/
+    reco — see ``actionTypes.test.ts``)."""
+
+    def test_segments_join_with_comma(self):
+        desc = build_switch_action_description(
+            {"SW_A": True, "SW_B": False, "SW_C": True},
+            voltage_level_id="VL_X",
+        )
+        assert desc.count(",") == 2  # 3 switches → 2 separators
+
+    def test_starts_with_french_label(self):
+        desc = build_switch_action_description({"SW_A": True})
+        assert desc.lower().startswith("manoeuvre manuelle")
+
+
+class TestCanonicalAliasSymmetry:
+    """``_require_action`` must resolve a combined id whatever its
+    "+"-component ordering: A+B and B+A both alias onto the canonical
+    sorted entry."""
+
+    def _service_with(self, registered_id, extra=None):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+        service._last_result = {
+            "prioritized_actions": {registered_id: {"observation": object()}}
+        }
+        if extra:
+            service._last_result["prioritized_actions"].update(extra)
+        return service
+
+    def test_resolves_either_order_for_two_part_id(self):
+        service = self._service_with("user_topo_A+user_topo_B")
+        # Both orderings must land on the same entry.
+        actions = service._require_action("user_topo_B+user_topo_A")
+        assert "user_topo_B+user_topo_A" in actions
+        assert actions["user_topo_B+user_topo_A"] is actions["user_topo_A+user_topo_B"]
+
+    def test_canonicalize_is_idempotent(self):
+        # Sanity: applying canonicalize twice doesn't shuffle further.
+        once = canonicalize_action_id("user_topo_Z+user_topo_A+user_topo_M")
+        twice = canonicalize_action_id(once)
+        assert once == twice
+        # Canonical key is alphabetically sorted.
+        assert once == "user_topo_A+user_topo_M+user_topo_Z"
+
+    def test_singleton_ids_pass_through_unchanged(self):
+        assert canonicalize_action_id("disco_LINE_A") == "disco_LINE_A"
+
+
+class TestTopologyPreviewEmptyAndPostAction:
+    """Additional ``get_topology_preview_sld`` paths the earlier tests
+    don't exercise: empty switches dict (no update_switches call) and
+    the post-action branch (``base_action_id`` provided → reads from
+    the action's network manager, not the contingency variant)."""
+
+    def _mock_net_with_sld(self):
+        mock_net = MagicMock()
+        mock_net.get_working_variant_id.return_value = "ContingencyVar"
+        mock_net.get_switches.return_value = pd.DataFrame(
+            {"open": [True], "voltage_level_id": ["VL_X"],
+             "kind": ["BREAKER"], "fictitious": [False], "retained": [True]},
+            index=["SW_X"],
+        )
+        mock_sld = MagicMock()
+        mock_sld._repr_svg_.return_value = "<svg/>"
+        mock_sld._metadata = "{}"
+        mock_net.get_single_line_diagram.return_value = mock_sld
+        return mock_net
+
+    def test_empty_switches_skips_update_call(self):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+        net = self._mock_net_with_sld()
+        service._get_base_network = lambda: net
+        service._get_contingency_variant = lambda norm: "ContingencyVar"
+        service._normalize_contingency_elements = staticmethod(lambda e: list(e))
+
+        result = service.get_topology_preview_sld(["LINE_1"], "VL_X", {})
+        assert result["stale_flows"] is True
+        net.update_switches.assert_not_called()
+        # Clone + remove still happen so the working variant is restored.
+        net.clone_variant.assert_called_once()
+        net.remove_variant.assert_called_once()
+
+    def test_post_action_path_uses_action_network_manager(self):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+        # Action observation owns its OWN network_manager (which owns
+        # its OWN network) — the preview must operate on THIS network,
+        # not the base contingency one. Mirrors get_action_variant_sld.
+        action_net = self._mock_net_with_sld()
+        nm = MagicMock()
+        nm.network = action_net
+        obs = MagicMock()
+        obs._network_manager = nm
+        obs._variant_id = "ActionVariant"
+
+        service._last_result = {
+            "prioritized_actions": {"act_42": {"observation": obs}}
+        }
+        service._normalize_contingency_elements = staticmethod(lambda e: list(e))
+
+        result = service.get_topology_preview_sld(
+            ["LINE_1"], "VL_X", {"SW_X": False}, base_action_id="act_42",
+        )
+        assert result["voltage_level_id"] == "VL_X"
+        # Cloned from the action variant, not the base contingency.
+        action_net.clone_variant.assert_called_once()
+        assert action_net.clone_variant.call_args[0][0] == "ActionVariant"
+        action_net.update_switches.assert_called_once()
+
+
+class TestSldTopologyPreviewEndpoint:
+    """HTTP-boundary coverage for /api/sld-topology-preview: payload
+    shape, success path, and error→400 translation.
+
+    Importing ``expert_backend.main`` pulls in
+    ``expert_op4grid_recommender.models.expert`` (via
+    ``expert_backend.recommenders``). Sandboxes that mock
+    ``expert_op4grid_recommender`` as a plain MagicMock cannot resolve
+    the submodule lookup, so we skip this whole class when the import
+    isn't satisfiable. CI installs the real package and runs it.
+    """
+
+    @pytest.fixture
+    def client_and_service(self):
+        pytest.importorskip("expert_op4grid_recommender.models.expert")
+        from expert_backend.main import app
+        with patch("expert_backend.main.recommender_service") as mock_rs:
+            yield TestClient(app), mock_rs
+
+    def test_routes_to_service_and_returns_payload(self, client_and_service):
+        client, mock_rs = client_and_service
+        mock_rs.get_topology_preview_sld.return_value = {
+            "svg": "<svg/>",
+            "sld_metadata": "{}",
+            "voltage_level_id": "VL_X",
+            "switch_states": {"SW_X": False},
+            "stale_flows": True,
+        }
+        body = {
+            "voltage_level_id": "VL_X",
+            "disconnected_elements": ["LINE_1"],
+            "switches": {"SW_X": False},
+            "base_action_id": None,
+        }
+        r = client.post("/api/sld-topology-preview", json=body)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["stale_flows"] is True
+        assert data["switch_states"] == {"SW_X": False}
+        mock_rs.get_topology_preview_sld.assert_called_once_with(
+            ["LINE_1"], "VL_X", {"SW_X": False}, base_action_id=None,
+        )
+
+    def test_post_action_id_is_forwarded(self, client_and_service):
+        client, mock_rs = client_and_service
+        mock_rs.get_topology_preview_sld.return_value = {
+            "svg": "<svg/>", "sld_metadata": None, "voltage_level_id": "VL_X",
+            "switch_states": {}, "stale_flows": True,
+        }
+        client.post("/api/sld-topology-preview", json={
+            "voltage_level_id": "VL_X",
+            "disconnected_elements": [],
+            "switches": {"SW_X": True},
+            "base_action_id": "disco_LINE_42",
+        })
+        kwargs = mock_rs.get_topology_preview_sld.call_args.kwargs
+        assert kwargs["base_action_id"] == "disco_LINE_42"
+
+    def test_service_error_is_translated_to_400(self, client_and_service):
+        client, mock_rs = client_and_service
+        mock_rs.get_topology_preview_sld.side_effect = RuntimeError("boom")
+        r = client.post("/api/sld-topology-preview", json={
+            "voltage_level_id": "VL_X",
+            "disconnected_elements": [],
+            "switches": {},
+        })
+        assert r.status_code == 400
+        assert "boom" in r.json()["detail"]
+
+
+class TestSimulateManualActionEndpointPlumbsVoltageLevel:
+    """``voltage_level_id`` must travel from the HTTP payload all the
+    way down to ``simulate_manual_action`` so auto-description picks
+    up the VL prefix."""
+
+    def test_voltage_level_id_forwarded(self):
+        pytest.importorskip("expert_op4grid_recommender.models.expert")
+        from expert_backend.main import app
+        with patch("expert_backend.main.recommender_service") as mock_rs:
+            mock_rs.simulate_manual_action.return_value = {
+                "action_id": "user_topo_VL_X_1",
+                "description_unitaire": "Manoeuvre manuelle sur VL_X: SW_A ouvert",
+                "rho_before": [], "rho_after": [], "max_rho": 0.0,
+                "max_rho_line": "N/A", "is_rho_reduction": False,
+                "non_convergence": None, "lines_overloaded": [],
+            }
+            client = TestClient(app)
+            r = client.post("/api/simulate-manual-action", json={
+                "action_id": "user_topo_VL_X_1",
+                "disconnected_elements": ["LINE_1"],
+                "action_content": {"switches": {"SW_A": True}},
+                "voltage_level_id": "VL_X",
+            })
+            assert r.status_code == 200
+            kwargs = mock_rs.simulate_manual_action.call_args.kwargs
+            assert kwargs["voltage_level_id"] == "VL_X"
+            assert kwargs["action_content"] == {"switches": {"SW_A": True}}

--- a/expert_backend/tests/test_sld_topology_edit.py
+++ b/expert_backend/tests/test_sld_topology_edit.py
@@ -154,6 +154,69 @@ class TestSimulateManualActionSwitchOnly:
         assert "SW_A ouvert" in desc
 
 
+class TestTopologyPreviewSld:
+    """get_topology_preview_sld clones a throwaway variant, applies the
+    switch overrides, renders with topological colouring, and always
+    removes the temp variant + restores the working variant."""
+
+    def _service_with_net(self):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+        mock_net = MagicMock()
+        mock_net.get_working_variant_id.return_value = "ContingencyVar"
+        mock_net.get_switches.return_value = pd.DataFrame(
+            {
+                "open": [True],
+                "voltage_level_id": ["VL_X"],
+                "kind": ["BREAKER"],
+                "fictitious": [False],
+                "retained": [True],
+            },
+            index=["SW_X"],
+        )
+        mock_sld = MagicMock()
+        mock_sld._repr_svg_.return_value = "<svg/>"
+        mock_sld._metadata = "{}"
+        mock_net.get_single_line_diagram.return_value = mock_sld
+        service._get_base_network = lambda: mock_net
+        service._get_contingency_variant = lambda norm: "ContingencyVar"
+        service._normalize_contingency_elements = staticmethod(lambda e: list(e))
+        return service, mock_net
+
+    def test_applies_switches_and_marks_stale(self):
+        service, mock_net = self._service_with_net()
+        result = service.get_topology_preview_sld(
+            ["LINE_1"], "VL_X", {"SW_X": False},
+        )
+        assert result["stale_flows"] is True
+        assert result["voltage_level_id"] == "VL_X"
+        # update_switches called with the override
+        mock_net.update_switches.assert_called_once()
+        _, kwargs = mock_net.update_switches.call_args
+        assert kwargs["id"] == ["SW_X"]
+        assert kwargs["open"] == [False]
+
+    def test_clones_and_removes_temp_variant(self):
+        service, mock_net = self._service_with_net()
+        service.get_topology_preview_sld(["LINE_1"], "VL_X", {"SW_X": False})
+        mock_net.clone_variant.assert_called_once()
+        clone_args = mock_net.clone_variant.call_args[0]
+        assert clone_args[0] == "ContingencyVar"
+        preview_variant = clone_args[1]
+        mock_net.remove_variant.assert_called_once_with(preview_variant)
+        # Working variant restored to the original.
+        assert mock_net.set_working_variant.call_args_list[-1][0][0] == "ContingencyVar"
+
+    def test_removes_temp_variant_even_on_render_failure(self):
+        service, mock_net = self._service_with_net()
+        mock_net.get_single_line_diagram.side_effect = RuntimeError("render boom")
+        with pytest.raises(RuntimeError):
+            service.get_topology_preview_sld(["LINE_1"], "VL_X", {"SW_X": False})
+        mock_net.remove_variant.assert_called_once()
+        assert mock_net.set_working_variant.call_args_list[-1][0][0] == "ContingencyVar"
+
+
 class TestSldEndpointSwitchStates:
     """get_*_sld endpoints expose switch_states alongside svg + metadata."""
 

--- a/expert_backend/tests/test_sld_topology_edit.py
+++ b/expert_backend/tests/test_sld_topology_edit.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for interactive SLD topology edit → manual action simulation.
+
+Covers the additive pieces wired in by this feature:
+  - ``extract_vl_switch_states`` filters fictitious switches and skips
+    cleanly on pypowsybl failure.
+  - ``is_switch_only_content`` / ``build_switch_action_description``
+    auto-naming contract.
+  - End-to-end: an SLD endpoint payload exposes ``switch_states``, and
+    ``simulate_manual_action`` accepts ``action_content={"switches":
+    {...}}`` + ``voltage_level_id`` and stamps a human-readable
+    description on the resulting action dict entry.
+"""
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from expert_backend.services.diagram.sld_render import extract_vl_switch_states
+from expert_backend.services.simulation_helpers import (
+    build_switch_action_description,
+    is_switch_only_content,
+)
+
+
+class TestExtractVlSwitchStates:
+    def test_filters_to_voltage_level(self):
+        network = MagicMock()
+        network.get_switches.return_value = pd.DataFrame(
+            {
+                "open": [True, False, True],
+                "voltage_level_id": ["VL_A", "VL_A", "VL_B"],
+                "kind": ["BREAKER", "DISCONNECTOR", "BREAKER"],
+                "fictitious": [False, False, False],
+                "retained": [True, True, True],
+            },
+            index=["SW_1", "SW_2", "SW_3"],
+        )
+        states = extract_vl_switch_states(network, "VL_A")
+        assert states == {"SW_1": True, "SW_2": False}
+
+    def test_excludes_fictitious(self):
+        network = MagicMock()
+        network.get_switches.return_value = pd.DataFrame(
+            {
+                "open": [True, False],
+                "voltage_level_id": ["VL_A", "VL_A"],
+                "kind": ["BREAKER", "BREAKER"],
+                "fictitious": [False, True],
+                "retained": [True, True],
+            },
+            index=["SW_REAL", "SW_FAKE"],
+        )
+        states = extract_vl_switch_states(network, "VL_A")
+        assert states == {"SW_REAL": True}
+
+    def test_returns_empty_on_pypowsybl_failure(self):
+        network = MagicMock()
+        network.get_switches.side_effect = RuntimeError("boom")
+        assert extract_vl_switch_states(network, "VL_A") == {}
+
+    def test_falls_back_when_extended_attributes_unsupported(self):
+        network = MagicMock()
+        df = pd.DataFrame(
+            {"open": [True], "voltage_level_id": ["VL_A"]}, index=["SW_X"]
+        )
+        # First call (with rich attributes) fails; second call succeeds.
+        network.get_switches.side_effect = [TypeError("unknown attr"), df]
+        states = extract_vl_switch_states(network, "VL_A")
+        assert states == {"SW_X": True}
+
+
+class TestIsSwitchOnlyContent:
+    def test_true_for_pure_switches_dict(self):
+        assert is_switch_only_content({"switches": {"SW_A": True}})
+
+    def test_false_for_empty_switches(self):
+        assert not is_switch_only_content({"switches": {}})
+
+    def test_false_when_other_keys_present(self):
+        assert not is_switch_only_content(
+            {"switches": {"SW_A": True}, "set_bus": {"loads_id": {}}}
+        )
+
+    def test_false_for_none(self):
+        assert not is_switch_only_content(None)
+
+
+class TestBuildSwitchActionDescription:
+    def test_with_vl(self):
+        desc = build_switch_action_description(
+            {"SW_A": True, "SW_B": False}, voltage_level_id="VL_PARIS"
+        )
+        assert "VL_PARIS" in desc
+        assert "SW_A ouvert" in desc
+        assert "SW_B fermé" in desc
+
+    def test_without_vl(self):
+        desc = build_switch_action_description({"SW_A": True})
+        assert "SW_A ouvert" in desc
+        assert ":" in desc
+
+    def test_empty(self):
+        assert "aucun" in build_switch_action_description({}).lower()
+
+
+class TestSimulateManualActionSwitchOnly:
+    """End-to-end: feed a switch-only action_content + voltage_level_id and
+    check the dict entry receives the auto-built description.
+
+    Bypasses the full simulate path (which needs a real recommender env)
+    by exercising ``_inject_action_content_entries`` directly.
+    """
+
+    def test_injects_human_readable_description(self):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+        service._dict_action = {}
+
+        service._inject_action_content_entries(
+            ["user_topo_VL_TEST_1"],
+            {"switches": {"SW_A": True, "SW_B": False}},
+            recent_actions={},
+            voltage_level_id="VL_TEST",
+        )
+
+        entry = service._dict_action["user_topo_VL_TEST_1"]
+        assert "VL_TEST" in entry["description_unitaire"]
+        assert "SW_A ouvert" in entry["description_unitaire"]
+        assert "SW_B fermé" in entry["description_unitaire"]
+        # Content round-trips the switches dict for env.action_space(...)
+        assert entry["content"]["switches"] == {"SW_A": True, "SW_B": False}
+
+    def test_skips_when_vl_missing(self):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+        service._dict_action = {}
+
+        service._inject_action_content_entries(
+            ["user_topo_x"],
+            {"switches": {"SW_A": True}},
+            recent_actions={},
+            voltage_level_id=None,
+        )
+        # Description is built even without VL — just without VL prefix.
+        desc = service._dict_action["user_topo_x"]["description_unitaire"]
+        assert "SW_A ouvert" in desc
+
+
+class TestSldEndpointSwitchStates:
+    """get_*_sld endpoints expose switch_states alongside svg + metadata."""
+
+    def test_get_n_sld_attaches_switch_states(self):
+        from expert_backend.services.recommender_service import RecommenderService
+
+        service = RecommenderService()
+
+        mock_net = MagicMock()
+        mock_net.get_working_variant_id.return_value = "InitialState"
+        mock_net.get_switches.return_value = pd.DataFrame(
+            {
+                "open": [False],
+                "voltage_level_id": ["VL_X"],
+                "kind": ["BREAKER"],
+                "fictitious": [False],
+                "retained": [True],
+            },
+            index=["SW_X"],
+        )
+        mock_sld = MagicMock()
+        mock_sld._repr_svg_.return_value = "<svg/>"
+        mock_sld._metadata = "{}"
+        mock_net.get_single_line_diagram.return_value = mock_sld
+
+        service._get_base_network = lambda: mock_net
+        service._get_n_variant = lambda: "InitialState"
+
+        result = service.get_n_sld("VL_X")
+        assert result["voltage_level_id"] == "VL_X"
+        assert result["switch_states"] == {"SW_X": False}

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -42,6 +42,11 @@ frontend/
     │   ├── useDiagrams.ts          # NAD fetching + tab management
     │   ├── usePanZoom.ts           # ViewBox state, zoom-to-element
     │   ├── useSldOverlay.ts        # Single-Line-Diagram overlay
+    │   ├── useSldTopologyEdit.ts    # Interactive SLD switch-edit:
+    │   │                            # editMode + pendingStates +
+    │   │                            # toggle / removeSwitch /
+    │   │                            # removeSwitches / focusedSwitchId
+    │   │                            # (see docs/features/sld-topology-edit.md)
     │   ├── useSession.ts           # Session save / restore
     │   ├── useDetachedTabs.ts      # Detached visualization windows
     │   ├── useTiedTabsSync.ts      # Mirror viewBox between detached + main
@@ -79,6 +84,14 @@ frontend/
     │   ├── CombinedActionsModal.tsx, ComputedPairsTable.tsx,
     │   ├── DetachableTabHost.tsx, ErrorBoundary.tsx, ExplorePairsTab.tsx,
     │   ├── MemoizedSvgContainer.tsx, SldOverlay.tsx,
+    │   ├── SldEditPanel.tsx        # Interactive maneuver list under
+    │   │                           # the SLD overlay — focus on row
+    │   │                           # click, ✕ per row, checkbox +
+    │   │                           # Remove selected (N), Reset,
+    │   │                           # Simulate action. Mirrors
+    │   │                           # manoeuvre_ihm's seq_delete /
+    │   │                           # seq_delete_many. See
+    │   │                           # docs/features/sld-topology-edit.md.
     │   ├── AppSidebar.tsx          # Sidebar layout shell (summary +
     │   │                           # contingency picker + children).
     │   │                           # Collapsible to a 32-px strip via

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -391,6 +391,18 @@ circle.nad-highlight {
     stroke-width: 2px !important;
 }
 
+/* Target-topology preview: flow values + arrows are stale (no load
+   flow was run) so they're greyed until the operator re-simulates.
+   pypowsybl renders feeder flow info as <text> and ARROW_* glyphs. */
+.sld-preview-stale text {
+    fill: var(--signal-delta-neutral) !important;
+    opacity: 0.55 !important;
+}
+.sld-preview-stale .sld-feeder-info,
+.sld-preview-stale [class*="ARROW"] {
+    opacity: 0.4 !important;
+}
+
 /* Pending switch toggles (interactive SLD topology edit). */
 .sld-user-toggle-open path,
 .sld-user-toggle-open line,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -391,6 +391,27 @@ circle.nad-highlight {
     stroke-width: 2px !important;
 }
 
+/* Pending switch toggles (interactive SLD topology edit). */
+.sld-user-toggle-open path,
+.sld-user-toggle-open line,
+.sld-user-toggle-open polyline,
+.sld-user-toggle-open rect,
+.sld-user-toggle-open circle {
+    stroke: var(--signal-edit-open) !important;
+    stroke-width: 2.5px !important;
+    stroke-dasharray: 4 2 !important;
+}
+
+.sld-user-toggle-closed path,
+.sld-user-toggle-closed line,
+.sld-user-toggle-closed polyline,
+.sld-user-toggle-closed rect,
+.sld-user-toggle-closed circle {
+    stroke: var(--signal-edit-closed) !important;
+    stroke-width: 2.5px !important;
+    stroke-dasharray: 4 2 !important;
+}
+
 .sld-delta-negative path,
 .sld-delta-negative line,
 .sld-delta-negative polyline,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -754,7 +754,12 @@ function App() {
         } else if (event.type === 'diagram') {
           const { type: _t, ...rest } = event;
           void _t;
-          diagrams.primeActionDiagram(actionId, rest as unknown as DiagramData & { svg: string }, voltageLevels.length);
+          // The backend canonicalises combined ids (sorts the "+"
+          // parts), so register the diagram under the id it actually
+          // stored — taken from the metrics event that always precedes
+          // the diagram event — not the raw request id.
+          const registeredId = metrics?.action_id ?? actionId;
+          diagrams.primeActionDiagram(registeredId, rest as unknown as DiagramData & { svg: string }, voltageLevels.length);
         } else if (event.type === 'error') {
           streamErr = (event.message as string) || 'stream error';
         }
@@ -773,6 +778,9 @@ function App() {
       if (streamErr) throw new Error(streamErr);
       if (!metrics) throw new Error('Stream ended without metrics event');
       const m = metrics as Awaited<ReturnType<typeof api.simulateManualAction>>;
+      // Backend-canonical id (sorted "+" parts) — use it for the card
+      // and the action-tab focus so every later lookup matches.
+      const registeredId = m.action_id || actionId;
       const detail: ActionDetail = {
         description_unitaire: m.description_unitaire,
         rho_before: m.rho_before,
@@ -789,9 +797,13 @@ function App() {
         curtailment_details: m.curtailment_details,
         pst_details: m.pst_details,
       };
-      wrappedManualActionAdded(actionId, detail, m.lines_overloaded || [], 'user');
+      wrappedManualActionAdded(registeredId, detail, m.lines_overloaded || [], 'user');
       sldTopologyEdit.reset();
       sldTopologyEdit.setEditMode(false);
+      // Switch the SLD overlay straight to the ACTION tab for the
+      // freshly-computed action so the operator sees the post-action
+      // state instead of staying on N-1.
+      handleVlDoubleClick(registeredId, vlName, 'action');
     } catch (e: unknown) {
       console.error('SLD topology edit simulation failed:', e);
       const err = e as { response?: { data?: { detail?: string } } };
@@ -802,6 +814,7 @@ function App() {
   }, [
     diagrams, sldTopologyEdit, selectedContingency, sldEditBaseActionId,
     result?.lines_overloaded, voltageLevels.length, wrappedManualActionAdded,
+    handleVlDoubleClick,
   ]);
 
   // Re-simulation of an already-present action (edit Target MW / tap on a
@@ -1788,6 +1801,10 @@ function App() {
             sldPreviewMetadata={sldPreview?.metadata ?? null}
             sldPreviewStale={!!sldPreview}
             sldPreviewLoading={sldPreviewLoading}
+            sldFocusedSwitchId={sldTopologyEdit.focusedSwitchId}
+            onSldSwitchFocus={sldTopologyEdit.setFocusedSwitch}
+            onSldSwitchRemove={sldTopologyEdit.removeSwitch}
+            onSldSwitchRemoveMany={sldTopologyEdit.removeSwitches}
             voltageLevels={voltageLevels}
             onVlOpen={handleVlOpen}
             onOverflowPinPreview={handlePinPreview}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { useDetachedTabs } from './hooks/useDetachedTabs';
 import { useTiedTabsSync, type PZInstance } from './hooks/useTiedTabsSync';
 import { useContingencyFetch } from './hooks/useContingencyFetch';
 import { useDiagramHighlights } from './hooks/useDiagramHighlights';
+import { useSldTopologyEdit } from './hooks/useSldTopologyEdit';
 import { interactionLogger } from './utils/interactionLogger';
 import { DEFAULT_ACTION_OVERVIEW_FILTERS } from './utils/actionTypes';
 import { applyVlTitles } from './utils/svgUtils';
@@ -647,6 +648,114 @@ function App() {
     },
     [selectedContingency, result?.lines_overloaded, result?.active_model, diagrams, voltageLevels.length, wrappedManualActionAdded]
   );
+
+  // Interactive SLD topology edit (useSldTopologyEdit). The baseline
+  // is the ``switch_states`` map the backend stamps on every SLD
+  // response; the hook drops stale toggles when it changes (VL switch,
+  // tab switch, action variant change).
+  const sldTopologyEdit = useSldTopologyEdit(diagrams.vlOverlay?.switch_states);
+  const [sldEditBusy, setSldEditBusy] = useState(false);
+  const sldEditBaseActionId = useMemo(() => {
+    const overlay = diagrams.vlOverlay;
+    if (!overlay) return null;
+    if (overlay.tab !== 'action') return null;
+    return overlay.actionId && overlay.actionId.length > 0 ? overlay.actionId : null;
+  }, [diagrams.vlOverlay]);
+
+  const handleSimulateSldEdit = useCallback(async () => {
+    const overlay = diagrams.vlOverlay;
+    const switches = sldTopologyEdit.changedSwitches;
+    if (!overlay || Object.keys(switches).length === 0) return;
+    if (selectedContingency.length === 0) {
+      setError('Select a contingency first.');
+      return;
+    }
+    const vlName = overlay.vlName;
+    const ts = Date.now();
+    const userPart = `user_topo_${vlName}_${ts}`;
+    const baseActionId = sldEditBaseActionId;
+    const actionId = baseActionId ? `${baseActionId}+${userPart}` : userPart;
+    interactionLogger.record('sld_topology_simulated', {
+      voltage_level_id: vlName,
+      switches,
+      combined_with: baseActionId,
+    });
+    setSldEditBusy(true);
+    try {
+      const response = await api.simulateAndVariantDiagramStream({
+        action_id: actionId,
+        disconnected_elements: selectedContingency,
+        action_content: { switches },
+        lines_overloaded: result?.lines_overloaded ?? null,
+        target_mw: null,
+        target_tap: null,
+        voltage_level_id: vlName,
+      });
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let metrics: Awaited<ReturnType<typeof api.simulateManualAction>> | null = null;
+      let streamErr: string | null = null;
+      const parseEvent = (line: string) => {
+        if (!line.trim()) return;
+        let event: Record<string, unknown>;
+        try { event = JSON.parse(line); } catch { return; }
+        if (event.type === 'metrics') {
+          const { type: _t, ...rest } = event;
+          void _t;
+          metrics = rest as Awaited<ReturnType<typeof api.simulateManualAction>>;
+        } else if (event.type === 'diagram') {
+          const { type: _t, ...rest } = event;
+          void _t;
+          diagrams.primeActionDiagram(actionId, rest as unknown as DiagramData & { svg: string }, voltageLevels.length);
+        } else if (event.type === 'error') {
+          streamErr = (event.message as string) || 'stream error';
+        }
+      };
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          if (buffer.trim()) parseEvent(buffer);
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop()!;
+        for (const line of lines) parseEvent(line);
+      }
+      if (streamErr) throw new Error(streamErr);
+      if (!metrics) throw new Error('Stream ended without metrics event');
+      const m = metrics as Awaited<ReturnType<typeof api.simulateManualAction>>;
+      const detail: ActionDetail = {
+        description_unitaire: m.description_unitaire,
+        rho_before: m.rho_before,
+        rho_after: m.rho_after,
+        max_rho: m.max_rho,
+        max_rho_line: m.max_rho_line,
+        is_rho_reduction: m.is_rho_reduction,
+        is_islanded: m.is_islanded,
+        n_components: m.n_components,
+        disconnected_mw: m.disconnected_mw,
+        non_convergence: m.non_convergence,
+        lines_overloaded_after: m.lines_overloaded_after,
+        load_shedding_details: m.load_shedding_details,
+        curtailment_details: m.curtailment_details,
+        pst_details: m.pst_details,
+      };
+      wrappedManualActionAdded(actionId, detail, m.lines_overloaded || [], 'user');
+      sldTopologyEdit.reset();
+      sldTopologyEdit.setEditMode(false);
+    } catch (e: unknown) {
+      console.error('SLD topology edit simulation failed:', e);
+      const err = e as { response?: { data?: { detail?: string } } };
+      setError(err?.response?.data?.detail || 'Simulation failed');
+    } finally {
+      setSldEditBusy(false);
+    }
+  }, [
+    diagrams, sldTopologyEdit, selectedContingency, sldEditBaseActionId,
+    result?.lines_overloaded, voltageLevels.length, wrappedManualActionAdded,
+  ]);
 
   // Re-simulation of an already-present action (edit Target MW / tap on a
   // suggested card). Does NOT move the action into the selected bucket.
@@ -1619,6 +1728,15 @@ function App() {
             vlOverlay={vlOverlay}
             onOverlayClose={handleOverlayClose}
             onOverlaySldTabChange={handleOverlaySldTabChange}
+            sldEditMode={sldTopologyEdit.editMode}
+            onSldEditModeChange={sldTopologyEdit.setEditMode}
+            sldEditPendingSwitches={sldTopologyEdit.pendingStates}
+            sldEditPendingChanges={sldTopologyEdit.pendingChanges}
+            onSldSwitchClick={sldTopologyEdit.toggleSwitch}
+            onSldEditSimulate={handleSimulateSldEdit}
+            onSldEditReset={sldTopologyEdit.reset}
+            sldEditBusy={sldEditBusy}
+            sldEditCombinedWithActionId={sldEditBaseActionId}
             voltageLevels={voltageLevels}
             onVlOpen={handleVlOpen}
             onOverflowPinPreview={handlePinPreview}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -662,6 +662,53 @@ function App() {
     return overlay.actionId && overlay.actionId.length > 0 ? overlay.actionId : null;
   }, [diagrams.vlOverlay]);
 
+  // Target-topology preview: when the operator has staged switch
+  // toggles, fetch a re-rendered SLD (target switch states +
+  // topological-colouring connectivity, no load flow) and show it in
+  // place of the baseline. Debounced so dragging through several
+  // toggles fires one request; a sequence guard drops stale responses.
+  const [sldPreview, setSldPreview] = useState<{ svg: string; metadata: string | null } | null>(null);
+  const [sldPreviewLoading, setSldPreviewLoading] = useState(false);
+  const sldPreviewSeqRef = useRef(0);
+  const changedSwitchesKey = useMemo(
+    () => JSON.stringify(sldTopologyEdit.changedSwitches),
+    [sldTopologyEdit.changedSwitches],
+  );
+  useEffect(() => {
+    const overlay = diagrams.vlOverlay;
+    const switches = sldTopologyEdit.changedSwitches;
+    const vlName = overlay?.vlName;
+    if (!overlay || !sldTopologyEdit.editMode || !vlName || Object.keys(switches).length === 0) {
+      setSldPreview(null);
+      setSldPreviewLoading(false);
+      return;
+    }
+    const seq = ++sldPreviewSeqRef.current;
+    setSldPreviewLoading(true);
+    const timer = setTimeout(async () => {
+      try {
+        const res = await api.getSldTopologyPreview({
+          voltageLevelId: vlName,
+          disconnectedElements: selectedContingency,
+          switches,
+          baseActionId: sldEditBaseActionId,
+        });
+        if (seq !== sldPreviewSeqRef.current) return;
+        setSldPreview({ svg: res.svg, metadata: res.sld_metadata ?? null });
+      } catch (e) {
+        if (seq !== sldPreviewSeqRef.current) return;
+        console.error('SLD topology preview failed:', e);
+        setSldPreview(null);
+      } finally {
+        if (seq === sldPreviewSeqRef.current) setSldPreviewLoading(false);
+      }
+    }, 280);
+    return () => clearTimeout(timer);
+    // changedSwitchesKey captures the switches dict by value; vlName +
+    // editMode + baseAction are the other inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [changedSwitchesKey, sldTopologyEdit.editMode, diagrams.vlOverlay?.vlName, sldEditBaseActionId, selectedContingency]);
+
   const handleSimulateSldEdit = useCallback(async () => {
     const overlay = diagrams.vlOverlay;
     const switches = sldTopologyEdit.changedSwitches;
@@ -1737,6 +1784,10 @@ function App() {
             onSldEditReset={sldTopologyEdit.reset}
             sldEditBusy={sldEditBusy}
             sldEditCombinedWithActionId={sldEditBaseActionId}
+            sldPreviewSvg={sldPreview?.svg ?? null}
+            sldPreviewMetadata={sldPreview?.metadata ?? null}
+            sldPreviewStale={!!sldPreview}
+            sldPreviewLoading={sldPreviewLoading}
             voltageLevels={voltageLevels}
             onVlOpen={handleVlOpen}
             onOverflowPinPreview={handlePinPreview}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -244,6 +244,28 @@ export const api = {
         );
         return response.data;
     },
+    /**
+     * Target-topology preview: re-render the VL SLD with the staged
+     * switch overrides applied (topological colouring, no load flow).
+     * `stale_flows` is always true — the caller greys the flow values.
+     */
+    getSldTopologyPreview: async (params: {
+        voltageLevelId: string;
+        disconnectedElements: string[];
+        switches: Record<string, boolean>;
+        baseActionId?: string | null;
+    }): Promise<{ svg: string; sld_metadata: string | null; voltage_level_id: string; switch_states?: Record<string, boolean>; stale_flows?: boolean }> => {
+        const response = await axios.post<{ svg: string; sld_metadata: string | null; voltage_level_id: string; switch_states?: Record<string, boolean>; stale_flows?: boolean }>(
+            `${API_BASE_URL}/api/sld-topology-preview`,
+            {
+                voltage_level_id: params.voltageLevelId,
+                disconnected_elements: params.disconnectedElements,
+                switches: params.switches,
+                base_action_id: params.baseActionId ?? null,
+            }
+        );
+        return response.data;
+    },
     getActionVariantSld: async (actionId: string, voltageLevelId: string): Promise<{ svg: string; sld_metadata: string | null; action_id: string; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; changed_switches?: Record<string, { from_open: boolean; to_open: boolean }>; switch_states?: Record<string, boolean> }> => {
         const response = await axios.post<{ svg: string; sld_metadata: string | null; action_id: string; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; changed_switches?: Record<string, { from_open: boolean; to_open: boolean }>; switch_states?: Record<string, boolean> }>(
             `${API_BASE_URL}/api/action-variant-sld`,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -230,22 +230,22 @@ export const api = {
         );
         return response.data;
     },
-    getNSld: async (voltageLevelId: string): Promise<{ svg: string; sld_metadata: string | null; voltage_level_id: string }> => {
-        const response = await axios.post<{ svg: string; sld_metadata: string | null; voltage_level_id: string }>(
+    getNSld: async (voltageLevelId: string): Promise<{ svg: string; sld_metadata: string | null; voltage_level_id: string; switch_states?: Record<string, boolean> }> => {
+        const response = await axios.post<{ svg: string; sld_metadata: string | null; voltage_level_id: string; switch_states?: Record<string, boolean> }>(
             `${API_BASE_URL}/api/n-sld`,
             { voltage_level_id: voltageLevelId }
         );
         return response.data;
     },
-    getContingencySld: async (disconnectedElements: string[], voltageLevelId: string): Promise<{ svg: string; sld_metadata: string | null; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta> }> => {
-        const response = await axios.post<{ svg: string; sld_metadata: string | null; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta> }>(
+    getContingencySld: async (disconnectedElements: string[], voltageLevelId: string): Promise<{ svg: string; sld_metadata: string | null; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; switch_states?: Record<string, boolean> }> => {
+        const response = await axios.post<{ svg: string; sld_metadata: string | null; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; switch_states?: Record<string, boolean> }>(
             `${API_BASE_URL}/api/contingency-sld`,
             { disconnected_elements: disconnectedElements, voltage_level_id: voltageLevelId }
         );
         return response.data;
     },
-    getActionVariantSld: async (actionId: string, voltageLevelId: string): Promise<{ svg: string; sld_metadata: string | null; action_id: string; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; changed_switches?: Record<string, { from_open: boolean; to_open: boolean }> }> => {
-        const response = await axios.post<{ svg: string; sld_metadata: string | null; action_id: string; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; changed_switches?: Record<string, { from_open: boolean; to_open: boolean }> }>(
+    getActionVariantSld: async (actionId: string, voltageLevelId: string): Promise<{ svg: string; sld_metadata: string | null; action_id: string; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; changed_switches?: Record<string, { from_open: boolean; to_open: boolean }>; switch_states?: Record<string, boolean> }> => {
+        const response = await axios.post<{ svg: string; sld_metadata: string | null; action_id: string; voltage_level_id: string; flow_deltas?: Record<string, FlowDelta>; reactive_flow_deltas?: Record<string, FlowDelta>; asset_deltas?: Record<string, AssetDelta>; changed_switches?: Record<string, { from_open: boolean; to_open: boolean }>; switch_states?: Record<string, boolean> }>(
             `${API_BASE_URL}/api/action-variant-sld`,
             { action_id: actionId, voltage_level_id: voltageLevelId }
         );
@@ -313,6 +313,7 @@ export const api = {
         lines_overloaded?: string[] | null;
         target_mw?: number | null;
         target_tap?: number | null;
+        voltage_level_id?: string | null;
         mode?: 'network' | 'delta';
     }): Promise<Response> => {
         const response = await fetch(`${API_BASE_URL}/api/simulate-and-variant-diagram`, {
@@ -325,6 +326,7 @@ export const api = {
                 lines_overloaded: params.lines_overloaded ?? null,
                 target_mw: params.target_mw ?? null,
                 target_tap: params.target_tap ?? null,
+                voltage_level_id: params.voltage_level_id ?? null,
                 mode: params.mode ?? 'network',
             }),
         });

--- a/frontend/src/components/SldEditPanel.test.tsx
+++ b/frontend/src/components/SldEditPanel.test.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SldEditPanel from './SldEditPanel';
+
+const defaultProps = {
+    pendingChanges: [],
+    onReset: vi.fn(),
+    onSimulate: vi.fn(),
+    onClose: vi.fn(),
+};
+
+describe('SldEditPanel', () => {
+    it('shows the empty-state hint when there are no pending changes', () => {
+        render(<SldEditPanel {...defaultProps} />);
+        expect(screen.getByText(/click any switch/i)).toBeInTheDocument();
+    });
+
+    it('renders one row per pending change with baseline→target direction', () => {
+        render(<SldEditPanel
+            {...defaultProps}
+            pendingChanges={[
+                { switchId: 'SW_A', baselineOpen: false, targetOpen: true },
+                { switchId: 'SW_B', baselineOpen: true, targetOpen: false },
+            ]}
+        />);
+        const a = screen.getByTestId('sld-edit-change-SW_A');
+        const b = screen.getByTestId('sld-edit-change-SW_B');
+        expect(a.textContent).toMatch(/fermé.*ouvert/);
+        expect(b.textContent).toMatch(/ouvert.*fermé/);
+    });
+
+    it('disables both action buttons when no changes are staged', () => {
+        render(<SldEditPanel {...defaultProps} />);
+        expect(screen.getByTestId('sld-edit-reset')).toBeDisabled();
+        expect(screen.getByTestId('sld-edit-simulate')).toBeDisabled();
+    });
+
+    it('enables and fires Reset / Simulate when changes exist', () => {
+        const onReset = vi.fn();
+        const onSimulate = vi.fn();
+        render(<SldEditPanel
+            {...defaultProps}
+            onReset={onReset}
+            onSimulate={onSimulate}
+            pendingChanges={[{ switchId: 'SW_A', baselineOpen: false, targetOpen: true }]}
+        />);
+        fireEvent.click(screen.getByTestId('sld-edit-reset'));
+        fireEvent.click(screen.getByTestId('sld-edit-simulate'));
+        expect(onReset).toHaveBeenCalledTimes(1);
+        expect(onSimulate).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a combined-with badge when combinedWithActionId is provided', () => {
+        render(<SldEditPanel
+            {...defaultProps}
+            pendingChanges={[{ switchId: 'SW_A', baselineOpen: false, targetOpen: true }]}
+            combinedWithActionId="disco_LINE_42"
+        />);
+        expect(screen.getByText(/combined with disco_LINE_42/i)).toBeInTheDocument();
+    });
+
+    it('disables Simulate when busy', () => {
+        render(<SldEditPanel
+            {...defaultProps}
+            pendingChanges={[{ switchId: 'SW_A', baselineOpen: false, targetOpen: true }]}
+            busy
+        />);
+        const sim = screen.getByTestId('sld-edit-simulate');
+        expect(sim).toBeDisabled();
+        expect(sim.textContent).toMatch(/simulating/i);
+    });
+
+    it('fires onClose when the ✕ is clicked', () => {
+        const onClose = vi.fn();
+        render(<SldEditPanel {...defaultProps} onClose={onClose} />);
+        fireEvent.click(screen.getByTestId('sld-edit-close'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/components/SldEditPanel.test.tsx
+++ b/frontend/src/components/SldEditPanel.test.tsx
@@ -84,4 +84,67 @@ describe('SldEditPanel', () => {
         fireEvent.click(screen.getByTestId('sld-edit-close'));
         expect(onClose).toHaveBeenCalledTimes(1);
     });
+
+    it('focuses a single switch when its row is clicked', () => {
+        const onFocus = vi.fn();
+        render(<SldEditPanel
+            {...defaultProps}
+            onFocus={onFocus}
+            pendingChanges={[
+                { switchId: 'SW_A', baselineOpen: false, targetOpen: true },
+                { switchId: 'SW_B', baselineOpen: true, targetOpen: false },
+            ]}
+        />);
+        fireEvent.click(screen.getByTestId('sld-edit-focus-SW_A'));
+        expect(onFocus).toHaveBeenCalledWith('SW_A');
+    });
+
+    it('clears focus when clicking the already-focused row', () => {
+        const onFocus = vi.fn();
+        render(<SldEditPanel
+            {...defaultProps}
+            focusedSwitchId="SW_A"
+            onFocus={onFocus}
+            pendingChanges={[{ switchId: 'SW_A', baselineOpen: false, targetOpen: true }]}
+        />);
+        fireEvent.click(screen.getByTestId('sld-edit-focus-SW_A'));
+        expect(onFocus).toHaveBeenCalledWith(null);
+    });
+
+    it('removes a single maneuver via its × button', () => {
+        const onRemove = vi.fn();
+        render(<SldEditPanel
+            {...defaultProps}
+            onRemove={onRemove}
+            pendingChanges={[{ switchId: 'SW_A', baselineOpen: false, targetOpen: true }]}
+        />);
+        fireEvent.click(screen.getByTestId('sld-edit-remove-SW_A'));
+        expect(onRemove).toHaveBeenCalledWith('SW_A');
+    });
+
+    it('removes a block of selected maneuvers', () => {
+        const onRemoveMany = vi.fn();
+        render(<SldEditPanel
+            {...defaultProps}
+            onRemoveMany={onRemoveMany}
+            pendingChanges={[
+                { switchId: 'SW_A', baselineOpen: false, targetOpen: true },
+                { switchId: 'SW_B', baselineOpen: true, targetOpen: false },
+                { switchId: 'SW_C', baselineOpen: false, targetOpen: true },
+            ]}
+        />);
+        fireEvent.click(screen.getByTestId('sld-edit-select-SW_A'));
+        fireEvent.click(screen.getByTestId('sld-edit-select-SW_C'));
+        fireEvent.click(screen.getByTestId('sld-edit-remove-selected'));
+        expect(onRemoveMany).toHaveBeenCalledTimes(1);
+        expect(new Set(onRemoveMany.mock.calls[0][0])).toEqual(new Set(['SW_A', 'SW_C']));
+    });
+
+    it('hides the block-remove button when nothing is selected', () => {
+        render(<SldEditPanel
+            {...defaultProps}
+            pendingChanges={[{ switchId: 'SW_A', baselineOpen: false, targetOpen: true }]}
+        />);
+        expect(screen.queryByTestId('sld-edit-remove-selected')).toBeNull();
+    });
 });

--- a/frontend/src/components/SldEditPanel.tsx
+++ b/frontend/src/components/SldEditPanel.tsx
@@ -4,8 +4,9 @@
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 // SPDX-License-Identifier: MPL-2.0
 
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import { colors, space, text, radius } from '../styles/tokens';
+import { interactionLogger } from '../utils/interactionLogger';
 import type { SwitchToggleEntry } from '../hooks/useSldTopologyEdit';
 
 export interface SldEditPanelProps {
@@ -25,12 +26,52 @@ export interface SldEditPanelProps {
      * resulting card will appear as a combined action.
      */
     combinedWithActionId?: string | null;
+    /**
+     * Maneuver-list interactions (mirrors ExpertOp's manoeuvre IHM):
+     * click a row to focus a single switch, × to remove one maneuver,
+     * checkbox-select + "Remove selected" to drop a block.
+     */
+    focusedSwitchId?: string | null;
+    onFocus?: (equipmentId: string | null) => void;
+    onRemove?: (equipmentId: string) => void;
+    onRemoveMany?: (equipmentIds: string[]) => void;
 }
 
 const SldEditPanel: React.FC<SldEditPanelProps> = ({
     pendingChanges, onReset, onSimulate, onClose, busy = false, combinedWithActionId = null,
+    focusedSwitchId = null, onFocus, onRemove, onRemoveMany,
 }) => {
     const hasChanges = pendingChanges.length > 0;
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+
+    // Intersect with the live change set so a selection left over from a
+    // removed maneuver is ignored (no pruning effect needed — stale ids
+    // simply never render and are filtered here before use).
+    const validSelected = useMemo(() => {
+        const present = new Set(pendingChanges.map(c => c.switchId));
+        return [...selected].filter(id => present.has(id));
+    }, [selected, pendingChanges]);
+
+    const toggleSelected = (switchId: string) => {
+        setSelected(prev => {
+            const next = new Set(prev);
+            if (next.has(switchId)) next.delete(switchId); else next.add(switchId);
+            return next;
+        });
+    };
+
+    const handleFocus = (switchId: string) => {
+        const nextFocus = focusedSwitchId === switchId ? null : switchId;
+        onFocus?.(nextFocus);
+        if (nextFocus) interactionLogger.record('sld_maneuver_focused', { equipment_id: nextFocus });
+    };
+
+    const handleRemoveSelected = () => {
+        if (validSelected.length === 0) return;
+        onRemoveMany?.(validSelected);
+        setSelected(new Set());
+    };
+
     return (
         <div
             data-testid="sld-edit-panel"
@@ -40,7 +81,7 @@ const SldEditPanel: React.FC<SldEditPanelProps> = ({
                 padding: space[2],
                 borderTop: `1px solid ${colors.border}`,
                 background: colors.surfaceMuted,
-                maxHeight: '40%', minHeight: 0, overflowY: 'auto', flexShrink: 0,
+                maxHeight: '45%', minHeight: 0, overflowY: 'auto', flexShrink: 0,
             }}
         >
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: space[1] }}>
@@ -67,14 +108,55 @@ const SldEditPanel: React.FC<SldEditPanelProps> = ({
                 <ul style={{
                     listStyle: 'none', padding: 0, margin: 0,
                     display: 'flex', flexDirection: 'column', gap: space.half,
-                    fontSize: text.xs, color: colors.textSecondary,
+                    fontSize: text.xs,
                 }}>
-                    {pendingChanges.map(({ switchId, baselineOpen, targetOpen }) => (
-                        <li key={switchId} data-testid={`sld-edit-change-${switchId}`} style={{ fontFamily: 'monospace' }}>
-                            <strong style={{ color: colors.textPrimary }}>{switchId}</strong>
-                            : {baselineOpen ? 'ouvert' : 'fermé'} → {targetOpen ? 'ouvert' : 'fermé'}
-                        </li>
-                    ))}
+                    {pendingChanges.map(({ switchId, baselineOpen, targetOpen }) => {
+                        const isFocused = focusedSwitchId === switchId;
+                        return (
+                            <li
+                                key={switchId}
+                                data-testid={`sld-edit-change-${switchId}`}
+                                style={{
+                                    display: 'flex', alignItems: 'center', gap: space[1],
+                                    padding: `${space.half} ${space[1]}`,
+                                    borderRadius: radius.sm,
+                                    background: isFocused ? colors.brandSoft : 'transparent',
+                                    border: `1px solid ${isFocused ? colors.brandMid : 'transparent'}`,
+                                }}
+                            >
+                                <input
+                                    type="checkbox"
+                                    data-testid={`sld-edit-select-${switchId}`}
+                                    checked={selected.has(switchId)}
+                                    onChange={() => toggleSelected(switchId)}
+                                    title="Select for block removal"
+                                    style={{ cursor: 'pointer', flexShrink: 0 }}
+                                />
+                                <button
+                                    data-testid={`sld-edit-focus-${switchId}`}
+                                    onClick={() => handleFocus(switchId)}
+                                    title="Highlight only this switch"
+                                    style={{
+                                        flex: 1, textAlign: 'left', cursor: 'pointer',
+                                        background: 'transparent', border: 'none', padding: 0,
+                                        color: colors.textSecondary, fontFamily: 'monospace', fontSize: text.xs,
+                                    }}
+                                >
+                                    <strong style={{ color: colors.textPrimary }}>{switchId}</strong>
+                                    {': '}{baselineOpen ? 'ouvert' : 'fermé'} → {targetOpen ? 'ouvert' : 'fermé'}
+                                </button>
+                                <button
+                                    data-testid={`sld-edit-remove-${switchId}`}
+                                    onClick={() => onRemove?.(switchId)}
+                                    title="Remove this maneuver"
+                                    style={{
+                                        border: 'none', background: 'transparent', color: colors.danger,
+                                        cursor: 'pointer', fontSize: text.sm, padding: `0 ${space.half}`, flexShrink: 0,
+                                    }}
+                                >✕</button>
+                            </li>
+                        );
+                    })}
                 </ul>
             ) : (
                 <span style={{ fontSize: text.xs, color: colors.textTertiary }}>
@@ -82,7 +164,20 @@ const SldEditPanel: React.FC<SldEditPanelProps> = ({
                 </span>
             )}
 
-            <div style={{ display: 'flex', gap: space[1], justifyContent: 'flex-end', marginTop: space[1] }}>
+            <div style={{ display: 'flex', gap: space[1], justifyContent: 'flex-end', marginTop: space[1], flexWrap: 'wrap' }}>
+                {validSelected.length > 0 && (
+                    <button
+                        data-testid="sld-edit-remove-selected"
+                        onClick={handleRemoveSelected}
+                        disabled={busy}
+                        style={{
+                            padding: `${space.half} ${space[2]}`, fontSize: text.xs,
+                            background: colors.surface, color: colors.danger,
+                            border: `1px solid ${colors.danger}`, borderRadius: radius.sm,
+                            cursor: busy ? 'not-allowed' : 'pointer',
+                        }}
+                    >Remove selected ({validSelected.length})</button>
+                )}
                 <button
                     data-testid="sld-edit-reset"
                     onClick={onReset}

--- a/frontend/src/components/SldEditPanel.tsx
+++ b/frontend/src/components/SldEditPanel.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import React from 'react';
+import { colors, space, text, radius } from '../styles/tokens';
+import type { SwitchToggleEntry } from '../hooks/useSldTopologyEdit';
+
+export interface SldEditPanelProps {
+    pendingChanges: SwitchToggleEntry[];
+    onReset: () => void;
+    onSimulate: () => void;
+    onClose: () => void;
+    /**
+     * When true the Simulate button is busy / disabled. Driven by the
+     * `simulateAndVariantDiagramStream` lifecycle in App.tsx.
+     */
+    busy?: boolean;
+    /**
+     * If non-null, the simulation will be combined with this action
+     * (the SLD was opened from a recommended action's variant). The
+     * panel surfaces this explicitly so the operator knows the
+     * resulting card will appear as a combined action.
+     */
+    combinedWithActionId?: string | null;
+}
+
+const SldEditPanel: React.FC<SldEditPanelProps> = ({
+    pendingChanges, onReset, onSimulate, onClose, busy = false, combinedWithActionId = null,
+}) => {
+    const hasChanges = pendingChanges.length > 0;
+    return (
+        <div
+            data-testid="sld-edit-panel"
+            style={{
+                display: 'flex', flexDirection: 'column',
+                gap: space[1],
+                padding: space[2],
+                borderTop: `1px solid ${colors.border}`,
+                background: colors.surfaceMuted,
+                maxHeight: '40%', minHeight: 0, overflowY: 'auto', flexShrink: 0,
+            }}
+        >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: space[1] }}>
+                <span style={{ fontSize: text.sm, fontWeight: 600, color: colors.textPrimary }}>
+                    Edit topology
+                    {combinedWithActionId
+                        ? <span style={{ marginLeft: space[1], fontSize: text.xs, color: colors.brandStrong, fontWeight: 500 }}>
+                            (combined with {combinedWithActionId})
+                        </span>
+                        : null}
+                </span>
+                <button
+                    data-testid="sld-edit-close"
+                    onClick={onClose}
+                    title="Exit edit mode"
+                    style={{
+                        border: 'none', background: 'transparent', color: colors.textTertiary,
+                        cursor: 'pointer', fontSize: text.sm, padding: 0,
+                    }}
+                >✕</button>
+            </div>
+
+            {hasChanges ? (
+                <ul style={{
+                    listStyle: 'none', padding: 0, margin: 0,
+                    display: 'flex', flexDirection: 'column', gap: space.half,
+                    fontSize: text.xs, color: colors.textSecondary,
+                }}>
+                    {pendingChanges.map(({ switchId, baselineOpen, targetOpen }) => (
+                        <li key={switchId} data-testid={`sld-edit-change-${switchId}`} style={{ fontFamily: 'monospace' }}>
+                            <strong style={{ color: colors.textPrimary }}>{switchId}</strong>
+                            : {baselineOpen ? 'ouvert' : 'fermé'} → {targetOpen ? 'ouvert' : 'fermé'}
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <span style={{ fontSize: text.xs, color: colors.textTertiary }}>
+                    Click any switch in the diagram to stage a change.
+                </span>
+            )}
+
+            <div style={{ display: 'flex', gap: space[1], justifyContent: 'flex-end', marginTop: space[1] }}>
+                <button
+                    data-testid="sld-edit-reset"
+                    onClick={onReset}
+                    disabled={!hasChanges || busy}
+                    style={{
+                        padding: `${space.half} ${space[2]}`, fontSize: text.xs,
+                        background: colors.surface, color: colors.textPrimary,
+                        border: `1px solid ${colors.border}`, borderRadius: radius.sm,
+                        cursor: (!hasChanges || busy) ? 'not-allowed' : 'pointer',
+                        opacity: (!hasChanges || busy) ? 0.6 : 1,
+                    }}
+                >Reset</button>
+                <button
+                    data-testid="sld-edit-simulate"
+                    onClick={onSimulate}
+                    disabled={!hasChanges || busy}
+                    style={{
+                        padding: `${space.half} ${space[2]}`, fontSize: text.xs, fontWeight: 600,
+                        background: (!hasChanges || busy) ? colors.disabled : colors.brand,
+                        color: colors.textOnBrand,
+                        border: 'none', borderRadius: radius.sm,
+                        cursor: (!hasChanges || busy) ? 'not-allowed' : 'pointer',
+                    }}
+                >{busy ? 'Simulating…' : 'Simulate action'}</button>
+            </div>
+        </div>
+    );
+};
+
+export default SldEditPanel;

--- a/frontend/src/components/SldOverlay.tsx
+++ b/frontend/src/components/SldOverlay.tsx
@@ -52,6 +52,18 @@ export interface SldOverlayProps {
     editSimulationBusy?: boolean;
     /** Base action id when editing on a post-action SLD (combined card). */
     editCombinedWithActionId?: string | null;
+    /**
+     * Target-topology preview. When set, the overlay renders this SVG
+     * (switches drawn in their target state + topological-colouring
+     * connectivity, computed by the backend) instead of the baseline,
+     * and greys the flow values via ``sld-preview-stale`` because no
+     * load flow was run. Cleared when the operator resets / exits edit
+     * mode or commits the simulation.
+     */
+    previewSvg?: string | null;
+    previewMetadata?: string | null;
+    previewStale?: boolean;
+    previewLoading?: boolean;
 }
 
 const SldOverlay: React.FC<SldOverlayProps> = ({
@@ -69,8 +81,19 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
     onResetEdit,
     editSimulationBusy = false,
     editCombinedWithActionId = null,
+    previewSvg = null,
+    previewMetadata = null,
+    previewStale = false,
+    previewLoading = false,
 }) => {
     const overlayBodyRef = useRef<HTMLDivElement>(null);
+    // When a target-topology preview is showing, the backend already
+    // drew the switches in target state with topological colouring, so
+    // the client-side delta / highlight / toggle-paint passes (which
+    // target the baseline SVG) are suppressed.
+    const previewActive = !!previewSvg;
+    const activeSvg = previewSvg ?? vlOverlay.svg;
+    const activeMetadata = previewMetadata ?? vlOverlay.sldMetadata;
     const [overlayPos, setOverlayPos] = useState({ x: 16, y: 16 });
     const [overlayTransform, setOverlayTransform] = useState({ scale: 1, tx: 0, ty: 0 });
 
@@ -96,6 +119,10 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
     useLayoutEffect(() => {
         const container = overlayBodyRef.current;
         if (!container) return;
+        // Preview render owns the canvas — its flows are greyed and its
+        // switches are already in target state; baseline deltas must not
+        // repaint over it.
+        if (previewActive) return;
 
         const deltaSig = JSON.stringify({
             svgLen: vlOverlay.svg?.length ?? 0,
@@ -456,6 +483,7 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
     useLayoutEffect(() => {
         const container = overlayBodyRef.current;
         if (!container || !vlOverlay.svg) return;
+        if (previewActive) return;
 
         // Compute a signature that summarises what SHOULD be highlighted
         // right now. If the signature hasn't changed AND the clones are
@@ -801,6 +829,9 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
             el.classList.remove('sld-user-toggle-closed');
         });
 
+        // Preview already draws switches in target state — no need to
+        // (and we shouldn't) paint toggle outlines over it.
+        if (previewActive) return;
         if (!editMode || !pendingSwitches || !vlOverlay.switch_states) return;
         if (Object.keys(pendingSwitches).length === 0) return;
 
@@ -864,9 +895,9 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
         if (!editMode || !onSwitchClick || !vlOverlay.switch_states) return;
 
         const svgToEquip = new Map<string, string>();
-        if (vlOverlay.sldMetadata) {
+        if (activeMetadata) {
             try {
-                const meta = JSON.parse(vlOverlay.sldMetadata) as {
+                const meta = JSON.parse(activeMetadata) as {
                     nodes?: SldFeederNode[];
                     feederInfos?: SldFeederNode[];
                     feederNodes?: SldFeederNode[];
@@ -908,7 +939,7 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
         };
         container.addEventListener('click', onClick, true);
         return () => { container.removeEventListener('click', onClick, true); };
-    }, [editMode, onSwitchClick, vlOverlay.sldMetadata, vlOverlay.switch_states, vlOverlay.svg]);
+    }, [editMode, onSwitchClick, activeMetadata, vlOverlay.switch_states, activeSvg]);
 
     // Non-passive wheel zoom on overlay body
     useEffect(() => {
@@ -1030,12 +1061,12 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                             style={{
                                 background: editMode ? colors.brand : colors.surfaceMuted,
                                 color: editMode ? colors.textOnBrand : colors.textPrimary,
-                                border: 'none', borderRadius: '4px', padding: '2px 8px',
-                                fontSize: '11px', fontWeight: editMode ? 'bold' : 'normal',
-                                cursor: 'pointer',
+                                border: 'none', borderRadius: '5px', padding: '5px 12px',
+                                fontSize: '12px', fontWeight: 600,
+                                cursor: 'pointer', whiteSpace: 'nowrap',
                             }}
-                            title={editMode ? 'Exit topology edit mode' : 'Enter topology edit mode'}
-                        >Edit</button>
+                            title={editMode ? 'Exit manual action mode' : 'Build a manual action by editing the topology'}
+                        >✎ Manual action</button>
                     )}
                     <button
                         onMouseDown={e => e.stopPropagation()}
@@ -1048,7 +1079,7 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
             {/* Body — pan/zoom canvas */}
             <div
                 ref={overlayBodyRef}
-                style={{ flex: 1, overflow: 'hidden', minHeight: 0, cursor: 'grab', userSelect: 'none' }}
+                style={{ flex: 1, overflow: 'hidden', minHeight: 0, cursor: 'grab', userSelect: 'none', position: 'relative' }}
                 onMouseDown={startOverlayPan}
             >
                 {vlOverlay.loading && (
@@ -1059,12 +1090,22 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                 {vlOverlay.error && (
                     <div style={{ padding: '12px', color: colors.danger, fontSize: '12px' }}>{vlOverlay.error}</div>
                 )}
-                {vlOverlay.svg && (
-                    <div style={{
-                        transformOrigin: '0 0',
-                        transform: `translate(${overlayTransform.tx}px,${overlayTransform.ty}px) scale(${overlayTransform.scale})`,
-                        padding: '4px',
-                    }} dangerouslySetInnerHTML={{ __html: vlOverlay.svg }} />
+                {activeSvg && (
+                    <div
+                        key={previewActive ? 'preview' : 'baseline'}
+                        className={previewStale ? 'sld-preview-stale' : undefined}
+                        style={{
+                            transformOrigin: '0 0',
+                            transform: `translate(${overlayTransform.tx}px,${overlayTransform.ty}px) scale(${overlayTransform.scale})`,
+                            padding: '4px',
+                        }} dangerouslySetInnerHTML={{ __html: activeSvg }} />
+                )}
+                {previewLoading && (
+                    <div data-testid="sld-preview-loading" style={{
+                        position: 'absolute', top: '8px', right: '8px',
+                        background: colors.brandSoft, color: colors.brandStrong,
+                        fontSize: '10px', fontWeight: 700, padding: '2px 8px', borderRadius: '10px',
+                    }}>Preview…</div>
                 )}
             </div>
             {editMode && onEditModeChange && pendingChanges && onSimulateEdit && onResetEdit && (

--- a/frontend/src/components/SldOverlay.tsx
+++ b/frontend/src/components/SldOverlay.tsx
@@ -9,6 +9,8 @@ import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import type { DiagramData, AnalysisResult, ActionDetail, VlOverlay, SldTab, SldFeederNode } from '../types';
 import { isCouplingAction } from '../utils/svgUtils';
 import { colors } from '../styles/tokens';
+import SldEditPanel from './SldEditPanel';
+import type { SwitchToggleEntry } from '../hooks/useSldTopologyEdit';
 
 export interface SldOverlayProps {
     vlOverlay: VlOverlay;
@@ -30,6 +32,26 @@ export interface SldOverlayProps {
      * pre-fix behaviour for legacy callers.
      */
     monitoringFactor?: number;
+    /**
+     * Interactive topology-edit affordance. When provided, the overlay
+     * exposes a Edit toggle next to the SLD-tab strip and renders the
+     * pending-changes panel under the SVG body. The actual state lives
+     * in ``useSldTopologyEdit`` on the App side; this component only
+     * forwards taps on the SVG to ``onSwitchClick``.
+     *
+     * The whole bundle is optional so older callers (overflow pin
+     * double-click, etc.) keep working without changes.
+     */
+    editMode?: boolean;
+    onEditModeChange?: (next: boolean) => void;
+    pendingSwitches?: Record<string, boolean>;
+    pendingChanges?: SwitchToggleEntry[];
+    onSwitchClick?: (equipmentId: string) => void;
+    onSimulateEdit?: () => void;
+    onResetEdit?: () => void;
+    editSimulationBusy?: boolean;
+    /** Base action id when editing on a post-action SLD (combined card). */
+    editCombinedWithActionId?: string | null;
 }
 
 const SldOverlay: React.FC<SldOverlayProps> = ({
@@ -38,6 +60,15 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
     n1Diagram, actionDiagram,
     selectedContingency, result,
     monitoringFactor = 0.95,
+    editMode = false,
+    onEditModeChange,
+    pendingSwitches,
+    pendingChanges,
+    onSwitchClick,
+    onSimulateEdit,
+    onResetEdit,
+    editSimulationBusy = false,
+    editCombinedWithActionId = null,
 }) => {
     const overlayBodyRef = useRef<HTMLDivElement>(null);
     const [overlayPos, setOverlayPos] = useState({ x: 16, y: 16 });
@@ -754,6 +785,131 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
         // of waiting for a tab switch to re-trigger the effect.
     });
 
+    // Repaint pending switch toggles whenever the override map or the
+    // SLD content changes. Walks the SLD metadata to find every SVG
+    // element id mapped to a switch equipmentId, then adds the
+    // ``sld-user-toggle-{open,closed}`` class on the enclosing cell
+    // (same ancestor lookup used by the delta + highlight passes).
+    useLayoutEffect(() => {
+        const container = overlayBodyRef.current;
+        if (!container) return;
+        const previous = container.querySelectorAll(
+            '.sld-user-toggle-open, .sld-user-toggle-closed',
+        );
+        previous.forEach(el => {
+            el.classList.remove('sld-user-toggle-open');
+            el.classList.remove('sld-user-toggle-closed');
+        });
+
+        if (!editMode || !pendingSwitches || !vlOverlay.switch_states) return;
+        if (Object.keys(pendingSwitches).length === 0) return;
+
+        const equipIdToSvgIds = new Map<string, string[]>();
+        if (vlOverlay.sldMetadata) {
+            try {
+                const meta = JSON.parse(vlOverlay.sldMetadata) as {
+                    nodes?: SldFeederNode[];
+                    feederInfos?: SldFeederNode[];
+                    feederNodes?: SldFeederNode[];
+                };
+                const sources = [
+                    ...(meta.nodes ?? []),
+                    ...(meta.feederInfos ?? []),
+                    ...(meta.feederNodes ?? []),
+                ];
+                for (const fn of sources) {
+                    if (fn.equipmentId && fn.id) {
+                        const ids = equipIdToSvgIds.get(fn.equipmentId) ?? [];
+                        ids.push(fn.id);
+                        equipIdToSvgIds.set(fn.equipmentId, ids);
+                    }
+                }
+            } catch {
+                return;
+            }
+        }
+
+        const elMap = new Map<string, Element>();
+        container.querySelectorAll('[id]').forEach(el => elMap.set(el.id, el));
+        const lookupById = (svgId: string): Element | undefined =>
+            elMap.get(svgId)
+            ?? elMap.get(svgId.replace(/\./g, '_'))
+            ?? elMap.get(svgId.replace(/_/g, '.'));
+
+        for (const [equipmentId, targetOpen] of Object.entries(pendingSwitches)) {
+            const svgIds = equipIdToSvgIds.get(equipmentId)
+                ?? equipIdToSvgIds.get(equipmentId.replace(/\./g, '_'))
+                ?? equipIdToSvgIds.get(equipmentId.replace(/_/g, '.'));
+            const candidates: Element[] = [];
+            for (const sid of svgIds ?? [equipmentId]) {
+                const el = lookupById(sid);
+                if (el) candidates.push(el);
+            }
+            for (const el of candidates) {
+                const cell = el.closest('.sld-extern-cell, .sld-intern-cell, .sld-shunt-cell') ?? el;
+                cell.classList.add(targetOpen ? 'sld-user-toggle-open' : 'sld-user-toggle-closed');
+            }
+        }
+    });
+
+    // Delegate switch clicks on the SVG body when edit mode is on.
+    // We attach to the body container (capture phase) so taps on the
+    // breaker's nested children still fire. The ``equipmentId`` is
+    // resolved via the SLD metadata — switches not present in the
+    // baseline ``switch_states`` map are silently ignored by
+    // ``useSldTopologyEdit.toggleSwitch``.
+    useEffect(() => {
+        const container = overlayBodyRef.current;
+        if (!container) return;
+        if (!editMode || !onSwitchClick || !vlOverlay.switch_states) return;
+
+        const svgToEquip = new Map<string, string>();
+        if (vlOverlay.sldMetadata) {
+            try {
+                const meta = JSON.parse(vlOverlay.sldMetadata) as {
+                    nodes?: SldFeederNode[];
+                    feederInfos?: SldFeederNode[];
+                    feederNodes?: SldFeederNode[];
+                };
+                const sources = [
+                    ...(meta.nodes ?? []),
+                    ...(meta.feederInfos ?? []),
+                    ...(meta.feederNodes ?? []),
+                ];
+                for (const fn of sources) {
+                    if (fn.equipmentId && fn.id) {
+                        svgToEquip.set(fn.id, fn.equipmentId);
+                        svgToEquip.set(fn.id.replace(/\./g, '_'), fn.equipmentId);
+                        svgToEquip.set(fn.id.replace(/_/g, '.'), fn.equipmentId);
+                    }
+                }
+            } catch {
+                return;
+            }
+        }
+        const editableSwitches = vlOverlay.switch_states;
+
+        const onClick = (ev: MouseEvent) => {
+            const target = ev.target as Element | null;
+            if (!target) return;
+            let cur: Element | null = target;
+            while (cur && cur !== container) {
+                if (cur.id) {
+                    const equip = svgToEquip.get(cur.id);
+                    if (equip && equip in editableSwitches) {
+                        ev.stopPropagation();
+                        ev.preventDefault();
+                        onSwitchClick(equip);
+                        return;
+                    }
+                }
+                cur = cur.parentElement;
+            }
+        };
+        container.addEventListener('click', onClick, true);
+        return () => { container.removeEventListener('click', onClick, true); };
+    }, [editMode, onSwitchClick, vlOverlay.sldMetadata, vlOverlay.switch_states, vlOverlay.svg]);
+
     // Non-passive wheel zoom on overlay body
     useEffect(() => {
         const el = overlayBodyRef.current;
@@ -865,12 +1021,29 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                         ))}
                     </div>
                 </div>
-                <button
-                    onMouseDown={e => e.stopPropagation()}
-                    onClick={(e) => { e.stopPropagation(); onOverlayClose(); }}
-                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '16px', color: colors.textTertiary, lineHeight: 1, padding: '0 2px' }}
-                    title="Close"
-                >✕</button>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                    {onEditModeChange && vlOverlay.tab !== 'n' && (vlOverlay.switch_states && Object.keys(vlOverlay.switch_states).length > 0) && (
+                        <button
+                            data-testid="sld-edit-toggle"
+                            onMouseDown={e => e.stopPropagation()}
+                            onClick={(e) => { e.stopPropagation(); onEditModeChange(!editMode); }}
+                            style={{
+                                background: editMode ? colors.brand : colors.surfaceMuted,
+                                color: editMode ? colors.textOnBrand : colors.textPrimary,
+                                border: 'none', borderRadius: '4px', padding: '2px 8px',
+                                fontSize: '11px', fontWeight: editMode ? 'bold' : 'normal',
+                                cursor: 'pointer',
+                            }}
+                            title={editMode ? 'Exit topology edit mode' : 'Enter topology edit mode'}
+                        >Edit</button>
+                    )}
+                    <button
+                        onMouseDown={e => e.stopPropagation()}
+                        onClick={(e) => { e.stopPropagation(); onOverlayClose(); }}
+                        style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '16px', color: colors.textTertiary, lineHeight: 1, padding: '0 2px' }}
+                        title="Close"
+                    >✕</button>
+                </div>
             </div>
             {/* Body — pan/zoom canvas */}
             <div
@@ -894,6 +1067,16 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                     }} dangerouslySetInnerHTML={{ __html: vlOverlay.svg }} />
                 )}
             </div>
+            {editMode && onEditModeChange && pendingChanges && onSimulateEdit && onResetEdit && (
+                <SldEditPanel
+                    pendingChanges={pendingChanges}
+                    onReset={onResetEdit}
+                    onSimulate={onSimulateEdit}
+                    onClose={() => onEditModeChange(false)}
+                    busy={editSimulationBusy}
+                    combinedWithActionId={editCombinedWithActionId}
+                />
+            )}
         </div>
     );
 };

--- a/frontend/src/components/SldOverlay.tsx
+++ b/frontend/src/components/SldOverlay.tsx
@@ -64,6 +64,15 @@ export interface SldOverlayProps {
     previewMetadata?: string | null;
     previewStale?: boolean;
     previewLoading?: boolean;
+    /**
+     * Maneuver-list focus: when set, only this switch's cell is
+     * outlined (the operator clicked its row in the panel). Null =
+     * outline every staged change.
+     */
+    focusedSwitchId?: string | null;
+    onSwitchFocus?: (equipmentId: string | null) => void;
+    onSwitchRemove?: (equipmentId: string) => void;
+    onSwitchRemoveMany?: (equipmentIds: string[]) => void;
 }
 
 const SldOverlay: React.FC<SldOverlayProps> = ({
@@ -85,6 +94,10 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
     previewMetadata = null,
     previewStale = false,
     previewLoading = false,
+    focusedSwitchId = null,
+    onSwitchFocus,
+    onSwitchRemove,
+    onSwitchRemoveMany,
 }) => {
     const overlayBodyRef = useRef<HTMLDivElement>(null);
     // When a target-topology preview is showing, the backend already
@@ -829,16 +842,17 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
             el.classList.remove('sld-user-toggle-closed');
         });
 
-        // Preview already draws switches in target state — no need to
-        // (and we shouldn't) paint toggle outlines over it.
-        if (previewActive) return;
+        // Always outline the changed switches — even on the preview —
+        // so the operator keeps seeing WHERE the topology changed. Uses
+        // the active metadata (preview metadata when previewing). When a
+        // maneuver row is focused, only that switch is outlined.
         if (!editMode || !pendingSwitches || !vlOverlay.switch_states) return;
         if (Object.keys(pendingSwitches).length === 0) return;
 
         const equipIdToSvgIds = new Map<string, string[]>();
-        if (vlOverlay.sldMetadata) {
+        if (activeMetadata) {
             try {
-                const meta = JSON.parse(vlOverlay.sldMetadata) as {
+                const meta = JSON.parse(activeMetadata) as {
                     nodes?: SldFeederNode[];
                     feederInfos?: SldFeederNode[];
                     feederNodes?: SldFeederNode[];
@@ -868,6 +882,7 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
             ?? elMap.get(svgId.replace(/_/g, '.'));
 
         for (const [equipmentId, targetOpen] of Object.entries(pendingSwitches)) {
+            if (focusedSwitchId && equipmentId !== focusedSwitchId) continue;
             const svgIds = equipIdToSvgIds.get(equipmentId)
                 ?? equipIdToSvgIds.get(equipmentId.replace(/\./g, '_'))
                 ?? equipIdToSvgIds.get(equipmentId.replace(/_/g, '.'));
@@ -1116,6 +1131,10 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                     onClose={() => onEditModeChange(false)}
                     busy={editSimulationBusy}
                     combinedWithActionId={editCombinedWithActionId}
+                    focusedSwitchId={focusedSwitchId}
+                    onFocus={onSwitchFocus}
+                    onRemove={onSwitchRemove}
+                    onRemoveMany={onSwitchRemoveMany}
                 />
             )}
         </div>

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -107,6 +107,10 @@ interface VisualizationPanelProps {
     onSldEditReset?: () => void;
     sldEditBusy?: boolean;
     sldEditCombinedWithActionId?: string | null;
+    sldPreviewSvg?: string | null;
+    sldPreviewMetadata?: string | null;
+    sldPreviewStale?: boolean;
+    sldPreviewLoading?: boolean;
     voltageLevels: string[];
     onVlOpen: (vlName: string) => void;
     /**
@@ -257,6 +261,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     onSldEditReset,
     sldEditBusy,
     sldEditCombinedWithActionId,
+    sldPreviewSvg,
+    sldPreviewMetadata,
+    sldPreviewStale,
+    sldPreviewLoading,
     voltageLevels,
     onVlOpen,
     onOverflowPinPreview,
@@ -1366,6 +1374,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         onResetEdit={onSldEditReset}
                         editSimulationBusy={sldEditBusy}
                         editCombinedWithActionId={sldEditCombinedWithActionId}
+                        previewSvg={sldPreviewSvg}
+                        previewMetadata={sldPreviewMetadata}
+                        previewStale={sldPreviewStale}
+                        previewLoading={sldPreviewLoading}
                     />
                 )}
 

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -111,6 +111,10 @@ interface VisualizationPanelProps {
     sldPreviewMetadata?: string | null;
     sldPreviewStale?: boolean;
     sldPreviewLoading?: boolean;
+    sldFocusedSwitchId?: string | null;
+    onSldSwitchFocus?: (equipmentId: string | null) => void;
+    onSldSwitchRemove?: (equipmentId: string) => void;
+    onSldSwitchRemoveMany?: (equipmentIds: string[]) => void;
     voltageLevels: string[];
     onVlOpen: (vlName: string) => void;
     /**
@@ -265,6 +269,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     sldPreviewMetadata,
     sldPreviewStale,
     sldPreviewLoading,
+    sldFocusedSwitchId,
+    onSldSwitchFocus,
+    onSldSwitchRemove,
+    onSldSwitchRemoveMany,
     voltageLevels,
     onVlOpen,
     onOverflowPinPreview,
@@ -1378,6 +1386,10 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         previewMetadata={sldPreviewMetadata}
                         previewStale={sldPreviewStale}
                         previewLoading={sldPreviewLoading}
+                        focusedSwitchId={sldFocusedSwitchId}
+                        onSwitchFocus={onSldSwitchFocus}
+                        onSwitchRemove={onSldSwitchRemove}
+                        onSwitchRemoveMany={onSldSwitchRemoveMany}
                     />
                 )}
 

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -93,6 +93,20 @@ interface VisualizationPanelProps {
     vlOverlay: VlOverlay | null;
     onOverlayClose: () => void;
     onOverlaySldTabChange: (tab: SldTab) => void;
+    /**
+     * Interactive SLD topology-edit wiring. Optional — when absent the
+     * SLD overlay renders without the Edit affordance (legacy
+     * behaviour). See ``useSldTopologyEdit`` in ``App.tsx``.
+     */
+    sldEditMode?: boolean;
+    onSldEditModeChange?: (next: boolean) => void;
+    sldEditPendingSwitches?: Record<string, boolean>;
+    sldEditPendingChanges?: import('../hooks/useSldTopologyEdit').SwitchToggleEntry[];
+    onSldSwitchClick?: (equipmentId: string) => void;
+    onSldEditSimulate?: () => void;
+    onSldEditReset?: () => void;
+    sldEditBusy?: boolean;
+    sldEditCombinedWithActionId?: string | null;
     voltageLevels: string[];
     onVlOpen: (vlName: string) => void;
     /**
@@ -234,6 +248,15 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
     vlOverlay,
     onOverlayClose,
     onOverlaySldTabChange,
+    sldEditMode,
+    onSldEditModeChange,
+    sldEditPendingSwitches,
+    sldEditPendingChanges,
+    onSldSwitchClick,
+    onSldEditSimulate,
+    onSldEditReset,
+    sldEditBusy,
+    sldEditCombinedWithActionId,
     voltageLevels,
     onVlOpen,
     onOverflowPinPreview,
@@ -1334,6 +1357,15 @@ const VisualizationPanel: React.FC<VisualizationPanelProps> = ({
                         selectedContingency={selectedContingency}
                         result={result}
                         monitoringFactor={monitoringFactor}
+                        editMode={sldEditMode}
+                        onEditModeChange={onSldEditModeChange}
+                        pendingSwitches={sldEditPendingSwitches}
+                        pendingChanges={sldEditPendingChanges}
+                        onSwitchClick={onSldSwitchClick}
+                        onSimulateEdit={onSldEditSimulate}
+                        onResetEdit={onSldEditReset}
+                        editSimulationBusy={sldEditBusy}
+                        editCombinedWithActionId={sldEditCombinedWithActionId}
                     />
                 )}
 

--- a/frontend/src/hooks/useSldOverlay.ts
+++ b/frontend/src/hooks/useSldOverlay.ts
@@ -62,11 +62,13 @@ export function useSldOverlay(activeTab: TabId, liveSelectedActionId?: string | 
             let reactiveFlowDeltas: Record<string, FlowDelta> | undefined;
             let assetDeltas: Record<string, AssetDelta> | undefined;
             let changedSwitches: Record<string, { from_open: boolean; to_open: boolean }> | undefined;
+            let switchStates: Record<string, boolean> | undefined;
 
             if (sldTab === 'n') {
                 const res = await api.getNSld(vlName);
                 svgData = res.svg;
                 metaData = res.sld_metadata ?? null;
+                switchStates = res.switch_states;
             } else if (sldTab === 'contingency') {
                 const res = await api.getContingencySld(contingencyElements, vlName);
                 svgData = res.svg;
@@ -74,6 +76,7 @@ export function useSldOverlay(activeTab: TabId, liveSelectedActionId?: string | 
                 flowDeltas = res.flow_deltas;
                 reactiveFlowDeltas = res.reactive_flow_deltas;
                 assetDeltas = res.asset_deltas;
+                switchStates = res.switch_states;
             } else {
                 // Fallback to the live selectedActionId if the
                 // overlay was opened from a tab where no action
@@ -99,6 +102,7 @@ export function useSldOverlay(activeTab: TabId, liveSelectedActionId?: string | 
                 reactiveFlowDeltas = res.reactive_flow_deltas;
                 assetDeltas = res.asset_deltas;
                 changedSwitches = res.changed_switches;
+                switchStates = res.switch_states;
                 // Persist the resolved actionId back onto the
                 // overlay so subsequent re-renders and highlight
                 // passes can find it on `vlOverlay.actionId`.
@@ -114,6 +118,7 @@ export function useSldOverlay(activeTab: TabId, liveSelectedActionId?: string | 
                         ...prev, svg: svgData, sldMetadata: metaData, loading: false,
                         flow_deltas: flowDeltas, reactive_flow_deltas: reactiveFlowDeltas, asset_deltas: assetDeltas,
                         changed_switches: changedSwitches,
+                        switch_states: switchStates,
                     }
                     : prev
             );

--- a/frontend/src/hooks/useSldTopologyEdit.test.ts
+++ b/frontend/src/hooks/useSldTopologyEdit.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSldTopologyEdit } from './useSldTopologyEdit';
+import { interactionLogger } from '../utils/interactionLogger';
+
+const baseline = (): Record<string, boolean> => ({
+    SW_A: false,
+    SW_B: true,
+    SW_C: false,
+});
+
+describe('useSldTopologyEdit', () => {
+    beforeEach(() => { interactionLogger.clear(); });
+
+    it('ignores toggles while edit mode is off', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        expect(result.current.changedSwitches).toEqual({});
+        expect(result.current.pendingChanges).toHaveLength(0);
+    });
+
+    it('records a switch toggle relative to baseline', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        expect(result.current.changedSwitches).toEqual({ SW_A: true });
+        expect(result.current.pendingChanges).toEqual([
+            { switchId: 'SW_A', baselineOpen: false, targetOpen: true },
+        ]);
+    });
+
+    it('removes the override when toggled back to baseline', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        expect(result.current.changedSwitches).toEqual({});
+    });
+
+    it('rejects taps on switches not in the baseline', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('UNKNOWN_SW'); });
+        expect(result.current.changedSwitches).toEqual({});
+    });
+
+    it('reset() clears all pending toggles and logs', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        act(() => { result.current.toggleSwitch('SW_B'); });
+        expect(result.current.changedSwitches).toEqual({ SW_A: true, SW_B: false });
+        act(() => { result.current.reset(); });
+        expect(result.current.changedSwitches).toEqual({});
+        const types = interactionLogger.getLog().map(e => e.type);
+        expect(types).toContain('sld_edit_reset');
+    });
+
+    it('switching edit mode off drops pending toggles', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        act(() => { result.current.setEditMode(false); });
+        expect(result.current.changedSwitches).toEqual({});
+    });
+
+    it('drops pending toggles when baseline identity changes', () => {
+        let baselineRef = baseline();
+        const { result, rerender } = renderHook(
+            (props: { b: Record<string, boolean> | undefined }) => useSldTopologyEdit(props.b),
+            { initialProps: { b: baselineRef } },
+        );
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        expect(result.current.changedSwitches).toEqual({ SW_A: true });
+
+        baselineRef = baseline();
+        rerender({ b: baselineRef });
+        expect(result.current.changedSwitches).toEqual({});
+    });
+
+    it('logs sld_switch_toggled on each successful toggle', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        const toggles = interactionLogger.getLog().filter(e => e.type === 'sld_switch_toggled');
+        expect(toggles).toHaveLength(1);
+        expect(toggles[0].details).toEqual({ equipment_id: 'SW_A' });
+    });
+});

--- a/frontend/src/hooks/useSldTopologyEdit.test.ts
+++ b/frontend/src/hooks/useSldTopologyEdit.test.ts
@@ -87,6 +87,35 @@ describe('useSldTopologyEdit', () => {
         expect(result.current.changedSwitches).toEqual({});
     });
 
+    it('removeSwitch drops a single staged change', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        act(() => { result.current.toggleSwitch('SW_B'); });
+        act(() => { result.current.removeSwitch('SW_A'); });
+        expect(result.current.changedSwitches).toEqual({ SW_B: false });
+    });
+
+    it('removeSwitches drops a block of staged changes', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        act(() => { result.current.toggleSwitch('SW_B'); });
+        act(() => { result.current.toggleSwitch('SW_C'); });
+        act(() => { result.current.removeSwitches(['SW_A', 'SW_C']); });
+        expect(result.current.changedSwitches).toEqual({ SW_B: false });
+    });
+
+    it('focus state tracks setFocusedSwitch and clears on removal', () => {
+        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        act(() => { result.current.setFocusedSwitch('SW_A'); });
+        expect(result.current.focusedSwitchId).toBe('SW_A');
+        act(() => { result.current.removeSwitch('SW_A'); });
+        expect(result.current.focusedSwitchId).toBeNull();
+    });
+
     it('logs sld_switch_toggled on each successful toggle', () => {
         const { result } = renderHook(() => useSldTopologyEdit(baseline()));
         act(() => { result.current.setEditMode(true); });

--- a/frontend/src/hooks/useSldTopologyEdit.test.ts
+++ b/frontend/src/hooks/useSldTopologyEdit.test.ts
@@ -17,18 +17,30 @@ const baseline = (): Record<string, boolean> => ({
     SW_C: false,
 });
 
+// IMPORTANT: each test passes a STABLE baseline reference. The hook
+// resets pendingStates whenever the baseline identity changes, so
+// recreating the object on every render (`() =>
+// useSldTopologyEdit(baseline())`) would call setState({}) inside
+// the effect on every render — an infinite loop that OOM'd CI before
+// the bail-out guard was added in the hook (see the comment on the
+// guarded useEffect). Keeping it stable here is the production
+// pattern: ``vlOverlay.switch_states`` only changes when a new SLD
+// payload arrives.
+
 describe('useSldTopologyEdit', () => {
     beforeEach(() => { interactionLogger.clear(); });
 
     it('ignores toggles while edit mode is off', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.toggleSwitch('SW_A'); });
         expect(result.current.changedSwitches).toEqual({});
         expect(result.current.pendingChanges).toHaveLength(0);
     });
 
     it('records a switch toggle relative to baseline', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         expect(result.current.changedSwitches).toEqual({ SW_A: true });
@@ -38,7 +50,8 @@ describe('useSldTopologyEdit', () => {
     });
 
     it('removes the override when toggled back to baseline', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         act(() => { result.current.toggleSwitch('SW_A'); });
@@ -46,14 +59,16 @@ describe('useSldTopologyEdit', () => {
     });
 
     it('rejects taps on switches not in the baseline', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('UNKNOWN_SW'); });
         expect(result.current.changedSwitches).toEqual({});
     });
 
     it('reset() clears all pending toggles and logs', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         act(() => { result.current.toggleSwitch('SW_B'); });
@@ -65,7 +80,8 @@ describe('useSldTopologyEdit', () => {
     });
 
     it('switching edit mode off drops pending toggles', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         act(() => { result.current.setEditMode(false); });
@@ -88,7 +104,8 @@ describe('useSldTopologyEdit', () => {
     });
 
     it('removeSwitch drops a single staged change', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         act(() => { result.current.toggleSwitch('SW_B'); });
@@ -97,7 +114,8 @@ describe('useSldTopologyEdit', () => {
     });
 
     it('removeSwitches drops a block of staged changes', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         act(() => { result.current.toggleSwitch('SW_B'); });
@@ -107,7 +125,8 @@ describe('useSldTopologyEdit', () => {
     });
 
     it('focus state tracks setFocusedSwitch and clears on removal', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         act(() => { result.current.setFocusedSwitch('SW_A'); });
@@ -117,11 +136,57 @@ describe('useSldTopologyEdit', () => {
     });
 
     it('logs sld_switch_toggled on each successful toggle', () => {
-        const { result } = renderHook(() => useSldTopologyEdit(baseline()));
+        const b = baseline();
+        const { result } = renderHook(() => useSldTopologyEdit(b));
         act(() => { result.current.setEditMode(true); });
         act(() => { result.current.toggleSwitch('SW_A'); });
         const toggles = interactionLogger.getLog().filter(e => e.type === 'sld_switch_toggled');
         expect(toggles).toHaveLength(1);
         expect(toggles[0].details).toEqual({ equipment_id: 'SW_A' });
+    });
+
+    // Regression: the baseline-change effect used to call
+    // ``setPendingStates({})`` unconditionally. When the parent passed
+    // a fresh object literal on every render (which renderHook does
+    // when the props callback re-creates it), React saw a new state
+    // value on every render → re-render → effect → setState → loop →
+    // OOM at ~4 GB. The hook now bails out via prev-equality and the
+    // test below would have failed-fast (timeout) on the old code.
+    it('does not infinite-loop when the baseline is recreated each render', () => {
+        const { result } = renderHook(
+            (props: { tick: number }) =>
+                // Same shape every render but a brand-new object → identity
+                // changes whenever ``tick`` does. The hook must not relay
+                // the change into an unconditional setState.
+                useSldTopologyEdit({ SW_A: false, _tick: props.tick > 0 } as unknown as Record<string, boolean>),
+            { initialProps: { tick: 0 } },
+        );
+        for (let i = 0; i < 50; i++) {
+            // Use renderHook's rerender via re-running act — each pass
+            // forces a fresh baseline literal. Without the bail-out
+            // this loop wedges.
+            act(() => { result.current.setEditMode(i % 2 === 0); });
+        }
+        expect(result.current.changedSwitches).toEqual({});
+    });
+
+    it('a no-op baseline change does not destroy a focus or staged toggle on the SAME identity', () => {
+        // Defensive: as long as the baseline reference is stable
+        // across renders that come from OTHER state changes, the
+        // hook must NOT drop overrides. This proves the effect's
+        // dep array is just the baseline (not e.g. pendingStates).
+        const b = baseline();
+        const { result, rerender } = renderHook(
+            (props: { b: Record<string, boolean> }) => useSldTopologyEdit(props.b),
+            { initialProps: { b } },
+        );
+        act(() => { result.current.setEditMode(true); });
+        act(() => { result.current.toggleSwitch('SW_A'); });
+        act(() => { result.current.setFocusedSwitch('SW_A'); });
+        // Force a re-render with the SAME baseline object.
+        rerender({ b });
+        rerender({ b });
+        expect(result.current.changedSwitches).toEqual({ SW_A: true });
+        expect(result.current.focusedSwitchId).toBe('SW_A');
     });
 });

--- a/frontend/src/hooks/useSldTopologyEdit.ts
+++ b/frontend/src/hooks/useSldTopologyEdit.ts
@@ -40,9 +40,26 @@ export interface SldTopologyEditState {
      */
     toggleSwitch: (equipmentId: string) => void;
     /**
+     * Remove a single staged change (the maneuver-list × button) —
+     * reverts the switch to its baseline state.
+     */
+    removeSwitch: (equipmentId: string) => void;
+    /**
+     * Remove several staged changes at once (the maneuver-list
+     * "Remove selected" block action). Mirrors ExpertOp's
+     * ``seq_delete_many``.
+     */
+    removeSwitches: (equipmentIds: string[]) => void;
+    /**
      * Drop all pending toggles. Logged as ``sld_edit_reset``.
      */
     reset: () => void;
+    /**
+     * When set, the SLD highlights ONLY this switch (the maneuver-list
+     * focus gesture). Null = highlight every staged change.
+     */
+    focusedSwitchId: string | null;
+    setFocusedSwitch: (equipmentId: string | null) => void;
     /**
      * Subset of ``pendingStates`` that differ from the baseline. This
      * is what the backend receives as ``action_content.switches``.
@@ -71,6 +88,7 @@ export function useSldTopologyEdit(
 ): SldTopologyEditState {
     const [editMode, setEditModeState] = useState(false);
     const [pendingStates, setPendingStates] = useState<Record<string, boolean>>({});
+    const [focusedSwitchId, setFocusedSwitchId] = useState<string | null>(null);
 
     // Stable identity probe for the baseline — used to drop stale
     // overrides when the operator switches VL or SLD tab. We don't
@@ -79,7 +97,7 @@ export function useSldTopologyEdit(
     // Same pattern as useDiagramHighlights's reattach-prune effect —
     // a guarded reset that must run on baseline change.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    useEffect(() => { setPendingStates({}); }, [baselineSwitchStates]);
+    useEffect(() => { setPendingStates({}); setFocusedSwitchId(null); }, [baselineSwitchStates]);
 
     const setEditMode = useCallback((next: boolean) => {
         setEditModeState(prev => {
@@ -89,6 +107,7 @@ export function useSldTopologyEdit(
         });
         if (!next) {
             setPendingStates({});
+            setFocusedSwitchId(null);
         }
     }, []);
 
@@ -111,7 +130,39 @@ export function useSldTopologyEdit(
         interactionLogger.record('sld_switch_toggled', { equipment_id: equipmentId });
     }, [editMode, baselineSwitchStates]);
 
+    const removeSwitch = useCallback((equipmentId: string) => {
+        setPendingStates(prev => {
+            if (!(equipmentId in prev)) return prev;
+            const next = { ...prev };
+            delete next[equipmentId];
+            return next;
+        });
+        setFocusedSwitchId(prev => (prev === equipmentId ? null : prev));
+        interactionLogger.record('sld_maneuver_removed', { equipment_ids: [equipmentId] });
+    }, []);
+
+    const removeSwitches = useCallback((equipmentIds: string[]) => {
+        if (equipmentIds.length === 0) return;
+        const drop = new Set(equipmentIds);
+        setPendingStates(prev => {
+            const next: Record<string, boolean> = {};
+            let changed = false;
+            for (const [k, v] of Object.entries(prev)) {
+                if (drop.has(k)) { changed = true; continue; }
+                next[k] = v;
+            }
+            return changed ? next : prev;
+        });
+        setFocusedSwitchId(prev => (prev && drop.has(prev) ? null : prev));
+        interactionLogger.record('sld_maneuver_removed', { equipment_ids: equipmentIds });
+    }, []);
+
+    const setFocusedSwitch = useCallback((equipmentId: string | null) => {
+        setFocusedSwitchId(equipmentId);
+    }, []);
+
     const reset = useCallback(() => {
+        setFocusedSwitchId(null);
         setPendingStates(prev => {
             if (Object.keys(prev).length === 0) return prev;
             interactionLogger.record('sld_edit_reset');
@@ -144,7 +195,11 @@ export function useSldTopologyEdit(
         setEditMode,
         pendingStates,
         toggleSwitch,
+        removeSwitch,
+        removeSwitches,
         reset,
+        focusedSwitchId,
+        setFocusedSwitch,
         changedSwitches,
         pendingChanges,
     };

--- a/frontend/src/hooks/useSldTopologyEdit.ts
+++ b/frontend/src/hooks/useSldTopologyEdit.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { interactionLogger } from '../utils/interactionLogger';
+
+export interface SwitchToggleEntry {
+    switchId: string;
+    baselineOpen: boolean;
+    targetOpen: boolean;
+}
+
+export interface SldTopologyEditState {
+    /**
+     * Edit mode is opt-in: when off, the SLD acts as a read-only
+     * visualisation (existing behaviour). Toggling it on enables click
+     * handlers on switch DOM elements.
+     */
+    editMode: boolean;
+    setEditMode: (next: boolean) => void;
+    /**
+     * Absolute target states keyed by ``equipmentId``: every entry
+     * overrides the displayed baseline. Only switches whose
+     * ``equipmentId`` is present in the SLD baseline are accepted —
+     * see ``toggleSwitch``.
+     */
+    pendingStates: Record<string, boolean>;
+    /**
+     * Toggle a switch: if no override exists, flip the baseline value;
+     * if an override exists, flip it again. When the resulting target
+     * equals the baseline the override is removed (so it doesn't show
+     * up in ``changedSwitches``).
+     *
+     * Silently ignored when ``editMode`` is off or the id is missing
+     * from the baseline — the SLD overlay click handler relies on this
+     * to filter taps on non-editable elements.
+     */
+    toggleSwitch: (equipmentId: string) => void;
+    /**
+     * Drop all pending toggles. Logged as ``sld_edit_reset``.
+     */
+    reset: () => void;
+    /**
+     * Subset of ``pendingStates`` that differ from the baseline. This
+     * is what the backend receives as ``action_content.switches``.
+     */
+    changedSwitches: Record<string, boolean>;
+    /**
+     * Per-switch diff descriptors for the side-panel UI. Stable order
+     * (insertion order of `pendingStates` keys) so re-renders don't
+     * shuffle the list.
+     */
+    pendingChanges: SwitchToggleEntry[];
+}
+
+/**
+ * Owns the pending switch overrides for the interactive SLD-edit
+ * gesture. The baseline is the ``switch_states`` map the backend
+ * stamped on the current SLD response (N-1 or post-action variant).
+ *
+ * The hook auto-resets pending overrides whenever the baseline
+ * identity changes (new VL opened, tab switched, action variant
+ * changed) — keeping stale toggles around would silently apply them
+ * to a different network state.
+ */
+export function useSldTopologyEdit(
+    baselineSwitchStates: Record<string, boolean> | undefined,
+): SldTopologyEditState {
+    const [editMode, setEditModeState] = useState(false);
+    const [pendingStates, setPendingStates] = useState<Record<string, boolean>>({});
+
+    // Stable identity probe for the baseline — used to drop stale
+    // overrides when the operator switches VL or SLD tab. We don't
+    // hash deeply: the backend re-issues the entire map every fetch,
+    // so the JS object identity already changes on every update.
+    // Same pattern as useDiagramHighlights's reattach-prune effect —
+    // a guarded reset that must run on baseline change.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    useEffect(() => { setPendingStates({}); }, [baselineSwitchStates]);
+
+    const setEditMode = useCallback((next: boolean) => {
+        setEditModeState(prev => {
+            if (prev === next) return prev;
+            interactionLogger.record('sld_edit_mode_toggled', { enabled: next });
+            return next;
+        });
+        if (!next) {
+            setPendingStates({});
+        }
+    }, []);
+
+    const toggleSwitch = useCallback((equipmentId: string) => {
+        if (!editMode) return;
+        const baseline = baselineSwitchStates;
+        if (!baseline || !(equipmentId in baseline)) return;
+        const baselineOpen = baseline[equipmentId];
+        setPendingStates(prev => {
+            const next = { ...prev };
+            const current = equipmentId in next ? next[equipmentId] : baselineOpen;
+            const flipped = !current;
+            if (flipped === baselineOpen) {
+                delete next[equipmentId];
+            } else {
+                next[equipmentId] = flipped;
+            }
+            return next;
+        });
+        interactionLogger.record('sld_switch_toggled', { equipment_id: equipmentId });
+    }, [editMode, baselineSwitchStates]);
+
+    const reset = useCallback(() => {
+        setPendingStates(prev => {
+            if (Object.keys(prev).length === 0) return prev;
+            interactionLogger.record('sld_edit_reset');
+            return {};
+        });
+    }, []);
+
+    const changedSwitches = useMemo(() => {
+        if (!baselineSwitchStates) return {};
+        const diff: Record<string, boolean> = {};
+        for (const [sid, target] of Object.entries(pendingStates)) {
+            if (baselineSwitchStates[sid] !== target) {
+                diff[sid] = target;
+            }
+        }
+        return diff;
+    }, [pendingStates, baselineSwitchStates]);
+
+    const pendingChanges = useMemo<SwitchToggleEntry[]>(() => {
+        if (!baselineSwitchStates) return [];
+        return Object.entries(changedSwitches).map(([switchId, targetOpen]) => ({
+            switchId,
+            baselineOpen: baselineSwitchStates[switchId],
+            targetOpen,
+        }));
+    }, [changedSwitches, baselineSwitchStates]);
+
+    return {
+        editMode,
+        setEditMode,
+        pendingStates,
+        toggleSwitch,
+        reset,
+        changedSwitches,
+        pendingChanges,
+    };
+}

--- a/frontend/src/hooks/useSldTopologyEdit.ts
+++ b/frontend/src/hooks/useSldTopologyEdit.ts
@@ -96,8 +96,20 @@ export function useSldTopologyEdit(
     // so the JS object identity already changes on every update.
     // Same pattern as useDiagramHighlights's reattach-prune effect —
     // a guarded reset that must run on baseline change.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    useEffect(() => { setPendingStates({}); setFocusedSwitchId(null); }, [baselineSwitchStates]);
+    //
+    // CRITICAL: the setter callbacks no-op when there's nothing to
+    // clear. Without the bail-out, a caller passing a fresh object
+    // literal on every render (which Re-renderHook does naturally in
+    // tests, and any non-memoised parent could do in production)
+    // would trigger an infinite render loop:
+    //   render → effect → setState({}) → render → effect → setState({}) …
+    // The bail-out keeps React's reconciliation short-circuit working
+    // (Object.is on the previous and next state → no re-render).
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setPendingStates(prev => (Object.keys(prev).length === 0 ? prev : {}));
+        setFocusedSwitchId(prev => (prev === null ? prev : null));
+    }, [baselineSwitchStates]);
 
     const setEditMode = useCallback((next: boolean) => {
         setEditModeState(prev => {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -134,6 +134,14 @@ remaining hex-literal count after each migration.
   --signal-delta-negative: #2196f3;
   --signal-delta-neutral: #999999;
 
+  /* ----- SLD interactive topology-edit highlight -----
+     The interactive SLD-edit feature (useSldTopologyEdit + SldEditPanel)
+     stages switch toggles in the frontend and visually marks the
+     pending breaker. Distinct hues from action / contingency / overload
+     so a toggled switch on an overloaded line still reads as both. */
+  --signal-edit-open: #d81b60;
+  --signal-edit-closed: #1976d2;
+
   /* ----- Action-overview pin palette -----
      Severity buckets for Remedial Action overview pins
      (utils/svg/actionPin{Data,Render}.ts + ActionOverviewDiagram.tsx).

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -561,6 +561,8 @@ export type InteractionType =
     | 'sld_overlay_closed'
     | 'sld_edit_mode_toggled'
     | 'sld_switch_toggled'
+    | 'sld_maneuver_removed'
+    | 'sld_maneuver_focused'
     | 'sld_edit_reset'
     | 'sld_topology_simulated'
     | 'overview_shown'

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -354,6 +354,15 @@ export interface VlOverlay {
     reactive_flow_deltas?: Record<string, FlowDelta>;
     asset_deltas?: Record<string, AssetDelta>;
     changed_switches?: Record<string, { from_open: boolean; to_open: boolean }>;
+    /**
+     * Baseline switch states for the displayed VL (``{switch_id:
+     * is_open}``). Drives the interactive SLD-edit feature in
+     * ``useSldTopologyEdit``: only switches present in this map are
+     * editable, and a toggle is computed as ``user_state !== baseline``.
+     * Backend populates this on every SLD endpoint via
+     * ``extract_vl_switch_states``.
+     */
+    switch_states?: Record<string, boolean>;
 }
 
 // ===== Session Save =====
@@ -550,6 +559,10 @@ export type InteractionType =
     | 'sld_overlay_opened'
     | 'sld_overlay_tab_changed'
     | 'sld_overlay_closed'
+    | 'sld_edit_mode_toggled'
+    | 'sld_switch_toggled'
+    | 'sld_edit_reset'
+    | 'sld_topology_simulated'
     | 'overview_shown'
     | 'overview_hidden'
     | 'overview_pin_clicked'

--- a/frontend/src/utils/actionTypes.test.ts
+++ b/frontend/src/utils/actionTypes.test.ts
@@ -212,6 +212,18 @@ describe('matchesActionTypeFilter', () => {
         expect(matchesActionTypeFilter('open', id, combinedManeuver, null)).toBe(true);
         expect(matchesActionTypeFilter('close', id, combinedManeuver, null)).toBe(true);
     });
+
+    // A single maneuver can open a coupling AND a line (comma-joined),
+    // so it must pass BOTH the open-coupling and line-disconnection
+    // filters.
+    const couplingPlusLineOpen = 'Manoeuvre manuelle sur COUCHP6: COUCHP6_COUCH6COUPL DJ_OC ouvert, COUCHP6_COUCH6CPVAN.1 DJ_OC ouvert';
+
+    it('matches a maneuver that opens both a coupling and a line on open AND disco', () => {
+        const id = 'user_topo_COUCHP6_1';
+        expect(matchesActionTypeFilter('open', id, couplingPlusLineOpen, null)).toBe(true);
+        expect(matchesActionTypeFilter('disco', id, couplingPlusLineOpen, null)).toBe(true);
+        expect(matchesActionTypeFilter('close', id, couplingPlusLineOpen, null)).toBe(false);
+    });
 });
 
 describe('classifyActionTypes (multi-bucket)', () => {

--- a/frontend/src/utils/actionTypes.test.ts
+++ b/frontend/src/utils/actionTypes.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import {
     classifyActionType,
+    classifyActionTypes,
     matchesActionTypeFilter,
     ACTION_TYPE_FILTER_TOKENS,
     ACTION_TYPE_LABELS,
@@ -188,6 +189,52 @@ describe('matchesActionTypeFilter', () => {
 
     it('specific filter does NOT match unknown bucket actions', () => {
         expect(matchesActionTypeFilter('disco', 'mystery', 'floats', null)).toBe(false);
+    });
+
+    // Manual SLD-edit maneuver cards use the past participles
+    // "ouvert"/"fermé" and may combine several switches.
+    const openManeuver = 'Manoeuvre manuelle sur COUCHP6: COUCHP6_COUCH6COUPL DJ_OC ouvert';
+    const closeManeuver = 'Manoeuvre manuelle sur PYMONP3: PYMONP3_PYMON3COUPL DJ_OC fermé';
+    const combinedManeuver = `[COMBINED] ${openManeuver} + ${closeManeuver}`;
+
+    it('matches an open-coupling maneuver on the open filter', () => {
+        expect(matchesActionTypeFilter('open', 'user_topo_COUCHP6_1', openManeuver, null)).toBe(true);
+        expect(matchesActionTypeFilter('close', 'user_topo_COUCHP6_1', openManeuver, null)).toBe(false);
+    });
+
+    it('matches a close-coupling maneuver on the close filter', () => {
+        expect(matchesActionTypeFilter('close', 'user_topo_PYMONP3_1', closeManeuver, null)).toBe(true);
+        expect(matchesActionTypeFilter('open', 'user_topo_PYMONP3_1', closeManeuver, null)).toBe(false);
+    });
+
+    it('matches a combined open+close maneuver on BOTH filters', () => {
+        const id = 'user_topo_COUCHP6_1+user_topo_PYMONP3_2';
+        expect(matchesActionTypeFilter('open', id, combinedManeuver, null)).toBe(true);
+        expect(matchesActionTypeFilter('close', id, combinedManeuver, null)).toBe(true);
+    });
+});
+
+describe('classifyActionTypes (multi-bucket)', () => {
+    it('returns a singleton for a normal recommender action', () => {
+        expect([...classifyActionTypes('disco_LINE_A', null, 'line_disconnection')]).toEqual(['disco']);
+    });
+
+    it('returns both open and close for a combined maneuver', () => {
+        const id = 'user_topo_A_1+user_topo_B_2';
+        const desc = '[COMBINED] Manoeuvre manuelle sur A: A_COUPL DJ_OC ouvert + Manoeuvre manuelle sur B: B_COUPL DJ_OC fermé';
+        const set = classifyActionTypes(id, desc, null);
+        expect(set.has('open')).toBe(true);
+        expect(set.has('close')).toBe(true);
+    });
+
+    it('buckets a non-coupling maneuver switch as disco/reco', () => {
+        const set = classifyActionTypes(
+            'user_topo_VL_1',
+            'Manoeuvre manuelle sur VL: VL_SOMELINE DJ ouvert',
+            null,
+        );
+        expect(set.has('disco')).toBe(true);
+        expect(set.has('open')).toBe(false);
     });
 });
 

--- a/frontend/src/utils/actionTypes.test.ts
+++ b/frontend/src/utils/actionTypes.test.ts
@@ -423,3 +423,99 @@ describe('rowPassesActionFilters', () => {
         }, 0.95)).toBe(true);
     });
 });
+
+// ---------------------------------------------------------------------
+// Regression — manual SLD-edit maneuver cards
+// ---------------------------------------------------------------------
+//
+// Each case traces back to a real bug surfaced during the SLD-edit
+// review:
+//
+//   1. "ouvert"/"fermé" vs "ouverture"/"fermeture" (the past
+//      participle the SLD-edit description uses).
+//   2. A [COMBINED] card opens one coupling AND closes another → must
+//      pass BOTH filters.
+//   3. A single maneuver toggles SEVERAL switches separated by ", "
+//      (coupling + line opened together) → must pass coupling-open
+//      AND line-disconnection.
+//   4. Manual maneuvers on non-coupling switches (lines / equipment)
+//      still bucket as disco / reco.
+//   5. user_topo_* id alone is enough to enter the manual-maneuver
+//      parsing path even when description is missing.
+
+describe('regression — manual SLD-edit maneuver cards', () => {
+    it('past-participle "ouvert" on a coupling → open bucket', () => {
+        expect(matchesActionTypeFilter(
+            'open', 'user_topo_VL_1',
+            'Manoeuvre manuelle sur VL: VL_COUPL DJ_OC ouvert', null,
+        )).toBe(true);
+    });
+
+    it('past-participle "fermé" on a coupling → close bucket', () => {
+        expect(matchesActionTypeFilter(
+            'close', 'user_topo_VL_1',
+            'Manoeuvre manuelle sur VL: VL_COUPL DJ_OC fermé', null,
+        )).toBe(true);
+    });
+
+    it('combined open-coupling + close-coupling card passes both filters', () => {
+        const id = 'user_topo_A_1+user_topo_B_2';
+        const desc = '[COMBINED] Manoeuvre manuelle sur A: A_COUPL DJ_OC ouvert + Manoeuvre manuelle sur B: B_COUPL DJ_OC fermé';
+        expect(matchesActionTypeFilter('open', id, desc, null)).toBe(true);
+        expect(matchesActionTypeFilter('close', id, desc, null)).toBe(true);
+        expect(matchesActionTypeFilter('disco', id, desc, null)).toBe(false);
+        expect(matchesActionTypeFilter('reco', id, desc, null)).toBe(false);
+    });
+
+    it('comma-joined coupling+line open passes BOTH open and disco', () => {
+        const id = 'user_topo_COUCHP6_1';
+        const desc = 'Manoeuvre manuelle sur COUCHP6: COUCHP6_COUCH6COUPL DJ_OC ouvert, COUCHP6_COUCH6CPVAN.1 DJ_OC ouvert';
+        expect(matchesActionTypeFilter('open', id, desc, null)).toBe(true);
+        expect(matchesActionTypeFilter('disco', id, desc, null)).toBe(true);
+        expect(matchesActionTypeFilter('close', id, desc, null)).toBe(false);
+        expect(matchesActionTypeFilter('reco', id, desc, null)).toBe(false);
+    });
+
+    it('comma-joined line open + coupling close gives disco AND close', () => {
+        const id = 'user_topo_X_1';
+        const desc = 'Manoeuvre manuelle sur X: X_LINE.1 DJ_OC ouvert, X_COUPL DJ_OC fermé';
+        const set = classifyActionTypes(id, desc, null);
+        expect(set.has('disco')).toBe(true);
+        expect(set.has('close')).toBe(true);
+        expect(set.has('open')).toBe(false);
+        expect(set.has('reco')).toBe(false);
+    });
+
+    it('manual maneuver on a line (no "coupl" token) does NOT match coupling filters', () => {
+        const id = 'user_topo_VL_1';
+        const desc = 'Manoeuvre manuelle sur VL: VL_SOMELINE.1 DJ_OC ouvert';
+        expect(matchesActionTypeFilter('disco', id, desc, null)).toBe(true);
+        expect(matchesActionTypeFilter('open', id, desc, null)).toBe(false);
+    });
+
+    it('id with user_topo_ prefix + empty description still drops through cleanly', () => {
+        // No description signals → no bucket added by the multi-bucket
+        // parser. Caller should treat it as "unknown" / "all" passes.
+        const set = classifyActionTypes('user_topo_VL_1', '', null);
+        expect(set.size).toBe(0);
+        expect(matchesActionTypeFilter('all', 'user_topo_VL_1', '', null)).toBe(true);
+        expect(matchesActionTypeFilter('disco', 'user_topo_VL_1', '', null)).toBe(false);
+    });
+
+    it('also matches the alternative spelling "manœuvre" with the ligature', () => {
+        // The frontend description builder uses "manoeuvre" (no
+        // ligature), but the parser must not refuse the curly-é
+        // spelling either — both forms travel via session reload.
+        const id = 'user_topo_VL_1';
+        const desc = 'Manœuvre manuelle sur VL: VL_COUPL DJ_OC ouvert';
+        expect(matchesActionTypeFilter('open', id, desc, null)).toBe(true);
+    });
+
+    it('singular classifier still returns ONE bucket for normal cards', () => {
+        // The non-manual recommender cards keep the old fast-path; only
+        // the manual-maneuver branch widens the result.
+        expect(classifyActionType('disco_LINE_A', null, 'line_disconnection')).toBe('disco');
+        expect(classifyActionType('reco_LINE_B', null, 'line_reconnection')).toBe('reco');
+        expect(classifyActionType('open_coupling_VL_X', null, 'open_coupling')).toBe('open');
+    });
+});

--- a/frontend/src/utils/actionTypes.ts
+++ b/frontend/src/utils/actionTypes.ts
@@ -202,12 +202,17 @@ export const classifyActionTypes = (
         || desc.includes('manoeuvre manuelle')
         || desc.includes('manœuvre manuelle');
     if (looksManual) {
-        for (const segment of desc.split('+')) {
-            const isCoupling = segment.includes('coupl');
+        // A single maneuver can toggle SEVERAL switches, joined by ", "
+        // ("…COUPL… ouvert, …CPVAN.1… ouvert"), and combined actions
+        // join maneuvers with " + ". Classify PER SWITCH clause —
+        // splitting on both separators — so a coupling-open in the same
+        // maneuver as a line-open doesn't mask the line as a coupling.
+        for (const clause of desc.split(/[+,]/)) {
+            const isCoupling = clause.includes('coupl');
             // `ouvert` also matches `ouverture`; `ferm` matches both
             // `fermé`/`ferme` and `fermeture`.
-            const opens = /ouvert/.test(segment);
-            const closes = /ferm[eé]/.test(segment);
+            const opens = /ouvert/.test(clause);
+            const closes = /ferm[eé]/.test(clause);
             if (opens) set.add(isCoupling ? 'open' : 'disco');
             if (closes) set.add(isCoupling ? 'close' : 'reco');
         }

--- a/frontend/src/utils/actionTypes.ts
+++ b/frontend/src/utils/actionTypes.ts
@@ -173,9 +173,56 @@ export const classifyActionType = (
 };
 
 /**
+ * Multi-bucket classifier: returns the SET of action-type buckets an
+ * action belongs to. Most actions belong to exactly one (the singular
+ * `classifyActionType` result), but **manual maneuver** cards — and
+ * especially `[COMBINED]` ones — can belong to several at once:
+ *
+ *   "[COMBINED] Manoeuvre manuelle sur COUCHP6: …COUPL… ouvert
+ *    + Manoeuvre manuelle sur PYMONP3: …COUPL… fermé"
+ *
+ * opens one coupling AND closes another, so it must pass BOTH the
+ * `open` and `close` type filters. The singular classifier also misses
+ * these because the SLD-edit descriptions use the past participles
+ * `ouvert` / `fermé` (not the recommender's nouns `ouverture` /
+ * `fermeture`). We parse the maneuver text per `+`-segment here.
+ */
+export const classifyActionTypes = (
+    actionId: string,
+    description: string | null | undefined,
+    scoreType: string | null | undefined,
+): Set<ActionTypeKind> => {
+    const set = new Set<ActionTypeKind>();
+    const primary = classifyActionType(actionId, description, scoreType);
+    if (primary !== 'unknown') set.add(primary);
+
+    const aid = actionId.toLowerCase();
+    const desc = (description ?? '').toLowerCase();
+    const looksManual = aid.includes('user_topo')
+        || desc.includes('manoeuvre manuelle')
+        || desc.includes('manœuvre manuelle');
+    if (looksManual) {
+        for (const segment of desc.split('+')) {
+            const isCoupling = segment.includes('coupl');
+            // `ouvert` also matches `ouverture`; `ferm` matches both
+            // `fermé`/`ferme` and `fermeture`.
+            const opens = /ouvert/.test(segment);
+            const closes = /ferm[eé]/.test(segment);
+            if (opens) set.add(isCoupling ? 'open' : 'disco');
+            if (closes) set.add(isCoupling ? 'close' : 'reco');
+        }
+    }
+    return set;
+};
+
+/**
  * True iff the classified bucket for an action matches the active
  * filter token. `all` matches everything; `unknown` matches only
  * when the filter is `all` (no chip for the unknown bucket today).
+ *
+ * Routes through the multi-bucket `classifyActionTypes` so a combined
+ * manual maneuver that both opens and closes a coupling passes either
+ * the `open` or the `close` filter.
  */
 export const matchesActionTypeFilter = (
     filter: ActionTypeFilterToken,
@@ -184,7 +231,7 @@ export const matchesActionTypeFilter = (
     scoreType: string | null | undefined,
 ): boolean => {
     if (filter === 'all') return true;
-    return classifyActionType(actionId, description, scoreType) === filter;
+    return classifyActionTypes(actionId, description, scoreType).has(filter as ActionTypeKind);
 };
 
 // ---------------------------------------------------------------------

--- a/frontend/src/utils/specConformance.test.ts
+++ b/frontend/src/utils/specConformance.test.ts
@@ -132,6 +132,12 @@ const SPEC: Record<string, SpecRow> = {
   sld_overlay_opened:             { required: new Set(['vl_name', 'action_id']) },
   sld_overlay_tab_changed:        { required: new Set(['tab', 'vl_name']) },
   sld_overlay_closed:             { required: new Set() },
+  sld_edit_mode_toggled:          { required: new Set(['enabled']) },
+  sld_switch_toggled:             { required: new Set(['equipment_id']) },
+  sld_maneuver_removed:           { required: new Set(['equipment_ids']) },
+  sld_maneuver_focused:           { required: new Set(['equipment_id']) },
+  sld_edit_reset:                 { required: new Set() },
+  sld_topology_simulated:         { required: new Set(['voltage_level_id', 'switches']), optional: new Set(['combined_with']) },
   // --- Session Management ---
   session_saved:                  { required: new Set(['output_folder']) },
   session_reload_modal_opened:    { required: new Set() },

--- a/scripts/check_standalone_parity.py
+++ b/scripts/check_standalone_parity.py
@@ -215,6 +215,12 @@ SPEC_DETAILS: dict[str, dict] = {
     "sld_overlay_opened":       _spec_row({"vl_name", "action_id"}),
     "sld_overlay_tab_changed":  _spec_row({"tab", "vl_name"}),
     "sld_overlay_closed":       _spec_row(set()),
+    "sld_edit_mode_toggled":    _spec_row({"enabled"}),
+    "sld_switch_toggled":       _spec_row({"equipment_id"}),
+    "sld_maneuver_removed":     _spec_row({"equipment_ids"}),
+    "sld_maneuver_focused":     _spec_row({"equipment_id"}),
+    "sld_edit_reset":           _spec_row(set()),
+    "sld_topology_simulated":   _spec_row({"voltage_level_id", "switches"}, {"combined_with"}),
     # --- Session Management ---
     "session_saved":            _spec_row({"output_folder"}),
     "session_reload_modal_opened": _spec_row(set()),


### PR DESCRIPTION
## Summary

Adds an interactive topology-edit affordance to the SLD overlay, allowing operators to stage switch toggles on a voltage-level diagram, preview the target topology with topological colouring, and simulate the resulting manual action. Mirrors the `manoeuvre_ihm` gesture from `expert_op4grid_recommender` adapted to the React/FastAPI stack.

## Key Changes

### Backend (`expert_backend/`)

- **`services/diagram/sld_render.py`**: Added `extract_vl_switch_states()` to extract baseline switch states (`{switch_id: is_open}`) for a voltage level, filtering fictitious/retained switches and gracefully handling pypowsybl failures.

- **`services/simulation_helpers.py`**: 
  - Added `is_switch_only_content()` to detect pure switch-only action payloads.
  - Added `build_switch_action_description()` to auto-generate human-readable French descriptions (e.g., "SW_A ouvert, SW_B fermé") for user-built SLD-edit actions.

- **`services/simulation_mixin.py`**: 
  - Updated `simulate_manual_action()` to accept `voltage_level_id` parameter.
  - Wired `_inject_action_content_entries()` to stamp auto-built descriptions on switch-only actions.

- **`services/diagram_mixin.py`**: 
  - Updated `get_n_sld()`, `get_contingency_sld()`, and `get_action_variant_sld()` to include `switch_states` in responses.
  - Added `get_topology_preview_sld()` endpoint handler to clone a throwaway variant, apply switch overrides, and re-render with topological colouring (no load flow).

- **`main.py`**: Added `SldTopologyPreviewRequest` model and `/api/sld-topology-preview` POST endpoint.

- **`tests/test_sld_topology_edit.py`**: Comprehensive test suite covering switch-state extraction, description building, and end-to-end action injection.

### Frontend (`frontend/src/`)

- **`hooks/useSldTopologyEdit.ts`**: New hook managing pending switch overrides with auto-reset on baseline change. Exports `SwitchToggleEntry` interface and `SldTopologyEditState` contract.

- **`components/SldEditPanel.tsx`**: New side panel rendering the maneuver list (baseline → target state transitions), with row-level focus/remove gestures and bulk "Remove selected" action. Shows "combined with" badge when editing on a post-action SLD.

- **`components/SldOverlay.tsx`**: 
  - Added edit-mode toggle button next to SLD-tab strip.
  - Integrated `SldEditPanel` below the SVG body.
  - Added target-topology preview rendering: when `previewSvg` is set, it replaces the baseline with topological-colouring output and suppresses client-side delta/highlight repaints.
  - Added pending-switch outline pass using `sld-user-toggle-{open,closed}` classes.
  - Wired click handlers to `onSwitchClick` for toggle staging.

- **`components/VisualizationPanel.tsx`**: Threaded SLD-edit props through to `SldOverlay`.

- **`App.tsx`**: 
  - Integrated `useSldTopologyEdit()` hook.
  - Added debounced (280 ms) target-topology preview fetch with sequence guard.
  - Wired `handleSimulateSldEdit()` to send user-built action to backend with combined-action id when applicable.
  - Integrated preview state management and error handling.

- **`api.ts`**: 
  - Updated `getNSld()`, `getContingencySld()`, `getActionVariantSld()` response types to include `switch_states`.
  - Added `getSldTopologyPreview()` POST method.
  - Updated `simulateAndVariantDiagramStream()` to accept `voltage_level_id` in request.

- **`types.ts

https://claude.ai/code/session_017KW1ZWW621YzerEZYUppWg