### PR TITLE
Game Mode: unique session names + lever-simulation feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and the project (informally) follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Game Mode — unique session names + lever-simulation feedback
+
+- **Duplicate session names are blocked.** `GET /api/game/player-sessions` now
+  returns the concrete `session_names` (sorted) alongside `session_count`. The
+  config screen auto-suggests the first *free* `<player> — session <n>` index
+  over the recorded names (so a re-play never re-suggests an existing name —
+  the old count-plus-one heuristic collided when the indices had gaps), and a
+  name that already exists **disables ▶ Start** with an inline warning (the
+  shared base keys retentions by session name, so a duplicate would merge two
+  runs).
+- **Beginner-assistance lever hints show simulation feedback.** Double-clicking
+  a most-used lever now shows a per-row **⏳ simulating… → ✓ simulated**
+  transition and **blocks a redundant re-run** — "simulated" is read from a new
+  `simulatedActionIds` set on the game-bridge snapshot, so a lever also flips ✓
+  when its action arrives through the recommender's suggestions, and a failed
+  run self-clears. `gameBridge.requestLeverInteraction` is now awaitable so the
+  panel can drive the transition.
+- **Injection levers simulate with the default incremental delta.** Redispatch
+  / load-shedding / curtailment levers (`redispatch:` / `ls:` / `rc:`) map to
+  the backend dynamic-action id and simulate with no `target_mw`, so
+  `_create_dynamic_actions_if_needed` applies the default incremental injection
+  delta — a double-click runs them straight away instead of degrading to
+  inspect. Only PST / raw `gen_p:` / `load_p:` levers still degrade (a tap /
+  signed setpoint is required).
+
 ### Dependencies — lift the pypowsybl upper bound
 
 - **`pypowsybl` is no longer capped below 1.15** (`pyproject.toml`). The earlier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,7 +337,7 @@ guards the reductions documented in
 | POST | `/api/compute-superposition` | Compute combined effect of two actions (superposition theorem) |
 | POST | `/api/game/log-solution` | Capitalise a Game Mode retained proposition into the shared solution base; returns the novelty verdict (+bonus points) and per-action usage frequencies |
 | GET  | `/api/game/lever-stats` | Most-used unitary levers of a (network, contingency) context in the shared solution base — the Game Mode beginner-assistance hints (top-N, tagged voltage_level / branch / generation / load) |
-| GET  | `/api/game/player-sessions` | Count of distinct sessions a player already recorded in the shared base — seeds the default session name / index on the Game Mode config screen |
+| GET  | `/api/game/player-sessions` | Distinct sessions a player already recorded in the shared base — `session_count` + the concrete `session_names` (sorted). Seeds the default session name / index on the Game Mode config screen (first free index) and blocks a colliding name before Start |
 | POST | `/api/save-session` | Save session folder with JSON snapshot + PDF copy |
 | GET  | `/api/list-sessions` | List available session folders in a directory |
 | POST | `/api/load-session` | Load session JSON and restore PDFs |

--- a/docs/features/game-mode-codabench.md
+++ b/docs/features/game-mode-codabench.md
@@ -18,9 +18,13 @@ Launch the frontend with `?game=1` (e.g. `http://localhost:5173/?game=1`):
 1. **Config screen** — a simple landing asks only what a participant needs to
    start: your **player name** (required — it signs the solutions you retain in
    the shared solution base, see below), the **session name** (auto-filled to
-   `<player> — session <n+1>`, where `n` counts the player's existing sessions
-   in the shared base via `GET /api/game/player-sessions`; editable), the
-   **beginner assistance** toggle, and **▶ Start session**. Below it, a preview
+   the first *free* `<player> — session <n>` index, scanning the player's
+   existing session names in the shared base via `GET /api/game/player-sessions`
+   so a re-play never re-suggests a name that already exists; editable but a
+   name that collides with one already recorded **blocks ▶ Start** with an
+   inline warning — the shared base keys retentions by session name, so a
+   duplicate would merge two runs), the **beginner assistance** toggle, and
+   **▶ Start session**. Below it, a preview
    card lists the configured studies and shows a map of the network you'll work
    on — the same thing the "Network (N)" NAD shows fully zoomed out (voltage
    levels from `grid_layout.json` with the transmission lines drawn as edges,
@@ -40,7 +44,12 @@ Launch the frontend with `?game=1` (e.g. `http://localhost:5173/?game=1`):
    assistance** enabled (config-screen checkbox, on by default), a
    collapsible 💡 hints panel lists the **5 levers most used by all players**
    on the current contingency, tagged by equipment family (voltage level /
-   branch / generation / load). **Star** the actions you
+   branch / generation / load). **Single-click** a lever to locate & inspect
+   it; **double-click** to simulate it — the row shows a **⏳ simulating…** →
+   **✓ simulated** transition and a second double-click is ignored once
+   simulated, so you never fire the same lever twice (a lever whose action
+   surfaces through the recommender's suggestions is marked ✓ too). **Star**
+   the actions you
    commit to (the star is capped at the configured max). Click **Next study →**
    (or let the timer expire) to advance. If your retained proposition turns
    out to be **new** in the shared base, a 🌟 toast tells you right away and
@@ -167,13 +176,26 @@ under a persistent root, exact-duplicate dedup, the player name as author).
   injection or coupling switch is resolved to its home VL through
   `/api/element-voltage-levels`), and opens that substation's SLD;
   **double-click** simulates the mapped action directly — a catalogue branch
