### PR TITLE
Fix handleManualReset to preserve contingency anchor in lastZoomState

### DIFF
--- a/frontend/src/hooks/useDiagrams.test.ts
+++ b/frontend/src/hooks/useDiagrams.test.ts
@@ -111,6 +111,48 @@ describe('useDiagrams — interaction logging', () => {
         expect(log[0].details).toEqual({ tab: 'n' });
     });
 
+    it('handleManualReset records the current contingency anchor so the auto-zoom effect does NOT re-zoom back onto the contingency (Unzoom must fully unzoom)', () => {
+        // Regression: handleManualReset used to reset lastZoomState to
+        // { query: '', branch: '' } while a contingency was still selected.
+        // The auto-zoom effect then saw branch '' !== contingency anchor,
+        // treated it as a branch change, and immediately re-zoomed onto the
+        // contingency — so Unzoom snapped back instead of fully unzooming.
+        const { result } = renderHook(() =>
+            useDiagrams([], [], ['LINE_A', 'LINE_B']),
+        );
+
+        // A viewBox must exist for the reset to write lastZoomState.
+        act(() => {
+            result.current.setOriginalViewBox({ x: 0, y: 0, w: 100, h: 100 });
+        });
+
+        act(() => {
+            result.current.handleManualReset();
+        });
+
+        expect(result.current.lastZoomState.current).toEqual({
+            query: '',
+            branch: 'LINE_A',
+        });
+    });
+
+    it('handleManualReset records an empty branch when no contingency is selected', () => {
+        const { result } = renderHook(() => useDiagrams([], [], []));
+
+        act(() => {
+            result.current.setOriginalViewBox({ x: 0, y: 0, w: 100, h: 100 });
+        });
+
+        act(() => {
+            result.current.handleManualReset();
+        });
+
+        expect(result.current.lastZoomState.current).toEqual({
+            query: '',
+            branch: '',
+        });
+    });
+
     it('logs sld_overlay_opened when handleVlDoubleClick is called', () => {
         const { result } = renderHook(() => useDiagrams([], [], []));
 

--- a/frontend/src/hooks/useDiagrams.ts
+++ b/frontend/src/hooks/useDiagrams.ts
@@ -770,7 +770,11 @@ export function useDiagrams(
 
     if (pz && viewBox) {
       pz.setViewBox(viewBox);
-      lastZoomState.current = { query: '', branch: '' };
+      // Record the current contingency anchor (not an empty branch) so the
+      // auto-zoom effect does NOT see a "branch change" and immediately
+      // re-zoom back onto the contingency — Unzoom must fully unzoom to the
+      // whole-network view and stay there.
+      lastZoomState.current = { query: '', branch: selectedContingency[0] || '' };
     }
 
     const container = tab === 'action' ? actionSvgContainerRef.current
@@ -778,7 +782,7 @@ export function useDiagrams(
     if (container) {
       container.querySelectorAll('.nad-highlight').forEach(el => el.classList.remove('nad-highlight'));
     }
-  }, [activeTab, actionPZ, nPZ, n1PZ, actionDiagram, nDiagram, n1Diagram, originalViewBox]);
+  }, [activeTab, actionPZ, nPZ, n1PZ, actionDiagram, nDiagram, n1Diagram, originalViewBox, selectedContingency]);
 
   // ===== Tab Synchronization =====
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
Fixes a regression in `handleManualReset` where the auto-zoom effect would immediately re-zoom back onto a contingency after an Unzoom action, preventing full unzoom to the whole-network view.

## Root Cause
When `handleManualReset` was called, it reset `lastZoomState` to `{ query: '', branch: '' }` regardless of whether a contingency was selected. The auto-zoom effect then detected `branch: ''` as different from the currently selected contingency anchor and treated it as a "branch change," triggering an immediate re-zoom onto the contingency.

## Key Changes
- **useDiagrams.ts**: Modified `handleManualReset` to record the current contingency anchor in `lastZoomState.branch` instead of always resetting to an empty string
  - When a contingency is selected: `branch: selectedContingency[0]`
  - When no contingency is selected: `branch: ''`
  - This prevents the auto-zoom effect from seeing a spurious "branch change" and re-zooming
- **useDiagrams.ts**: Added `selectedContingency` to the dependency array of the `handleManualReset` effect
- **useDiagrams.test.ts**: Added two regression tests
  - Test 1: Verifies that `handleManualReset` records the current contingency anchor when one is selected
  - Test 2: Verifies that `handleManualReset` records an empty branch when no contingency is selected

## Implementation Details
The fix ensures that `lastZoomState` always reflects the actual zoom context after a manual reset, so the auto-zoom effect can correctly distinguish between a true branch/contingency change and a reset operation.

https://claude.ai/code/session_017NW8qmnpwiRzxKBxs6ZPuD