### PR TITLE
Track the recommender's unified simulation module in the test mock list

### DIFF
--- a/expert_backend/tests/conftest.py
+++ b/expert_backend/tests/conftest.py
@@ -41,7 +41,10 @@ _MOCK_MODULES = [
     "expert_op4grid_recommender.action_evaluation",
     "expert_op4grid_recommender.action_evaluation.classifier",
     "expert_op4grid_recommender.environment_pypowsybl",
-    "expert_op4grid_recommender.utils.simulation_pypowsybl",
+    # utils.simulation is the single backend-agnostic simulation module since the
+    # recommender's R4 refactor unified the grid2op/pypowsybl pair (the old
+    # utils.simulation_pypowsybl was deleted).
+    "expert_op4grid_recommender.utils.simulation",
     "expert_op4grid_recommender.environment",
     "expert_op4grid_recommender.pypowsybl_backend",
     "expert_op4grid_recommender.pypowsybl_backend.simulation_env",


### PR DESCRIPTION
Companion to the `expert_op4grid_recommender` **R4** refactor (v0.2.8), which merged the grid2op / pypowsybl simulation helpers into a single backend-agnostic `utils.simulation` module and **deleted** `utils.simulation_pypowsybl`.

## Change
- `expert_backend/tests/conftest.py`: update the domain-package mock list to reference `expert_op4grid_recommender.utils.simulation` instead of the now-deleted `utils.simulation_pypowsybl`, keeping the mock layer accurate.

## Why it's safe
- No production Co-Study code imports either module (only `utils.superposition`, `utils.make_env_utils`, `environment*`, `models`, `pypowsybl_backend.simulation_env`, `config`, and the `main` API are used), so the integration is otherwise unchanged.
- Verified against the **real** edited recommender: the backend test suite passes (888 tests). The only failures are environmental (missing Graphviz `dot` binary) plus two golden-trace tests that **fail identically on the pre-refactor recommender** — i.e. pre-existing recommender/pypowsybl version drift, not caused by this change.
- The recommender's config contract is preserved (its `config` module stays plain and mutable), so Co-Study's direct `config.*` mutations keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014npyG1CZHF5LxRL8sa39op