### PR TITLE
Make Game-Mode lever hints locate, inspect, and simulate on click

### DIFF
--- a/docs/features/game-mode-codabench.md
+++ b/docs/features/game-mode-codabench.md
@@ -162,11 +162,20 @@ under a persistent root, exact-duplicate dedup, the player name as author).
   config-screen **Beginner assistance** checkbox on (default), the
   `GameHintsPanel` shows the top 5 for the current study in a collapsible
   in-play panel — best-effort like the log itself (no data or no backend →
-  the panel stays hidden). **Clicking a lever pre-fills the Inspect field**
-  (auto-zoom included) with the underlying element — `leverInspectTarget`
-  strips the `disco_`/`reco_` catalogue prefixes down to the branch id —
-  via a `gameBridge.registerInspector` / `requestInspect` pair, so App.tsx
-  stays decoupled from game internals (one guarded registration effect).
+  the panel stays hidden). Each lever is **actionable**: **single-click**
+  locates & inspects it — fills the Inspect field, centers the NAD (an
+  injection or coupling switch is resolved to its home VL through
+  `/api/element-voltage-levels`), and opens that substation's SLD;
+  **double-click** simulates the mapped action directly — a catalogue branch
+  disco/reco (`handleSimulateUnsimulatedAction`) or a coupling maneuver at the
+  resolved VL (`handleSimulateLever`), producing a card in the feed. A
+  magnitude-free injection / PST lever carries no self-contained action, so a
+  double-click degrades to inspect with a hint to set the amount in the SLD.
+  The game side maps a lever signature to a workspace-agnostic
+  `LeverInteraction` (`buildLeverInteraction`) and routes it via a
+  `gameBridge.registerLeverHandler` / `requestLeverInteraction` pair (App's
+  handler lives in the `useLeverInteraction` hook; single-click is deferred so
+  a double-click pre-empts it), so App.tsx stays decoupled from game internals.
 - **Flow** — `useGameSession` fires the log at every study commit,
   fire-and-forget (a failed log never blocks or breaks the game — the study
   simply carries no `solutionFeedback`). The session log is *derived* from

--- a/expert_backend/services/network_service.py
+++ b/expert_backend/services/network_service.py
@@ -495,7 +495,14 @@ class NetworkService:
         }
 
     def get_element_voltage_levels(self, element_id: str) -> list:
-        """Resolve an equipment ID (line, transformer, or VL) to its voltage level IDs."""
+        """Resolve an equipment ID to its voltage level IDs.
+
+        Handles voltage levels, branches (lines / 2-winding transformers →
+        two VLs) and single-VL equipment: generators, loads and switches
+        (busbar couplers / disconnectors). The single-VL cases back the
+        Game-Mode lever hints, which must locate an injection or a coupling
+        switch on the network and open its substation SLD.
+        """
         if not self.network:
             raise ValueError("Network not loaded")
 
@@ -526,7 +533,38 @@ class NetworkService:
                 vls.add(row['voltage_level2_id'])
             return sorted(vls)
 
+        # Single-VL equipment: generators and loads each live in exactly one VL.
+        gen_vl = self._get_gen_vl_map().get(element_id)
+        if isinstance(gen_vl, str) and gen_vl:
+            return [gen_vl]
+        load_vl = self._get_load_vl_map().get(element_id)
+        if isinstance(load_vl, str) and load_vl:
+            return [load_vl]
+
+        # Switches (busbar couplers / disconnectors) also belong to one VL.
+        switch_vl = self._get_switch_voltage_level(element_id)
+        if switch_vl:
+            return [switch_vl]
+
         return []
+
+    def _get_switch_voltage_level(self, switch_id: str) -> str | None:
+        """Return the voltage level ID a switch belongs to, or None.
+
+        Queried on demand (not memoized) — the only caller is the interactive
+        element→VL resolution, hit on a user gesture, so a per-call
+        ``get_switches()`` is cheap enough and keeps the reset() surface small.
+        """
+        try:
+            switches = self.network.get_switches()
+        except Exception:
+            return None
+        if (switches is None or not hasattr(switches, 'index')
+                or switch_id not in switches.index
+                or 'voltage_level_id' not in getattr(switches, 'columns', [])):
+            return None
+        vl = switches.loc[switch_id, 'voltage_level_id']
+        return vl if isinstance(vl, str) and vl else None
 
     def get_load_voltage_level(self, load_id: str) -> str | None:
         """Return the voltage level ID that a given load belongs to."""

--- a/expert_backend/tests/test_network_service.py
+++ b/expert_backend/tests/test_network_service.py
@@ -378,3 +378,33 @@ class TestGetElementVoltageLevels:
         """The default mock network has no get_switches DataFrame; resolution
         must fall through to [] rather than raise."""
         assert mock_network_service.get_element_voltage_levels("SOME_SWITCH") == []
+
+    def test_switch_with_blank_voltage_level_returns_empty(self):
+        service = self._service_with_injections_and_switches()
+        service.network.get_switches.return_value = pd.DataFrame(
+            {"voltage_level_id": [""]}, index=["SW_BLANK"])
+        assert service.get_element_voltage_levels("SW_BLANK") == []
+
+    def test_switch_with_non_string_voltage_level_returns_empty(self):
+        service = self._service_with_injections_and_switches()
+        service.network.get_switches.return_value = pd.DataFrame(
+            {"voltage_level_id": [float("nan")]}, index=["SW_NAN"])
+        assert service.get_element_voltage_levels("SW_NAN") == []
+
+    def test_get_switches_error_is_tolerated(self):
+        """A network backend that raises on get_switches must not 500 the
+        resolution — the switch probe swallows it and falls through to []."""
+        service = self._service_with_injections_and_switches()
+        service.network.get_switches.side_effect = RuntimeError("switch query failed")
+        assert service.get_element_voltage_levels("MYSTERY") == []
+
+    def test_switches_without_voltage_level_column_returns_empty(self):
+        service = self._service_with_injections_and_switches()
+        service.network.get_switches.return_value = pd.DataFrame(
+            {"kind": ["BREAKER"]}, index=["SW_NOCOL"])
+        assert service.get_element_voltage_levels("SW_NOCOL") == []
+
+    def test_branch_resolution_precedes_injection_and_switch_lookup(self, mock_network_service):
+        """A line id resolves to its two VLs even though generators / loads /
+        switches are now probed too — branch precedence is preserved."""
+        assert mock_network_service.get_element_voltage_levels("LINE_A") == ["VL1", "VL2"]

--- a/expert_backend/tests/test_network_service.py
+++ b/expert_backend/tests/test_network_service.py
@@ -331,3 +331,50 @@ class TestGetElementVoltageLevels:
     def test_unknown_element_returns_empty(self, mock_network_service):
         result = mock_network_service.get_element_voltage_levels("NONEXISTENT")
         assert result == []
