### PR TITLE
fix(game): attribute the novelty bonus to its scenario's score, not the global total 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ and the project (informally) follows [Semantic Versioning](https://semver.org/).
   `applyLoadedConfig`) raced `loadGameStudy` and overwrote the study's paths
   with `config.json`'s. The hydration now skips the grid paths in Game Mode —
   the active study owns them — so the field always reflects the loaded grid.
+- **Fixed: novelty bonus attributed to the global score instead of its
+  scenario.** The results screen (`GameResults.tsx`) showed each solved
+  study's `🌟 new +N` badge in the Result column, but the Score column next
+  to it still displayed the bare per-study score — the bonus only ever
+  appeared as a single lump sum tacked onto the already-averaged session
+  final score ("80.5 + 60 = 140.5 with bonus"). The Score column now adds
+  the bonus directly to the scenario that earned it, and the session-level
+  "with bonus" figure is derived from those bonus-inclusive per-study totals
+  (their mean) instead of a flat sum added after averaging. The twin-locked
+  60/25/15 `scoring.ts` formula (and the Codabench-submitted JSON) are
+  unchanged — this is a display-only fix.
 
 ### Game Mode — solution capitalisation: shared base, novelty bonus, usage-frequency feedback
 

--- a/frontend/src/game/GameResults.test.tsx
+++ b/frontend/src/game/GameResults.test.tsx
@@ -79,6 +79,29 @@ describe('GameResults — solution capitalisation feedback', () => {
     expect(screen.getByText(/retained in 3 \/ 4 prior retentions \(75%\)/)).toBeInTheDocument();
   });
 
