### PR TITLE
Fix OverloadInfoPopover clipping by anchoring to fixed position

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           command: |
             python -m pip install --upgrade pip
             pip install ".[test]"
-            pip install --no-deps expert_op4grid_recommender
+            pip install --no-deps --no-cache-dir "expert_op4grid_recommender==0.2.3.post1"
       - run:
           name: Run Pytest
           command: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[test]"
-          pip install --no-deps expert_op4grid_recommender
+          pip install --no-deps --no-cache-dir "expert_op4grid_recommender==0.2.3.post1"
       - name: Run Pytest (excluding graphviz-dependent tests)
         run: pytest --ignore=expert_backend/tests/test_overflow_html_dim_logic.py
 
@@ -91,6 +91,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[test]"
-          pip install --no-deps expert_op4grid_recommender
+          pip install --no-deps --no-cache-dir "expert_op4grid_recommender==0.2.3.post1"
       - name: Run graphviz-dependent Pytest subset
         run: pytest expert_backend/tests/test_overflow_html_dim_logic.py

--- a/frontend/src/components/SidebarSummary.tsx
+++ b/frontend/src/components/SidebarSummary.tsx
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useLayoutEffect, type CSSProperties } from 'react';
 import type { ActionOverviewFilters } from '../types';
 import { colors, radius, space, text } from '../styles/tokens';
 import ActionFilterRings from './ActionFilterRings';
@@ -86,6 +86,7 @@ export default function SidebarSummary({
   const hasFilters = !!hasActions && !!overviewFilters && !!onOverviewFiltersChange;
   const [popoverOpen, setPopoverOpen] = useState(false);
   const hideTimerRef = useRef<number | null>(null);
+  const bubbleRef = useRef<HTMLButtonElement>(null);
 
   const cancelHide = useCallback(() => {
     if (hideTimerRef.current != null) {
@@ -233,6 +234,7 @@ export default function SidebarSummary({
               onMouseLeave={scheduleHide}
             >
               <button
+                ref={bubbleRef}
                 data-testid="sidebar-summary-overloads-bubble"
                 onClick={(e) => { e.stopPropagation(); setPopoverOpen(o => !o); }}
                 aria-label="Overload details"
@@ -269,6 +271,7 @@ export default function SidebarSummary({
                   monitoringHint={monitoringHint}
                   onAssetClick={onOverloadClick}
                   displayName={displayName}
+                  anchorRef={bubbleRef}
                 />
               )}
             </span>
@@ -297,6 +300,11 @@ interface OverloadInfoPopoverProps {
   monitoringHint?: string | null;
   onAssetClick: (actionId: string, assetName: string, tab: 'n' | 'contingency') => void;
   displayName: (id: string) => string;
+  /** The `?` bubble button the popover anchors to. The popover renders with
+   *  `position: fixed` computed from this element's bounding rect so it
+   *  escapes the sidebar's `overflow: hidden` clipping and always paints
+   *  above the network visualization. */
+  anchorRef: React.RefObject<HTMLButtonElement | null>;
 }
 
 function OverloadInfoPopover({
@@ -311,21 +319,53 @@ function OverloadInfoPopover({
   monitoringHint,
   onAssetClick,
   displayName,
+  anchorRef,
 }: OverloadInfoPopoverProps) {
   const formatRho = (v: number | undefined) =>
     v == null || Number.isNaN(v) ? null : `${(v * 100).toFixed(1)}%`;
   const hasDeselected = n1LinesOverloaded.some(name => !(selectedOverloads?.has(name) ?? true));
+
+  // The sidebar that hosts the `?` bubble sets `overflow: hidden`, so an
+  // absolutely-positioned popover gets clipped (and visually masked by the
+  // network visualization) the moment it spills past the sidebar edge.
+  // Anchor with `position: fixed` against the button's viewport rect instead
+  // so the popover escapes the clip and always paints on top.
+  const POPOVER_MAX_WIDTH = 320;
+  const MARGIN = 8;
+  const [fixedPos, setFixedPos] = useState<CSSProperties>({
+    position: 'fixed',
+    visibility: 'hidden',
+    top: 0,
+    left: 0,
+  });
+
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    // Align the popover's left edge to the bubble, clamped to the viewport.
+    const left = Math.max(
+      MARGIN,
+      Math.min(rect.left, vw - POPOVER_MAX_WIDTH - MARGIN),
+    );
+    setFixedPos({
+      position: 'fixed',
+      left,
+      top: Math.min(rect.bottom + 4, vh - MARGIN),
+      maxHeight: vh - rect.bottom - 2 * MARGIN,
+      overflowY: 'auto',
+    });
+  }, [anchorRef]);
 
   return (
     <div
       data-testid="overload-info-popover"
       role="dialog"
       style={{
-        position: 'absolute',
-        top: '100%',
-        left: 0,
-        marginTop: space[1],
-        zIndex: 50,
+        ...fixedPos,
+        zIndex: 300,
         background: colors.surface,
         border: `1px solid ${colors.border}`,
         borderRadius: radius.md,


### PR DESCRIPTION
## Summary
The `OverloadInfoPopover` component was being clipped by the sidebar's `overflow: hidden` CSS property, causing it to be visually masked when it extended beyond the sidebar edge. This change anchors the popover to a fixed viewport position computed from the bubble button's bounding rect, allowing it to escape the sidebar's clipping context and always render above the network visualization.

## Key Changes
- Added `useLayoutEffect` and `CSSProperties` type imports to support dynamic positioning
- Created `bubbleRef` to track the `?` bubble button element that anchors the popover
- Passed `anchorRef` prop to `OverloadInfoPopover` with full JSDoc documentation explaining the fixed-positioning strategy
- Implemented `useLayoutEffect` hook in `OverloadInfoPopover` to:
  - Compute the bubble button's viewport bounding rect on mount/update
  - Calculate popover left position clamped to viewport with 8px margin
  - Calculate popover top position below the button, clamped to viewport height
  - Set `maxHeight` and `overflowY: 'auto'` to handle content overflow
- Changed popover positioning from `position: absolute` with `top: 100%` to `position: fixed` with computed coordinates
- Increased z-index from 50 to 300 to ensure the popover paints above other UI layers

## Implementation Details
The popover now uses `getBoundingClientRect()` to anchor against the button's viewport position rather than relying on CSS relative positioning. This allows it to escape the sidebar's `overflow: hidden` clipping while maintaining proper alignment and viewport bounds. The popover respects a maximum width of 320px and maintains 8px margins from viewport edges.

https://claude.ai/code/session_01S3qvwmZJ9miE3JzqwFG7u2