### PR TITLE
Fix manual-action persistence across Step-2 re-runs and SLD highlights

### DIFF
--- a/docs/features/sld-topology-edit.md
+++ b/docs/features/sld-topology-edit.md
@@ -106,6 +106,64 @@ frontend ALSO adopts the canonical id (taken from `metrics.action_id`)
 when registering the card so subsequent fetches start from the same
 key.
 
+### Manual-action persistence (the "not found in last analysis result" class of bug)
+
+A manually-simulated action's card lives in the frontend feed, but the
+SLD / NAD action-variant endpoints resolve it server-side through
+`_require_action(action_id)`, which reads
+`_last_result["prioritized_actions"]`. Three independent gaps used to
+let that lookup 400 while the operator stared at a live card. All three
+are now closed:
+
+1. **Registration was gated on the absence of a pypowsybl warning.**
+   `simulation_mixin._register_action_result` only stored the action
+   when `not info_action.get("exception")`. pypowsybl raises a
+   *non-fatal* warning on a no-op switch toggle (e.g. closing a coupler
+   that is already closed — the `rho_before == rho_after` case), so the
+   action silently never entered `_last_result`. Registration now keys
+   off `obs_simu_action is not None` ALONE; the warning still travels to
+   the frontend via the `non_convergence` field.
+
+2. **An `Analyze & Suggest` re-run clobbered hand-simulated actions.**
+   `run_analysis_step2` replaces `_last_result` with a fresh discovery
+   result containing only the recommender's suggestions.
+   `analysis_mixin._merge_preserved_simulated_actions` now re-attaches,
+   after the suggested feed is built, every prior entry that (a) is not
+   already refreshed by the new suggestions and (b) carries a live
+   `observation`. Preserved actions stay resolvable for the diagram
+   endpoints WITHOUT re-entering the suggested-actions feed the frontend
+   already has.
+
+3. **Defensive fallback in `_require_action`.** Manual actions are
+   always merged into `_dict_action` (with their observation) regardless
+   of `_last_result` state. When an action is missing from
+   `_last_result["prioritized_actions"]` but present in `_dict_action`
+   with a live observation, `_require_action` now promotes it back into
+   the prioritized-actions dict instead of raising. The genuine
+   "No analysis result available. Run analysis first." branch is kept
+   for the truly-uninitialised case (no observation anywhere).
+
+### Action-tab switch highlight for interactive maneuvers
+
+The action-tab SLD highlights the breaker(s) the maneuver toggled. Two
+properties make this robust for `user_topo_*` actions, which — unlike
+suggested grid2op actions — carry no round-tripped `action_topology`:
+
+- **`SldOverlay` highlights the UNION of `changed_switches` (the
+  backend N-1-vs-action switch diff on the `/api/action-variant-sld`
+  response) and `action_topology.switches`.** Neither source alone is
+  complete: suggested actions often have an empty
+  `action_topology.switches` (the diff is the only signal), while
+  interactive maneuvers may produce an empty diff (no-op toggle) but
+  always know which switches the operator clicked. The highlight pass
+  is no longer gated behind `if (action_topology)` — that gate left the
+  interactive maneuver's coupler un-highlighted.
+- **`App.tsx::handleSimulateSldEdit` folds the operator's toggled switch
+  IDs into the card's `action_topology.switches`.** Those IDs come
+  straight from the SLD's `switch_states`, so they always resolve back
+  to an SVG cell via the `equipmentId → SVG id` map — guaranteeing the
+  highlight even when the backend diff is empty.
+
 ## Frontend contract
 
 | File | Role |
@@ -113,7 +171,8 @@ key.
 | `hooks/useSldTopologyEdit.ts` | Owns the pending overrides, focus state, and the toggle / removeSwitch / removeSwitches / reset / setFocusedSwitch API. Auto-drops stale overrides on baseline identity change. |
 | `components/SldEditPanel.tsx` | Side panel under the SLD body — maneuver list, focus on row click, `×` per row, checkbox + **Remove selected (N)** for blocks, combined-with badge, Reset / Simulate buttons. |
 | `components/SldOverlay.tsx` | Header `✎ Manual action` button, switch-click delegation via SLD metadata `equipmentId → SVG id` map (dot/underscore variants handled), toggle outlines + focused-switch filter — applied **also on the preview** so the highlight persists. |