+
+    @staticmethod
+    def _service_with_injections_and_switches():
+        """A NetworkService whose network also exposes generators, loads and
+        switches — the single-VL equipment the Game-Mode lever hints locate."""
+        from expert_backend.services.network_service import NetworkService
+
+        network = MagicMock()
+        network.get_voltage_levels.return_value = pd.DataFrame(
+            {"nominal_v": [400.0, 225.0]}, index=["VL1", "VL2"])
+        network.get_lines.return_value = pd.DataFrame(
+            {"voltage_level1_id": [], "voltage_level2_id": []}, index=[])
+        network.get_2_windings_transformers.return_value = pd.DataFrame(
+            {"voltage_level1_id": [], "voltage_level2_id": []}, index=[])
+        network.get_generators.return_value = pd.DataFrame(
+            {"voltage_level_id": ["VL1"], "energy_source": ["WIND"],
+             "min_p": [0.0], "max_p": [100.0]},
+            index=["GEN_1"])
+        network.get_loads.return_value = pd.DataFrame(
+            {"voltage_level_id": ["VL2"]}, index=["LOAD_1"])
+        network.get_switches.return_value = pd.DataFrame(
+            {"voltage_level_id": ["VL1"]}, index=["VL1_COUPL"])
+
+        service = NetworkService()
+        service.network = network
+        return service
+
+    def test_generator_resolves_to_its_voltage_level(self):
+        service = self._service_with_injections_and_switches()
+        assert service.get_element_voltage_levels("GEN_1") == ["VL1"]
+
+    def test_load_resolves_to_its_voltage_level(self):
+        service = self._service_with_injections_and_switches()
+        assert service.get_element_voltage_levels("LOAD_1") == ["VL2"]
+
+    def test_switch_resolves_to_its_voltage_level(self):
+        service = self._service_with_injections_and_switches()
+        assert service.get_element_voltage_levels("VL1_COUPL") == ["VL1"]
+
+    def test_unknown_injection_still_returns_empty(self):
+        service = self._service_with_injections_and_switches()
+        assert service.get_element_voltage_levels("GEN_NOPE") == []
+
+    def test_switch_lookup_tolerates_network_without_switches(self, mock_network_service):
+        """The default mock network has no get_switches DataFrame; resolution
+        must fall through to [] rather than raise."""
+        assert mock_network_service.get_element_voltage_levels("SOME_SWITCH") == []

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -60,9 +60,15 @@ frontend/
     │   ├── useActionDiagramCache.ts # D4 sub-hook of useDiagrams — prime-then-
     │   │                           # paint action-variant NAD cache (cleared on
     │   │                           # contingency change)
-    │   ├── useManualSimulation.ts  # D4 — the two operator "simulate now" flows
-    │   │                           # (pin double-click + interactive SLD edit) +
-    │   │                           # the shared SLD-edit state, extracted from App
+    │   ├── useManualSimulation.ts  # D4 — the operator "simulate now" flows
+    │   │                           # (pin double-click + interactive SLD edit +
+    │   │                           # handleSimulateLever for a coupling lever
+    │   │                           # hint) sharing one streamSimulateToCard
+    │   │                           # helper, plus the shared SLD-edit state
+    │   ├── useLeverInteraction.ts  # Game-Mode beginner-assistance wiring:
+    │   │                           # registers the gameBridge lever handler —
+    │   │                           # single-click locate+inspect (VL resolve +
+    │   │                           # SLD open), double-click simulate
     │   ├── usePanZoom.ts           # ViewBox state, zoom-to-element
     │   ├── useSldOverlay.ts        # Single-Line-Diagram overlay
     │   ├── useSldTopologyEdit.ts    # Interactive SLD edit (switches +
@@ -569,11 +575,18 @@ exactly as before.
   most used by all players on the current contingency
   (`GET /api/game/lever-stats`), tagged voltage level / branch /
   generation / load. Best-effort like the solution log — no data or no
