### PR TITLE
Add HuggingFace Space demo link and context to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Co-Study4Grid
 
+> **Want to try being a dispatcher?** Jump into this challenge to try it yourself: [![Open in HuggingFace Space](https://img.shields.io/badge/%F0%9F%A4%97%20HuggingFace-Open%20the%20demo-yellow)](https://amarot-co-study4grid.hf.space/)
+>
+> The demo runs the [European-Wide Studies in Practice](#european-wide-studies-in-practice) cases highlighted below.
+
 **Co-Study4Grid** is a full-stack web application for **power grid contingency analysis and remedial action search**. It provides an interactive interface on top of the [`expert_op4grid_recommender`](https://github.com/marota/Expert_op4grid_recommender) library, letting grid operators simulate element disconnections, visualize and analyze network overflows, and explore prioritized remedial actions — topology changes, PST tap adjustments, renewable curtailment, load shedding, and generation redispatch — individually or combined.It adopts the supportive framework mindset from AI4RealNet European project, empowering and supporting the user in developping its expertise rather than automating it.
 
 The remedial action recommender is **pluggable**: pick the expert rule-based system, a random


### PR DESCRIPTION
## Summary
Enhanced the README with a prominent call-to-action banner linking to the HuggingFace Space demo, allowing users to try the dispatcher experience interactively without local setup.

## Changes
- Added a "Want to try being a dispatcher?" banner at the top of the README with a clickable HuggingFace Space badge
- Included a note clarifying that the demo runs the European-Wide Studies in Practice cases
- Positioned the banner before the main project description to maximize visibility for new visitors

## Details
The new section uses a blockquote format (markdown `>`) to visually distinguish the call-to-action from the main content, and includes a direct link to the live demo at `https://amarot-co-study4grid.hf.space/`. This lowers the barrier to entry for users interested in exploring the application's capabilities before diving into documentation or local installation.

https://claude.ai/code/session_01RfDuV2BqsFFNtnQP7dkmiL