### PR TITLE
Add antenna (islanded-pocket) notice UI and backend support

### DIFF
--- a/expert_backend/services/analysis_mixin.py
+++ b/expert_backend/services/analysis_mixin.py
@@ -841,8 +841,19 @@ class AnalysisMixin(_Base):
         new_ids = [original_ids[i] for i in selected_indices]
         context["lines_overloaded_ids"] = new_ids
 
-        original_kept = set(context["lines_overloaded_ids_kept"])
-        context["lines_overloaded_ids_kept"] = [idx for idx in new_ids if idx in original_kept]
+        original_kept_raw = context.get("lines_overloaded_ids_kept")
+        if original_kept_raw is None:
+            # Antenna (islanded-pocket) mode: the island guard kept no
+            # overloads for the standard overflow graph, so upstream
+            # leaves ``lines_overloaded_ids_kept`` as None and drives a
+            # synthetic downstream graph instead (``antenna_mode=True``;
+            # ``run_analysis_step2_graph`` dispatches to the antenna path
+            # before ever reading this key). Preserve None — narrowing the
+            # operator's selection must not fabricate a kept-list.
+            context["lines_overloaded_ids_kept"] = None
+        else:
+            original_kept = set(original_kept_raw)
+            context["lines_overloaded_ids_kept"] = [idx for idx in new_ids if idx in original_kept]
         context["lines_overloaded_names"] = [all_names[i] for i in selected_indices]
 
         if not monitor_deselected and all_overloads:

--- a/expert_backend/services/analysis_mixin.py
+++ b/expert_backend/services/analysis_mixin.py
@@ -733,6 +733,10 @@ class AnalysisMixin(_Base):
                 "lines_overloaded": results["lines_overloaded_names"],
                 "pre_existing_overloads": results.get("pre_existing_overloads", []),
                 "combined_actions": results.get("combined_actions", {}),