-| `App.tsx::handleSimulateSldEdit` | Streams `/api/simulate-and-variant-diagram` with `action_content={switches}` + `voltage_level_id`, primes the action-variant diagram under the **backend-canonical** id (`metrics.action_id`), pushes the card via `wrappedManualActionAdded(_, _, _, 'user')`, then `handleVlDoubleClick(id, vl, 'action')` to auto-focus the new action's tab. |
+| `App.tsx::handleSimulateSldEdit` | Streams `/api/simulate-and-variant-diagram` with `action_content={switches}` + `voltage_level_id`, primes the action-variant diagram under the **backend-canonical** id (`metrics.action_id`), folds the toggled `switches` into the card's `action_topology.switches` (so the action-tab highlight is guaranteed), pushes the card via `wrappedManualActionAdded(_, _, _, 'user')`, then `handleVlDoubleClick(id, vl, 'action')` to auto-focus the new action's tab. |
+| `components/SldOverlay.tsx` (highlight pass) | Highlights the UNION of `vlOverlay.changed_switches` and `actionDetail.action_topology.switches`; not gated on `action_topology` presence. The highlight signature includes both switch-key sets so a re-fetch re-plants the clones. |
 | `App.tsx::sldPreview` | Debounced fetch of `/api/sld-topology-preview` with sequence guard. |
 | `styles/tokens.css` | `--signal-edit-open` / `--signal-edit-closed` token pair for the toggle outline. |
 | `App.css` | `.sld-user-toggle-{open,closed}` (dashed outline) + `.sld-preview-stale` (grey flow values). |
@@ -189,6 +248,23 @@ mirrored in the conformance contract
   — HTTP-boundary tests via FastAPI `TestClient` (skipped in sandboxes
   that mock `expert_op4grid_recommender.models`).
 
+Manual-action persistence (`expert_backend/tests/test_preserve_simulated_actions.py`):
+
+- `test_preserves_manual_action_not_in_new_results` /
+  `test_does_not_overwrite_refreshed_action` /
+  `test_skips_entries_without_observation` /
+  `test_noop_on_empty_prior` /
+  `test_creates_prioritized_actions_bucket_if_missing` —
+  `_merge_preserved_simulated_actions` survival of hand-simulated
+  actions across an `Analyze & Suggest` re-run.
+- `test_register_action_result_registers_even_with_info_exception` /
+  `test_register_action_result_skips_when_obs_is_none` — registration
+  no longer gated on the non-fatal `info_action.exception` flag.
+- `test_require_action_promotes_from_dict_action_when_missing` /
+  `test_require_action_still_raises_for_truly_unknown_action` —
+  `_dict_action → _last_result` promotion fallback + the preserved
+  "truly unknown" raise.
+
 ### Frontend
 
 - `hooks/useSldTopologyEdit.test.ts` — toggle / reset / remove single /
@@ -204,6 +280,12 @@ mirrored in the conformance contract
   bucket for normal cards.
 - `utils/specConformance.test.ts` — `SPEC` rows for the six
   `sld_*` interaction types.
+- `components/SldOverlay.test.tsx` — action-tab switch highlight:
+  `highlights a coupler switch via changed_switches when
+  action_topology is absent (interactive user_topo maneuver)` and
+  `highlights a toggled switch from action_topology.switches when the
+  backend diff is empty` cover the union-of-sources highlight for
+  interactive maneuvers.
 
 ## Limitation: which backend
 

--- a/expert_backend/services/analysis_mixin.py
+++ b/expert_backend/services/analysis_mixin.py
@@ -649,6 +649,10 @@ class AnalysisMixin:
                 action_prediction_time = total_disc_time
                 assessment_time = 0.0
 
+            # Capture manually-simulated actions BEFORE the fresh
+            # discovery result clobbers `_last_result` — see
+            # `_merge_preserved_simulated_actions`.
+            prior_actions = (self._last_result or {}).get("prioritized_actions") or {}
             self._last_result = results
 
             _t_enrich = time.time()
@@ -659,6 +663,12 @@ class AnalysisMixin:
             # Never leak combined-action ids into the main actions feed —
             # those are estimations that live in `combined_actions`.
             enriched_actions = {aid: data for aid, data in enriched_actions.items() if "+" not in aid}