-  backend hides the panel. Clicking a lever pre-fills the Inspect field
-  (auto-zoom) with its element (`leverInspectTarget`) through the
-  `gameBridge.registerInspector` / `requestInspect` pair — App registers
-  `handleInspectQueryChange` in one `isGameMode()`-guarded effect and
-  never imports game internals beyond the bridge/solutionLog helpers.
+  backend hides the panel. A lever is actionable: **single-click** locates &
+  inspects it (fills the Inspect field, centers the NAD — resolving an
+  injection / coupling switch to its home VL via `/api/element-voltage-levels`
+  — and opens that substation's SLD), **double-click** simulates the mapped
+  action (a catalogue branch disco/reco, or a coupling maneuver at the
+  resolved VL; magnitude-free injection / PST levers degrade to inspect). The
+  game side turns a lever signature into a workspace-agnostic `LeverInteraction`
+  (`buildLeverInteraction` in `solutionLog.ts`) and routes it through the
+  `gameBridge.registerLeverHandler` / `requestLeverInteraction` pair; the App
+  handler lives in the `useLeverInteraction` hook (single-click deferred so a
+  double-click pre-empts it), so App.tsx still never imports game internals
+  beyond the bridge/solutionLog helpers.
 - **`presets.ts`** lists curated **solvable** fr225_400 contingencies; keep
   them winnable (the `scripts/game_mode/e2e_game_session.py` backend replay
   verifies `can_proceed=True`).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import { useTiedTabsSync, type PZInstance } from './hooks/useTiedTabsSync';
 import { useContingencyFetch } from './hooks/useContingencyFetch';
 import { useDiagramHighlights } from './hooks/useDiagramHighlights';
 import { useManualSimulation } from './hooks/useManualSimulation';
+import { useLeverInteraction } from './hooks/useLeverInteraction';
 import { interactionLogger } from './utils/interactionLogger';
 import { gameBridge } from './game/gameBridge';
 import { buildChosenActionRecord } from './game/solutionLog';
@@ -587,6 +588,7 @@ function App() {
     sldPreviewLoading,
     handleSimulateUnsimulatedAction,
     handleSimulateSldEdit,
+    handleSimulateLever,
   } = useManualSimulation({
     diagrams,
     selectedContingency,
@@ -1287,13 +1289,6 @@ function App() {
     diagrams.setInspectQuery(q);
   }, [diagrams]);
 
-  // Game Mode: the hints panel pre-fills the Inspect field through the
-  // same handler the search box uses (auto-zoom included).
-  useEffect(() => {
-    if (!gameBridge.isGameMode()) return;
-    gameBridge.registerInspector(handleInspectQueryChange);
-  }, [handleInspectQueryChange]);
-
   const handleToggleVoltageLevelNames = useCallback((show: boolean) => {
     interactionLogger.record('vl_names_toggled', { show });
     setShowVoltageLevelNames(show);
@@ -1316,6 +1311,12 @@ function App() {
     // "Action '' not found in last analysis result".
     handleVlDoubleClick(selectedActionId || '', vlName);
   }, [handleVlDoubleClick, selectedActionId]);
+
+  // Game Mode beginner assistance: single-click a lever hint to locate +
+  // inspect it (opening the substation SLD), double-click to simulate it.
+  useLeverInteraction({
+    diagrams, handleSimulateUnsimulatedAction, handleSimulateLever, handleVlOpen,
+  });
 
   // Clicking a (relabelled) feeder name on the SLD jumps to the far-end VL's
   // SLD, keeping the current sub-tab so the same contingency / overload stays

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -118,6 +118,13 @@ export const api = {
         );
         return response.data;
     },
+    getElementVoltageLevels: async (elementId: string): Promise<{ voltage_level_ids: string[] }> => {
+        const response = await axios.get<{ voltage_level_ids: string[] }>(
+            `${API_BASE_URL}/api/element-voltage-levels`,
+            { params: { element_id: elementId } }
+        );
+        return response.data;
+    },
     getNetworkDiagram: async (): Promise<DiagramData & { svg: string }> => {
         const res = await fetch(`${API_BASE_URL}/api/network-diagram?format=text`);
         if (!res.ok) {

--- a/frontend/src/game/GameHintsPanel.test.tsx
+++ b/frontend/src/game/GameHintsPanel.test.tsx
@@ -63,18 +63,39 @@ describe('GameHintsPanel', () => {
     expect(screen.getByText(/From 7 retained solutions by all players/)).toBeInTheDocument();
   });
 
-  it('pre-fills the Inspect field with the lever element on click', async () => {
-    const inspect = vi.spyOn(gameBridge, 'requestInspect');
+  it('requests an inspect interaction after the single-click delay', async () => {
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction');
     getGameLeverStats.mockResolvedValue(stats());
     render(<GameHintsPanel study={STUDY} />);
-    await waitFor(() => expect(screen.getByText(/disco_LINE_A/)).toBeInTheDocument());
+    await screen.findByText(/disco_LINE_A/);
 
-    // Catalogue disco lever → the embedded branch id reaches Inspect.
+    // Single-click is deferred so a double-click can pre-empt it.
     fireEvent.click(screen.getByText(/disco_LINE_A/));
-    expect(inspect).toHaveBeenCalledWith('LINE_A');
-    // Injection lever → the generator name itself.
-    fireEvent.click(screen.getByText(/G1/));
-    expect(inspect).toHaveBeenCalledWith('G1');
+    expect(lever).not.toHaveBeenCalled();
+    await waitFor(() => expect(lever).toHaveBeenCalledWith(
+      expect.objectContaining({ inspectQuery: 'LINE_A', simulate: { actionId: 'disco_LINE_A' } }),
+      'inspect',
+    ));
+  });
+
+  it('requests a simulate interaction on double-click and cancels the pending inspect', async () => {
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction');
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/VL1_COUPL/);
+
+    const target = screen.getByText(/VL1_COUPL/);
+    fireEvent.click(target);       // schedules the deferred inspect
+    fireEvent.doubleClick(target); // pre-empts it and fires the simulate now
+
+    expect(lever).toHaveBeenCalledTimes(1);
+    expect(lever).toHaveBeenCalledWith(
+      expect.objectContaining({ inspectQuery: 'VL1_COUPL', simulate: { switches: { VL1_COUPL: true } } }),
+      'simulate',
+    );
+    // Wait past the single-click delay — the pending inspect stays cancelled.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(lever).toHaveBeenCalledTimes(1);
   });
 
   it('collapses to a pill and reopens', async () => {

--- a/frontend/src/game/GameHintsPanel.test.tsx
+++ b/frontend/src/game/GameHintsPanel.test.tsx
@@ -98,6 +98,37 @@ describe('GameHintsPanel', () => {
     expect(lever).toHaveBeenCalledTimes(1);
   });
 
+  it('single-clicks a magnitude-free injection lever to a simulate-less inspect', async () => {
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction');
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/G1/);
+
+    fireEvent.click(screen.getByText(/G1/));
+    await waitFor(() => expect(lever).toHaveBeenCalled());
+    const [interaction, mode] = lever.mock.calls.at(-1)!;
+    expect(interaction).toMatchObject({ inspectQuery: 'G1', category: 'generation' });
+    expect(interaction.simulate).toBeUndefined();
+    expect(mode).toBe('inspect');
+  });
+
+  it('double-clicks a catalogue branch lever to a simulate-by-action-id', async () => {
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction');
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/disco_LINE_A/);
+
+    const target = screen.getByText(/disco_LINE_A/);
+    fireEvent.click(target);
+    fireEvent.doubleClick(target);
+
+    expect(lever).toHaveBeenCalledTimes(1);
+    expect(lever).toHaveBeenCalledWith(
+      expect.objectContaining({ inspectQuery: 'LINE_A', simulate: { actionId: 'disco_LINE_A' } }),
+      'simulate',
+    );
+  });
+
   it('collapses to a pill and reopens', async () => {
     getGameLeverStats.mockResolvedValue(stats());
     render(<GameHintsPanel study={STUDY} />);

--- a/frontend/src/game/GameHintsPanel.tsx
+++ b/frontend/src/game/GameHintsPanel.tsx
@@ -5,14 +5,18 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../api';
 import { colors, space, text, radius } from '../styles/tokens';
 import type { GameLeverStatWire } from '../types';
 import { gameBridge } from './gameBridge';
 import { GAME_HUD_HEIGHT } from './GameHud';
-import { leverInspectTarget } from './solutionLog';
+import { buildLeverInteraction } from './solutionLog';
 import type { GameStudy } from './types';
+
+/** Single-click is deferred this long so a double-click can pre-empt it.
+ *  Mirrors the VL-disk interactions' `VL_SINGLE_CLICK_DELAY_MS`. */
+const LEVER_SINGLE_CLICK_DELAY_MS = 250;
 
 interface GameHintsPanelProps {
   study: GameStudy;
@@ -46,6 +50,30 @@ export default function GameHintsPanel({ study }: GameHintsPanelProps) {
   const [levers, setLevers] = useState<GameLeverStatWire[]>([]);
   const [total, setTotal] = useState(0);
   const [open, setOpen] = useState(true);
+
+  // A single-click locates + inspects the lever; a double-click simulates it.
+  // The single-click action is deferred so a double-click can pre-empt it —
+  // otherwise the first click of a double-click would fire an inspect too.
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (clickTimerRef.current !== null) clearTimeout(clickTimerRef.current);
+  }, []);
+
+  const handleLeverClick = useCallback((lever: GameLeverStatWire) => {
+    if (clickTimerRef.current !== null) clearTimeout(clickTimerRef.current);
+    clickTimerRef.current = setTimeout(() => {
+      clickTimerRef.current = null;
+      gameBridge.requestLeverInteraction(buildLeverInteraction(lever), 'inspect');
+    }, LEVER_SINGLE_CLICK_DELAY_MS);
+  }, []);
+
+  const handleLeverDoubleClick = useCallback((lever: GameLeverStatWire) => {
+    if (clickTimerRef.current !== null) {
+      clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+    }
+    gameBridge.requestLeverInteraction(buildLeverInteraction(lever), 'simulate');
+  }, []);
 
   // No synchronous state reset here: GameShell keys the panel by study id,
   // so each study mounts a fresh panel with empty initial state.
@@ -117,8 +145,9 @@ export default function GameHintsPanel({ study }: GameHintsPanelProps) {
         {levers.map((lever) => (
           <li key={lever.signature} style={{ marginBottom: space.half }}>
             <button
-              onClick={() => gameBridge.requestInspect(leverInspectTarget(lever))}
-              title={`${lever.sample_description ?? lever.label} — click to locate it in the Inspect field`}
+              onClick={() => handleLeverClick(lever)}
+              onDoubleClick={() => handleLeverDoubleClick(lever)}
+              title={`${lever.sample_description ?? lever.label} — click to locate & inspect, double-click to simulate`}
               style={{
                 border: 'none', background: 'transparent', padding: 0,
                 cursor: 'pointer', fontWeight: 600, fontSize: text.sm,
@@ -136,7 +165,7 @@ export default function GameHintsPanel({ study }: GameHintsPanelProps) {
       </ol>
       <p style={{ margin: `${space[1]} 0 0`, fontSize: text.xs, color: colors.textTertiary }}>
         From {total} retained solution{total === 1 ? '' : 's'} by all players on this
-        contingency. Click a lever to pre-fill the Inspect field and locate it.
+        contingency. Click a lever to locate & inspect it; double-click to simulate it.
       </p>
     </div>
   );

--- a/frontend/src/game/gameBridge.test.ts
+++ b/frontend/src/game/gameBridge.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { gameBridge } from './gameBridge';
+import type { LeverInteraction } from '../types';
+
+const INTERACTION: LeverInteraction = {
+    inspectQuery: 'LINE_A',
+    category: 'branch',
+    simulate: { actionId: 'disco_LINE_A' },
+};
+
+describe('gameBridge — lever interaction handler', () => {
+    // NOTE: `gameBridge` is a module singleton and there is no unregister API,
+    // so the "no handler yet" case must be asserted FIRST, before any test
+    // registers one (Vitest runs a file's tests in definition order and gives
+    // each test file its own module registry).
+    it('requestLeverInteraction is a no-op before any handler is registered', () => {
+        expect(() => gameBridge.requestLeverInteraction(INTERACTION, 'inspect')).not.toThrow();
+    });
+
+    it('routes the interaction AND mode to the registered handler', () => {
+        const handler = vi.fn();
+        gameBridge.registerLeverHandler(handler);
+
+        gameBridge.requestLeverInteraction(INTERACTION, 'simulate');
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(INTERACTION, 'simulate');
+    });
+
+    it('a later registration replaces the earlier handler', () => {
+        const first = vi.fn();
+        const second = vi.fn();
+        gameBridge.registerLeverHandler(first);
+        gameBridge.registerLeverHandler(second);
+
+        gameBridge.requestLeverInteraction(INTERACTION, 'inspect');
+
+        expect(first).not.toHaveBeenCalled();
+        expect(second).toHaveBeenCalledWith(INTERACTION, 'inspect');
+    });
+
+    it('forwards both modes through the same handler', () => {
+        const handler = vi.fn();
+        gameBridge.registerLeverHandler(handler);
+
+        gameBridge.requestLeverInteraction(INTERACTION, 'inspect');
+        gameBridge.requestLeverInteraction(INTERACTION, 'simulate');
+
+        expect(handler.mock.calls.map((c) => c[1])).toEqual(['inspect', 'simulate']);
+    });
+});

--- a/frontend/src/game/gameBridge.ts
+++ b/frontend/src/game/gameBridge.ts
@@ -5,7 +5,11 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
+import type { LeverInteraction } from '../types';
 import type { ChosenActionRecord, GameStudy } from './types';
+
+/** How a lever hint was activated: single-click inspects, double-click simulates. */
+export type LeverInteractionMode = 'inspect' | 'simulate';
 
 // ---------------------------------------------------------------------------
 // gameBridge — decoupling layer between the Game Mode shell and the App.
@@ -37,13 +41,13 @@ const EMPTY_SNAPSHOT: GameStudySnapshot = {
 
 type SnapshotListener = (s: GameStudySnapshot) => void;
 type StudyLoader = (study: GameStudy) => Promise<void>;
-type InspectHandler = (query: string) => void;
+type LeverInteractionHandler = (interaction: LeverInteraction, mode: LeverInteractionMode) => void;
 
 class GameBridge {
   private snapshot: GameStudySnapshot = EMPTY_SNAPSHOT;
   private listeners = new Set<SnapshotListener>();
   private loader: StudyLoader | null = null;
-  private inspector: InspectHandler | null = null;
+  private leverHandler: LeverInteractionHandler | null = null;
   private maxActions = 3;
 
   /**
@@ -67,11 +71,12 @@ class GameBridge {
   }
 
   /**
-   * App registers its Inspect-field setter so game UI (the hints panel)
-   * can pre-fill it — same auto-zoom path as typing in the box.
+   * App registers the handler that drives the workspace from a lever hint
+   * (the beginner-assistance panel): single-click locates the element (and
+   * opens the substation SLD), double-click simulates the mapped action.
    */
-  registerInspector(inspector: InspectHandler): void {
-    this.inspector = inspector;
+  registerLeverHandler(handler: LeverInteractionHandler): void {
+    this.leverHandler = handler;
   }
 
   /** App publishes the current physical snapshot; shell listeners fire. */
@@ -117,9 +122,9 @@ class GameBridge {
     return this.loader(study);
   }
 
-  /** Shell asks App to pre-fill the Inspect field. No-op before App mounts. */
-  requestInspect(query: string): void {
-    this.inspector?.(query);
+  /** Game UI asks App to inspect or simulate a lever. No-op before App mounts. */
+  requestLeverInteraction(interaction: LeverInteraction, mode: LeverInteractionMode): void {
+    this.leverHandler?.(interaction, mode);
   }
 
   getSnapshot(): GameStudySnapshot {

--- a/frontend/src/game/solutionLog.test.ts
+++ b/frontend/src/game/solutionLog.test.ts
@@ -9,12 +9,13 @@ import type { ActionDetail, AnalysisResult, LogGameSolutionResponse } from '../t
 import {
   buildActionLevers,
   buildChosenActionRecord,
+  buildLeverInteraction,
   buildSolutionLogRequest,
   leverInspectTarget,
   sessionNoveltyBonus,
   toStudyFeedback,
 } from './solutionLog';
-import type { GameSessionConfig, GameStudy, GameStudyResult } from './types';
+import type { GameLeverStatWire, GameSessionConfig, GameStudy, GameStudyResult } from './types';
 
 function detail(over: Partial<ActionDetail> = {}): ActionDetail {
   return {
@@ -275,6 +276,49 @@ describe('toStudyFeedback / sessionNoveltyBonus', () => {
     expect(leverInspectTarget({ signature: 'redispatch:G1', label: 'G1' })).toBe('G1');
     expect(leverInspectTarget({ signature: 'switch:VL1_COUPL=true', label: 'VL1_COUPL' }))
       .toBe('VL1_COUPL');
+  });
+
+  describe('buildLeverInteraction', () => {
+    const lever = (over: Partial<GameLeverStatWire>): GameLeverStatWire => ({
+      signature: 'action:disco_LINE_A', label: 'disco_LINE_A', category: 'branch',
+      count: 1, share: 1, ...over,
+    });
+
+    it('maps a catalogue branch lever to an inspectable branch + simulatable action id', () => {
+      const i = buildLeverInteraction(lever({ signature: 'action:disco_LINE_A', label: 'disco_LINE_A' }));
+      expect(i.inspectQuery).toBe('LINE_A');       // branch id, for centering
+      expect(i.category).toBe('branch');
+      expect(i.simulate).toEqual({ actionId: 'disco_LINE_A' }); // full id, for simulating
+    });
+
+    it('maps a switch/coupling lever to its VL-openable id + a switch maneuver', () => {
+      const i = buildLeverInteraction(lever({
+        signature: 'switch:VL1_COUPL=true', label: 'VL1_COUPL', category: 'voltage_level',
+      }));
+      expect(i.inspectQuery).toBe('VL1_COUPL');
+      expect(i.category).toBe('voltage_level');
+      expect(i.simulate).toEqual({ switches: { VL1_COUPL: true } });
+    });
+
+    it('parses the target open-state of a switch lever (false closes it)', () => {
+      const i = buildLeverInteraction(lever({
+        signature: 'switch:SW_9=false', label: 'SW_9', category: 'voltage_level',
+      }));
+      expect(i.simulate).toEqual({ switches: { SW_9: false } });
+    });
+
+    it('leaves magnitude-free injection levers without a simulate spec', () => {
+      const redispatch = buildLeverInteraction(lever({
+        signature: 'redispatch:G1', label: 'G1', category: 'generation',
+      }));
+      expect(redispatch.inspectQuery).toBe('G1');
+      expect(redispatch.simulate).toBeUndefined();
+
+      const shedding = buildLeverInteraction(lever({
+        signature: 'ls:LOAD_9', label: 'LOAD_9', category: 'load',
+      }));
+      expect(shedding.simulate).toBeUndefined();
+    });
   });
 
   it('sums the per-study bonus points on top of the Codabench score', () => {

--- a/frontend/src/game/solutionLog.test.ts
+++ b/frontend/src/game/solutionLog.test.ts
@@ -319,6 +319,31 @@ describe('toStudyFeedback / sessionNoveltyBonus', () => {
       }));
       expect(shedding.simulate).toBeUndefined();
     });
+
+    it('keeps a non-branch catalogue action id verbatim (no disco/reco strip)', () => {
+      const i = buildLeverInteraction(lever({
+        signature: 'action:open_coupler_VL_X', label: 'open_coupler_VL_X', category: 'voltage_level',
+      }));
+      // Not a disco_/reco_ id → the id passes through for both inspect + simulate.
+      expect(i.inspectQuery).toBe('open_coupler_VL_X');
+      expect(i.simulate).toEqual({ actionId: 'open_coupler_VL_X' });
+    });
+
+    it('leaves PST and other levers without a simulate spec (magnitude-free / opaque)', () => {
+      expect(buildLeverInteraction(lever({
+        signature: 'pst:PST_1', label: 'PST_1', category: 'branch',
+      })).simulate).toBeUndefined();
+      expect(buildLeverInteraction(lever({
+        signature: 'load_p:LOAD_2', label: 'LOAD_2', category: 'load',
+      })).simulate).toBeUndefined();
+    });
+
+    it('defaults a switch lever with no explicit target-state to open', () => {
+      const i = buildLeverInteraction(lever({
+        signature: 'switch:SW_7', label: 'SW_7', category: 'voltage_level',
+      }));
+      expect(i.simulate).toEqual({ switches: { SW_7: true } });
+    });
   });
 
   it('sums the per-study bonus points on top of the Codabench score', () => {

--- a/frontend/src/game/solutionLog.ts
+++ b/frontend/src/game/solutionLog.ts
@@ -27,6 +27,8 @@
 import type {
   ActionDetail,
   AnalysisResult,
+  GameLeverStatWire,
+  LeverInteraction,
   LogGameSolutionRequest,
   LogGameSolutionResponse,
 } from '../types';
@@ -213,4 +215,31 @@ export function leverInspectTarget(lever: { signature: string; label: string }):
     return branch ? branch[1] : actionId;
   }
   return lever.label;
+}
+
+/**
+ * Translate a lever hint into a workspace interaction the App handler can act
+ * on without knowing lever-signature semantics:
+ *   - `inspectQuery` locates the element (branch id, injection / switch name);
+ *   - `simulate` is present only when the lever maps to a fully-specified
+ *     action — a catalogue branch disco/reco (`action:<id>`) or a coupling
+ *     maneuver (`switch:<id>=<state>`). Magnitude-free injection / PST levers
+ *     carry no `simulate`, so a double-click on them degrades to inspect.
+ */
+export function buildLeverInteraction(lever: GameLeverStatWire): LeverInteraction {
+  const interaction: LeverInteraction = {
+    inspectQuery: leverInspectTarget(lever),
+    category: lever.category,
+  };
+  const { signature } = lever;
+  if (signature.startsWith('action:')) {
+    interaction.simulate = { actionId: signature.slice('action:'.length) };
+  } else if (signature.startsWith('switch:')) {
+    const body = signature.slice('switch:'.length);
+    const eq = body.lastIndexOf('=');
+    const switchId = eq >= 0 ? body.slice(0, eq) : body;
+    const targetOpen = eq >= 0 ? body.slice(eq + 1) === 'true' : true;
+    interaction.simulate = { switches: { [switchId]: targetOpen } };
+  }
+  return interaction;
 }

--- a/frontend/src/hooks/useLeverInteraction.test.ts
+++ b/frontend/src/hooks/useLeverInteraction.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const registerLeverHandler = vi.fn();
+const isGameMode = vi.fn(() => true);
+vi.mock('../game/gameBridge', () => ({
+    gameBridge: {
+        isGameMode: () => isGameMode(),
+        registerLeverHandler: (fn: unknown) => registerLeverHandler(fn),
+    },
+}));
+
+const getElementVoltageLevels = vi.fn();
+vi.mock('../api', () => ({
+    api: { getElementVoltageLevels: (id: string) => getElementVoltageLevels(id) },
+}));
+
+const notifyError = vi.fn();
+const notifyInfo = vi.fn();
+vi.mock('../utils/notifications', () => ({
+    notifyError: (m: string) => notifyError(m),
+    notifyInfo: (m: string) => notifyInfo(m),
+}));
+
+import { useLeverInteraction, type LeverInteractionParams } from './useLeverInteraction';
+import type { DiagramsState } from './useDiagrams';
+import type { LeverInteraction } from '../types';
+
+type Handler = (i: LeverInteraction, mode: 'inspect' | 'simulate') => Promise<void>;
+
+function makeParams(over: Partial<LeverInteractionParams> = {}): LeverInteractionParams {
+    return {
+        diagrams: {
+            activeTab: 'contingency',
+            setInspectQuery: vi.fn(),
+            zoomToElement: vi.fn(),
+        } as unknown as DiagramsState,
+        handleSimulateUnsimulatedAction: vi.fn().mockResolvedValue(undefined),
+        handleSimulateLever: vi.fn().mockResolvedValue(undefined),
+        handleVlOpen: vi.fn(),
+        ...over,
+    };
+}
+
+/** Render the hook and return the handler it registered on the bridge. */
+function renderAndGetHandler(params: LeverInteractionParams): Handler {
+    renderHook(() => useLeverInteraction(params));
+    return registerLeverHandler.mock.calls.at(-1)?.[0] as Handler;
+}
+
+describe('useLeverInteraction', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        isGameMode.mockReturnValue(true);
+    });
+
+    it('registers a lever handler only in game mode', () => {
+        isGameMode.mockReturnValue(false);
+        renderHook(() => useLeverInteraction(makeParams()));
+        expect(registerLeverHandler).not.toHaveBeenCalled();
+
+        isGameMode.mockReturnValue(true);
+        renderHook(() => useLeverInteraction(makeParams()));
+        expect(registerLeverHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('inspect on a branch lever centers on the branch itself (no VL lookup, no SLD)', async () => {
+        const params = makeParams();
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => { await handler({ inspectQuery: 'LINE_A', category: 'branch' }, 'inspect'); });
+
+        expect(params.diagrams.setInspectQuery).toHaveBeenCalledWith('LINE_A');
+        expect(getElementVoltageLevels).not.toHaveBeenCalled();
+        expect(params.diagrams.zoomToElement).toHaveBeenCalledWith('LINE_A', 'contingency');
+        expect(params.handleVlOpen).not.toHaveBeenCalled();
+    });
+
+    it('inspect on an injection lever resolves its VL, centers there and opens the SLD', async () => {
+        getElementVoltageLevels.mockResolvedValue({ voltage_level_ids: ['VL_G1'] });
+        const params = makeParams();
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => { await handler({ inspectQuery: 'G1', category: 'generation' }, 'inspect'); });
+
+        expect(getElementVoltageLevels).toHaveBeenCalledWith('G1');
+        expect(params.diagrams.zoomToElement).toHaveBeenCalledWith('VL_G1', 'contingency');
+        expect(params.handleVlOpen).toHaveBeenCalledWith('VL_G1');
+    });
+
+    it('simulate on a catalogue lever runs the action id directly', async () => {
+        const params = makeParams();
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => {
+            await handler({ inspectQuery: 'LINE_A', category: 'branch', simulate: { actionId: 'disco_LINE_A' } }, 'simulate');
+        });
+
+        expect(params.handleSimulateUnsimulatedAction).toHaveBeenCalledWith('disco_LINE_A');
+        // Direct simulate short-circuits — no VL lookup / centering.
+        expect(getElementVoltageLevels).not.toHaveBeenCalled();
+        expect(params.diagrams.zoomToElement).not.toHaveBeenCalled();
+    });
+
+    it('simulate on a coupling lever resolves the VL and runs the maneuver', async () => {
+        getElementVoltageLevels.mockResolvedValue({ voltage_level_ids: ['VL_SW'] });
+        const params = makeParams();
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => {
+            await handler({ inspectQuery: 'SW1', category: 'voltage_level', simulate: { switches: { SW1: true } } }, 'simulate');
+        });
+
+        expect(params.handleSimulateLever).toHaveBeenCalledWith({ voltageLevelId: 'VL_SW', switches: { SW1: true } });
+        expect(params.handleVlOpen).not.toHaveBeenCalled();
+    });
+
+    it('warns when a coupling maneuver cannot be located to a single VL', async () => {
+        getElementVoltageLevels.mockResolvedValue({ voltage_level_ids: [] });
+        const params = makeParams();
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => {
+            await handler({ inspectQuery: 'SW1', category: 'voltage_level', simulate: { switches: { SW1: true } } }, 'simulate');
+        });
+
+        expect(params.handleSimulateLever).not.toHaveBeenCalled();
+        expect(notifyError).toHaveBeenCalledWith('Could not locate the substation for this maneuver.');
+    });
+
+    it('double-clicking a magnitude-free injection lever degrades to inspect with a hint', async () => {
+        getElementVoltageLevels.mockResolvedValue({ voltage_level_ids: ['VL_G1'] });
+        const params = makeParams();
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => { await handler({ inspectQuery: 'G1', category: 'generation' }, 'simulate'); });
+
+        expect(notifyInfo).toHaveBeenCalledWith('Set the amount in the substation diagram, then Simulate.');
+        expect(params.handleSimulateLever).not.toHaveBeenCalled();
+        expect(params.handleSimulateUnsimulatedAction).not.toHaveBeenCalled();
+        // Falls through to inspect: centers on the VL and opens its SLD.
+        expect(params.diagrams.zoomToElement).toHaveBeenCalledWith('VL_G1', 'contingency');
+        expect(params.handleVlOpen).toHaveBeenCalledWith('VL_G1');
+    });
+
+    it('falls back to centering on the id when VL resolution fails', async () => {
+        getElementVoltageLevels.mockRejectedValue(new Error('not loaded'));
+        const params = makeParams();
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => { await handler({ inspectQuery: 'G1', category: 'generation' }, 'inspect'); });
+
+        expect(params.diagrams.zoomToElement).toHaveBeenCalledWith('G1', 'contingency');
+        expect(params.handleVlOpen).not.toHaveBeenCalled();
+    });
+
+    it('remaps the overflow tab to the contingency tab for centering', async () => {
+        const params = makeParams({
+            diagrams: {
+                activeTab: 'overflow',
+                setInspectQuery: vi.fn(),
+                zoomToElement: vi.fn(),
+            } as unknown as DiagramsState,
+        });
+        const handler = renderAndGetHandler(params);
+
+        await act(async () => { await handler({ inspectQuery: 'LINE_A', category: 'branch' }, 'inspect'); });
+
+        expect(params.diagrams.setInspectQuery).toHaveBeenCalledWith('LINE_A');
+        expect(params.diagrams.zoomToElement).toHaveBeenCalledWith('LINE_A', 'contingency');
+    });
+});

--- a/frontend/src/hooks/useLeverInteraction.ts
+++ b/frontend/src/hooks/useLeverInteraction.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2025-2026, RTE (https://www.rte-france.com)
+// This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+// If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+// you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+
+// Game-Mode beginner-assistance wiring, extracted from App.tsx to keep the
+// hub under its size ceiling. Registers a handler on `gameBridge` that drives
+// the workspace from a lever hint (the "most-used levers" panel):
+//   - single-click ('inspect'): fill the Inspect field, center the NAD on the
+//     element (resolving an injection / coupling switch to its home VL), and
+//     open that substation's SLD so the beginner can inspect it;
+//   - double-click ('simulate'): run the mapped action directly — a catalogue
+//     branch disco/reco, or a coupling maneuver at the resolved VL. Magnitude-
+//     free injection / PST levers carry no action, so they degrade to inspect
+//     with a hint to set the amount in the SLD.
+//
+// App keeps ownership of the collaborators (diagrams + the two simulate
+// entry points + the SLD opener) and passes them in, so this stays a thin
+// orchestrator and the bare (non-game) app never touches the bridge.
+
+import { useCallback, useEffect } from 'react';
+import { api } from '../api';
+import { gameBridge, type LeverInteractionMode } from '../game/gameBridge';
+import { notifyError, notifyInfo } from '../utils/notifications';
+import type { LeverInteraction } from '../types';
+import type { DiagramsState } from './useDiagrams';
+
+export interface LeverInteractionParams {
+    diagrams: DiagramsState;
+    /** Simulate a catalogue action (branch disco/reco) by id. */
+    handleSimulateUnsimulatedAction: (actionId: string) => Promise<void>;
+    /** Simulate a coupling maneuver (switch toggle) at a resolved VL. */
+    handleSimulateLever: (spec: { voltageLevelId: string; switches: Record<string, boolean> }) => Promise<void>;
+    /** Open the SLD overlay for a voltage level. */
+    handleVlOpen: (vlName: string) => void;
+}
+
+export function useLeverInteraction(params: LeverInteractionParams): void {
+    const { diagrams, handleSimulateUnsimulatedAction, handleSimulateLever, handleVlOpen } = params;
+
+    const handleLeverInteraction = useCallback(
+        async (interaction: LeverInteraction, mode: LeverInteractionMode) => {
+            const { inspectQuery, category, simulate } = interaction;
+            // The overflow tab isn't a NAD — center on the contingency tab instead.
+            const tab = diagrams.activeTab === 'overflow' ? 'contingency' : diagrams.activeTab;
+
+            // Fill the Inspect field with the clicked element (both modes). We
+            // center explicitly below, so use the plain setter that doesn't pin
+            // a focus tab (an injection / switch name never matches a NAD id,
+            // which would otherwise leave that pin dangling).
+            diagrams.setInspectQuery(inspectQuery);
+
+            // A catalogue action (branch disco/reco) simulates directly by id.
+            if (mode === 'simulate' && simulate?.actionId) {
+                await handleSimulateUnsimulatedAction(simulate.actionId);
+                return;
+            }
+
+            // Resolve the element's home VL for everything that isn't a branch
+            // (a branch spans two VLs and is centered directly by its own id).
+            let homeVl: string | null = null;
+            if (category !== 'branch') {
+                try {
+                    const { voltage_level_ids } = await api.getElementVoltageLevels(inspectQuery);
+                    if (voltage_level_ids.length === 1) homeVl = voltage_level_ids[0];
+                } catch {
+                    // Resolution is best-effort — fall through to centering on the id.
+                }
+            }
+
+            // A coupling maneuver simulates directly once we know its VL.
+            if (mode === 'simulate' && simulate?.switches) {
+                if (homeVl) await handleSimulateLever({ voltageLevelId: homeVl, switches: simulate.switches });
+                else notifyError('Could not locate the substation for this maneuver.');
+                return;
+            }
+
+            // Magnitude-free lever double-clicked: it can't be simulated as-is,
+            // so guide the operator to set the amount in the SLD, then fall
+            // through to inspect (locate + open the substation).
+            if (mode === 'simulate' && !simulate) {
+                notifyInfo('Set the amount in the substation diagram, then Simulate.');
+            }
+
+            // Inspect: center the NAD, and open the SLD when the lever lives in
+            // one substation (an injection or a coupling switch → a single VL).
+            if (homeVl) {
+                diagrams.zoomToElement(homeVl, tab);
+                handleVlOpen(homeVl);
+            } else {
+                diagrams.zoomToElement(inspectQuery, tab);
+            }
+        },
+        [diagrams, handleSimulateUnsimulatedAction, handleSimulateLever, handleVlOpen],
+    );
+
+    useEffect(() => {
+        if (!gameBridge.isGameMode()) return;
+        gameBridge.registerLeverHandler(handleLeverInteraction);
+    }, [handleLeverInteraction]);
+}

--- a/frontend/src/hooks/useManualSimulation.test.ts
+++ b/frontend/src/hooks/useManualSimulation.test.ts
@@ -112,6 +112,55 @@ describe('useManualSimulation', () => {
         });
     });
 
+    describe('handleSimulateLever', () => {
+        it('is a no-op when no switches are staged', async () => {
+            const { result } = renderHook(() => useManualSimulation(makeParams()));
+
+            await act(async () => { await result.current.handleSimulateLever({ voltageLevelId: 'VL1', switches: {} }); });
+
+            expect(mockSimStream).not.toHaveBeenCalled();
+        });
+
+        it('errors (no API call) when no contingency is selected', async () => {
+            const setError = vi.fn();
+            const { result } = renderHook(() =>
+                useManualSimulation(makeParams({ selectedContingency: [], setError })));
+
+            await act(async () => {
+                await result.current.handleSimulateLever({ voltageLevelId: 'VL1', switches: { SW: true } });
+            });
+
+            expect(setError).toHaveBeenCalledWith('Select a contingency first.');
+            expect(mockSimStream).not.toHaveBeenCalled();
+        });
+
+        it('streams the coupling maneuver and registers a user-provenance card', async () => {
+            const diagrams = makeDiagrams();
+            const wrappedManualActionAdded = vi.fn();
+            mockSimStream.mockResolvedValue(ndjson([
+                { type: 'metrics', action_id: 'user_topo_VL1_1', description_unitaire: 'coupling', rho_before: [1], rho_after: [0.8], max_rho: 0.8, max_rho_line: 'LINE_1', is_rho_reduction: true, lines_overloaded: [] },
+                { type: 'diagram', svg: '<svg/>', metadata: '{}', action_id: 'user_topo_VL1_1' },
+            ]));
+            const { result } = renderHook(() => useManualSimulation(makeParams({ diagrams, wrappedManualActionAdded })));
+
+            await act(async () => {
+                await result.current.handleSimulateLever({ voltageLevelId: 'VL1', switches: { SW_A: true } });
+            });
+
+            // Request carries the switch content + the resolved VL id.
+            expect(mockSimStream).toHaveBeenCalledWith(expect.objectContaining({
+                action_content: { switches: { SW_A: true } },
+                voltage_level_id: 'VL1',
+                disconnected_elements: ['LINE_X'],
+            }));
+            // Card registered under the backend-canonical id with 'user' provenance.
+            expect(diagrams.primeActionDiagram).toHaveBeenCalledWith('user_topo_VL1_1', expect.objectContaining({ svg: '<svg/>' }), 1);
+            expect(wrappedManualActionAdded).toHaveBeenCalledWith(
+                'user_topo_VL1_1', expect.objectContaining({ max_rho: 0.8 }), [], 'user',
+            );
+        });
+    });
+
     describe('handleSimulateSldEdit', () => {
         it('is a no-op when nothing is staged', async () => {
             const { result } = renderHook(() =>

--- a/frontend/src/hooks/useManualSimulation.test.ts
+++ b/frontend/src/hooks/useManualSimulation.test.ts
@@ -159,6 +159,21 @@ describe('useManualSimulation', () => {
                 'user_topo_VL1_1', expect.objectContaining({ max_rho: 0.8 }), [], 'user',
             );
         });
+
+        it('surfaces a stream error event via setError and registers no card', async () => {
+            const setError = vi.fn();
+            const wrappedManualActionAdded = vi.fn();
+            mockSimStream.mockResolvedValue(ndjson([{ type: 'error', message: 'islanded' }]));
+            const { result } = renderHook(() =>
+                useManualSimulation(makeParams({ setError, wrappedManualActionAdded })));
+
+            await act(async () => {
+                await result.current.handleSimulateLever({ voltageLevelId: 'VL1', switches: { SW_A: true } });
+            });
+
+            expect(setError).toHaveBeenCalledWith('islanded');
+            expect(wrappedManualActionAdded).not.toHaveBeenCalled();
+        });
     });
 
     describe('handleSimulateSldEdit', () => {

--- a/frontend/src/hooks/useManualSimulation.ts
+++ b/frontend/src/hooks/useManualSimulation.ts
@@ -57,10 +57,83 @@ export interface ManualSimulationState {
     handleSimulateUnsimulatedAction: (actionId: string) => Promise<void>;
     /** Simulate the staged SLD breaker/injection edit as one manual action. */
     handleSimulateSldEdit: () => Promise<void>;
+    /**
+     * Simulate a coupling maneuver straight from a Game-Mode lever hint —
+     * a fully-specified switch toggle at a resolved voltage level, streamed
+     * into one manual-action card (no SLD staging step).
+     */
+    handleSimulateLever: (spec: { voltageLevelId: string; switches: Record<string, boolean> }) => Promise<void>;
+}
+
+type SimMetrics = Awaited<ReturnType<typeof api.simulateManualAction>>;
+type SimStreamRequest = Parameters<typeof api.simulateAndVariantDiagramStream>[0];
+
+/** Build the enriched ActionDetail card payload from a metrics event. */
+function detailFromMetrics(m: SimMetrics): ActionDetail {
+    return {
+        description_unitaire: m.description_unitaire,
+        rho_before: m.rho_before,
+        rho_after: m.rho_after,
+        max_rho: m.max_rho,
+        max_rho_line: m.max_rho_line,
+        is_rho_reduction: m.is_rho_reduction,
+        is_islanded: m.is_islanded,
+        n_components: m.n_components,
+        disconnected_mw: m.disconnected_mw,
+        non_convergence: m.non_convergence,
+        lines_overloaded_after: m.lines_overloaded_after,
+        half_open_overloads: m.half_open_overloads,
+        // Carry the topology so the SLD/NAD highlight marks EVERY affected
+        // feeder (e.g. a redispatch AND a load shedding at the same VL).
+        action_topology: m.action_topology,
+        load_shedding_details: m.load_shedding_details,
+        curtailment_details: m.curtailment_details,
+        redispatch_details: m.redispatch_details,
+        pst_details: m.pst_details,
+    };
 }
 
 export function useManualSimulation(params: ManualSimulationParams): ManualSimulationState {
     const { diagrams, selectedContingency, result, voltageLevels, wrappedManualActionAdded, setError } = params;
+
+    // Shared "simulate → prime diagram → register card" pipeline used by the
+    // overview-pin and coupling-lever flows. Consumes the NDJSON stream once
+    // (metrics + diagram events), primes the action diagram under the backend-
+    // canonical id, and registers the card. Throws on a stream/metrics error so
+    // callers surface it through `setError`; returns the registered id +
+    // metrics on success. (handleSimulateSldEdit keeps its own copy — it has
+    // extra staging-reset + SLD-retarget concerns around the same core.)
+    const streamSimulateToCard = useCallback(
+        async (req: SimStreamRequest, origin: string): Promise<{ registeredId: string; metrics: SimMetrics }> => {
+            const response = await api.simulateAndVariantDiagramStream(req);
+            let metrics: SimMetrics | null = null;
+            let streamErr: string | null = null;
+            for await (const raw of parseNdjsonStream(response)) {
+                const event = raw as Record<string, unknown>;
+                if (event.type === 'metrics') {
+                    const { type: _t, ...rest } = event;
+                    void _t;
+                    metrics = rest as SimMetrics;
+                } else if (event.type === 'diagram') {
+                    const { type: _t, ...rest } = event;
+                    void _t;
+                    // Register under the id the backend actually stored (it
+                    // canonicalises combined "+" ids) — from the metrics event
+                    // that always precedes the diagram — not the request id.
+                    const registeredId = metrics?.action_id ?? req.action_id;
+                    diagrams.primeActionDiagram(registeredId, rest as unknown as DiagramData & { svg: string }, voltageLevels.length);
+                } else if (event.type === 'error') {
+                    streamErr = (event.message as string) || 'stream error';
+                }
+            }
+            if (streamErr) throw new Error(streamErr);
+            if (!metrics) throw new Error('Stream ended without metrics event');
+            const registeredId = metrics.action_id || req.action_id;
+            wrappedManualActionAdded(registeredId, detailFromMetrics(metrics), metrics.lines_overloaded || [], origin);
+            return { registeredId, metrics };
+        },
+        [diagrams, voltageLevels.length, wrappedManualActionAdded],
+    );
 
     const handleSimulateUnsimulatedAction = useCallback(
         async (actionId: string) => {
@@ -69,64 +142,54 @@ export function useManualSimulation(params: ManualSimulationParams): ManualSimul
                 return;
             }
             try {
-                const response = await api.simulateAndVariantDiagramStream({
+                // An unsimulated pin is a scored-but-not-yet-materialised action
+                // from the recommender's score table — the operator only triggered
+                // its simulation, so its provenance is the model that scored it,
+                // NOT "user".
+                await streamSimulateToCard({
                     action_id: actionId,
                     disconnected_elements: selectedContingency,
                     action_content: null,
                     lines_overloaded: result?.lines_overloaded ?? null,
                     target_mw: null,
                     target_tap: null,
-                });
-                let metrics: Awaited<ReturnType<typeof api.simulateManualAction>> | null = null;
-                let streamErr: string | null = null;
-                for await (const raw of parseNdjsonStream(response)) {
-                    const event = raw as Record<string, unknown>;
-                    if (event.type === 'metrics') {
-                        const { type: _t, ...rest } = event;
-                        void _t;
-                        metrics = rest as Awaited<ReturnType<typeof api.simulateManualAction>>;
-                    } else if (event.type === 'diagram') {
-                        const { type: _t, ...rest } = event;
-                        void _t;
-                        diagrams.primeActionDiagram(actionId, rest as unknown as DiagramData & { svg: string }, voltageLevels.length);
-                    } else if (event.type === 'error') {
-                        streamErr = (event.message as string) || 'stream error';
-                    }
-                }
-                if (streamErr) throw new Error(streamErr);
-                if (!metrics) throw new Error('Stream ended without metrics event');
-                const detail: ActionDetail = {
-                    description_unitaire: metrics.description_unitaire,
-                    rho_before: metrics.rho_before,
-                    rho_after: metrics.rho_after,
-                    max_rho: metrics.max_rho,
-                    max_rho_line: metrics.max_rho_line,
-                    is_rho_reduction: metrics.is_rho_reduction,
-                    is_islanded: metrics.is_islanded,
-                    n_components: metrics.n_components,
-                    disconnected_mw: metrics.disconnected_mw,
-                    non_convergence: metrics.non_convergence,
-                    lines_overloaded_after: metrics.lines_overloaded_after,
-                    half_open_overloads: metrics.half_open_overloads,
-                    action_topology: metrics.action_topology,
-                    load_shedding_details: metrics.load_shedding_details,
-                    curtailment_details: metrics.curtailment_details,
-                    redispatch_details: metrics.redispatch_details,
-                    pst_details: metrics.pst_details,
-                };
-                // An unsimulated pin is a scored-but-not-yet-materialised
-                // action from the recommender's score table — the operator
-                // only triggered its simulation, so its provenance is the
-                // model that scored it, NOT "user".
-                wrappedManualActionAdded(
-                    actionId, detail, metrics.lines_overloaded || [], result?.active_model || 'expert',
-                );
+                }, result?.active_model || 'expert');
             } catch (e: unknown) {
                 console.error('Unsimulated pin simulation failed:', e);
                 setError(apiErrorMessage(e, 'Simulation failed'));
             }
         },
-        [selectedContingency, result?.lines_overloaded, result?.active_model, diagrams, voltageLevels.length, wrappedManualActionAdded, setError],
+        [selectedContingency, result?.lines_overloaded, result?.active_model, streamSimulateToCard, setError],
+    );
+
+    const handleSimulateLever = useCallback(
+        async (spec: { voltageLevelId: string; switches: Record<string, boolean> }) => {
+            const { voltageLevelId, switches } = spec;
+            if (Object.keys(switches).length === 0) return;
+            if (selectedContingency.length === 0) {
+                setError('Select a contingency first.');
+                return;
+            }
+            const actionId = `user_topo_${voltageLevelId}_${Date.now()}`;
+            interactionLogger.record('sld_topology_simulated', {
+                voltage_level_id: voltageLevelId, switches,
+            });
+            try {
+                await streamSimulateToCard({
+                    action_id: actionId,
+                    disconnected_elements: selectedContingency,
+                    action_content: { switches },
+                    lines_overloaded: result?.lines_overloaded ?? null,
+                    target_mw: null,
+                    target_tap: null,
+                    voltage_level_id: voltageLevelId,
+                }, 'user');
+            } catch (e: unknown) {
+                console.error('Lever maneuver simulation failed:', e);
+                setError(apiErrorMessage(e, 'Simulation failed'));
+            }
+        },
+        [selectedContingency, result?.lines_overloaded, streamSimulateToCard, setError],
     );
 
     // Interactive SLD topology edit (useSldTopologyEdit). The baseline is
@@ -336,5 +399,6 @@ export function useManualSimulation(params: ManualSimulationParams): ManualSimul
         sldPreviewLoading,
         handleSimulateUnsimulatedAction,
         handleSimulateSldEdit,
+        handleSimulateLever,
     };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -869,13 +869,40 @@ export interface LogGameSolutionRequest {
     actions: GameSolutionActionWire[];
 }
 
+/** Equipment family a Game-Mode lever acts on. */
+export type LeverCategory = 'voltage_level' | 'branch' | 'generation' | 'load' | 'other';
+
 export interface GameLeverStatWire {
     signature: string;
     label: string;
-    category: 'voltage_level' | 'branch' | 'generation' | 'load' | 'other';
+    category: LeverCategory;
     count: number;
     share: number;
     sample_description?: string | null;
+}
+
+/**
+ * How a Game-Mode lever hint should drive the workspace when clicked. The
+ * game layer computes this from a lever signature (see
+ * `game/solutionLog.ts#buildLeverInteraction`) so the App handler stays
+ * oblivious to lever-signature semantics: it just inspects / simulates.
+ */
+export interface LeverInteraction {
+    /** Element id/name to show in the Inspect field and center the NAD on. */
+    inspectQuery: string;
+    /** Equipment family — drives whether inspect also opens the substation SLD. */
+    category: LeverCategory;
+    /**
+     * Fully-specified action to run on a double-click, when the lever maps to
+     * one. Absent for magnitude-free injection / PST levers, which fall back to
+     * inspect (the operator sets the amount in the SLD themselves).
+     */
+    simulate?: {
+        /** Catalogue action id (branch disconnection / reconnection). */
+        actionId?: string;
+        /** Coupling maneuver: switch id → target open-state. */
+        switches?: Record<string, boolean>;
+    };
 }
 
 export interface GameLeverStatsResponse {


### PR DESCRIPTION
## Summary

In Game Mode, the beginner-assistance **"most-used levers"** panel previously only pre-filled the Inspect field when a lever was clicked — it did not center on the asset, did not open the substation SLD, and offered no way to act on a lever. This makes each lever fully actionable:

- **Single-click → locate & inspect**: fills the Inspect field, centers the NAD on the element (resolving an injection or coupling switch to its home voltage level), and opens that substation's SLD so the beginner can inspect it.
- **Double-click → simulate**: runs the mapped action directly — a catalogue branch disco/reco or a coupling maneuver at the resolved VL — producing a card in the feed.
- Magnitude-free injection / PST levers carry no self-contained action (the amount differs per retained solution), so a double-click degrades to inspect with a hint to set the amount in the SLD.

The single-click action is deferred (250 ms) so a double-click pre-empts it, mirroring the existing VL-disk interaction convention.

## Changes

**Backend**
- `NetworkService.get_element_voltage_levels` now also resolves generators, loads, and switches to their home voltage level (single-VL equipment). This is what lets an injection or coupling lever be located and its SLD opened. Existing branch/VL resolution keeps precedence; the switch probe is defensive (tolerates a missing column, a blank/non-string VL, or a backend that raises).

**Frontend**
- `game/solutionLog.ts`: `buildLeverInteraction` maps a lever signature to a workspace-agnostic `LeverInteraction` (inspect target + category + optional `simulate` spec).
- `game/gameBridge.ts`: replaces the inspect-only hook with a `registerLeverHandler` / `requestLeverInteraction` pair.
- `game/GameHintsPanel.tsx`: single-click (deferred) / double-click wiring on each lever.
- `hooks/useLeverInteraction.ts` (new): the App-side handler (VL resolution + centering + SLD open + simulate dispatch), kept out of `App.tsx` to stay under the hub size ceiling.
- `hooks/useManualSimulation.ts`: adds `handleSimulateLever` for coupling maneuvers, sharing a new `streamSimulateToCard` helper with the existing overview-pin flow.
- `api.ts` / `types.ts`: `getElementVoltageLevels` method + `LeverCategory` / `LeverInteraction` types.

App.tsx still never imports game internals beyond the bridge / solutionLog helpers.

## Tests

- **Backend** (`test_network_service.py`, +10): generator / load / switch resolution, plus switch-probe robustness (blank / non-string VL, `get_switches` raising, missing column) and branch precedence.
- **Frontend** (+20): `gameBridge.test.ts` (new — the lever handler pair), `buildLeverInteraction` signature mapping, `GameHintsPanel` single/double-click, `useLeverInteraction` (all inspect/simulate branches, VL-resolution fallback, overflow-tab remap), and `useManualSimulation.handleSimulateLever` (stream + error paths).

Full suite green: frontend 1893 passed / 3 skipped, backend `test_network_service.py` 41 passed, code-quality gate OK, ESLint + ruff clean.

## Docs

Updated `frontend/CLAUDE.md` and `docs/features/game-mode-codabench.md` to describe the new single-click / double-click behavior and the `useLeverInteraction` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)