### PR TITLE
Add Generalized Superposition Theorem (GST) support for injection actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ plugs the recommender library's GST (`compute_combined_pair_gst`) into Co-Study.
 - **Docs**: `docs/features/combined-actions.md` documents the AC-anchoring of the
   GST estimate and how to read it (trust `target_max_rho`; the off-target global
   max can flip between near-equal low-flow lines; injection+injection is
-  lower-confidence).
+  lower-confidence, with the measured `BEON` 5.6 % est vs 38.1 % sim example),
+  and points to the library's "Known larger-error cases" catalog.
 
 ### Redispatching action type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ plugs the recommender library's GST (`compute_combined_pair_gst`) into Co-Study.
     combined for estimation" caveat banners.
 - **Tests**: new GST cases in `expert_backend/tests/test_superposition_service.py`
   (topology+injection, injection-first, injection+injection, `is_injection_action`).
+- **Diagnostic**: `scripts/gst_estimation_vs_simulation_small_grid.py` — a
+  library-level (no running backend) reproduction of the GST estimate-vs-
+  simulation behaviour on the small grid, including a direct-DC exactness proof
+  showing the AC est-vs-sim gap is AC-nonlinearity (0 MW error in DC), not a bug.
+- **Docs**: `docs/features/combined-actions.md` documents the AC-anchoring of the
+  GST estimate and how to read it (trust `target_max_rho`; the off-target global
+  max can flip between near-equal low-flow lines; injection+injection is
+  lower-confidence).
 
 ### Redispatching action type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and the project (informally) follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Generalized Superposition Theorem (GST) for combined-pair estimation
+
+The combined-pair **estimation** (`POST /api/compute-superposition`, Explore
+Pairs tab) now supports pairs that involve an **injection** action — load
+shedding, renewable curtailment, redispatch — not just topology actions. This
+plugs the recommender library's GST (`compute_combined_pair_gst`) into Co-Study.
+
+- **Backend** (`services/`):
+  - `simulation_helpers.is_injection_action(action_id, dict_action, classifier)`
+    — new detector (id prefix + classifier type), kept in sync with the library.
+  - `simulation_mixin.compute_superposition` — computes `act1_is_injection` /
+    `act2_is_injection`, no longer bails out with "cannot identify elements" for
+    an injection action (they carry no topology element), and forwards the flags
+    to `compute_combined_pair_superposition` (GST path). The injection action is
+    returned with `beta = 1.0`, so `compute_combined_rho` /
+    `_augment_superposition_result` work unchanged.
+- **Frontend**:
+  - `CombinedActionsModal` — `hasRestricted` is now always `false`; LS /
+    curtailment / redispatch are estimable.
+  - `ExplorePairsTab` — removed the "load shedding / curtailment cannot be
+    combined for estimation" caveat banners.
+- **Tests**: new GST cases in `expert_backend/tests/test_superposition_service.py`
+  (topology+injection, injection-first, injection+injection, `is_injection_action`).
+
 ### Redispatching action type
 
 End-to-end support for **redispatching** remedial actions (raise / lower a

--- a/docs/features/combined-actions.md
+++ b/docs/features/combined-actions.md
@@ -131,6 +131,29 @@ On the frontend the Explore Pairs tab no longer blocks estimation for
 LS / curtailment / redispatch (`hasRestricted` is always `false` now, and the
 "cannot be combined for estimation" caveats were removed).
 
+**Estimation accuracy / AC anchoring.** The GST reads only AC load-flow values
+(both the injection superposition term and the injection-shifted beta), so it is
+anchored at the true AC operating point — but the superposition *law* is
+DC-exact only, so AC nonlinearities are not reproduced. Consequences operators
+see:
+
+- The **on-target overload** (the line the contingency overloads) is predicted
+  reliably — that is what `target_max_rho` reports, and it matches simulation.
+- The **global `max_rho` line can flip** between two near-equally-loaded
+  monitored lines (e.g. estimate `C.FOUL31MERVA` ~74 % vs simulation
+  `PYMONL31SAISS` ~70 %). This is a few-MW AC flow-split error on low-flow
+  parallel-corridor lines, **not a bug** — it is provably 0 MW in DC (a direct
+  `run_dc` check reconstructs the pair exactly) and appears identically on
+  pure-topology pairs. So trust `target_max_rho`; treat the off-target global max
+  as indicative.
+- **Injection + injection** pairs are lower-confidence (two large injections
+  compound the AC error); prefer a full simulation for those.
+
+The library diagnostic
+`scripts/gst_estimation_vs_simulation_small_grid.py` reproduces all of this
+(EST-vs-GST per-pair accuracy + the DC-exactness proof) at the library level, no
+running backend required.
+
 ### Full simulation
 
 Combines individual grid2op action objects and runs a full load flow.

--- a/docs/features/combined-actions.md
+++ b/docs/features/combined-actions.md
@@ -147,7 +147,16 @@ see:
   pure-topology pairs. So trust `target_max_rho`; treat the off-target global max
   as indicative.
 - **Injection + injection** pairs are lower-confidence (two large injections
-  compound the AC error); prefer a full simulation for those.
+  compound the AC error). Example: `load_shedding_P.SAO3TR312 +
+  load_shedding_BEON3 TR311` over-predicts the relief on the target line
+  (`BEON L31CPVAN` estimated ~5.6 % vs simulated ~38.1 %; mean rho gap ~4 pts,
+  worst ~33 pts). Prefer a full simulation for these.
+
+The two known larger-error cases (heavily-loaded-line disconnection onto a
+low-flow corridor → off-target max-line flip; and injection+injection → relief
+over-prediction) are catalogued with measured numbers, root cause and how to
+read them in the `expert_op4grid_recommender` library docs:
+`docs/superposition_module.md` §10 "Known larger-error cases".
 
 The library diagnostic
 `scripts/gst_estimation_vs_simulation_small_grid.py` reproduces all of this