+
+            # Re-attach hand-simulated actions so the diagram / SLD
+            # endpoints can still resolve them after the re-run. Done
+            # AFTER `enriched_actions` is built so preserved actions stay
+            # out of the freshly-suggested feed the frontend already has.
+            self._merge_preserved_simulated_actions(prior_actions)
 
             # Enrich each pre-computed pair with a `target_max_rho` /
             # `target_max_rho_line` scoped to the user-selected overloads
@@ -705,6 +715,37 @@ class AnalysisMixin:
         except Exception as e:
             logger.exception("Backend Error in Analysis Resolution")
             yield {"type": "error", "message": f"Backend Error in Analysis Resolution: {str(e)}"}
+
+    def _merge_preserved_simulated_actions(self, prior_actions: dict) -> None:
+        """Re-attach manually-simulated actions after a Step-2 re-run.
+
+        ``run_analysis_step2_discovery`` returns a fresh
+        ``prioritized_actions`` dict containing only the recommender's
+        suggestions, and ``self._last_result`` was just replaced with it.
+        Any action the operator simulated by hand — interactive SLD-edit
+        ``user_topo_*`` maneuvers, manually-picked actions — would
+        therefore disappear from ``_last_result``, and the diagram / SLD
+        endpoints that resolve an action through ``_require_action`` would
+        reject it with "not found in last analysis result" even though the
+        card is still live in the frontend's feed (the reported 400 on
+        ``/api/action-variant-sld``).
+
+        Carry over every prior entry that (a) is not already refreshed by
+        the new suggestions and (b) carries a live ``observation`` — i.e.
+        it was actually simulated, so its pypowsybl variant is still
+        resolvable for diagram generation. The merge mutates
+        ``_last_result`` only (not the yielded ``enriched_actions``), so
+        preserved actions stay resolvable without re-entering the
+        suggested-actions feed.
+        """
+        if not prior_actions or not isinstance(self._last_result, dict):
+            return
+        actions = self._last_result.setdefault("prioritized_actions", {})
+        for action_id, data in prior_actions.items():
+            if action_id in actions:
+                continue
+            if isinstance(data, dict) and data.get("observation") is not None:
+                actions[action_id] = data
 
     def _augment_combined_actions_with_target_max_rho(self, results: dict, context: dict) -> None:
         """Add ``target_max_rho`` / ``target_max_rho_line`` to each

--- a/expert_backend/services/diagram_mixin.py
+++ b/expert_backend/services/diagram_mixin.py
@@ -738,10 +738,23 @@ class DiagramMixin:
         subclass) so the API layer can tell this *expected* post-reload
         condition from a genuine fault — see the class docstring.
         """
+        # Preserve the "No analysis result" branch only when _last_result
+        # is genuinely uninitialised AND the action is not hand-simulated
+        # (the latter live in _dict_action with their observation). The
+        # promotion fallback below handles the manual-action case so the
+        # operator's live SLD card stays resolvable.
         if not self._last_result or not self._last_result.get("prioritized_actions"):
-            raise ActionResultUnavailableError(
-                "No analysis result available. Run analysis first."
-            )
+            dict_action = self._dict_action or {}
+            canon = canonicalize_action_id(action_id)
+            entry = dict_action.get(action_id) or dict_action.get(canon)
+            if not (isinstance(entry, dict) and entry.get("observation") is not None):
+                raise ActionResultUnavailableError(
+                    "No analysis result available. Run analysis first."
+                )
+            if self._last_result is None:
+                self._last_result = {"prioritized_actions": {}}
+            if "prioritized_actions" not in self._last_result:
+                self._last_result["prioritized_actions"] = {}
         actions = self._last_result["prioritized_actions"]
         if action_id not in actions:
             # Combined actions are stored under a CANONICAL key (the
@@ -755,9 +768,29 @@ class DiagramMixin:
             if canon != action_id and canon in actions:
                 actions[action_id] = actions[canon]
             else:
-                raise ActionResultUnavailableError(
-                    f"Action '{action_id}' not found in last analysis result."
-                )
+                # Defensive fallback: a manually-simulated action that
+                # for any reason didn't make it into
+                # ``_last_result["prioritized_actions"]`` (e.g. the
+                # exception-gate regression in ``_register_action_result``
+                # before it was relaxed, or a step2 re-run that
+                # didn't carry it over) is still merged into
+                # ``_dict_action`` with its live observation. Promote it
+                # back to the prioritized-actions dict so the SLD / NAD
+                # endpoints can resolve it instead of 400'ing with the
+                # "not found in last analysis result" the operator
+                # otherwise sees while staring at a live action card.
+                dict_action = self._dict_action or {}
+                entry = dict_action.get(action_id) or dict_action.get(canon)
+                if isinstance(entry, dict) and entry.get("observation") is not None:
+                    actions[action_id] = entry
+                    logger.info(
+                        "[_require_action] Promoted '%s' from _dict_action to "
+                        "_last_result['prioritized_actions']", action_id,
+                    )
+                else:
+                    raise ActionResultUnavailableError(
+                        f"Action '{action_id}' not found in last analysis result."
+                    )
         return actions
 
     def _lf_status_for_variant(self, network, variant_id: str, disconnected_elements):

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -639,13 +639,30 @@ class SimulationMixin:
 
         Uses merge (not replace) on `_dict_action` so the library's
         `_identify_action_elements` can still find the original structure.