-  disco/reco (`handleSimulateUnsimulatedAction`) or a coupling maneuver at the
-  resolved VL (`handleSimulateLever`), producing a card in the feed. A
-  magnitude-free injection / PST lever carries no self-contained action, so a
-  double-click degrades to inspect with a hint to set the amount in the SLD.
-  The game side maps a lever signature to a workspace-agnostic
+  disco/reco (`handleSimulateUnsimulatedAction`), an **injection** (redispatch
+  / load-shedding / curtailment) run with the backend's **default incremental
+  delta** (the lever signature maps to the backend dynamic-action id —
+  `redispatch:<g>` → `redispatch_<g>`, `ls:<l>` → `load_shedding_<l>`,
+  `rc:<g>` → `curtail_<g>` — simulated with no `target_mw`, so
+  `_create_dynamic_actions_if_needed` applies the default delta), or a coupling
+  maneuver at the resolved VL (`handleSimulateLever`), producing a card in the
+  feed. Only a **PST** lever or a raw `gen_p:` / `load_p:` setpoint lever still
+  degrades to inspect with a hint to set the amount in the SLD (a tap / signed
+  setpoint is needed). **Simulation feedback:** the double-clicked lever shows a
+  **⏳ simulating… → ✓ simulated** transition, and re-simulation is blocked —
+  the panel reads the App-published `simulatedActionIds` set on the game bridge
+  snapshot, so a lever also flips to ✓ when its action arrives through the
+  recommender's suggestions, and a failed run self-clears (its id never enters
+  the set) leaving the lever runnable again; a coupling maneuver (whose fresh
+  `user_topo_*` id the snapshot can't match) is marked done locally on
+  completion. The game side maps a lever signature to a workspace-agnostic
   `LeverInteraction` (`buildLeverInteraction`) and routes it via a
-  `gameBridge.registerLeverHandler` / `requestLeverInteraction` pair (App's
+  `gameBridge.registerLeverHandler` / `requestLeverInteraction` pair — now
+  awaitable so the panel can drive the simulating→simulated transition (App's
   handler lives in the `useLeverInteraction` hook; single-click is deferred so
   a double-click pre-empts it), so App.tsx stays decoupled from game internals.
 - **Flow** — `useGameSession` fires the log at every study commit,

--- a/expert_backend/CLAUDE.md
+++ b/expert_backend/CLAUDE.md
@@ -394,9 +394,12 @@ Game Mode:
   (network, contingency) context, tagged by equipment family
   (`voltage_level` / `branch` / `generation` / `load` / `other`).
   Read-only store scan; feeds the Game Mode beginner-assistance panel.
-- `GET /api/game/player-sessions` — count of distinct sessions a player
-  already recorded in the shared base (`player_session_count`); seeds the
-  default session name / index on the Game Mode config screen. Read-only.
+- `GET /api/game/player-sessions` — distinct sessions a player already
+  recorded in the shared base (`player_session_count`): `session_count` +
+  the concrete `session_names` (sorted, case-insensitive). Seeds the default
+  session name (first FREE `<player> — session <n>` index) AND lets the config
+  screen block a colliding name before Start — a count-plus-one heuristic
+  re-suggests a taken name when the recorded indices have gaps. Read-only.
 
 OS pickers & static:
 - `GET  /api/pick-path?type=file|dir` — spawns a tkinter subprocess.

--- a/expert_backend/openapi.snapshot.json
+++ b/expert_backend/openapi.snapshot.json
@@ -858,6 +858,14 @@
           "session_count": {
             "title": "Session Count",
             "type": "integer"
+          },
+          "session_names": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Session Names",
+            "type": "array"
           }
         },
         "required": [

--- a/expert_backend/services/game_solution_models.py
+++ b/expert_backend/services/game_solution_models.py
@@ -102,3 +102,8 @@ class PlayerSessionsResponse(BaseModel):
     # Distinct sessions this player already recorded in the shared base;
     # seeds the default session name (`<player> — session <count+1>`).
     session_count: int
+    # The concrete distinct session names (sorted, case-insensitive). The
+    # config screen suggests the first free `session <n>` index over these
+    # and blocks a name that already exists — a count-plus-one heuristic
+    # re-suggests a taken name when the recorded indices have gaps.
+    session_names: list[str] = []

--- a/expert_backend/services/game_solutions.py
+++ b/expert_backend/services/game_solutions.py
@@ -464,18 +464,24 @@ def log_solution(payload: dict) -> dict:
 
 
 def player_session_count(player: str) -> dict:
-    """How many distinct sessions ``player`` has already recorded in the base.
+    """Distinct sessions ``player`` has already recorded in the shared base.
 
     Used to seed a default session name / index on the Game Mode config
-    screen (``<player> — session <n+1>``). A "session" is a distinct
-    ``session_name`` under which the player signed at least one retained
-    solution; the player handle match is case-insensitive. Read-only scan of
-    the effective base — a player who never retained anything (or an empty
-    handle) counts as zero.
+    screen AND to reject a colliding name before "Start session". A
+    "session" is a distinct ``session_name`` under which the player signed at
+    least one retained solution; the player handle match is case-insensitive.
+    Read-only scan of the effective base — a player who never retained
+    anything (or an empty handle) yields an empty set.
+
+    Returns both the count and the concrete ``session_names`` (sorted) so the
+    config screen can (a) auto-suggest the first free ``session <n>`` index
+    even when the recorded names have gaps, and (b) block a name that already
+    exists — a count-plus-one heuristic alone re-suggests a taken name when
+    the indices are non-contiguous.
     """
     name = (player or "").strip()
     if not name:
-        return {"player": "", "session_count": 0}
+        return {"player": "", "session_count": 0, "session_names": []}
     target = name.casefold()
     base = _effective_base_dir()
     sessions: set[str] = set()
@@ -491,4 +497,5 @@ def player_session_count(player: str) -> dict:
                         session_name = str(retention.get("session_name") or "").strip()
                         if session_name:
                             sessions.add(session_name)
-    return {"player": name, "session_count": len(sessions)}
+    ordered = sorted(sessions, key=str.casefold)
+    return {"player": name, "session_count": len(ordered), "session_names": ordered}

--- a/expert_backend/tests/CLAUDE.md
+++ b/expert_backend/tests/CLAUDE.md
@@ -209,12 +209,18 @@ covers the per-commit solution log: payload shape, skip-when-empty, async
 feedback merge into the derived session log, novelty toast, fail-soft on a
 rejected POST). `solutionLog.test.ts` covers the lever/signature computation
 (MW-agnostic injection levers, manual-maneuver decomposition, catalogue
-fallback) + wire payload/feedback mapping + bonus summation;
+fallback) + the `buildLeverInteraction` mapping (injection levers →
+dynamic-action id) + wire payload/feedback mapping + bonus summation;
 `GameResults.test.tsx` covers the novelty-bonus / usage-frequency rendering;
+`GameConfigScreen.test.tsx` covers the landing (incl. the first-free session
+index over the recorded `session_names`, and the duplicate-name Start block);
 `GameHintsPanel.test.tsx` covers the beginner-assistance lever hints
-(category tags, collapse/reopen, hidden on empty base / failed fetch).
+(category tags, collapse/reopen, hidden on empty base / failed fetch, the
+simulating→simulated feedback, the re-run block, cross-marking from the
+`simulatedActionIds` snapshot, and the injection-lever default-delta simulate).
 The backend twin is `expert_backend/tests/test_game_solutions.py` (store,
-novelty, dedup, frequencies, lever stats + categories, endpoints). The real-backend replay lives in
+novelty, dedup, frequencies, lever stats + categories, player session names,
+endpoints). The real-backend replay lives in
 `scripts/game_mode/e2e_game_session.py` (not part of the Vitest suite; needs
 pypowsybl + `expert_op4grid_recommender`).
 

--- a/expert_backend/tests/test_game_solutions.py
+++ b/expert_backend/tests/test_game_solutions.py
@@ -330,16 +330,29 @@ def test_player_session_count_counts_distinct_sessions(store_dir):
     game_solutions.log_solution(payload(player="bob", session_name="s9"))
 
     assert game_solutions.player_session_count("alice") == {
-        "player": "alice", "session_count": 2}
+        "player": "alice", "session_count": 2, "session_names": ["s1", "s2"]}
     # Handle match is case-insensitive.
     assert game_solutions.player_session_count("ALICE")["session_count"] == 2
-    assert game_solutions.player_session_count("bob")["session_count"] == 1
-    assert game_solutions.player_session_count("carol")["session_count"] == 0
+    assert game_solutions.player_session_count("bob") == {
+        "player": "bob", "session_count": 1, "session_names": ["s9"]}
+    assert game_solutions.player_session_count("carol") == {
+        "player": "carol", "session_count": 0, "session_names": []}
+
+
+def test_player_session_names_are_returned_sorted(store_dir):
+    # Record out of natural order — the response is sorted case-insensitively
+    # so the config screen can pick the first free index / detect a collision.
+    for name in ("amarot — session 3", "amarot — session 1", "amarot — session 2"):
+        game_solutions.log_solution(payload(player="amarot", session_name=name))
+    result = game_solutions.player_session_count("amarot")
+    assert result["session_count"] == 3
+    assert result["session_names"] == [
+        "amarot — session 1", "amarot — session 2", "amarot — session 3"]
 
 
 def test_player_session_count_empty_handle(store_dir):
     assert game_solutions.player_session_count("  ") == {
-        "player": "", "session_count": 0}
+        "player": "", "session_count": 0, "session_names": []}
 
 
 # ---------------------------------------------------------------------------
@@ -458,7 +471,8 @@ def test_player_sessions_endpoint(store_dir, client):
         player="alice", session_name="s2", contingency_id="c2"))
     resp = client.get("/api/game/player-sessions", params={"player": "alice"})
     assert resp.status_code == 200
-    assert resp.json() == {"player": "alice", "session_count": 2}
+    assert resp.json() == {
+        "player": "alice", "session_count": 2, "session_names": ["s1", "s2"]}
 
     empty = client.get("/api/game/player-sessions", params={"player": ""})
-    assert empty.json() == {"player": "", "session_count": 0}
+    assert empty.json() == {"player": "", "session_count": 0, "session_names": []}

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -68,7 +68,9 @@ frontend/
     │   ├── useLeverInteraction.ts  # Game-Mode beginner-assistance wiring:
     │   │                           # registers the gameBridge lever handler —
     │   │                           # single-click locate+inspect (VL resolve +
-    │   │                           # SLD open), double-click simulate
+    │   │                           # SLD open), double-click simulate (branch
+    │   │                           # disco/reco + injection default-delta +
+    │   │                           # coupling maneuver)
     │   ├── usePanZoom.ts           # ViewBox state, zoom-to-element
     │   ├── useSldOverlay.ts        # Single-Line-Diagram overlay
     │   ├── useSldTopologyEdit.ts    # Interactive SLD edit (switches +
@@ -552,7 +554,9 @@ exactly as before.
 
 - **`gameBridge.ts`** is the decoupling singleton (mirrors
   `interactionLogger`): `App` registers a study loader and publishes its
-  physical snapshot `{ baselineMaxRho, chosenActions }`; `GameShell` /
+  physical snapshot `{ baselineMaxRho, chosenActions, simulatedActionIds }`
+  (`simulatedActionIds` = every materialised action id, so the hints panel
+  can mark a lever "simulated"); `GameShell` /
   `useGameSession` drive study loads, read results, and enforce the
   ≤ 3-action cap — so **`App.tsx` keeps only three `isGameMode()`-guarded
   touch points** (`loadGameStudy`, the publish effect, and the
@@ -579,11 +583,20 @@ exactly as before.
   inspects it (fills the Inspect field, centers the NAD — resolving an
   injection / coupling switch to its home VL via `/api/element-voltage-levels`
   — and opens that substation's SLD), **double-click** simulates the mapped
-  action (a catalogue branch disco/reco, or a coupling maneuver at the
-  resolved VL; magnitude-free injection / PST levers degrade to inspect). The
-  game side turns a lever signature into a workspace-agnostic `LeverInteraction`
-  (`buildLeverInteraction` in `solutionLog.ts`) and routes it through the
-  `gameBridge.registerLeverHandler` / `requestLeverInteraction` pair; the App
+  action (a catalogue branch disco/reco, an **injection** — redispatch /
+  load-shedding / curtailment — run with the backend's default incremental
+  delta via its dynamic-action id, or a coupling maneuver at the resolved VL;
+  only PST / raw `gen_p:` / `load_p:` levers still degrade to inspect). The
+  panel shows a per-lever **⏳ simulating… → ✓ simulated** transition and
+  **blocks a redundant re-run** — "simulated" is read from the App-published
+  `simulatedActionIds` snapshot set (so a lever also flips ✓ when its action
+  arrives through the recommender's suggestions, and a failed run self-clears),
+  with a local fallback for coupling maneuvers whose fresh id the snapshot
+  can't match. The game side turns a lever signature into a workspace-agnostic
+  `LeverInteraction` (`buildLeverInteraction` in `solutionLog.ts` — injection
+  signatures map to the dynamic-action id) and routes it through the
+  `gameBridge.registerLeverHandler` / `requestLeverInteraction` pair (awaitable,
+  so the panel can drive the simulating→simulated transition); the App
   handler lives in the `useLeverInteraction` hook (single-click deferred so a
   double-click pre-empts it), so App.tsx still never imports game internals
   beyond the bridge/solutionLog helpers.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1199,6 +1199,10 @@ function App() {
       contingencyElementIds: selectedContingency,
       baselineMaxRho,
       chosenActions,
+      // Every action that has a materialised result — recommender-suggested,
+      // manually simulated, or lever-driven. The hints panel marks these
+      // levers "simulated" and blocks a redundant re-run.
+      simulatedActionIds: result ? Object.keys(result.actions) : [],
     });
   }, [result, selectedActionIds, selectedContingency, n1Diagram]);
 

--- a/frontend/src/game/GameConfigScreen.test.tsx
+++ b/frontend/src/game/GameConfigScreen.test.tsx
@@ -14,7 +14,10 @@ const mockApi = vi.hoisted(() => ({ getPlayerSessions: vi.fn() }));
 vi.mock('../api', () => ({ api: mockApi }));
 
 beforeEach(() => {
-  mockApi.getPlayerSessions.mockResolvedValue({ player: 'amarot', session_count: 2 });
+  mockApi.getPlayerSessions.mockResolvedValue({
+    player: 'amarot', session_count: 2,
+    session_names: ['amarot — session 1', 'amarot — session 2'],
+  });
 });
 afterEach(() => { cleanup(); vi.clearAllMocks(); });
 
@@ -46,7 +49,57 @@ describe('GameConfigScreen landing', () => {
     fireEvent.change(screen.getByTestId('game-player'), { target: { value: 'amarot' } });
     await new Promise((r) => setTimeout(r, 400));
     expect(sessionInput().value).toBe('My custom run');
-    expect(mockApi.getPlayerSessions).not.toHaveBeenCalled();
+    // The names are still fetched (they drive the duplicate block), but the
+    // typed name is preserved.
+    expect(mockApi.getPlayerSessions).toHaveBeenCalledWith('amarot');
+  });
+
+  it('auto-suggests the first FREE index, skipping gaps in the recorded names', async () => {
+    // Recorded {1, 3} → the count-plus-one heuristic would collide on 3; the
+    // names-based suggestion fills the gap and picks 2.
+    mockApi.getPlayerSessions.mockResolvedValue({
+      player: 'amarot', session_count: 2,
+      session_names: ['amarot — session 1', 'amarot — session 3'],
+    });
+    render(<GameConfigScreen onStart={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('game-player'), { target: { value: 'amarot' } });
+    await waitFor(() => expect(sessionInput().value).toBe('amarot — session 2'));
+  });
+
+  it('suggests the next index after finishing a session (no collision)', async () => {
+    // Sessions 1-3 already recorded → the next free index is 4, never a
+    // re-suggested 3 (the reported bug).
+    mockApi.getPlayerSessions.mockResolvedValue({
+      player: 'amarot', session_count: 3,
+      session_names: ['amarot — session 1', 'amarot — session 2', 'amarot — session 3'],
+    });
+    render(<GameConfigScreen onStart={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('game-player'), { target: { value: 'amarot' } });
+    await waitFor(() => expect(sessionInput().value).toBe('amarot — session 4'));
+  });
+
+  it('blocks Start and shows an error when the name collides with an existing session', async () => {
+    const onStart = vi.fn();
+    render(<GameConfigScreen onStart={onStart} />);
+    fireEvent.change(screen.getByTestId('game-player'), { target: { value: 'amarot' } });
+    await waitFor(() => expect(sessionInput().value).toBe('amarot — session 3'));
+    // Type a name that already exists (case-insensitive).
+    fireEvent.change(sessionInput(), { target: { value: 'Amarot — Session 1' } });
+    await waitFor(() => expect(screen.getByTestId('game-session-name-error')).toBeInTheDocument());
+    expect(screen.getByTestId('game-start')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('game-start'));
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('re-enables Start once the colliding name is changed to a free one', async () => {
+    render(<GameConfigScreen onStart={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('game-player'), { target: { value: 'amarot' } });
+    await waitFor(() => expect(sessionInput().value).toBe('amarot — session 3'));
+    fireEvent.change(sessionInput(), { target: { value: 'amarot — session 2' } });
+    await waitFor(() => expect(screen.getByTestId('game-start')).toBeDisabled());
+    fireEvent.change(sessionInput(), { target: { value: 'amarot — session 9' } });
+    expect(screen.queryByTestId('game-session-name-error')).toBeNull();
+    expect(screen.getByTestId('game-start')).not.toBeDisabled();
   });
 
   it('lists the configured studies and shows the network preview', () => {

--- a/frontend/src/game/GameConfigScreen.tsx
+++ b/frontend/src/game/GameConfigScreen.tsx
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // This file is part of Co-Study4Grid a Power Grid Study tool Assistant Interface to help solve contigencies for a grid state under study.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { api } from '../api';
 import { colors, space, text, radius } from '../styles/tokens';
 import {
@@ -58,12 +58,36 @@ const btn = (bg: string, fg: string): React.CSSProperties => ({
 
 let customSeq = 0;
 
+/** Lower-cased trimmed key used to compare session names case-insensitively. */
+const sessionKey = (name: string): string => name.trim().toLowerCase();
+
+/**
+ * First `<player> — session <n>` name (n ≥ 1) not already taken. Scanning the
+ * concrete names — rather than count + 1 — fills gaps and never re-suggests an
+ * existing name when the recorded indices are non-contiguous (e.g. sessions
+ * {1, 3} → suggests 2, not a colliding 3).
+ */
+function firstFreeSessionName(player: string, taken: Set<string>): string {
+  let n = 1;
+  while (taken.has(sessionKey(`${player} — session ${n}`))) n += 1;
+  return `${player} — session ${n}`;
+}
+
 export default function GameConfigScreen({ onStart }: GameConfigScreenProps) {
   const [player, setPlayer] = useState('');
   const [sessionName, setSessionName] = useState('');
   // True once the player types their own session name — stops the auto-default
-  // effect from overwriting it.
+  // effect from overwriting it. Mirrored in a ref so the debounced fetch
+  // callback reads the current value (its closure would otherwise be stale).
   const [sessionNameEdited, setSessionNameEdited] = useState(false);
+  const sessionNameEditedRef = useRef(sessionNameEdited);
+  useEffect(() => { sessionNameEditedRef.current = sessionNameEdited; }, [sessionNameEdited]);
+  // Session names this player already recorded in the shared base — the
+  // auto-suggest picks the first free index over them and Start is blocked
+  // when the entered name collides with one.
+  const [existingSessions, setExistingSessions] = useState<string[]>([]);
+  const takenSessions = useMemo(
+    () => new Set(existingSessions.map(sessionKey)), [existingSessions]);
   const [minutes, setMinutes] = useState(5);
   const [seconds, setSeconds] = useState(0);
   const [maxActions, setMaxActions] = useState(3);
@@ -86,23 +110,36 @@ export default function GameConfigScreen({ onStart }: GameConfigScreenProps) {
 
   const timerSeconds = minutes * 60 + seconds;
 
-  // Seed a default session name from the player handle + the next session
-  // index (counting the player's existing sessions in the shared base). Runs
-  // only until the player edits the name; debounced so it doesn't fire per
-  // keystroke. Falls back to "session 1" when the backend is unreachable
-  // (standalone build / offline), so the game stays playable.
+  // Fetch the player's existing session names from the shared base, then seed
+  // a default that skips every taken index (so a re-play never re-suggests a
+  // name that already exists). The fetch runs on every player change — even
+  // after the name is edited — because the names also drive the duplicate
+  // block below; only the auto-fill is gated on `sessionNameEdited`. Debounced
+  // so it doesn't fire per keystroke; falls back to "session 1" / no known
+  // sessions when the backend is unreachable (standalone build / offline).
   useEffect(() => {
-    if (sessionNameEdited) return;
     const name = player.trim();
     if (!name) {
-      setSessionName('');
+      setExistingSessions([]);
+      if (!sessionNameEditedRef.current) setSessionName('');
       return;
     }
     let cancelled = false;
     const timer = window.setTimeout(() => {
       api.getPlayerSessions(name)
-        .then((r) => { if (!cancelled) setSessionName(`${name} — session ${r.session_count + 1}`); })
-        .catch(() => { if (!cancelled) setSessionName(`${name} — session 1`); });
+        .then((r) => {
+          if (cancelled) return;
+          const names = r.session_names ?? [];
+          setExistingSessions(names);
+          if (!sessionNameEditedRef.current) {
+            setSessionName(firstFreeSessionName(name, new Set(names.map(sessionKey))));
+          }
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setExistingSessions([]);
+          if (!sessionNameEditedRef.current) setSessionName(`${name} — session 1`);
+        });
     }, 350);
     return () => { cancelled = true; window.clearTimeout(timer); };
   }, [player, sessionNameEdited]);
@@ -155,7 +192,12 @@ export default function GameConfigScreen({ onStart }: GameConfigScreenProps) {
     : studies.length > 0 &&
       studies.every((s) => s.networkPath && s.actionFilePath && s.contingencyElementId);
   const timerValid = timerSeconds >= 10;
-  const canStart = !needPlayer && studiesValid && timerValid;
+  // A session name the player already recorded blocks Start — the shared
+  // solution base keys retentions by session name, so a duplicate would
+  // merge two runs. Only meaningful once a name is entered.
+  const trimmedSession = sessionName.trim();
+  const duplicateSession = trimmedSession.length > 0 && takenSessions.has(sessionKey(trimmedSession));
+  const canStart = !needPlayer && studiesValid && timerValid && !duplicateSession;
 
   const start = () => {
     if (!canStart) return;
@@ -177,9 +219,11 @@ export default function GameConfigScreen({ onStart }: GameConfigScreenProps) {
 
   const startHint = needPlayer
     ? 'Enter your player name to start.'
-    : (!studiesValid || !timerValid)
-      ? 'Some studies need attention — open ⚙ Configure settings below to fix them.'
-      : '';
+    : duplicateSession
+      ? 'You already played a session with this name — pick another.'
+      : (!studiesValid || !timerValid)
+        ? 'Some studies need attention — open ⚙ Configure settings below to fix them.'
+        : '';
 
   return (
     <div style={{
@@ -265,10 +309,18 @@ export default function GameConfigScreen({ onStart }: GameConfigScreenProps) {
 
           <div style={{ marginTop: space[3] }}>
             <label style={labelStyle} htmlFor="game-session-name">Session name</label>
-            <input id="game-session-name" data-testid="game-session-name" style={inputStyle}
+            <input id="game-session-name" data-testid="game-session-name"
+              style={{ ...inputStyle, borderColor: duplicateSession ? colors.dangerText : colors.border }}
+              aria-invalid={duplicateSession}
               value={sessionName}
               placeholder={player.trim() ? '' : 'auto — set from your player name'}
               onChange={(e) => { setSessionName(e.target.value); setSessionNameEdited(true); }} />
+            {duplicateSession && (
+              <p data-testid="game-session-name-error"
+                style={{ color: colors.dangerText, fontSize: text.xs, margin: `${space.half} 0 0` }}>
+                You already played “{trimmedSession}” — pick another name.
+              </p>
+            )}
           </div>
 
           <label style={{

--- a/frontend/src/game/GameHintsPanel.test.tsx
+++ b/frontend/src/game/GameHintsPanel.test.tsx
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { api } from '../api';
 import type { GameLeverStatsResponse } from '../types';
 import { gameBridge } from './gameBridge';
@@ -17,6 +17,23 @@ vi.mock('../api', () => ({
 }));
 
 const getGameLeverStats = vi.mocked(api.getGameLeverStats);
+
+/** A promise whose resolution the test controls (to hold a simulation open). */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+/** Publish an App-side snapshot with the given materialised action ids. */
+function publishSimulated(simulatedActionIds: string[]): void {
+  gameBridge.publishSnapshot({
+    contingencyElementIds: ['ctg_1'],
+    baselineMaxRho: 1.2,
+    chosenActions: [],
+    simulatedActionIds,
+  });
+}
 
 const STUDY: GameStudy = {
   id: 's1',
@@ -43,10 +60,12 @@ function stats(over: Partial<GameLeverStatsResponse> = {}): GameLeverStatsRespon
 describe('GameHintsPanel', () => {
   beforeEach(() => {
     getGameLeverStats.mockReset();
+    gameBridge.reset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    gameBridge.reset();
   });
 
   it('lists the most-used levers with their equipment category', async () => {
@@ -93,12 +112,13 @@ describe('GameHintsPanel', () => {
       expect.objectContaining({ inspectQuery: 'VL1_COUPL', simulate: { switches: { VL1_COUPL: true } } }),
       'simulate',
     );
-    // Wait past the single-click delay — the pending inspect stays cancelled.
-    await new Promise((r) => setTimeout(r, 300));
+    // Wait past the single-click delay — the pending inspect stays cancelled
+    // (also lets the async simulate settle its status state inside act).
+    await act(async () => { await new Promise((r) => setTimeout(r, 300)); });
     expect(lever).toHaveBeenCalledTimes(1);
   });
 
-  it('single-clicks a magnitude-free injection lever to a simulate-less inspect', async () => {
+  it('single-clicks an injection lever to inspect (even though it can simulate)', async () => {
     const lever = vi.spyOn(gameBridge, 'requestLeverInteraction');
     getGameLeverStats.mockResolvedValue(stats());
     render(<GameHintsPanel study={STUDY} />);
@@ -107,8 +127,11 @@ describe('GameHintsPanel', () => {
     fireEvent.click(screen.getByText(/G1/));
     await waitFor(() => expect(lever).toHaveBeenCalled());
     const [interaction, mode] = lever.mock.calls.at(-1)!;
-    expect(interaction).toMatchObject({ inspectQuery: 'G1', category: 'generation' });
-    expect(interaction.simulate).toBeUndefined();
+    // A redispatch lever now carries a simulate spec (default incremental
+    // delta), but a single-click still only locates & inspects it.
+    expect(interaction).toMatchObject({
+      inspectQuery: 'G1', category: 'generation', simulate: { actionId: 'redispatch_G1' },
+    });
     expect(mode).toBe('inspect');
   });
 
@@ -127,6 +150,84 @@ describe('GameHintsPanel', () => {
       expect.objectContaining({ inspectQuery: 'LINE_A', simulate: { actionId: 'disco_LINE_A' } }),
       'simulate',
     );
+    await act(async () => { await Promise.resolve(); }); // settle the async status update
+  });
+
+  it('double-clicks a redispatch lever to simulate it (default incremental delta)', async () => {
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction');
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/G1/);
+
+    const target = screen.getByText(/G1/);
+    fireEvent.click(target);
+    fireEvent.doubleClick(target);
+
+    // The lever maps to the backend dynamic-action id; simulated with no MW so
+    // the backend applies its default incremental injection delta.
+    expect(lever).toHaveBeenCalledWith(
+      expect.objectContaining({ inspectQuery: 'G1', simulate: { actionId: 'redispatch_G1' } }),
+      'simulate',
+    );
+    await waitFor(() => expect(lever).toHaveBeenCalled());
+  });
+
+  it('shows a simulating → simulated transition on a lever double-click', async () => {
+    const d = deferred();
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction').mockReturnValue(d.promise);
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/disco_LINE_A/);
+
+    fireEvent.doubleClick(screen.getByText(/disco_LINE_A/));
+    expect(lever).toHaveBeenCalledWith(
+      expect.objectContaining({ simulate: { actionId: 'disco_LINE_A' } }), 'simulate');
+    const status = await screen.findByTestId('game-lever-status-action:disco_LINE_A');
+    expect(status).toHaveTextContent(/simulating/);
+
+    // Resolve the run and let App publish the materialised action id.
+    await act(async () => { d.resolve(); await d.promise; publishSimulated(['disco_LINE_A']); });
+    await waitFor(() => expect(
+      screen.getByTestId('game-lever-status-action:disco_LINE_A')).toHaveTextContent(/simulated/));
+  });
+
+  it('marks a lever simulated when its action arrives through the suggestions', async () => {
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/disco_LINE_A/);
+    // No double-click here — the recommender simulated it and App published it.
+    act(() => publishSimulated(['disco_LINE_A']));
+    await waitFor(() => expect(
+      screen.getByTestId('game-lever-status-action:disco_LINE_A')).toHaveTextContent(/simulated/));
+  });
+
+  it('blocks a second simulation once a lever is already simulated', async () => {
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction');
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/disco_LINE_A/);
+    act(() => publishSimulated(['disco_LINE_A']));
+    await waitFor(() => expect(
+      screen.getByTestId('game-lever-status-action:disco_LINE_A')).toHaveTextContent(/simulated/));
+
+    fireEvent.doubleClick(screen.getByText(/disco_LINE_A/));
+    expect(lever).not.toHaveBeenCalled();
+  });
+
+  it('ignores a second double-click while a simulation is still in flight', async () => {
+    const d = deferred();
+    const lever = vi.spyOn(gameBridge, 'requestLeverInteraction').mockReturnValue(d.promise);
+    getGameLeverStats.mockResolvedValue(stats());
+    render(<GameHintsPanel study={STUDY} />);
+    await screen.findByText(/disco_LINE_A/);
+
+    const target = screen.getByText(/disco_LINE_A/);
+    fireEvent.doubleClick(target);
+    await screen.findByTestId('game-lever-status-action:disco_LINE_A');
+    fireEvent.doubleClick(target); // still simulating → ignored
+    expect(lever).toHaveBeenCalledTimes(1);
+
+    await act(async () => { d.resolve(); await d.promise; });
   });
 
   it('collapses to a pill and reopens', async () => {

--- a/frontend/src/game/GameHintsPanel.tsx
+++ b/frontend/src/game/GameHintsPanel.tsx
@@ -8,7 +8,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '../api';
 import { colors, space, text, radius } from '../styles/tokens';
-import type { GameLeverStatWire } from '../types';
+import type { GameLeverStatWire, LeverInteraction } from '../types';
 import { gameBridge } from './gameBridge';
 import { GAME_HUD_HEIGHT } from './GameHud';
 import { buildLeverInteraction } from './solutionLog';
@@ -17,6 +17,9 @@ import type { GameStudy } from './types';
 /** Single-click is deferred this long so a double-click can pre-empt it.
  *  Mirrors the VL-disk interactions' `VL_SINGLE_CLICK_DELAY_MS`. */
 const LEVER_SINGLE_CLICK_DELAY_MS = 250;
+
+/** Simulation state of one lever, driving the inline feedback + re-run block. */
+type LeverSimStatus = 'idle' | 'simulating' | 'simulated';
 
 interface GameHintsPanelProps {
   study: GameStudy;
@@ -51,6 +54,33 @@ export default function GameHintsPanel({ study }: GameHintsPanelProps) {
   const [total, setTotal] = useState(0);
   const [open, setOpen] = useState(true);
 
+  // Simulation feedback state. `inFlight` marks a lever whose simulation is
+  // running (the "simulating…" chip + re-run block); `localDone` marks
+  // coupling maneuvers whose fresh `user_topo_*` id the workspace snapshot
+  // can't match back to a lever. Action-id levers (branch disco/reco +
+  // injections) are marked "simulated" straight from `simulatedIds`, the set
+  // of materialised action ids the App publishes on the game bridge — so a
+  // lever also flips to "simulated" when its action arrives through the
+  // recommender's suggestions, and a failed run self-clears (its id never
+  // enters the set) leaving the lever runnable again.
+  const [inFlight, setInFlight] = useState<Set<string>>(() => new Set());
+  const [localDone, setLocalDone] = useState<Set<string>>(() => new Set());
+  const [simulatedIds, setSimulatedIds] = useState<Set<string>>(
+    () => new Set(gameBridge.getSnapshot().simulatedActionIds));
+  useEffect(() => {
+    setSimulatedIds(new Set(gameBridge.getSnapshot().simulatedActionIds));
+    return gameBridge.subscribe((snap) => setSimulatedIds(new Set(snap.simulatedActionIds)));
+  }, []);
+
+  const leverStatus = useCallback((lever: GameLeverStatWire): LeverSimStatus => {
+    const sig = lever.signature;
+    if (inFlight.has(sig)) return 'simulating';
+    if (localDone.has(sig)) return 'simulated';
+    const actionId = buildLeverInteraction(lever).simulate?.actionId;
+    if (actionId && simulatedIds.has(actionId)) return 'simulated';
+    return 'idle';
+  }, [inFlight, localDone, simulatedIds]);
+
   // A single-click locates + inspects the lever; a double-click simulates it.
   // The single-click action is deferred so a double-click can pre-empt it —
   // otherwise the first click of a double-click would fire an inspect too.
@@ -63,17 +93,43 @@ export default function GameHintsPanel({ study }: GameHintsPanelProps) {
     if (clickTimerRef.current !== null) clearTimeout(clickTimerRef.current);
     clickTimerRef.current = setTimeout(() => {
       clickTimerRef.current = null;
-      gameBridge.requestLeverInteraction(buildLeverInteraction(lever), 'inspect');
+      void gameBridge.requestLeverInteraction(buildLeverInteraction(lever), 'inspect');
     }, LEVER_SINGLE_CLICK_DELAY_MS);
   }, []);
 
-  const handleLeverDoubleClick = useCallback((lever: GameLeverStatWire) => {
+  const handleLeverDoubleClick = useCallback(async (lever: GameLeverStatWire) => {
     if (clickTimerRef.current !== null) {
       clearTimeout(clickTimerRef.current);
       clickTimerRef.current = null;
     }
-    gameBridge.requestLeverInteraction(buildLeverInteraction(lever), 'simulate');
-  }, []);
+    const interaction: LeverInteraction = buildLeverInteraction(lever);
+    // Magnitude-free lever (PST / raw gen_p / load_p) → nothing to simulate;
+    // let the handler degrade to inspect without any status tracking.
+    if (!interaction.simulate) {
+      void gameBridge.requestLeverInteraction(interaction, 'simulate');
+      return;
+    }
+    // Already simulating or simulated → ignore, so a second double-click can't
+    // fire a duplicate simulation of the same lever.
+    if (leverStatus(lever) !== 'idle') return;
+    const sig = lever.signature;
+    setInFlight((prev) => new Set(prev).add(sig));
+    try {
+      await gameBridge.requestLeverInteraction(interaction, 'simulate');
+      // Coupling maneuvers register under a fresh user_topo_<vl>_<ts> id the
+      // snapshot can't map back to this lever, so record completion locally.
+      // Action-id levers rely on `simulatedIds` (self-correcting on failure).
+      if (!interaction.simulate.actionId) {
+        setLocalDone((prev) => new Set(prev).add(sig));
+      }
+    } finally {
+      setInFlight((prev) => {
+        const next = new Set(prev);
+        next.delete(sig);
+        return next;
+      });
+    }
+  }, [leverStatus]);
 
   // No synchronous state reset here: GameShell keys the panel by study id,
   // so each study mounts a fresh panel with empty initial state.
@@ -142,30 +198,51 @@ export default function GameHintsPanel({ study }: GameHintsPanelProps) {
         </button>
       </div>
       <ol style={{ margin: 0, paddingLeft: space[4] }}>
-        {levers.map((lever) => (
-          <li key={lever.signature} style={{ marginBottom: space.half }}>
-            <button
-              onClick={() => handleLeverClick(lever)}
-              onDoubleClick={() => handleLeverDoubleClick(lever)}
-              title={`${lever.sample_description ?? lever.label} — click to locate & inspect, double-click to simulate`}
-              style={{
-                border: 'none', background: 'transparent', padding: 0,
-                cursor: 'pointer', fontWeight: 600, fontSize: text.sm,
-                color: colors.infoText, textDecoration: 'underline',
-                textUnderlineOffset: 2,
-              }}
-            >
-              {CATEGORY_ICONS[lever.category]} {lever.label}
-            </button>
-            <span style={{ color: colors.textTertiary, fontSize: text.xs }}>
-              {' '}— {LEVER_CATEGORY_LABELS[lever.category]} · used {lever.count}×
-            </span>
-          </li>
-        ))}
+        {levers.map((lever) => {
+          const status = leverStatus(lever);
+          const done = status === 'simulated';
+          const busy = status === 'simulating';
+          return (
+            <li key={lever.signature} style={{ marginBottom: space.half }}>
+              <button
+                onClick={() => handleLeverClick(lever)}
+                onDoubleClick={() => handleLeverDoubleClick(lever)}
+                title={done
+                  ? `${lever.sample_description ?? lever.label} — already simulated; click to locate & inspect`
+                  : `${lever.sample_description ?? lever.label} — click to locate & inspect, double-click to simulate`}
+                data-testid={`game-lever-${lever.signature}`}
+                style={{
+                  border: 'none', background: 'transparent', padding: 0,
+                  cursor: 'pointer', fontWeight: 600, fontSize: text.sm,
+                  color: colors.infoText, textDecoration: 'underline',
+                  textUnderlineOffset: 2, opacity: done ? 0.65 : 1,
+                }}
+              >
+                {CATEGORY_ICONS[lever.category]} {lever.label}
+              </button>
+              <span style={{ color: colors.textTertiary, fontSize: text.xs }}>
+                {' '}— {LEVER_CATEGORY_LABELS[lever.category]} · used {lever.count}×
+              </span>
+              {busy && (
+                <span data-testid={`game-lever-status-${lever.signature}`}
+                  style={{ color: colors.infoText, fontSize: text.xs, fontWeight: 600, marginLeft: space[1] }}>
+                  ⏳ simulating…
+                </span>
+              )}
+              {done && (
+                <span data-testid={`game-lever-status-${lever.signature}`}
+                  style={{ color: colors.successText, fontSize: text.xs, fontWeight: 600, marginLeft: space[1] }}>
+                  ✓ simulated
+                </span>
+              )}
+            </li>
+          );
+        })}
       </ol>
       <p style={{ margin: `${space[1]} 0 0`, fontSize: text.xs, color: colors.textTertiary }}>
         From {total} retained solution{total === 1 ? '' : 's'} by all players on this
-        contingency. Click a lever to locate & inspect it; double-click to simulate it.
+        contingency. Click a lever to locate & inspect it; double-click to simulate it
+        (once — a ✓ marks levers already simulated).
       </p>
     </div>
   );

--- a/frontend/src/game/gameBridge.ts
+++ b/frontend/src/game/gameBridge.ts
@@ -31,17 +31,28 @@ export interface GameStudySnapshot {
   baselineMaxRho: number | null;
   /** Remedial actions the player has starred, with their resulting loading. */
   chosenActions: ChosenActionRecord[];
+  /**
+   * Ids of every action already simulated (materialised with a result) in the
+   * workspace — recommender-suggested, manually simulated, or lever-driven.
+   * The beginner-assistance panel reads it to mark a lever "simulated" (even
+   * when the action surfaced through the recommender's suggestions) and to
+   * block a redundant second simulation of the same lever.
+   */
+  simulatedActionIds: string[];
 }
 
 const EMPTY_SNAPSHOT: GameStudySnapshot = {
   contingencyElementIds: [],
   baselineMaxRho: null,
   chosenActions: [],
+  simulatedActionIds: [],
 };
 
 type SnapshotListener = (s: GameStudySnapshot) => void;
 type StudyLoader = (study: GameStudy) => Promise<void>;
-type LeverInteractionHandler = (interaction: LeverInteraction, mode: LeverInteractionMode) => void;
+type LeverInteractionHandler = (
+  interaction: LeverInteraction, mode: LeverInteractionMode,
+) => void | Promise<void>;
 
 class GameBridge {
   private snapshot: GameStudySnapshot = EMPTY_SNAPSHOT;
@@ -122,9 +133,12 @@ class GameBridge {
     return this.loader(study);
   }
 
-  /** Game UI asks App to inspect or simulate a lever. No-op before App mounts. */
-  requestLeverInteraction(interaction: LeverInteraction, mode: LeverInteractionMode): void {
-    this.leverHandler?.(interaction, mode);
+  /** Game UI asks App to inspect or simulate a lever. Resolves when the
+   *  handler settles so the caller (the hints panel) can show a
+   *  simulating → simulated transition; resolves immediately before App
+   *  mounts (no handler registered yet). */
+  requestLeverInteraction(interaction: LeverInteraction, mode: LeverInteractionMode): Promise<void> {
+    return Promise.resolve(this.leverHandler?.(interaction, mode));
   }
 
   getSnapshot(): GameStudySnapshot {

--- a/frontend/src/game/solutionLog.test.ts
+++ b/frontend/src/game/solutionLog.test.ts
@@ -307,17 +307,24 @@ describe('toStudyFeedback / sessionNoveltyBonus', () => {
       expect(i.simulate).toEqual({ switches: { SW_9: false } });
     });
 
-    it('leaves magnitude-free injection levers without a simulate spec', () => {
+    it('maps redispatch / shedding / curtailment levers to their dynamic-action id', () => {
+      // These simulate with the backend's DEFAULT incremental injection delta
+      // (no MW carried), so a double-click runs them without an amount prompt.
       const redispatch = buildLeverInteraction(lever({
         signature: 'redispatch:G1', label: 'G1', category: 'generation',
       }));
       expect(redispatch.inspectQuery).toBe('G1');
-      expect(redispatch.simulate).toBeUndefined();
+      expect(redispatch.simulate).toEqual({ actionId: 'redispatch_G1' });
 
       const shedding = buildLeverInteraction(lever({
         signature: 'ls:LOAD_9', label: 'LOAD_9', category: 'load',
       }));
-      expect(shedding.simulate).toBeUndefined();
+      expect(shedding.simulate).toEqual({ actionId: 'load_shedding_LOAD_9' });
+
+      const curtail = buildLeverInteraction(lever({
+        signature: 'rc:WIND_3', label: 'WIND_3', category: 'generation',
+      }));
+      expect(curtail.simulate).toEqual({ actionId: 'curtail_WIND_3' });
     });
 
     it('keeps a non-branch catalogue action id verbatim (no disco/reco strip)', () => {

--- a/frontend/src/game/solutionLog.ts
+++ b/frontend/src/game/solutionLog.ts
@@ -218,13 +218,44 @@ export function leverInspectTarget(lever: { signature: string; label: string }):
 }
 
 /**
+ * Injection lever prefix → the backend dynamic-action id prefix it maps to.
+ * The backend auto-creates these on the fly (`_create_dynamic_actions_if_needed`)
+ * and, when simulated with no `target_mw`, applies the DEFAULT incremental
+ * injection delta (`REDISPATCH_DEFAULT_DELTA_MW` for redispatch, the full-reduction
+ * default for shedding / curtailment). So a magnitude-free lever can be
+ * simulated straight from a double-click without the operator entering an amount.
+ * PST (`pst:`) and the raw `gen_p:` / `load_p:` levers stay magnitude-free
+ * (a tap variation / signed setpoint is needed), so they still degrade to inspect.
+ */
+const INJECTION_LEVER_ACTION_PREFIX: Record<string, string> = {
+  redispatch: 'redispatch_',
+  ls: 'load_shedding_',
+  rc: 'curtail_',
+};
+
+/**
+ * Backend dynamic-action id an injection lever maps to (or `null` for a lever
+ * that can't be simulated without a magnitude). Exported so the hints panel can
+ * tell whether a lever's action already sits in the workspace's simulated set.
+ */
+export function injectionLeverActionId(signature: string): string | null {
+  const colon = signature.indexOf(':');
+  if (colon <= 0) return null;
+  const prefix = INJECTION_LEVER_ACTION_PREFIX[signature.slice(0, colon)];
+  const body = signature.slice(colon + 1);
+  return prefix && body ? `${prefix}${body}` : null;
+}
+
+/**
  * Translate a lever hint into a workspace interaction the App handler can act
  * on without knowing lever-signature semantics:
  *   - `inspectQuery` locates the element (branch id, injection / switch name);
- *   - `simulate` is present only when the lever maps to a fully-specified
- *     action — a catalogue branch disco/reco (`action:<id>`) or a coupling
- *     maneuver (`switch:<id>=<state>`). Magnitude-free injection / PST levers
- *     carry no `simulate`, so a double-click on them degrades to inspect.
+ *   - `simulate` is present when the lever maps to a fully-specified action —
+ *     a catalogue branch disco/reco (`action:<id>`), a coupling maneuver
+ *     (`switch:<id>=<state>`), or an injection (`redispatch:` / `ls:` / `rc:`)
+ *     re-run with the default incremental delta. Magnitude-free PST / raw
+ *     `gen_p:` / `load_p:` levers carry no `simulate`, so a double-click on
+ *     them degrades to inspect.
  */
 export function buildLeverInteraction(lever: GameLeverStatWire): LeverInteraction {
   const interaction: LeverInteraction = {
@@ -240,6 +271,9 @@ export function buildLeverInteraction(lever: GameLeverStatWire): LeverInteractio
     const switchId = eq >= 0 ? body.slice(0, eq) : body;
     const targetOpen = eq >= 0 ? body.slice(eq + 1) === 'true' : true;
     interaction.simulate = { switches: { [switchId]: targetOpen } };
+  } else {
+    const actionId = injectionLeverActionId(signature);
+    if (actionId) interaction.simulate = { actionId };
   }
   return interaction;
 }

--- a/frontend/src/hooks/useLeverInteraction.test.ts
+++ b/frontend/src/hooks/useLeverInteraction.test.ts
@@ -134,7 +134,9 @@ describe('useLeverInteraction', () => {
         expect(notifyError).toHaveBeenCalledWith('Could not locate the substation for this maneuver.');
     });
 
-    it('double-clicking a magnitude-free injection lever degrades to inspect with a hint', async () => {
+    it('double-clicking a magnitude-free lever (PST / raw setpoint) degrades to inspect with a hint', async () => {
+        // redispatch / ls / rc levers now carry a simulate spec; a lever that
+        // reaches the handler with NO simulate (PST, raw gen_p/load_p) degrades.
         getElementVoltageLevels.mockResolvedValue({ voltage_level_ids: ['VL_G1'] });
         const params = makeParams();
         const handler = renderAndGetHandler(params);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -915,6 +915,13 @@ export interface PlayerSessionsResponse {
     player: string;
     /** Distinct sessions this player already recorded in the shared base. */
     session_count: number;
+    /**
+     * The concrete distinct session names (sorted, case-insensitive). The
+     * config screen suggests the first free `session <n>` index over these
+     * and blocks a name that already exists (a count-plus-one heuristic
+     * re-suggests a taken name when the recorded indices have gaps).
+     */
+    session_names: string[];
 }
 
 export interface LogGameSolutionResponse {


### PR DESCRIPTION
## Summary

Two Game Mode fixes reported from a live session:

1. **Duplicate session names are blocked.** After finishing "session 3", the
   config screen kept re-suggesting `session 3` (a name that already existed),
   and nothing stopped you from starting a run under a name already in the
   shared base.
2. **Lever hints now give simulation feedback and can't be double-simulated**,
   and **injection levers simulate with the default incremental delta** instead
   of degrading to "set the amount in the SLD".

## Changes

### Session naming
- `GET /api/game/player-sessions` now returns the concrete **`session_names`**
  (sorted) alongside `session_count`.
- The config screen auto-suggests the **first *free*** `<player> — session <n>`
  index by scanning those names — fixing the root cause: the old
  `count + 1` heuristic re-suggested a taken name whenever the recorded indices
  had gaps (e.g. `{1, 3}` → suggested the colliding `3`).
- A name that already exists **disables ▶ Start** with an inline warning (the
  shared base keys retentions by session name, so a duplicate would merge two
  runs).

### Lever-simulation feedback (beginner-assistance hints)
- Double-clicking a most-used lever shows a per-row **⏳ simulating… → ✓
  simulated** transition (`gameBridge.requestLeverInteraction` is now
  awaitable).
- A second double-click on a simulated lever is **ignored** (no accidental
  re-simulation).
- "Simulated" is read from a new **`simulatedActionIds`** set on the game-bridge
  snapshot, so a lever also flips to ✓ when its action arrives through the
  recommender's suggestions; a failed run self-clears (its id never enters the
  set) so the lever stays runnable.

### Injection levers
- `redispatch:` / `ls:` / `rc:` levers map to the backend dynamic-action id and
  simulate with no `target_mw`, so `_create_dynamic_actions_if_needed` applies
  the **default incremental injection delta** — a double-click runs them
  straight away. Only PST / raw `gen_p:` / `load_p:` levers still degrade to
  inspect (a tap / signed setpoint is required).

## Tests & docs
- **Backend:** `player_session_count` names + endpoint response
  (`test_game_solutions.py`); regenerated `openapi.snapshot.json`.
- **Frontend:** config first-free-index + duplicate-block tests; hints-panel
  simulating→simulated feedback, re-run block, cross-marking, and injection
  default-delta simulate; updated `buildLeverInteraction` / `useLeverInteraction`
  tests.
- Updated `docs/features/game-mode-codabench.md`, the three `CLAUDE.md` guides,
  the test-conventions guide, and `CHANGELOG.md`.

## Verification
- Frontend: full Vitest suite **1902 passed** (3 pre-existing skips); `tsc -b`
  clean; ESLint 0 errors; code-quality gate OK; standalone parity 30/30 + full
  Layer-1 parity.
- Backend: game + OpenAPI-contract tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)