--- a/docs/features/combined-actions.md
+++ b/docs/features/combined-actions.md
@@ -109,6 +109,28 @@ Where:
 
 **Flag:** Results always have `is_estimated: true`
 
+#### Generalized Superposition Theorem (GST) — injection actions
+
+The EST formula above combines two **topology** actions. When a pair involves an
+**injection** action — load shedding (`set_load_p`), curtailment / redispatch
+(`set_gen_p`) — `compute_superposition` detects it via
+`simulation_helpers.is_injection_action` and forwards `act1_is_injection` /
+`act2_is_injection` to `compute_combined_pair_superposition`, which routes to the
+library's **GST** (`compute_combined_pair_gst`).
+
+The integration point is deliberately thin: the GST reports an injection action
+with **`beta = 1.0`** and the topology action with its (injection-shifted) beta.
+With that convention the EST `rho_combined` formula above is **unchanged** — it
+already reproduces the exact GST loading — so `compute_combined_rho` and
+`_augment_superposition_result` need no GST-specific branch. The only backend
+changes are: (1) detect injection actions, (2) skip the "cannot identify
+elements" bail-out for them (they carry no topology element), (3) pass the
+injection flags through.
+
+On the frontend the Explore Pairs tab no longer blocks estimation for
+LS / curtailment / redispatch (`hasRestricted` is always `false` now, and the
+"cannot be combined for estimation" caveats were removed).
+
 ### Full simulation
 
 Combines individual grid2op action objects and runs a full load flow.
@@ -238,10 +260,11 @@ ways:
 
 - **Load-shedding and curtailment are now allowed in combined pairs**
   (commit `a019555`). Previously restricted to topology actions, the
-  Explore Pairs tab now accepts LS / curtailment on either side as
-  long as the pair is simulated (the superposition-estimation path
-  still requires both actions to have a pre-computed beta, which only
-  exists for topology actions).
+  Explore Pairs tab now accepts LS / curtailment on either side. As of
+  the Generalized Superposition Theorem work (see "Generalized
+  Superposition Theorem (GST)" below) the **superposition-estimation
+  path also handles these injection actions** — they no longer require
+  a full simulation just to preview the combined loading.
 - **"Simulate Combined" moved out of the action card** (commit
   `e871006`). The trigger now lives in the modal footer. After a
   simulate-only pair lands, the resulting card is shown in the main
@@ -330,5 +353,8 @@ When modifying combined actions logic:
 - [ ] `simulationFeedback` state must be cleared when the selected pair changes
 - [ ] The modal must stay open during simulation so the user sees feedback
 - [ ] Test both tabs: Computed Pairs uses `handleSimulate(pairId)`, Explore uses `handleSimulate()` (no args)
-- [ ] Load-shedding / curtailment pairs work via simulate-only; the
-      estimation preview path is still topology-only.
+- [ ] Load-shedding / curtailment / redispatch pairs work via BOTH the
+      estimation preview (GST) and full simulation. When adding a new
+      injection-type action, make sure `is_injection_action`
+      (`simulation_helpers.py`) recognises its id prefix / classifier
+      type so `compute_superposition` routes the pair to the GST.

--- a/expert_backend/services/simulation_helpers.py
+++ b/expert_backend/services/simulation_helpers.py
@@ -209,6 +209,33 @@ def is_pst_action(action_id: str, dict_action: dict | None, classifier: Any) -> 
     )
 
 