+                # Present only for the islanded-pocket (antenna) case: describes
+                # the disconnected radial zone + its net direction so the UI can
+                # flag that recommendations are injection-only. None otherwise.
+                "antenna_meta": results.get("antenna_meta"),
                 "lines_we_care_about": list(lines_we_care_about) if lines_we_care_about is not None else None,
                 "active_model": (
                     self.get_active_model_name()

--- a/expert_backend/services/overflow_overlay.py
+++ b/expert_backend/services/overflow_overlay.py
@@ -102,6 +102,13 @@ def _build_overlay_block() -> str:
      This file only adds interactive affordances (cursor / opacity). */
   .cs4g-pin {{ pointer-events: auto; cursor: pointer; }}
 
+  /* Hide the synthetic upstream "grid source" node (and its edge) that the
+     recommender injects into an islanded-pocket ("antenne") overflow graph to
+     anchor the constrained path's amont side. It is a modelling artifact, not
+     a real substation, so it must not show in the viewer. */
+  .node[data-name="__GRID_SOURCE__"],
+  .edge[data-attr-name="__GRID_SOURCE__"] {{ display: none; }}
+
   /* ``ACTION PINS FILTERS`` section appended at the BOTTOM of the
      iframe's sidebar. The section is ALWAYS visible (it carries the
      pins on/off toggle, so it must be reachable before any pin has

--- a/expert_backend/tests/test_overflow_overlay.py
+++ b/expert_backend/tests/test_overflow_overlay.py
@@ -45,6 +45,14 @@ class TestInjectOverlay:
         assert 0 < style_at < body_close
         assert 0 < script_at < body_close
 
+    def test_synthetic_grid_source_node_is_hidden(self) -> None:
+        # The recommender injects a synthetic "__GRID_SOURCE__" upstream node
+        # into an islanded-pocket ("antenne") overflow graph. It is a modelling
+        # artifact and must be hidden by the viewer overlay CSS.
+        out = inject_overlay(_BASE_HTML)
+        assert '.node[data-name="__GRID_SOURCE__"]' in out
+        assert '.edge[data-attr-name="__GRID_SOURCE__"]' in out
+
     def test_pin_message_listener_is_injected(self) -> None:
         out = inject_overlay(_BASE_HTML)
         assert "cs4g:pins" in out

--- a/expert_backend/tests/test_overload_filtering.py
+++ b/expert_backend/tests/test_overload_filtering.py
@@ -125,6 +125,47 @@ class TestOverloadFiltering:
 
     @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
     @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
+    def test_run_analysis_step2_antenna_mode_none_kept_ids(self, mock_run_discovery, mock_run_graph, service):
+        """Antenna (islanded-pocket) mode: lines_overloaded_ids_kept is None.
+
+        When the contingency breaks the grid apart, upstream
+        run_analysis_step1 returns a full context but with
+        lines_overloaded_ids_kept=None (the island guard keeps no
+        overloads for the standard graph; a synthetic downstream graph
+        is built instead). The step-2 narrow helper must preserve None
+        rather than crash with 'NoneType' object is not iterable.
+        """
+        mock_run_graph.side_effect = lambda ctx: ctx
+        mock_run_discovery.return_value = {
+            "prioritized_actions": {},
+            "action_scores": {},
+            "lines_overloaded_names": ["L1", "L2"],
+        }
+
+        service._analysis_context = {
+            "env": MagicMock(),
+            "lines_overloaded_names": ["L1", "L2"],
+            "lines_overloaded_ids": [0, 1],
+            "lines_overloaded_ids_kept": None,
+            "antenna_mode": True,
+            "lines_we_care_about": {"L1", "L2", "L3"},
+        }
+
+        # Must not raise.
+        list(service.run_analysis_step2(
+            selected_overloads=["L1"],
+            all_overloads=["L1", "L2"],
+            monitor_deselected=False,
+        ))
+
+        # None is preserved so the upstream antenna path still dispatches,
+        # while the operator's selection narrows the rest of the context.
+        assert service._analysis_context["lines_overloaded_ids_kept"] is None
+        assert service._analysis_context["lines_overloaded_names"] == ["L1"]
+        assert service._analysis_context["lines_overloaded_ids"] == [0]
+
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_graph")
+    @patch("expert_backend.services.analysis_mixin.run_analysis_step2_discovery")
     def test_run_analysis_step2_handles_invalid_names_in_selection(self, mock_run_discovery, mock_run_graph, service):
         """Verify that invalid names in selected_overloads are ignored."""
         mock_run_graph.side_effect = lambda ctx: ctx

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import './App.css';
 import VisualizationPanel from './components/VisualizationPanel';
 import ActionFeed from './components/ActionFeed';
+import AntennaNotice from './components/AntennaNotice';
 import Header from './components/Header';
 import AppSidebar from './components/AppSidebar';
 import StatusToasts from './components/StatusToasts';
@@ -1807,6 +1808,9 @@ function App() {
           onOverviewFiltersChange={setOverviewFilters}
           hasActions={Object.keys(result?.actions || {}).length > 0}
         >
+          {sidebarSwitchedToFeed && result?.antenna_meta && (
+            <AntennaNotice meta={result.antenna_meta} />
+          )}
           {sidebarSwitchedToFeed && (
           <ActionFeed
             actions={result?.actions || {}}

--- a/frontend/src/components/AntennaNotice.test.tsx
+++ b/frontend/src/components/AntennaNotice.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import AntennaNotice from './AntennaNotice';
+import type { AntennaMeta } from '../types';
+
+const baseMeta: AntennaMeta = {
+    constraint_line_name: 'LINE_X',
+    root_sub_name: 'SUB_ROOT',
+    antenna_sub_names: ['S1', 'S2', 'S3'],
+    n_subs: 3,
+    total_prod_mw: 0,
+    total_load_mw: 60,
+    net_mw: -60,
+    direction: 'consumer',
+};
+
+describe('AntennaNotice', () => {
+    it('names the constraint line, the root and the pocket size', () => {
+        render(<AntennaNotice meta={baseMeta} />);
+        const notice = screen.getByTestId('antenna-notice');
+        expect(notice).toHaveTextContent('LINE_X');
+        expect(notice).toHaveTextContent('SUB_ROOT');
+        expect(notice).toHaveTextContent('3');
+        expect(notice).toHaveTextContent('S1, S2, S3');
+    });
+
+    it('describes a consumer pocket as load shedding / redispatch-up', () => {
+        render(<AntennaNotice meta={baseMeta} />);
+        expect(screen.getByTestId('antenna-notice')).toHaveTextContent(/load shedding/i);
+    });
+
+    it('describes a producer pocket as curtailment / redispatch-down', () => {
+        render(<AntennaNotice meta={{ ...baseMeta, direction: 'producer', net_mw: 140 }} />);
+        expect(screen.getByTestId('antenna-notice')).toHaveTextContent(/curtailment/i);
+    });
+
+    it('truncates a long pocket list with a "+N more" suffix', () => {
+        const many = Array.from({ length: 10 }, (_, i) => `Sub${i}`);
+        render(<AntennaNotice meta={{ ...baseMeta, antenna_sub_names: many, n_subs: 10 }} />);
+        expect(screen.getByTestId('antenna-notice')).toHaveTextContent('+4 more');
+    });
+});

--- a/frontend/src/components/AntennaNotice.tsx
+++ b/frontend/src/components/AntennaNotice.tsx
@@ -1,0 +1,55 @@
+import type { AntennaMeta } from '../types';
+import { colors, space, text, radius } from '../styles/tokens';
+
+interface AntennaNoticeProps {
+    meta: AntennaMeta;
+}
+
+/**
+ * Banner shown when the contingency islands a radial ("antenne") pocket of
+ * substations. In that case the overflow graph is a synthetic downstream graph
+ * of the disconnected zone and the recommender only proposes injection actions
+ * (load shedding / curtailment / redispatch) — topological actions are filtered
+ * out because they cannot help an isolated pocket.
+ */
+function AntennaNotice({ meta }: AntennaNoticeProps) {
+    const subs = meta.antenna_sub_names || [];
+    const shown = subs.slice(0, 6);
+    const extra = subs.length - shown.length;
+    const directionLabel = meta.direction === 'producer'
+        ? 'net producer (export) — curtailment / redispatch-down'
+        : 'net consumer (import) — load shedding / redispatch-up';
+
+    return (
+        <div
+            role="status"
+            data-testid="antenna-notice"
+            style={{
+                background: colors.warningSoft,
+                border: `1px solid ${colors.warningBorder}`,
+                color: colors.warningText,
+                borderRadius: radius.md,
+                padding: `${space[2]} ${space[3]}`,
+                margin: `${space[2]} 0`,
+                fontSize: text.sm,
+                lineHeight: 1.4,
+            }}
+        >
+            <div style={{ fontWeight: 600, marginBottom: space.half }}>
+                ⚠ Islanded radial pocket — injection actions only
+            </div>
+            <div>
+                Disconnecting the overloaded line <strong>{meta.constraint_line_name}</strong> isolates a
+                radial pocket of <strong>{meta.n_subs}</strong> substation{meta.n_subs > 1 ? 's' : ''} fed
+                from <strong>{meta.root_sub_name}</strong>. Topological actions can't help an isolated zone,
+                so only load shedding, curtailment and redispatch are suggested.
+            </div>
+            <div style={{ marginTop: space.half, color: colors.textSecondary }}>
+                Pocket: {shown.join(', ')}{extra > 0 ? ` +${extra} more` : ''} · {directionLabel}
+                {' '}({meta.net_mw} MW net).
+            </div>
+        </div>
+    );
+}
+
+export default AntennaNotice;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -197,6 +197,26 @@ export interface AnalysisResult {
     // overhead. Difference vs. the sum of the per-stage timings above
     // is the "transit" overhead.
     wall_clock_time?: number;
+    // Present only when the contingency islands a radial ("antenne")
+    // pocket: the overflow graph is a synthetic downstream graph of the
+    // disconnected zone and recommendations are injection-only (load
+    // shedding / curtailment / redispatch). Null/absent otherwise.
+    antenna_meta?: AntennaMeta | null;
+}
+
+// Describes the disconnected radial pocket of an islanded-contingency
+// ("antenne") analysis. Mirrors the recommender's antenna_meta dict.
+export interface AntennaMeta {
+    constraint_line_name: string;
+    root_sub_name: string;
+    antenna_sub_names: string[];
+    n_subs: number;
+    total_prod_mw: number;
+    total_load_mw: number;
+    net_mw: number;
+    // "producer" (net export → curtailment / redispatch-down) or
+    // "consumer" (net import → load shedding / redispatch-up).
+    direction: 'producer' | 'consumer';
 }
 
 export interface BranchResponse {


### PR DESCRIPTION
## Summary

Adds frontend and backend support for displaying information about islanded-pocket ("antenne") contingencies, where a disconnection breaks the grid into isolated zones. The UI now shows a warning banner explaining that only injection actions (load shedding, curtailment, redispatch) are recommended for such cases, and hides the synthetic `__GRID_SOURCE__` node used internally by the recommender.

## Key Changes

**Frontend:**
- New `AntennaNotice` component that displays a styled warning banner with details about the islanded pocket:
  - Constraint line name, root substation, and pocket size
  - List of substations in the pocket (truncated to 6 with "+N more" suffix)
  - Direction classification (producer/consumer) and net MW
  - Explanation that topological actions cannot help isolated zones
- Added `AntennaMeta` TypeScript interface to `types.ts` mirroring the recommender's antenna metadata
- Integrated `AntennaNotice` into `App.tsx` to display when `result.antenna_meta` is present
- Added comprehensive unit tests for the component covering all display variants

**Backend:**
- Modified `analysis_mixin.py` to pass `antenna_meta` from recommender results through to the API response
- Fixed `_narrow_context_to_selected_overloads()` to handle `lines_overloaded_ids_kept=None` in antenna mode (preserves None rather than crashing on NoneType iteration)
- Added test case `test_run_analysis_step2_antenna_mode_none_kept_ids` to verify antenna mode context narrowing
- Updated `overflow_overlay.py` to inject CSS hiding the synthetic `__GRID_SOURCE__` node and its edges in the interactive overflow viewer
- Added test case `test_synthetic_grid_source_node_is_hidden` to verify the CSS injection

## Implementation Details

- The antenna notice only renders when the sidebar is switched to the feed view and `antenna_meta` is present
- Substation list truncation at 6 items keeps the UI compact while showing "+N more" for longer lists
- Direction classification ("producer" vs "consumer") determines the recommended action types displayed
- Backend preserves `None` for `lines_overloaded_ids_kept` in antenna mode to allow upstream antenna-specific graph dispatch logic to proceed uninterrupted
- CSS hiding of `__GRID_SOURCE__` uses data attributes to target the synthetic node without affecting real substations

https://claude.ai/code/session_01G98jPDQCUoczpkHbeshENj