+
+        Registers in ``_last_result["prioritized_actions"]`` whenever a
+        live ``obs_simu_action`` was produced — even when
+        ``info_action["exception"]`` is set. The exception flag from
+        pypowsybl can fire on non-fatal warnings (e.g. a no-op
+        SLD-edit maneuver that doesn't actually change the variant), and
+        gating registration on its absence used to silently drop those
+        actions from the lookup the diagram / SLD endpoints rely on —
+        leaving the operator's card live in the UI but causing a 400 on
+        the next ``/api/action-variant-sld``. The ``non_convergence``
+        field already carries the warning to the frontend.
         """
-        if not info_action.get("exception") and obs_simu_action is not None:
+        if obs_simu_action is not None:
             if self._last_result is None:
                 self._last_result = {"prioritized_actions": {}}
             if "prioritized_actions" not in self._last_result:
                 self._last_result["prioritized_actions"] = {}
             self._last_result["prioritized_actions"][action_id] = action_data
+        else:
+            logger.info(
+                "[simulate_manual_action] Skipping _last_result registration for '%s' "
+                "(obs_simu_action is None, info_action.exception=%r)",
+                action_id, info_action.get("exception"),
+            )
 
         if self._dict_action is None:
             self._dict_action = {}

--- a/expert_backend/tests/test_preserve_simulated_actions.py
+++ b/expert_backend/tests/test_preserve_simulated_actions.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Regression tests for ``_merge_preserved_simulated_actions``.
+
+A Step-2 re-run (Analyze & Suggest) replaces ``_last_result`` with a fresh
+discovery result. Any action the operator simulated by hand — interactive
+SLD-edit ``user_topo_*`` maneuvers, manually-picked actions — would
+otherwise vanish from ``_last_result``, so the diagram / SLD endpoints that
+resolve an action through ``_require_action`` reject it with
+"not found in last analysis result" even though the card is still live in
+the frontend feed.
+"""
+
+from expert_backend.services.recommender_service import RecommenderService
+
+
+def _svc():
+    return RecommenderService()
+
+
+def test_preserves_manual_action_not_in_new_results():
+    svc = _svc()
+    # Simulate a Step-2 result that just clobbered _last_result.
+    svc._last_result = {"prioritized_actions": {"disco_LINE_A": {"observation": object()}}}
+    prior = {
+        "user_topo_PYMONP3_123": {"observation": object(), "description": "manual"},
+        "disco_LINE_A": {"observation": object()},  # already refreshed
+    }
+    svc._merge_preserved_simulated_actions(prior)
+    actions = svc._last_result["prioritized_actions"]
+    # The manual action is carried over.
+    assert "user_topo_PYMONP3_123" in actions
+    assert actions["user_topo_PYMONP3_123"]["description"] == "manual"
+
+
+def test_does_not_overwrite_refreshed_action():
+    svc = _svc()
+    fresh = {"observation": object(), "tag": "fresh"}
+    svc._last_result = {"prioritized_actions": {"disco_LINE_A": fresh}}
+    prior = {"disco_LINE_A": {"observation": object(), "tag": "stale"}}
+    svc._merge_preserved_simulated_actions(prior)
+    # The new suggestion wins — the stale prior entry must not clobber it.
+    assert svc._last_result["prioritized_actions"]["disco_LINE_A"]["tag"] == "fresh"
+
+
+def test_skips_entries_without_observation():
+    svc = _svc()
+    svc._last_result = {"prioritized_actions": {}}
+    # An entry that was never actually simulated (no live observation /
+    # resolvable variant) must NOT be re-attached — it can't drive a
+    # diagram and would only mask the real "run analysis first" error.
+    prior = {"phantom": {"description": "no obs"}}
+    svc._merge_preserved_simulated_actions(prior)
+    assert "phantom" not in svc._last_result["prioritized_actions"]
+
+
+def test_noop_on_empty_prior():
+    svc = _svc()
+    svc._last_result = {"prioritized_actions": {"disco_LINE_A": {"observation": object()}}}
+    svc._merge_preserved_simulated_actions({})
+    assert list(svc._last_result["prioritized_actions"]) == ["disco_LINE_A"]
+
+
+def test_creates_prioritized_actions_bucket_if_missing():
+    svc = _svc()
+    svc._last_result = {}
+    prior = {"user_topo_X_1": {"observation": object()}}
+    svc._merge_preserved_simulated_actions(prior)
+    assert "user_topo_X_1" in svc._last_result["prioritized_actions"]

--- a/expert_backend/tests/test_preserve_simulated_actions.py
+++ b/expert_backend/tests/test_preserve_simulated_actions.py
@@ -71,3 +71,77 @@ def test_creates_prioritized_actions_bucket_if_missing():
     prior = {"user_topo_X_1": {"observation": object()}}
     svc._merge_preserved_simulated_actions(prior)
     assert "user_topo_X_1" in svc._last_result["prioritized_actions"]
+
+
+# ---------------------------------------------------------------------------
+# Registration & resilient lookup
+# ---------------------------------------------------------------------------
+
+
+def test_register_action_result_registers_even_with_info_exception():
+    """A non-fatal pypowsybl warning on info_action must NOT drop the
+    action from _last_result['prioritized_actions']. The non_convergence
+    field already carries the warning to the frontend; gating
+    registration on the exception flag silently produced 400s on the
+    next /api/action-variant-sld call because the live action card had
+    no backing entry.
+    """
+    svc = _svc()
+    svc._dict_action = {}
+    info_action = {"exception": ["non-fatal: variant unchanged"]}
+    obs = object()
+    svc._register_action_result(
+        "user_topo_PYMONP3_123",
+        {"observation": obs, "description": "manual"},
+        info_action,
+        obs,
+    )
+    actions = svc._last_result["prioritized_actions"]
+    assert "user_topo_PYMONP3_123" in actions
+    assert actions["user_topo_PYMONP3_123"]["observation"] is obs
+
+
+def test_register_action_result_skips_when_obs_is_none():
+    svc = _svc()
+    svc._dict_action = {}
+    svc._register_action_result(
+        "user_topo_X",
+        {"observation": None},
+        {"exception": None},
+        None,
+    )
+    # No prior _last_result existed, and the obs is missing — must remain
+    # untouched (or empty if created).
+    assert svc._last_result is None or not svc._last_result.get(
+        "prioritized_actions", {}
+    ).get("user_topo_X")
+
+
+def test_require_action_promotes_from_dict_action_when_missing():
+    """``_require_action`` must promote a hand-simulated action from
+    ``_dict_action`` (where it is always merged) to
+    ``_last_result['prioritized_actions']`` when the latter doesn't have
+    it — defensive recovery for the operator's live SLD action card.
+    """
+    svc = _svc()
+    svc._last_result = {"prioritized_actions": {}}
+    obs = object()
+    svc._dict_action = {
+        "user_topo_MORBRP6_456": {
+            "observation": obs,
+            "description": "manual",
+        }
+    }
+    actions = svc._require_action("user_topo_MORBRP6_456")
+    assert "user_topo_MORBRP6_456" in actions
+    assert actions["user_topo_MORBRP6_456"]["observation"] is obs
+
+
+def test_require_action_still_raises_for_truly_unknown_action():
+    svc = _svc()
+    svc._last_result = {"prioritized_actions": {}}
+    svc._dict_action = {}
+    import pytest
+    from expert_backend.services.diagram_mixin import ActionResultUnavailableError
+    with pytest.raises(ActionResultUnavailableError):
+        svc._require_action("totally_unknown_xyz")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -796,6 +796,19 @@ function App() {
         load_shedding_details: m.load_shedding_details,
         curtailment_details: m.curtailment_details,
         pst_details: m.pst_details,
+        // Carry the backend-computed topology so the SLD/NAD highlight
+        // pipeline treats this interactive maneuver like any suggested
+        // action (target-equipment halos, breaker highlight). The
+        // operator's toggled switch IDs come straight from the SLD's
+        // switch_states, so they always resolve back to a cell — fold
+        // them into `action_topology.switches` so the breaker highlight
+        // is guaranteed even when the backend N-1-vs-action switch diff
+        // comes back empty.
+        action_topology: {
+          lines_ex_bus: {}, lines_or_bus: {}, gens_bus: {}, loads_bus: {},
+          ...(m.action_topology ?? {}),
+          switches: { ...(m.action_topology?.switches ?? {}), ...switches },
+        },
       };
       wrappedManualActionAdded(registeredId, detail, m.lines_overloaded || [], 'user');
       sldTopologyEdit.reset();

--- a/frontend/src/components/SldOverlay.test.tsx
+++ b/frontend/src/components/SldOverlay.test.tsx
@@ -489,6 +489,112 @@ describe('SldOverlay', () => {
             expect(container.querySelector('#cell_pst.sld-highlight-action-original')).toBeTruthy();
         });
 
+        it('highlights a coupler switch via changed_switches when action_topology is absent (interactive user_topo maneuver)', () => {
+            // Regression for the interactively-applied SLD-edit maneuver
+            // (`user_topo_*`): the manual ActionDetail carries no
+            // `action_topology`, so the breaker-highlight block — which
+            // was gated behind `if (topo)` — never ran and the toggled
+            // coupler stayed un-highlighted (unlike the equivalent
+            // suggested node_merging action). The backend-computed
+            // `changed_switches` on the SLD response must drive the
+            // highlight regardless of topology presence.
+            const svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+                + '<g><rect id="cell_coupler" width="10" height="10"/></g>'
+                + '</svg>';
+            const vlOverlay: VlOverlay = {
+                vlName: 'PYMONP3',
+                actionId: 'user_topo_PYMONP3_1780561955322',
+                svg,
+                sldMetadata: JSON.stringify({
+                    nodes: [{ id: 'cell_coupler', equipmentId: 'PYMON3COUPL' }],
+                }),
+                loading: false,
+                error: null,
+                tab: 'action' as SldTab,
+                changed_switches: { PYMON3COUPL: { from_open: true, to_open: false } },
+            };
+            const detail = {
+                description_unitaire: 'Manoeuvre manuelle sur PYMONP3: PYMON3COUPL DJ_OC fermé',
+                rho_before: [0.96],
+                rho_after: [0.9],
+                max_rho: 0.9,
+                max_rho_line: 'TRI.PY761',
+                is_rho_reduction: true,
+                // No action_topology — the interactive-maneuver trigger.
+            };
+            const { container } = render(
+                <SldOverlay
+                    {...defaultProps}
+                    vlOverlay={vlOverlay}
+                    result={{
+                        actions: { 'user_topo_PYMONP3_1780561955322': detail },
+                        lines_overloaded: [],
+                        pdf_path: null,
+                        pdf_url: null,
+                        message: '',
+                        dc_fallback: false,
+                    } as unknown as AnalysisResult}
+                />,
+            );
+            // The toggled switch must be highlighted even though
+            // action_topology is absent. (isCouplingAction is mocked to
+            // false at the top of this file, so the class is the purple
+            // breaker class rather than the yellow coupling class — the
+            // regression under test is that the cell is highlighted AT
+            // ALL, which the old `if (topo)` gate prevented.)
+            expect(container.querySelector('#cell_coupler.sld-highlight-breaker-original')).toBeTruthy();
+            expect(container.querySelectorAll('.sld-highlight-clone').length).toBeGreaterThan(0);
+        });
+
+        it('highlights a toggled switch from action_topology.switches when the backend diff is empty', () => {
+            // The interactive SLD-edit flow folds the operator's toggled
+            // switch IDs into action_topology.switches (App.tsx). When the
+            // backend N-1-vs-action diff returns no changed_switches, the
+            // highlight must still fire off the topology switches (union).
+            const svg = '<svg xmlns="http://www.w3.org/2000/svg">'
+                + '<g><rect id="cell_coupler" width="10" height="10"/></g>'
+                + '</svg>';
+            const vlOverlay: VlOverlay = {
+                vlName: 'MORBRP6',
+                actionId: 'user_topo_MORBRP6_1780603014530',
+                svg,
+                sldMetadata: JSON.stringify({
+                    nodes: [{ id: 'cell_coupler', equipmentId: 'MORBR6COUPL' }],
+                }),
+                loading: false,
+                error: null,
+                tab: 'action' as SldTab,
+                // No changed_switches from the backend.
+            };
+            const detail = {
+                description_unitaire: 'Manoeuvre manuelle sur MORBRP6: MORBR6COUPL DJ_OC fermé',
+                rho_before: [0.96],
+                rho_after: [0.9],
+                max_rho: 0.9,
+                max_rho_line: 'X',
+                is_rho_reduction: true,
+                action_topology: {
+                    lines_ex_bus: {}, lines_or_bus: {}, gens_bus: {}, loads_bus: {},
+                    switches: { MORBR6COUPL: false },
+                },
+            };
+            const { container } = render(
+                <SldOverlay
+                    {...defaultProps}
+                    vlOverlay={vlOverlay}
+                    result={{
+                        actions: { 'user_topo_MORBRP6_1780603014530': detail },
+                        lines_overloaded: [],
+                        pdf_path: null,
+                        pdf_url: null,
+                        message: '',
+                        dc_fallback: false,
+                    } as unknown as AnalysisResult}
+                />,
+            );
+            expect(container.querySelector('#cell_coupler.sld-highlight-breaker-original')).toBeTruthy();
+        });
+
         it('falls back to SVG <text> search when SLD metadata equipmentId does not match load_name', () => {
             // Regression for the case observed on `bare_env_small_grid_test`:
             // the backend's LS action carries `load_name: "P.SAO3TR311"`

--- a/frontend/src/components/SldOverlay.tsx
+++ b/frontend/src/components/SldOverlay.tsx
@@ -521,6 +521,9 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
             changedSwitches: vlOverlay.changed_switches
                 ? Object.keys(vlOverlay.changed_switches).sort()
                 : [],
+            topoSwitches: actionDetailForSig?.action_topology?.switches
+                ? Object.keys(actionDetailForSig.action_topology.switches).sort()
+                : [],
             branch: selectedContingency.join('+'),
             n1Overloads: result?.lines_overloaded ?? [],
             actionOverloads: actionDetailForSig?.lines_overloaded_after ?? [],
@@ -739,26 +742,37 @@ const SldOverlay: React.FC<SldOverlayProps> = ({
                 }
             }
 
-            if (topo) {
-
-                // Highlight affected breakers/switches.
-                // Prefer changed_switches from SLD response (robust N-1 vs action comparison)
-                // over action_topology.switches (may be empty for grid2op actions).
+            // Highlight affected breakers/switches.
+            // Prefer changed_switches from SLD response (robust N-1 vs action comparison)
+            // over action_topology.switches (may be empty for grid2op actions).
+            // changed_switches is the authoritative backend diff and must drive
+            // the highlight even when action_topology is absent — the case for
+            // interactively-applied SLD-edit maneuvers (`user_topo_*` actions)
+            // whose ActionDetail carries no topology round-trip. Gating this
+            // block on `topo` left their coupler/breaker change un-highlighted.
+            {
                 const changedSwitches = vlOverlay.changed_switches;
-                const topoSwitches = topo.switches as Record<string, unknown> | undefined;
-                const switchSource = changedSwitches && Object.keys(changedSwitches).length > 0
-                    ? changedSwitches
-                    : topoSwitches;
+                const topoSwitches = topo?.switches as Record<string, unknown> | undefined;
+                // Highlight the UNION of the backend N-1-vs-action diff
+                // and the action's own topology switches. Neither source
+                // alone is complete: grid2op suggested actions often carry
+                // an empty `action_topology.switches` (so the diff is the
+                // only signal), while interactively-applied SLD-edit
+                // maneuvers carry the operator's toggled switch IDs in
+                // `action_topology.switches` but may produce an empty diff.
+                // Taking the union highlights the change in both flows.
+                const switchIds = new Set<string>([
+                    ...Object.keys(changedSwitches ?? {}),
+                    ...Object.keys(topoSwitches ?? {}),
+                ]);
                 // Coupling action breakers highlighted yellow (same as action targets);
                 // regular breaker/switch actions use purple.
                 const breakerClass = isCoupling ? 'sld-highlight-action' : 'sld-highlight-breaker';
-                if (switchSource) {
-                    for (const switchId of Object.keys(switchSource)) {
-                        const cell = findCellForEquipment(switchId);
-                        if (cell && !highlightedCells.has(cell)) {
-                            cloneHighlight(cell, breakerClass);
-                            highlightedCells.add(cell);
-                        }
+                for (const switchId of switchIds) {
+                    const cell = findCellForEquipment(switchId);
+                    if (cell && !highlightedCells.has(cell)) {
+                        cloneHighlight(cell, breakerClass);
+                        highlightedCells.add(cell);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Closes three independent gaps that caused "not found in last analysis result" 400s on `/api/action-variant-sld` when operators interactively simulated SLD-edit maneuvers (`user_topo_*` actions). The operator's card remained live in the frontend feed, but the backend's action-lookup pipeline couldn't resolve it. All three issues are now fixed, and the action-tab switch highlight is robust for both suggested and interactive maneuvers.

## Key Changes

### Backend: Manual-action persistence

1. **`simulation_mixin._register_action_result`** — Registration no longer gated on `info_action["exception"]` absence. pypowsybl raises non-fatal warnings on no-op toggles (e.g. closing an already-closed coupler), and the old gate silently dropped those actions from `_last_result`. Now keys off `obs_simu_action is not None` alone; the warning still travels via `non_convergence`.

2. **`analysis_mixin._merge_preserved_simulated_actions`** (new method) — After a Step-2 re-run replaces `_last_result` with fresh discovery results, re-attaches every prior manually-simulated action that (a) isn't already refreshed by new suggestions and (b) carries a live `observation`. Preserved actions stay resolvable for diagram endpoints without re-entering the suggested-actions feed.

3. **`diagram_mixin._require_action`** — Defensive fallback: when an action is missing from `_last_result["prioritized_actions"]` but present in `_dict_action` with a live observation, promotes it back instead of raising. Keeps the genuine "No analysis result available" branch for truly-uninitialised cases.

### Frontend: Action-tab switch highlight for interactive maneuvers

1. **`SldOverlay.tsx`** — Highlights the **union** of `vlOverlay.changed_switches` (backend N-1-vs-action diff) and `actionDetail.action_topology.switches`. Neither source alone is complete: suggested actions often have empty `action_topology.switches` (diff is the only signal), while interactive maneuvers may produce empty diff but always know which switches the operator clicked. The highlight block is no longer gated on `action_topology` presence — that gate left interactive maneuvers' couplers un-highlighted.

2. **`App.tsx::handleSimulateSldEdit`** — Folds the operator's toggled switch IDs into the card's `action_topology.switches`. Those IDs come straight from the SLD's `switch_states`, guaranteeing they resolve back to SVG cells — ensuring the highlight even when the backend diff is empty.

## Testing

- **Backend** (`expert_backend/tests/test_preserve_simulated_actions.py`): 8 new regression tests covering `_merge_preserved_simulated_actions`, `_register_action_result`, and `_require_action` promotion fallback.
- **Frontend** (`components/SldOverlay.test.tsx`): 2 new tests for action-tab switch highlight with and without `action_topology` presence.
- **Documentation** (`docs/features/sld-topology-edit.md`): Detailed explanation of the three persistence gaps, the union-of-sources highlight strategy, and the frontend contract updates.

## Implementation Details

- The merge in `_merge_preserved_simulated_actions` mutates `_last_result` only (not the yielded `enriched_actions`), so preserved actions stay resolvable without re-entering the suggested-actions feed the frontend already has.
- The highlight signature in `SldOverlay` now includes both switch-key sets (`changedSwitches` + `topoSwitches`), so a re-fetch re-plants the clones correctly.
- Logging added to `_register_action_result` and `_require_action` for observability of the fallback paths.

https://claude.ai/code/session_014MAqfB6wRZ8sa8ciwu92e8