+# Injection-action detection — kept in sync with the recommender library's
+# ``superposition.is_injection_action`` (id prefix + classifier action type).
+# Replicated here (rather than imported) so it stays correct when the library
+# module is stubbed by the test mock layer, exactly like ``is_pst_action``.
+_INJECTION_ID_PREFIXES: tuple[str, ...] = ("load_shedding_", "curtail_", "redispatch_")
+_INJECTION_ACTION_TYPES: frozenset[str] = frozenset({
+    "load_power_reduction", "gen_power_reduction", "gen_redispatch",
+    "open_load", "open_gen",
+})
+
+
+def is_injection_action(action_id: str, dict_action: dict | None, classifier: Any) -> bool:
+    """Detect injection actions (load shedding / curtailment / redispatch).
+
+    These change only nodal injections (``set_load_p`` / ``set_gen_p``), not the
+    topology, and are combined with topology actions through the Generalized
+    Superposition Theorem (GST). Detection is by action-id prefix and, when the
+    classifier resolves a type, by the injection action types — mirroring the
+    library's ``superposition.is_injection_action``.
+    """
+    if action_id and action_id.startswith(_INJECTION_ID_PREFIXES):
+        return True
+    desc = (dict_action or {}).get(action_id, {})
+    action_type = classifier.identify_action_type(desc, by_description=True)
+    return action_type in _INJECTION_ACTION_TYPES
+
+
 def pst_fallback_line_idxs(
     action_id: str,
     dict_action: dict | None,

--- a/expert_backend/services/simulation_mixin.py
+++ b/expert_backend/services/simulation_mixin.py
@@ -36,6 +36,7 @@ from expert_backend.services.simulation_helpers import (
     compute_redispatch_setpoint,
     compute_target_max_rho,
     extract_action_topology,
+    is_injection_action,
     is_pst_action,
     is_switch_only_content,
     normalise_non_convergence,
@@ -738,7 +739,13 @@ class SimulationMixin:
         line_idxs2, sub_idxs2 = self._identify_elements_with_pst_fallback(
             action2_id, all_actions, classifier, env
         )
-        if (not line_idxs1 and not sub_idxs1) or (not line_idxs2 and not sub_idxs2):
+        # Injection actions (load shedding / curtailment / redispatch) carry no
+        # topology element — they are combined via the Generalized Superposition
+        # Theorem. Only topology actions must resolve to a switched element.
+        act1_is_injection = is_injection_action(action1_id, self._dict_action, classifier)
+        act2_is_injection = is_injection_action(action2_id, self._dict_action, classifier)
+        if (not act1_is_injection and not line_idxs1 and not sub_idxs1) or \
+           (not act2_is_injection and not line_idxs2 and not sub_idxs2):
             return {
                 "error": (
                     f"Cannot identify elements for one or both actions "
@@ -802,12 +809,12 @@ class SimulationMixin:
 
         logger.info("[compute_superposition] Calling compute_combined_pair_superposition with:")
         logger.info(
-            "  act1_line_idxs=%s, act1_sub_idxs=%s, act1_is_pst=%s",
-            line_idxs1, sub_idxs1, act1_is_pst,
+            "  act1_line_idxs=%s, act1_sub_idxs=%s, act1_is_pst=%s, act1_is_injection=%s",
+            line_idxs1, sub_idxs1, act1_is_pst, act1_is_injection,
         )
         logger.info(
-            "  act2_line_idxs=%s, act2_sub_idxs=%s, act2_is_pst=%s",
-            line_idxs2, sub_idxs2, act2_is_pst,
+            "  act2_line_idxs=%s, act2_sub_idxs=%s, act2_is_pst=%s, act2_is_injection=%s",
+            line_idxs2, sub_idxs2, act2_is_pst, act2_is_injection,
         )
         combined_id = f"{action1_id}+{action2_id}"
         result = compute_combined_pair_superposition(
@@ -821,6 +828,8 @@ class SimulationMixin:
             obs_combined=all_actions.get(combined_id, {}).get("observation"),
             act1_is_pst=act1_is_pst,
             act2_is_pst=act2_is_pst,
+            act1_is_injection=act1_is_injection,
+            act2_is_injection=act2_is_injection,
         )
 
         if "error" not in result:

--- a/expert_backend/tests/test_superposition_service.py
+++ b/expert_backend/tests/test_superposition_service.py
@@ -659,5 +659,118 @@ def test_augment_combined_actions_with_target_max_rho_is_noop_without_context():
     assert "target_max_rho_line" not in pair
 
 
+def test_compute_superposition_allows_injection_action(recommender):
+    """An injection action (load shedding / curtailment / redispatch) has no
+    topology element — it must NOT trigger the 'cannot identify elements'
+    bail-out, and must be forwarded to the library with act_is_injection=True
+    so the Generalized Superposition Theorem (GST) path handles the pair."""
+    topo_id = "disco_LINE1"
+    inj_id = "load_shedding_LOAD_7"
+    obs_topo = _make_obs([0.9], [0.0])      # LINE1 disconnected
+    obs_inj = _make_obs([0.85], [85.0])     # injection state
+    actions = {
+        topo_id: {"action": MagicMock(), "observation": obs_topo},
+        inj_id: {"action": MagicMock(), "observation": obs_inj},
+    }
+    da = {
+        topo_id: {"content": {"set_bus": {"lines_or_bus": {"LINE1": -1}}},
+                  "description_unitaire": "Open LINE1"},
+        inj_id: {"content": {"set_load_p": {"LOAD_7": 0.0}},
+                 "description_unitaire": "Load shedding LOAD_7"},
+    }
+    _setup_superposition_env(recommender, actions, da)
+
+    def side_effect(act_obj, aid, dict_action, classifier, env):
+        # topology action resolves to a line; injection action has no element
+        return ([0], []) if aid == topo_id else ([], [])
+
+    with patch('expert_backend.services.simulation_mixin._identify_action_elements', side_effect=side_effect), \
+         patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_combine:
+        # injection is reported with beta = 1.0 (GST convention)
+        mock_combine.return_value = {"betas": [0.7, 1.0], "p_or_combined": [100.0]}
+        result = recommender.compute_superposition(topo_id, inj_id, "contingency")
+
+        assert "error" not in result, f"injection pair must not bail out: {result.get('error')}"
+        ck = mock_combine.call_args.kwargs
+        assert ck.get("act1_is_injection") is False
+        assert ck.get("act2_is_injection") is True
+        assert result["is_estimated"] is True
+        assert "betas" in result
+
+
+def test_compute_superposition_injection_first(recommender):
+    """Injection action on the FIRST side — act1_is_injection must be True."""
+    inj_id = "curtail_GEN_2"
+    topo_id = "disco_LINE1"
+    obs_inj = _make_obs([0.85], [85.0])
+    obs_topo = _make_obs([0.9], [0.0])
+    actions = {
+        inj_id: {"action": MagicMock(), "observation": obs_inj},
+        topo_id: {"action": MagicMock(), "observation": obs_topo},
+    }
+    da = {
+        inj_id: {"content": {"set_gen_p": {"GEN_2": 0.0}}, "description_unitaire": "Curtail GEN_2"},
+        topo_id: {"content": {"set_bus": {"lines_or_bus": {"LINE1": -1}}}, "description_unitaire": "Open LINE1"},
+    }
+    _setup_superposition_env(recommender, actions, da)
+
+    def side_effect(act_obj, aid, dict_action, classifier, env):
+        return ([], []) if aid == inj_id else ([0], [])
+
+    with patch('expert_backend.services.simulation_mixin._identify_action_elements', side_effect=side_effect), \
+         patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_combine:
+        mock_combine.return_value = {"betas": [1.0, 0.7], "p_or_combined": [100.0]}
+        result = recommender.compute_superposition(inj_id, topo_id, "contingency")
+
+        assert "error" not in result
+        ck = mock_combine.call_args.kwargs
+        assert ck.get("act1_is_injection") is True
+        assert ck.get("act2_is_injection") is False
+
+
+def test_compute_superposition_injection_plus_injection(recommender):
+    """Two injection actions (no topology element on either side) are still
+    estimated via the GST (pure injection superposition)."""
+    inj1 = "curtail_GEN_2"
+    inj2 = "load_shedding_LOAD_7"
+    obs1 = _make_obs([0.9], [90.0])
+    obs2 = _make_obs([0.85], [85.0])
+    actions = {
+        inj1: {"action": MagicMock(), "observation": obs1},
+        inj2: {"action": MagicMock(), "observation": obs2},
+    }
+    da = {
+        inj1: {"content": {"set_gen_p": {"GEN_2": 0.0}}, "description_unitaire": "Curtail"},
+        inj2: {"content": {"set_load_p": {"LOAD_7": 0.0}}, "description_unitaire": "Shed"},
+    }
+    _setup_superposition_env(recommender, actions, da)
+
+    with patch('expert_backend.services.simulation_mixin._identify_action_elements', return_value=([], [])), \
+         patch('expert_backend.services.simulation_mixin.compute_combined_pair_superposition') as mock_combine:
+        mock_combine.return_value = {"betas": [1.0, 1.0], "p_or_combined": [100.0]}
+        result = recommender.compute_superposition(inj1, inj2, "contingency")
+
+        assert "error" not in result
+        ck = mock_combine.call_args.kwargs
+        assert ck.get("act1_is_injection") is True
+        assert ck.get("act2_is_injection") is True
+
+
+def test_is_injection_action_helper():
+    """The backend injection detector matches the library convention by id
+    prefix (independent of the classifier, so it works under the test mock
+    layer too)."""
+    from expert_backend.services.simulation_helpers import is_injection_action
+    classifier = MagicMock()
+    classifier.identify_action_type.return_value = "unknown"
+    assert is_injection_action("load_shedding_LOAD_5", {}, classifier) is True
+    assert is_injection_action("curtail_GEN_2", {}, classifier) is True
+    assert is_injection_action("redispatch_GEN_7", {}, classifier) is True
+    assert is_injection_action("disco_LINE_3", {}, classifier) is False
+    # classifier-resolved injection type also counts
+    classifier.identify_action_type.return_value = "load_power_reduction"
+    assert is_injection_action("x", {"x": {}}, classifier) is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/frontend/src/components/CombinedActionsModal.tsx
+++ b/frontend/src/components/CombinedActionsModal.tsx
@@ -311,14 +311,11 @@ const CombinedActionsModal: React.FC<Props> = ({
 
     if (!isOpen) return null;
 
-    // Check if any selected action involves load shedding or curtailment (combination not supported)
-    const allActions = { ...simulatedActions, ...analysisResult?.actions };
-    const selectedActionsDetails = Array.from(selectedIds).map(id => allActions[id]);
-    const hasRestricted = selectedActionsDetails.some(detail =>
-        (detail?.load_shedding_details && detail.load_shedding_details.length > 0) ||
-        (detail?.curtailment_details && detail.curtailment_details.length > 0) ||
-        (detail?.redispatch_details && detail.redispatch_details.length > 0)
-    );
+    // Estimation is available for every action type: the Generalized
+    // Superposition Theorem (GST) now combines load shedding / curtailment /
+    // redispatch (injection changes) with topology actions, so no selection is
+    // restricted from the estimation path anymore.
+    const hasRestricted = false;
 
     const handleToggle = (id: string) => {
         setSimulationFeedback(null);

--- a/frontend/src/components/ExplorePairsTab.tsx
+++ b/frontend/src/components/ExplorePairsTab.tsx
@@ -112,36 +112,6 @@ const ExplorePairsTab: React.FC<ExplorePairsTabProps> = ({
                                 <span>{type.replace(/_/g, ' ').toUpperCase()}</span>
                                 <span>{filteredList.filter(item => item.type === type).length} actions</span>
                             </div>
-                            {(type === 'load_shedding' || type === 'ls') && (
-                                <div style={{
-                                    padding: '6px 10px',
-                                    background: colors.warningSoft,
-                                    color: colors.warningText,
-                                    borderBottom: `1px solid ${colors.warningBorder}`,
-                                    fontSize: '11px',
-                                    fontWeight: 600,
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: '6px'
-                                }}>
-                                    <span>⚠️</span> Load shedding actions cannot be combined for estimation.
-                                </div>
-                            )}
-                            {(type === 'renewable_curtailment' || type === 'rc') && (
-                                <div style={{
-                                    padding: '6px 10px',
-                                    background: colors.infoSoft,
-                                    color: colors.infoText,
-                                    borderBottom: `1px solid ${colors.infoBorder}`,
-                                    fontSize: '11px',
-                                    fontWeight: 600,
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: '6px'
-                                }}>
-                                    <span>ℹ️</span> Renewable curtailment actions cannot be combined for estimation.
-                                </div>
-                            )}
                             <table className="action-table" style={{ margin: 0, border: 'none' }}>
                                 <tbody>
                                     {filteredList

--- a/scripts/gst_estimation_vs_simulation_small_grid.py
+++ b/scripts/gst_estimation_vs_simulation_small_grid.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Characterise the Generalized Superposition Theorem (GST) estimate vs. full
+simulation on the small test grid, **at the library level** (pure pypowsybl
+backend — no running FastAPI backend required).
+
+Unlike ``test_estimation_vs_simulation_small_grid.py`` (which drives the HTTP
+backend), this script loads ``SimulationEnvironment`` directly, applies the
+contingency, simulates each remedial action and the combined pair, runs the
+library's ``compute_combined_pair_superposition`` (which routes injection pairs
+to the GST), and prints a per-pair accuracy breakdown restricted to the
+monitored lines.
+
+It reproduces the two findings discussed in the GST review:
+
+  1. **GST pairs (topology + injection) estimate as accurately as the
+     pre-existing EST pairs (topology + topology).** The injection term
+     (beta = 1.0) adds no error beyond the inherent AC-vs-DC linearisation
+     limit. The per-line rho gap (mean ~1-2 pts, occasional ~15 pts on
+     parallel corridors) is the same for both — it flips the *global* max-rho
+     line between near-equally-loaded monitored lines but the on-target
+     overload is predicted correctly.
+
+  2. **Injection + injection pairs are weaker** (two large injections compound
+     the AC nonlinearity), so they over-predict combined relief.
+
+Run:
+    # default paths resolve to <repo>/data/...
+    python scripts/gst_estimation_vs_simulation_small_grid.py
+
+Env:
+    GST_NETWORK_PATH    - override the .xiidm path
+    GST_MONITORED_CSV   - override the monitored-lines CSV path
+    GST_CONTINGENCY     - override the contingency element (default P.SAOL31RONCI)
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+warnings.filterwarnings("ignore")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NETWORK_PATH = os.environ.get(
+    "GST_NETWORK_PATH", str(REPO_ROOT / "data/bare_env_small_grid_test/grid.xiidm"))
+MONITORED_CSV = os.environ.get(
+    "GST_MONITORED_CSV", str(REPO_ROOT / "data/lignes_a_monitorer.csv"))
+CONTINGENCY = os.environ.get("GST_CONTINGENCY", "P.SAOL31RONCI")
+WORSENING_THRESHOLD = 0.02  # pre-existing-overload symmetric band
+
+
+def _load_monitored(path):
+    if not os.path.exists(path):
+        return set()
+    with open(path) as f:
+        return {row["branches"] for row in csv.DictReader(f)}
+
+
+def main():
+    try:
+        from expert_op4grid_recommender.pypowsybl_backend.simulation_env import (
+            SimulationEnvironment,
+        )
+        from expert_op4grid_recommender.utils.superposition import (
+            compute_combined_pair_superposition,
+        )
+    except Exception as e:  # pragma: no cover - environment guard
+        print(f"[SKIP] pypowsybl / expert_op4grid_recommender unavailable: {e}")
+        return 0
+
+    if not os.path.exists(NETWORK_PATH):
+        print(f"[SKIP] network not found: {NETWORK_PATH}")
+        return 0
+
+    monitored = _load_monitored(MONITORED_CSV)
+    env = SimulationEnvironment(network_path=NETWORK_PATH)
+    obs_n = env.get_obs()
+    name_line = list(obs_n.name_line)
+    n = len(name_line)
+    idx = {nm: i for i, nm in enumerate(name_line)}
+    rho_n = np.asarray(obs_n.rho)
+
+    obs_start = obs_n.simulate(env.action_space({"set_line_status": [(CONTINGENCY, -1)]}))[0]
+    rho0 = np.asarray(obs_start.rho)
+
+    # Monitored, non-contingency, not pre-existing-overloaded lines (the same
+    # scope the backend uses to pick the reported max_rho).
+    mon = np.array([
+        (name_line[i] in monitored and name_line[i] != CONTINGENCY and rho_n[i] < 1.0)
+        for i in range(n)
+    ]) if monitored else (rho_n < 1.0)
+    pre = rho_n >= 1.0
+
+    def masked_max(rho):
+        not_impacted = (rho >= rho_n * (1 - WORSENING_THRESHOLD)) & (rho <= rho_n * (1 + WORSENING_THRESHOLD))
+        elig = mon & ~(pre & not_impacted)
+        if not elig.any():
+            return "N/A", 0.0
+        j = int(np.argmax(np.where(elig, rho, -1.0)))
+        return name_line[j], float(rho[j])
+
+    def build(spec):
+        kind, name = spec
+        if kind == "disco":
+            return env.action_space({"set_line_status": [(name, -1)]})
+        if kind == "reco":
+            return env.action_space({"set_line_status": [(name, +1)]})
+        if kind == "ls":
+            return env.action_space({"set_load_p": {name: 0.0}})
+        raise ValueError(spec)
+
+    def elem(spec):
+        kind, name = spec
+        if kind in ("disco", "reco"):
+            return [idx[name]], [], False
+        return [], [], True  # injection: no topology element
+
+    def diagnose(kind_tag, label, s1, s2):
+        a1, a2 = build(s1), build(s2)
+        o1 = obs_start.simulate(a1)[0]
+        o2 = obs_start.simulate(a2)[0]
+        otgt = obs_start.simulate(a1 + a2)[0]
+        li1, si1, inj1 = elem(s1)
+        li2, si2, inj2 = elem(s2)
+        res = compute_combined_pair_superposition(
+            obs_start, o1, o2, li1, si1, li2, si2,
+            act1_is_injection=inj1, act2_is_injection=inj2)
+        print("=" * 78)
+        print(f"[{kind_tag}] {label}")
+        if "error" in res:
+            print(f"    ERROR: {res['error']}")
+            return
+        b = np.asarray(res["betas"])
+        rho_sim = np.asarray(otgt.rho)
+        # default direct-rho superposition (matches compute_combined_rho)
+        rho_est = np.abs((1 - b.sum()) * rho0 + b[0] * np.asarray(o1.rho) + b[1] * np.asarray(o2.rho))
+        p_gst = np.asarray(res["p_or_combined"])
+        p_tgt = np.asarray(otgt.p_or)
+        gap = np.abs(rho_est - rho_sim)[mon] * 100
+        fgap = np.abs(p_gst - p_tgt)[mon]
+        el, ev = masked_max(rho_est)
+        sl, sv = masked_max(rho_sim)
+        print(f"    betas={np.round(b, 3).tolist()}")
+        print(f"    monitored-line rho gap: mean={gap.mean():.1f}  max={gap.max():.1f} pts "
+              f"| flow gap: mean={fgap.mean():.2f}  max={fgap.max():.2f} MW")
+        print(f"    EST max(monitored) = {ev * 100:5.1f}% on {el}")
+        print(f"    SIM max(monitored) = {sv * 100:5.1f}% on {sl}"
+              f"   {'[max line MATCH]' if el == sl else '[max line FLIPPED]'}")
+
+    print(f"network    : {NETWORK_PATH}")
+    print(f"contingency: {CONTINGENCY}")
+    print(f"monitored  : {len(monitored)} lines\n")
+    print("EST = topology+topology (no injection) ; GST = with injection\n")
+
+    # Topology-only EST pairs (baseline accuracy).
+    diagnose("EST", "reco_GEN.PY762 + disco_BEON L31CPVAN",
+             ("reco", "GEN.PY762"), ("disco", "BEON L31CPVAN"))
+    diagnose("EST", "disco_BEON L31CPVAN + reco_BOISSL61GEN.P",
+             ("disco", "BEON L31CPVAN"), ("reco", "BOISSL61GEN.P"))
+    # GST topology + injection pairs (should match EST accuracy).
+    diagnose("GST", "disco_BEON L31CPVAN + load_shedding_P.SAO3TR312",
+             ("disco", "BEON L31CPVAN"), ("ls", "P.SAO3TR312"))
+    diagnose("GST", "disco_BEON L31CPVAN + load_shedding_BEON3 TR311",
+             ("disco", "BEON L31CPVAN"), ("ls", "BEON3 TR311"))
+    # GST injection + injection pair (weaker: AC nonlinearity compounds).
+    diagnose("GST", "load_shedding_P.SAO3TR312 + load_shedding_BEON3 TR311",
+             ("ls", "P.SAO3TR312"), ("ls", "BEON3 TR311"))
+
+    dc_exactness_check()
+    return 0
+
+
+def dc_exactness_check():
+    """Prove the GST formula is EXACT in true DC for the flagged pair
+    (disco_BEON L31CPVAN + load_shedding_P.SAO3TR312), via a direct pypowsybl
+    DC load flow on the 4 states. If the GST reconstructs the DC combined flows
+    to ~0 MW, the est-vs-sim gap seen on the AC grid is AC-nonlinearity, not a
+    formula error.
+    """
+    try:
+        import pypowsybl.network as pn
+        import pypowsybl.loadflow as lf
+    except Exception as e:  # pragma: no cover
+        print(f"\n[DC-exactness check skipped: {e}]")
+        return
+    cont, beon, cfou, pymon, load = (
+        CONTINGENCY, "BEON L31CPVAN", "C.FOUL31MERVA", "PYMONL31SAISS", "P.SAO3TR312")
+    base = pn.load(NETWORK_PATH)
+    lines, loads = base.get_lines(), base.get_loads()
+
+    def rid(idx_obj, nm):
+        return nm if nm in idx_obj.index else next(
+            (i for i in idx_obj.index if i.strip() == nm.strip()), None)
+
+    lid = {k: rid(lines, k) for k in (cont, beon, cfou, pymon)}
+    load_id = rid(loads, load)
+    if any(v is None for v in lid.values()) or load_id is None:
+        print("\n[DC-exactness check skipped: element name mapping failed]")
+        return
+
+    def dc(disco_beon=False, shed=False):
+        net = pn.load(NETWORK_PATH)
+        net.update_lines(id=lid[cont], connected1=False, connected2=False)
+        if disco_beon:
+            net.update_lines(id=lid[beon], connected1=False, connected2=False)
+        if shed:
+            net.update_loads(id=load_id, p0=0.0)
+        lf.run_dc(net, parameters=lf.Parameters(distributed_slack=True))
+        flows = net.get_lines()
+        return {nm: float(flows.loc[lid[nm], "p1"]) for nm in (beon, cfou, pymon)}
+
+    ref, disco, shed, both = dc(), dc(True), dc(False, True), dc(True, True)
+    beta = shed[beon] / ref[beon]  # GST topology beta = f_BEON(shed)/f_BEON(ref)
+    print("\n" + "=" * 78)
+    print("[DC-EXACTNESS] disco_BEON L31CPVAN + load_shedding_P.SAO3TR312 (true DC)")
+    print(f"    GST beta(disco) = {beta:.4f}")
+    for nm in (cfou, pymon):
+        gst = (1 - beta) * ref[nm] + beta * disco[nm] + (shed[nm] - ref[nm])
+        print(f"    {nm:14s}: GST={gst:8.3f}  DC_sim={both[nm]:8.3f}  err={gst - both[nm]:+.4f} MW")
+    print("    -> ~0 MW error confirms the GST is exact in DC; the AC est-vs-sim")
+    print("       gap is AC-nonlinearity on low-flow coupled lines, not a bug.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Extends combined-pair **estimation** to support injection actions (load shedding, curtailment, redispatch) alongside topology actions by integrating the recommender library's Generalized Superposition Theorem (GST). Previously, pairs involving injections could only be simulated; now they can be estimated via superposition, matching the accuracy of pure-topology pairs while anchoring to the true AC operating point.

## Key Changes

### Backend (`expert_backend/services/`)

- **`simulation_helpers.py`**: Added `is_injection_action()` detector that identifies load shedding, curtailment, and redispatch actions by id prefix (`load_shedding_`, `curtail_`, `redispatch_`) and classifier action type. Kept in sync with the library's `superposition.is_injection_action`.

- **`simulation_mixin.py`**: Modified `compute_superposition()` to:
  - Compute `act1_is_injection` and `act2_is_injection` flags for both actions
  - Skip the "cannot identify elements" bail-out for injection actions (they carry no topology element)
  - Forward the injection flags to `compute_combined_pair_superposition()` so the library routes to the GST path
  - Injection actions are returned with `beta = 1.0` (GST convention), so existing `compute_combined_rho` and `_augment_superposition_result` logic works unchanged

### Frontend (`frontend/src/components/`)

- **`CombinedActionsModal.tsx`**: Removed the `hasRestricted` check that blocked load shedding / curtailment / redispatch from estimation. Set `hasRestricted = false` unconditionally since all action types are now estimable via GST.

- **`ExplorePairsTab.tsx`**: Removed the warning banners ("Load shedding / curtailment actions cannot be combined for estimation") that previously appeared above those action lists.

### Tests (`expert_backend/tests/test_superposition_service.py`)

Added four new test cases:
- `test_compute_superposition_allows_injection_action`: Validates topology+injection pair estimation
- `test_compute_superposition_injection_first`: Validates injection on the first side
- `test_compute_superposition_injection_plus_injection`: Validates pure injection+injection pairs
- `test_is_injection_action_helper`: Unit tests the injection detector

### Documentation & Diagnostics

- **`docs/features/combined-actions.md`**: Documented the GST integration, AC-anchoring behavior, and known larger-error cases (off-target max-line flip on parallel corridors; injection+injection over-prediction). Explains how to read results (trust `target_max_rho`; the global max can flip between near-equal low-flow lines).

- **`scripts/gst_estimation_vs_simulation_small_grid.py`**: New library-level diagnostic script that reproduces GST estimate-vs-simulation behavior on the small grid without running the backend. Includes a direct-DC exactness proof showing the AC est-vs-sim gap is AC-nonlinearity (0 MW error in DC), not a formula bug.

- **`CHANGELOG.md`**: Documented the GST feature, backend/frontend changes, test additions, and diagnostic script.

## Implementation Details

- The GST formula is **exact in DC** but AC-nonlinear, so the superposition law reproduces AC flows only to the extent the grid is linear. The backend detects this by anchoring to AC load-flow values (both the injection superposition term and the injection-shifted beta).

- The integration is deliberately thin: injection actions report `beta = 1.0`, topology actions report their (injection-shifted) beta, and the existing EST `rho_combined` formula already reproduces the exact GST loading. No GST-specific branches needed in `compute_combined_rho` or result augmentation.

- Injection+injection pairs are lower-confidence (two large injections compound AC error); the docs and diagnostic script catalog the measured accuracy gap (e.g., `load_shedding_P.SAO3TR312 + load_shedding_BEON3 TR311

https://claude.ai/code/session_01UQxnPH6uCbL616aWMR5muF