+  it('adds the bonus to the scenario that earned it, not just to the global score', () => {
+    // Single study: physical=60, actions=25, time=6 -> sc.total=91, +20 bonus -> 111.0.
+    const log = sessionLog([
+      studyResult({
+        solutionFeedback: {
+          studyId: 's1',
+          novelty: { newProposition: true, newLevers: ['action:disco_A'], effective: true, bonusPoints: 20 },
+          frequencies: [],
+        },
+      }),
+    ]);
+
+    render(<GameResults log={log} onReplay={vi.fn()} />);
+
+    // Score column shows the bonus-inclusive total for that scenario, with
+    // a breakdown of the base + bonus, not the bare base score.
+    expect(screen.getByText('111.0')).toBeInTheDocument();
+    expect(screen.getByText('91.0 + 20 bonus')).toBeInTheDocument();
+    // The session-level "with bonus" figure matches the same 111.0 (mean
+    // of one bonus-inclusive study), not a naive base + total-bonus sum.
+    expect(screen.getByText(/session score with bonus: 111\.0/)).toBeInTheDocument();
+  });
+
   it('flags a novel-but-ineffective proposition without paying the bonus', () => {
     const log = sessionLog([
       studyResult({

--- a/frontend/src/game/GameResults.tsx
+++ b/frontend/src/game/GameResults.tsx
@@ -9,7 +9,7 @@ import { colors, space, text, radius } from '../styles/tokens';
 import { buildSessionCsv, downloadFile, slugifySession } from './gameLog';
 import { scoreSession } from './scoring';
 import { sessionNoveltyBonus } from './solutionLog';
-import type { ActionUsageFrequency, GameSessionLog } from './types';
+import type { ActionUsageFrequency, GameSessionLog, GameStudyResult } from './types';
 
 interface GameResultsProps {
   log: GameSessionLog;
@@ -40,10 +40,21 @@ function frequencyLabel(f: ActionUsageFrequency): string {
   return `retained in ${f.count} / ${f.total} prior retentions (${(f.share * 100).toFixed(0)}%)`;
 }
 
+/** Novelty bonus earned on one study — the score.perStudy entry stays twin-locked to the Codabench formula. */
+function studyBonus(s: GameStudyResult): number {
+  return s.solutionFeedback?.novelty.bonusPoints ?? 0;
+}
+
 export default function GameResults({ log, onReplay }: GameResultsProps) {
   const score = scoreSession(log);
   const slug = slugifySession(log.sessionName);
   const noveltyBonus = sessionNoveltyBonus(log.studies);
+  // Bonus is attributed to the scenario that earned it, then the session
+  // total is derived from those bonus-inclusive per-study scores — not a
+  // lump sum tacked onto the already-averaged final score.
+  const finalScoreWithBonus = score.nStudies
+    ? score.perStudy.reduce((sum, sc, i) => sum + sc.total + studyBonus(log.studies[i]), 0) / score.nStudies
+    : score.finalScore;
   const studiesWithFeedback = log.studies.filter(
     (s) => s.solutionFeedback && s.solutionFeedback.frequencies.length > 0);
 
@@ -81,12 +92,12 @@ export default function GameResults({ log, onReplay }: GameResultsProps) {
             </div>
             {noveltyBonus > 0 && (
               <div style={{ fontSize: text.sm, color: colors.accentText, marginTop: space[1], fontWeight: 600 }}>
-                🌟 +{noveltyBonus} novelty bonus pts — {score.finalScore.toFixed(1)} + {noveltyBonus} = {(score.finalScore + noveltyBonus).toFixed(1)} with bonus
+                🌟 +{noveltyBonus} novelty bonus pts added to the scenarios that earned them (see Score column) — session score with bonus: {finalScoreWithBonus.toFixed(1)}
               </div>
             )}
             <div style={{ fontSize: text.xs, color: colors.textTertiary, marginTop: space[1] }}>
               Score = mean of per-study scores (physical result 60% · action economy 25% · speed 15%).
-              {noveltyBonus > 0 && ' The novelty bonus rewards solutions never retained before and is shown on top of the Codabench score.'}
+              {noveltyBonus > 0 && ' The novelty bonus rewards solutions never retained before and is added directly to the score of the scenario that earned it.'}
             </div>
           </div>
         </div>
@@ -111,6 +122,7 @@ export default function GameResults({ log, onReplay }: GameResultsProps) {
             <tbody>
               {log.studies.map((s, i) => {
                 const sc = score.perStudy[i];
+                const bonus = studyBonus(s);
                 return (
                   <tr key={s.studyId}>
                     <td style={td}>{i + 1}</td>
@@ -153,7 +165,14 @@ export default function GameResults({ log, onReplay }: GameResultsProps) {
                     <td style={td}>{pct(s.baselineMaxRho)} → {pct(s.finalMaxRho)}</td>
                     <td style={td}>{s.numActions} / {s.maxActions}</td>
                     <td style={td}>{(s.durationMs / 1000).toFixed(0)}s / {s.timeLimitSeconds}s</td>
-                    <td style={{ ...td, fontWeight: 700 }}>{sc.total.toFixed(1)}</td>
+                    <td style={{ ...td, fontWeight: 700 }}>
+                      {(sc.total + bonus).toFixed(1)}
+                      {bonus > 0 && (
+                        <div style={{ fontSize: text.xs, fontWeight: 400, color: colors.accentText }}>
+                          {sc.total.toFixed(1)} + {bonus} bonus
+                        </div>
+                      )}
+                    </td>
                   </tr>
                 );
               })}


### PR DESCRIPTION
GameResults showed each solved study's 🌟 new +N badge in the Result column, but the Score column next to it kept displaying the bare per-study score — the bonus only ever appeared as one lump sum tacked onto the already-averaged session final score ("80.5 + 60 = 140.5 with bonus"). The Score column now adds the bonus directly to the scenario that earned it, and the session-level "with bonus" figure is the mean of those bonus-inclusive per-study totals instead of a flat sum added after averaging.

The twin-locked 60/25/15 scoring.ts formula (and the Codabench- submitted JSON) are untouched — this is a display-only fix.


Claude-Session: https://claude.ai/code/session_01SF6dtDvDsp75aRJj4Pkkfp